### PR TITLE
Add a way to display errors from scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AUX Changelog
 
+## V1.0.24
+
+### Date: TBD
+
+### Changes:
+
+-   :bug: Bug Fixes
+
+    -   Fixed the color encoding of sprites to use sRGB instead of linear.
+
 ## V1.0.23
 
 ### Date: 4/12/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ### Changes:
 
+-   :rocket: Improvements
+
+    -   Added a button on the sheet code editor to show errors that the script has run into.
+        -   It is very basic at the moment. There are no line/column numbers, no timestamps, and no way to clear the errors.
+        -   Errors are automatically pulled from error space and queried based on the following tags:
+            -   `auxError` must be `true`
+            -   `auxErrorBot` must be the ID of the bot whose script is in the editor.
+            -   `auxErrorTag` must be the name of the tag that is being edited.
+        -   The following tags are displayed for each error:
+            -   `auxErrorName` is the name of the error that occurred.
+            -   `auxErrorMessage` is the message that the error contained.
+
 -   :bug: Bug Fixes
 
     -   Fixed the color encoding of sprites to use sRGB instead of linear.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   :bug: Bug Fixes
 
     -   Fixed the color encoding of sprites to use sRGB instead of linear.
+    -   Fixed an issue where atoms would be sorted improperly because their causes were improperly treated as different.
 
 ## V1.0.23
 

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -16,9 +16,11 @@ import {
     atom,
     atomId,
     WeaveResult,
+    addAtom,
 } from '@casual-simulation/causal-trees/core2';
 import { botAdded, botRemoved, botUpdated } from '../bots';
 import { BotStateUpdates } from './AuxStateHelpers';
+import reducer from './AuxWeaveReducer';
 
 describe('AuxCausalTree2', () => {
     describe('addAuxAtom()', () => {
@@ -30,6 +32,99 @@ describe('AuxCausalTree2', () => {
             expect(result.update).toEqual({
                 test: createBot('test'),
             });
+        });
+
+        it('should handle issue where the atom is not overwriting a previous value', () => {
+            const tree = auxTree('a');
+
+            const site1 = 'e4fc0a5b-1b58-46f9-ae3b-67769153903f';
+            const root = atom(atomId(site1, 1989, null), null, {
+                type: 1,
+                id: '98b4f896-413d-4875-9ddc-dd394f16c034',
+            });
+            expect(root.hash).toEqual(
+                'ccd9cea8f83001344e4be0202ad1116bbde20976c8b9dfa8953b1c9713860626'
+            );
+
+            const result1 = tree.weave.insert(root);
+            expect(result1).toEqual({
+                type: 'atom_added',
+                atom: root,
+            });
+            const update1 = reducer(tree.weave, result1, {});
+            expect(update1).toEqual({
+                '98b4f896-413d-4875-9ddc-dd394f16c034': createBot(
+                    '98b4f896-413d-4875-9ddc-dd394f16c034'
+                ),
+            });
+
+            const auxColor = atom(atomId(site1, 1996, null), root, {
+                type: 2,
+                name: 'auxColor',
+            });
+            expect(auxColor.hash).toEqual(
+                '5f02d0e3e44f1b4766eb5b31741c655edd025215d691f6b722e707e52eb19cee'
+            );
+
+            const result2 = tree.weave.insert(auxColor);
+            expect(result2).toEqual({
+                type: 'atom_added',
+                atom: auxColor,
+            });
+            const update2 = reducer(tree.weave, result2, {});
+            expect(update2).toEqual({});
+
+            const site2 = '6999e06b-7a56-4ea8-9e94-b9b104ee9360';
+            const first = atom(atomId(site2, 2091), auxColor, {
+                type: 3,
+                value: '#89ead4',
+            });
+
+            expect(first.hash).toEqual(
+                '2cc72a94414a0f18419be38cf3e04f581d376afdb0c34e83bfcd104094ba3eed'
+            );
+            const result3 = tree.weave.insert(first);
+            expect(result3).toEqual({
+                type: 'atom_added',
+                atom: first,
+            });
+            const update3 = reducer(tree.weave, result3, {});
+            expect(update3).toEqual({
+                '98b4f896-413d-4875-9ddc-dd394f16c034': {
+                    tags: {
+                        auxColor: '#89ead4',
+                    },
+                },
+            });
+
+            const site3 = '63b35cc1-b05e-4cbe-a25a-3e0262a36f6a';
+            const second = atom(atomId(site3, 3431), auxColor, {
+                type: 3,
+                value: '#89e',
+            });
+            expect(second.hash).toEqual(
+                '93955f3f854f4b0a9c315a7eda40afd2c0427fa342508a0eddedcfe4ec5fa583'
+            );
+            const result4 = tree.weave.insert(second);
+            expect(result4).toEqual({
+                type: 'atom_added',
+                atom: second,
+            });
+            const update4 = reducer(tree.weave, result4, {});
+            expect(update4).toEqual({
+                '98b4f896-413d-4875-9ddc-dd394f16c034': {
+                    tags: {
+                        auxColor: '#89e',
+                    },
+                },
+            });
+
+            expect(tree.weave.getAtoms()).toEqual([
+                root,
+                auxColor,
+                second,
+                first,
+            ]);
         });
     });
 

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.css
@@ -6,6 +6,7 @@
 }
 
 .code-editor-wrapper {
+    position: relative;
     width: 100%;
 
     /* Height is 100% the container minus the height of the breadcrumbs container */
@@ -20,4 +21,85 @@
     border-bottom: solid 1px var(--bot-cell-border-color);
     user-select: none;
     cursor: row-resize;
+
+    display: flex;
+}
+
+.editor-breadcrumbs .bot-tag {
+    flex: 1 1;
+}
+
+.editor-breadcrumbs .editor-errors {
+    flex: 0 1 120px;
+    text-align: right;
+}
+
+.editor-breadcrumbs .editor-errors > div {
+    display: inline-block;
+    padding: 0 8px;
+}
+
+.editor-breadcrumbs .editor-errors > .editor-button {
+    cursor: pointer;
+}
+
+.editor-breadcrumbs .editor-errors > .editor-button:hover {
+    background-color: #999;
+    color: #000;
+}
+
+.editor-errors .error-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 20px !important;
+    color: #c22;
+}
+
+.editor-button.active {
+    background-color: #999;
+    color: #000;
+}
+
+.errors-wrapper {
+    position: absolute;
+    z-index: 1;
+    background-color: #fff;
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+
+    overflow-y: scroll;
+    padding: 8px;
+}
+
+.error-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.error {
+    margin-bottom: 4px;
+    display: flex;
+}
+
+.error-details {
+    flex: 1 1;
+}
+
+.error-count {
+    flex: 0 0 28px;
+    align-self: center;
+    text-align: center;
+    background-color: #aaa;
+    border-radius: 28px;
+    width: 28px;
+    height: 28px;
+    line-height: 28px;
+    margin-right: 8px;
+}
+
+.error-name {
+    font-size: 20px;
+    font-weight: 700;
 }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -1,7 +1,14 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop, Watch } from 'vue-property-decorator';
-import { Bot, isScript, isFormula } from '@casual-simulation/aux-common';
+import {
+    Bot,
+    isScript,
+    isFormula,
+    ScriptError,
+    PrecalculatedBot,
+    loadBots,
+} from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { SubscriptionLike, Subscription } from 'rxjs';
 import { appManager } from '../../AppManager';
@@ -16,6 +23,9 @@ import {
     setActiveModel,
 } from '../../MonacoHelpers';
 import * as monaco from '../../MonacoLibs';
+import { filter, tap } from 'rxjs/operators';
+import groupBy from 'lodash/groupBy';
+import sumBy from 'lodash/sumBy';
 
 setup();
 
@@ -32,6 +42,13 @@ export default class MonacoTagEditor extends Vue {
     private _simulation: BrowserSimulation;
     private _sub: Subscription;
     private _model: monaco.editor.ITextModel;
+    private _allErrors: BotError[];
+    private _errorIds: Set<string>;
+    private _requestedErrors: Set<string>;
+
+    scriptErrors: BotError[];
+
+    showErrors: boolean;
 
     @Watch('tag')
     tagChanged() {
@@ -41,6 +58,16 @@ export default class MonacoTagEditor extends Vue {
     @Watch('bot')
     botChanged() {
         this._updateModel();
+    }
+
+    get errorsCount() {
+        return sumBy(this.scriptErrors, e => e.count);
+    }
+
+    get errorsLabel() {
+        return this.errorsCount > 1
+            ? `${this.errorsCount} Errors`
+            : `${this.errorsCount} Error`;
     }
 
     get isScript() {
@@ -57,13 +84,68 @@ export default class MonacoTagEditor extends Vue {
         return false;
     }
 
+    constructor() {
+        super();
+        this.scriptErrors = [];
+        this.showErrors = false;
+    }
+
     created() {
+        this._allErrors = [];
+        this._errorIds = new Set();
+        this._requestedErrors = new Set();
+        this.showErrors = false;
+
         this._sub = new Subscription();
         this._sub.add(
             appManager.whileLoggedIn((user, sim) => {
                 this._simulation = sim;
                 const sub = watchSimulation(sim);
+
+                const sub2 = sim.watcher.botsDiscovered
+                    .pipe(
+                        tap(bots => {
+                            let update = false;
+                            for (let b of bots) {
+                                if (
+                                    b.space !== 'error' ||
+                                    b.values['auxError'] !== true
+                                ) {
+                                    continue;
+                                }
+                                if (this._errorIds.has(b.id)) {
+                                    continue;
+                                }
+
+                                let error = {
+                                    botId: b.values['auxErrorBot'],
+                                    tag: b.values['auxErrorTag'],
+                                    message: b.values['auxErrorMessage'],
+                                    name: b.values['auxErrorName'],
+                                    stack: b.values['auxErrorStack'],
+                                } as BotError;
+
+                                this._errorIds.add(b.id);
+                                this._allErrors.push(error);
+
+                                if (
+                                    this.bot &&
+                                    this.bot.id === error.botId &&
+                                    this.tag === error.tag
+                                ) {
+                                    update = true;
+                                }
+                            }
+                            if (update) {
+                                this.$nextTick(() => {
+                                    this._updateModel();
+                                });
+                            }
+                        })
+                    )
+                    .subscribe(null, e => console.error(e));
                 this._sub.add(sub);
+                this._sub.add(sub2);
                 return [sub];
             })
         );
@@ -88,6 +170,10 @@ export default class MonacoTagEditor extends Vue {
         setActiveModel(null);
     }
 
+    toggleErrors() {
+        this.showErrors = !this.showErrors;
+    }
+
     private _updateModel() {
         const bot = this.bot;
         const tag = this.tag;
@@ -105,5 +191,47 @@ export default class MonacoTagEditor extends Vue {
         if (this.$refs.editor) {
             (<MonacoEditor>this.$refs.editor).setModel(this._model);
         }
+
+        const scriptErrors = this._allErrors.filter(
+            e => e.botId === bot.id && e.tag === tag
+        );
+        const grouped = groupBy(scriptErrors, e => `${e.name}${e.message}`);
+        this.scriptErrors = Object.keys(grouped).map(k => {
+            let error = grouped[k][0];
+            return {
+                ...error,
+                count: grouped[k].length,
+            };
+        });
+
+        const requestId = `${bot.id}-${tag}`;
+        if (!this._requestedErrors.has(requestId)) {
+            this._requestedErrors.add(requestId);
+            this._simulation.helper.transaction(
+                loadBots('error', [
+                    {
+                        tag: 'auxError',
+                        value: true,
+                    },
+                    {
+                        tag: 'auxErrorBot',
+                        value: bot.id,
+                    },
+                    {
+                        tag: 'auxErrorTag',
+                        value: tag,
+                    },
+                ])
+            );
+        }
     }
+}
+
+interface BotError {
+    count: number;
+    name: string;
+    message: string;
+    stack: string;
+    tag: string;
+    botId: string;
 }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -7,8 +7,35 @@
                 :isFormula="isFormula"
                 :allowCloning="false"
             ></bot-tag>
+            <div class="editor-errors">
+                <div v-if="scriptErrors.length === 0">
+                    No Errors
+                </div>
+                <div
+                    v-else
+                    class="editor-button"
+                    :class="{ active: showErrors }"
+                    @click="toggleErrors()"
+                >
+                    <md-icon class="error-icon">error</md-icon>
+                    {{ errorsLabel }}
+                </div>
+            </div>
         </div>
         <div class="code-editor-wrapper">
+            <div v-if="showErrors" class="errors-wrapper">
+                <ul class="error-list">
+                    <li v-for="(error, index) in scriptErrors" :key="index" class="error">
+                        <div class="error-count">
+                            <span>{{ error.count }}</span>
+                        </div>
+                        <div class="error-details">
+                            <div class="error-name">{{ error.name }}</div>
+                            <span class="error-message">{{ error.message }}</span>
+                        </div>
+                    </li>
+                </ul>
+            </div>
             <monaco-editor ref="editor" @focus="editorFocused" @blur="editorBlured"></monaco-editor>
         </div>
     </div>

--- a/src/aux-vm/DebugHelpers.ts
+++ b/src/aux-vm/DebugHelpers.ts
@@ -1,0 +1,20 @@
+import merge from 'lodash/merge';
+
+/**
+ * Adds the given function with the given name to the global aux namespace.
+ * @param name The name of the function.
+ * @param func The function.
+ */
+export function addDebugApi(name: string, func: (...args: any[]) => any) {
+    mergeIntoAuxNamespace({
+        [name]: func,
+    });
+}
+
+function mergeIntoAuxNamespace(data: any) {
+    if (typeof self !== 'undefined') {
+        merge(self, {
+            aux: data,
+        });
+    }
+}

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -39,6 +39,7 @@ import { StatusHelper } from './StatusHelper';
 import { StoredAux } from '../StoredAux';
 import pick from 'lodash/pick';
 import flatMap from 'lodash/flatMap';
+import { addDebugApi } from '../DebugHelpers';
 
 export interface AuxChannelOptions {
     sandboxFactory?: (lib: SandboxLibrary) => Sandbox;
@@ -127,6 +128,8 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
                 message: err.toString(),
             });
         });
+
+        addDebugApi('getChannel', () => this);
     }
 
     async init(
@@ -580,3 +583,5 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
 
     closed: boolean;
 }
+
+addDebugApi('getChannel', () => null as any);

--- a/src/causal-trees/core2/Atom2.spec.ts
+++ b/src/causal-trees/core2/Atom2.spec.ts
@@ -7,6 +7,7 @@ import {
     atomIdToString,
     idEquals,
     isAtom,
+    AtomId,
 } from './Atom2';
 
 describe('Atom2', () => {
@@ -88,6 +89,20 @@ describe('Atom2', () => {
         });
     });
 
+    describe('atomId()', () => {
+        const excludePriorityCases = [['null', null], ['undefined', undefined]];
+        it.each(excludePriorityCases)(
+            'should exclude the priority if it is %s',
+            (desc, val) => {
+                expect('priority' in atomId('a', 1, val)).toBe(false);
+            }
+        );
+
+        it('should include the priority if it is 0', () => {
+            expect('priority' in atomId('a', 1, 0)).toBe(true);
+        });
+    });
+
     describe('idEquals()', () => {
         it('should be equal to other IDs', () => {
             expect(idEquals(atomId('a', 1), atomId('a', 1))).toBe(true);
@@ -100,6 +115,26 @@ describe('Atom2', () => {
             expect(idEquals(atomId('b', 2), atomId('a', 1))).toBe(false);
             expect(idEquals(atomId('a', 1, 1), atomId('a', 1))).toBe(false);
             expect(idEquals(atomId('a', 1, 1), atomId('a', 1, 2))).toBe(false);
+        });
+
+        it('should handle null/undefined priorities', () => {
+            const first = {
+                site: 'a',
+                timestamp: 1,
+            } as AtomId;
+            const second = {
+                site: 'a',
+                timestamp: 1,
+                priority: null,
+            } as AtomId;
+            const third = {
+                site: 'a',
+                timestamp: 1,
+                priority: undefined,
+            } as AtomId;
+            expect(idEquals(first, second)).toBe(true);
+            expect(idEquals(first, third)).toBe(true);
+            expect(idEquals(second, third)).toBe(true);
         });
     });
 

--- a/src/causal-trees/core2/Atom2.ts
+++ b/src/causal-trees/core2/Atom2.ts
@@ -121,11 +121,18 @@ export function atomId(
     timestamp: number,
     priority?: number
 ): AtomId {
-    return {
-        site,
-        timestamp,
-        priority,
-    };
+    if (typeof priority === 'number') {
+        return {
+            site,
+            timestamp,
+            priority,
+        };
+    } else {
+        return {
+            site,
+            timestamp,
+        };
+    }
 }
 
 /**
@@ -199,7 +206,11 @@ export function idEquals(first: AtomId, second: AtomId) {
             second &&
             second.site === first.site &&
             second.timestamp === first.timestamp &&
-            second.priority === first.priority)
+            (second.priority === first.priority ||
+                (second.priority === null &&
+                    typeof first.priority === 'undefined') ||
+                (typeof second.priority === 'undefined' &&
+                    first.priority === null)))
     );
 }
 

--- a/src/causal-trees/core2/Weave2.spec.ts
+++ b/src/causal-trees/core2/Weave2.spec.ts
@@ -8,7 +8,7 @@ import {
     AtomRemovedResult,
     addedAtom,
 } from './Weave2';
-import { atom, atomId } from './Atom2';
+import { atom, atomId, Atom } from './Atom2';
 import { createAtom } from './SiteStatus';
 
 describe('Weave2', () => {
@@ -395,6 +395,92 @@ describe('Weave2', () => {
             weave.insert(atom1);
 
             expect(weave.getAtoms()).toEqual([root1, atom1, root2]);
+        });
+
+        it('should properly sort atoms that have null/undefined priorities in the causes', () => {
+            const root1 = atom(atomId('a', 0), null, {});
+            const root2 = atom(atomId('a', 0), null, {});
+            const root3 = atom(atomId('a', 0), null, {});
+            const first = atom(atomId('a', 5), root1, {});
+            first.cause.priority = null;
+
+            const second = atom(atomId('b', 10), root2, {});
+            second.id.priority = undefined;
+
+            weave.insert(root3);
+            weave.insert(first);
+            weave.insert(second);
+
+            expect(weave.getAtoms()).toEqual([root3, second, first]);
+        });
+
+        describe('bugs', () => {
+            it('should handle issue where the atom is not overwriting a previous value', () => {
+                const site1 = 'e4fc0a5b-1b58-46f9-ae3b-67769153903f';
+                const root = atom(atomId(site1, 1989, null), null, {
+                    type: 1,
+                    id: '98b4f896-413d-4875-9ddc-dd394f16c034',
+                });
+                expect(root.hash).toEqual(
+                    'ccd9cea8f83001344e4be0202ad1116bbde20976c8b9dfa8953b1c9713860626'
+                );
+
+                let result = weave.insert(root);
+                expect(result).toEqual({
+                    type: 'atom_added',
+                    atom: root,
+                });
+
+                const auxColor = atom(atomId(site1, 1996, null), root, {
+                    type: 2,
+                    name: 'auxColor',
+                });
+                expect(auxColor.hash).toEqual(
+                    '5f02d0e3e44f1b4766eb5b31741c655edd025215d691f6b722e707e52eb19cee'
+                );
+
+                result = weave.insert(auxColor);
+                expect(result).toEqual({
+                    type: 'atom_added',
+                    atom: auxColor,
+                });
+
+                const site2 = '6999e06b-7a56-4ea8-9e94-b9b104ee9360';
+                const first = atom(atomId(site2, 2091), auxColor, {
+                    type: 3,
+                    value: '#89ead4',
+                });
+
+                expect(first.hash).toEqual(
+                    '2cc72a94414a0f18419be38cf3e04f581d376afdb0c34e83bfcd104094ba3eed'
+                );
+                result = weave.insert(first);
+                expect(result).toEqual({
+                    type: 'atom_added',
+                    atom: first,
+                });
+
+                const site3 = '63b35cc1-b05e-4cbe-a25a-3e0262a36f6a';
+                const second = atom(atomId(site3, 3431), auxColor, {
+                    type: 3,
+                    value: '#89e',
+                });
+                expect(second.hash).toEqual(
+                    '93955f3f854f4b0a9c315a7eda40afd2c0427fa342508a0eddedcfe4ec5fa583'
+                );
+                result = weave.insert(second);
+                expect(result).toEqual({
+                    type: 'atom_added',
+                    atom: second,
+                });
+
+                expect(weave.getAtoms()).toEqual([
+                    root,
+                    auxColor,
+                    second,
+                    first,
+                ]);
+            });
         });
     });
 

--- a/src/causal-trees/core2/__snapshots__/Atom2.spec.ts.snap
+++ b/src/causal-trees/core2/__snapshots__/Atom2.spec.ts.snap
@@ -5,7 +5,6 @@ Object {
   "cause": null,
   "hash": "a72872ffa3664d13ce709e7083444c479f5a674d8df0bc70e0b1870425cc8fc7",
   "id": Object {
-    "priority": undefined,
     "site": "A",
     "timestamp": 1,
   },


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added a button on the sheet code editor to show errors that the script has run into.
        -   It is very basic at the moment. There are no line/column numbers, no timestamps, and no way to clear the errors.
        -   Errors are automatically pulled from error space and queried based on the following tags:
            -   `auxError` must be `true`
            -   `auxErrorBot` must be the ID of the bot whose script is in the editor.
            -   `auxErrorTag` must be the name of the tag that is being edited.
        -   The following tags are displayed for each error:
            -   `auxErrorName` is the name of the error that occurred.
            -   `auxErrorMessage` is the message that the error contained.

-   :bug: Bug Fixes

    -   Fixed the color encoding of sprites to use sRGB instead of linear.
    -   Fixed an issue where atoms would be sorted improperly because their causes were improperly treated as different.