### PR TITLE
Add API functions for errors, add billboardFront, and add the ability to sequence animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
     -   Added the ability to set `auxFormAnimation` to an array.
         -   When set, the list of animations will play in sequence.
         -   The last animation will loop forever until changed.
+    -   Added the `experiment.localFormAnimation(bot, animation)` function to play an animation locally.
+        -   It will interrupt and restore whichever animation is already playing on the bot.
 
 ## V1.0.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
         -   `tag` is the tag that the errors should be loaded for.
     -   Added the `server.destroyErrors()` function to clear all the errors in the universe.
     -   Added the `billboardFront` auxOrientationMode option to billboard the front of a bot instead of its top.
+    -   Added the ability to set `auxFormAnimation` to an array.
+        -   When set, the list of animations will play in sequence.
+        -   The last animation will loop forever until changed.
 
 ## V1.0.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@
 
 ### Changes:
 
+-   :boom: Breaking Changes
+
+    -   Renamed the `billboardZ` auxOrientationMode option to `billboardTop`.
+
 -   :rocket: Improvements
 
     -   Added the `server.loadErrors(bot, tag)` function to make loading error bots from the error space easy.
         -   `bot` is the bot or bot ID that the errors should be loaded for.
         -   `tag` is the tag that the errors should be loaded for.
     -   Added the `server.destroyErrors()` function to clear all the errors in the universe.
+    -   Added the `billboardFront` auxOrientationMode option to billboard the front of a bot instead of its top.
 
 ## V1.0.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
     -   Added the `experiment.localFormAnimation(bot, animation)` function to play an animation locally.
         -   It will interrupt and restore whichever animation is already playing on the bot.
 
+-   :bug: Bug Fixes
+
+    -   Fixed an issue where tags that were added via the sheet would not be recognized by the `getMod()` function.
+
 ## V1.0.24
 
 ### Date: 4/14/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CasualOS Changelog
 
+## V1.0.25
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Added the `server.loadErrors(bot, tag)` function to make loading error bots from the error space easy.
+        -   `bot` is the bot or bot ID that the errors should be loaded for.
+        -   `tag` is the tag that the errors should be loaded for.
+    -   Added the `server.destroyErrors()` function to clear all the errors in the universe.
+
 ## V1.0.24
 
 ### Date: 4/14/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2417,4 +2417,26 @@ The **second parameter** is the largest allowed value that can be generated.
 const number = math.random(0, Math.PI);
 ```
 
+## Experimental Actions
+
+### `experiment.localFormAnimation(bot, animation)`
+
+<FunctionCode name='localFormAnimation'/>
+
+Locally plays the given animation on the given bot.
+
+If an animation is already playing, it will be interrupted.
+When the given animation is finished playing, the interrupted animation will be restored.
+
+The **first parameter** is the Bot or Bot ID that the animation should be played on.
+
+The **second parameter** is the name or index of the animation that should be played.
+
+#### Examples
+
+1. Play the "jump" animation on this bot.
+```typescript
+experiment.localFormAnimation(this, "jump");
+```
+
 [listen-tag]: docs/listen-tags

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2237,9 +2237,9 @@ The **second parameter** is the name of the tag that the errors should be loaded
 server.loadErrors(this, tagName);
 ```
 
-### `server.clearErrors()`
+### `server.destroyErrors()`
 
-<FunctionCode name='clearErrors'/>
+<FunctionCode name='destroyErrors'/>
 
 Destroys all the error bots.
 
@@ -2247,7 +2247,7 @@ Destroys all the error bots.
 
 1. Destroy all the error bots in this universe:
 ```typescript
-server.clearErrors();
+server.destroyErrors();
 ```
 
 ## Utility Actions

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2211,6 +2211,45 @@ server.loadFile('/2/book.txt', 'My memoirs', {
 });
 ```
 
+### `server.loadErrors(bot, tag)`
+
+<FunctionCode name='loadErrors'/>
+
+Loads the errors for the given bot and tag.
+Note that the bots don't load immediately. They will automatically be added to the universe state once they have been loaded.
+
+Can be called multiple times for the same bot/tag combination to load errors that have been created since the last time they were loaded.
+
+Finds bots by searching the error space for bots with the following tags:
+
+-   `auxError` must be set to true.
+-   `auxErrorBot` must be the ID of the bot that was specified.
+-   `auxErrorTag` must be the tag that was specified.
+
+The **first parameter** is the Bot or Bot ID that the errors should be loaded for.
+
+The **second parameter** is the name of the tag that the errors should be loaded for.
+
+#### Examples:
+
+1. Load all errors that have occurred for this script:
+```typescript
+server.loadErrors(this, tagName);
+```
+
+### `server.clearErrors()`
+
+<FunctionCode name='clearErrors'/>
+
+Destroys all the error bots.
+
+#### Examples:
+
+1. Destroy all the error bots in this universe:
+```typescript
+server.clearErrors();
+```
+
 ## Utility Actions
 
 ### `setTag(bot, tag, value)`

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -598,10 +598,13 @@ The mode that determines how the bot automatically rotates.
     The bot does not rotate automatically. (default)
   </PossibleValueCode>
   <PossibleValueCode value='billboard'>
-    The bot rotates left, right, up, and down automatically to face the player.
+    The bot rotates left, right, up, and down automatically to point its top face towards the player.
   </PossibleValueCode>
-  <PossibleValueCode value='billboardZ'>
-    The bot rotates left and right automatically to face the player.
+  <PossibleValueCode value='billboardTop'>
+    The bot rotates left and right automatically to point its top face towards the player.
+  </PossibleValueCode>
+  <PossibleValueCode value='billboardFront'>
+    The bot rotates left and right automatically to point its front face towards the player.
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -477,6 +477,10 @@ Only works for mesh forms.
     Play the animation at the given index.
     Useful for exploring possible animations if you don't have the name.
   </PossibleValue>
+  <PossibleValue value='An array of numbers or strings'>
+    Plays the given list of animations in sequence.
+    The last animation will loop forever.
+  </PossibleValue>
 </PossibleValuesTable>
 
 ### `auxGLTFVersion`

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -68,6 +68,7 @@ import {
     addState,
     LoadBotsAction,
     ClearSpaceAction,
+    LocalFormAnimationAction,
 } from '../bots/BotEvents';
 import {
     calculateActionResultsUsingContext,
@@ -2380,6 +2381,19 @@ function inSheet(): boolean {
     return false;
 }
 
+/**
+ * Plays the given animation on the given bot locally.
+ * Reverts back to the original animation when done playing.
+ * @param bot The bot.
+ * @param animation The animation to play.
+ */
+function localFormAnimation(
+    bot: Bot | string,
+    animation: string | number
+): LocalFormAnimationAction {
+    return null;
+}
+
 function __energyCheck() {
     let current = getEnergy();
     current -= 1;
@@ -2467,6 +2481,10 @@ const server = {
     loadErrors,
 };
 
+const experiment = {
+    localFormAnimation,
+};
+
 /**
  * Defines a set of functions that relate to common math operations.
  */
@@ -2494,6 +2512,7 @@ export default {
     player,
     server,
     action: actionNamespace,
+    experiment,
 
     // Global functions
     create,

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -66,6 +66,7 @@ import {
     requestFullscreen,
     exitFullscreen,
     addState,
+    ClearSpaceAction,
 } from '../bots/BotEvents';
 import {
     calculateActionResultsUsingContext,
@@ -1871,6 +1872,13 @@ function serverSaveFile(path: string, data: string, options?: SaveFileOptions) {
 }
 
 /**
+ * Clears all the errors in the universe.
+ */
+function clearErrors(): ClearSpaceAction {
+    return null;
+}
+
+/**
  * subrtacts the given diff from the given bot.
  * @param bot The bot.
  * @param diff The diff to apply.
@@ -2445,6 +2453,7 @@ const server = {
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,
     setupUniverse,
+    clearErrors,
 };
 
 /**

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -1875,7 +1875,7 @@ function serverSaveFile(path: string, data: string, options?: SaveFileOptions) {
 /**
  * Clears all the errors in the universe.
  */
-function clearErrors(): ClearSpaceAction {
+function destroyErrors(): ClearSpaceAction {
     return null;
 }
 
@@ -2463,7 +2463,7 @@ const server = {
     loadFile: serverLoadFile,
     saveFile: serverSaveFile,
     setupUniverse,
-    clearErrors,
+    destroyErrors,
     loadErrors,
 };
 

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -66,6 +66,7 @@ import {
     requestFullscreen,
     exitFullscreen,
     addState,
+    LoadBotsAction,
     ClearSpaceAction,
 } from '../bots/BotEvents';
 import {
@@ -1879,6 +1880,15 @@ function clearErrors(): ClearSpaceAction {
 }
 
 /**
+ * Loads the errors for the given bot and tag.
+ * @param bot The bot that the errors should be loaded for.
+ * @param tag The tag that the errors should be loaded for.
+ */
+function loadErrors(bot: string | Bot, tag: string): LoadBotsAction {
+    return null;
+}
+
+/**
  * subrtacts the given diff from the given bot.
  * @param bot The bot.
  * @param diff The diff to apply.
@@ -2454,6 +2464,7 @@ const server = {
     saveFile: serverSaveFile,
     setupUniverse,
     clearErrors,
+    loadErrors,
 };
 
 /**

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -304,7 +304,11 @@ export type BotLabelAnchor =
 /**
  * Defines the possible bot orientation modes.
  */
-export type BotOrientationMode = 'absolute' | 'billboard' | 'billboardZ';
+export type BotOrientationMode =
+    | 'absolute'
+    | 'billboard'
+    | 'billboardTop'
+    | 'billboardFront';
 
 /**
  * Defines the possible bot anchor points.

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1271,7 +1271,12 @@ export function getBotOrientationMode(
             DEFAULT_ORIENTATION_MODE
         )
     );
-    if (mode === 'absolute' || mode === 'billboard' || mode === 'billboardZ') {
+    if (
+        mode === 'absolute' ||
+        mode === 'billboard' ||
+        mode === 'billboardTop' ||
+        mode === 'billboardFront'
+    ) {
         return mode;
     }
     return DEFAULT_ORIENTATION_MODE;

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -82,7 +82,8 @@ export type ExtraActions =
     | RequestFullscreenAction
     | ExitFullscreenAction
     | LoadBotsAction
-    | ClearSpaceAction;
+    | ClearSpaceAction
+    | LocalFormAnimationAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -1089,6 +1090,24 @@ export interface ClearSpaceAction {
 }
 
 /**
+ * Defines an event that runs an animation locally over
+ * whatever existing animations are playing.
+ */
+export interface LocalFormAnimationAction {
+    type: 'local_form_animation';
+
+    /**
+     * The bot to run the animation on.
+     */
+    botId: string;
+
+    /**
+     * The animation to run.
+     */
+    animation: number | string;
+}
+
+/**
  * Defines an event that enables AR on the device.
  */
 export interface EnableARAction {
@@ -1927,5 +1946,21 @@ export function clearSpace(space: BotSpace): ClearSpaceAction {
     return {
         type: 'clear_space',
         space: space,
+    };
+}
+
+/**
+ * Requests that the given animation be played for the given bot locally.
+ * @param botId The bot ID.
+ * @param animation The animation.
+ */
+export function localFormAnimation(
+    botId: string,
+    animation: string | number
+): LocalFormAnimationAction {
+    return {
+        type: 'local_form_animation',
+        botId,
+        animation,
     };
 }

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -81,7 +81,8 @@ export type ExtraActions =
     | ShowJoinCodeAction
     | RequestFullscreenAction
     | ExitFullscreenAction
-    | LoadBotsAction;
+    | LoadBotsAction
+    | ClearSpaceAction;
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -1073,6 +1074,21 @@ export interface TagFilter {
 }
 
 /**
+ * Defines an event that clears all bots from a space.
+ *
+ * Only supported for the following spaces:
+ * - error
+ */
+export interface ClearSpaceAction {
+    type: 'clear_space';
+
+    /**
+     * The space to clear.
+     */
+    space: BotSpace;
+}
+
+/**
  * Defines an event that enables AR on the device.
  */
 export interface EnableARAction {
@@ -1896,5 +1912,20 @@ export function loadBots(space: BotSpace, tags: TagFilter[]): LoadBotsAction {
         type: 'load_bots',
         space: space,
         tags: tags,
+    };
+}
+
+/**
+ * Requests that all the bots in the given space be cleared.
+ *
+ * Only supported for the following spaces:
+ * - error
+ *
+ * @param space The space to clear.
+ */
+export function clearSpace(space: BotSpace): ClearSpaceAction {
+    return {
+        type: 'clear_space',
+        space: space,
     };
 }

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -3448,7 +3448,12 @@ export function botCalculationContextTests(
     });
 
     describe('getBotOrientationMode()', () => {
-        const cases = [['absolute'], ['billboard'], ['billboardZ']];
+        const cases = [
+            ['absolute'],
+            ['billboard'],
+            ['billboardTop'],
+            ['billboardFront'],
+        ];
         it.each(cases)('should return %s', (mode: string) => {
             const bot = createBot('test', {
                 auxOrientationMode: <any>mode,

--- a/src/aux-common/partitions/BotClient.ts
+++ b/src/aux-common/partitions/BotClient.ts
@@ -12,6 +12,12 @@ export interface BotClient {
     addBots(universe: string, added: Bot[]): Promise<void>;
 
     /**
+     * Clears all the bots in the given universe.
+     * @param universe The universe to clear.
+     */
+    clearBots(universe: string): Promise<void>;
+
+    /**
      * Searches for bots matching the given tags in the given universe.
      * @param universe The universe.
      * @param tags The tags to search for.

--- a/src/aux-common/partitions/BotPartition.ts
+++ b/src/aux-common/partitions/BotPartition.ts
@@ -39,6 +39,7 @@ import {
     Bot,
     BotsState,
 } from '../bots';
+import values from 'lodash/values';
 
 /**
  * Attempts to create a BotPartition from the given config.
@@ -122,6 +123,8 @@ export class BotPartitionImpl implements BotPartition {
         for (let e of events) {
             if (e.type === 'load_bots') {
                 this._loadBots(e);
+            } else if (e.type === 'clear_space') {
+                this._clearBots();
             }
         }
 
@@ -181,5 +184,14 @@ export class BotPartitionImpl implements BotPartition {
             }
             this._onBotsAdded.next(sorted);
         }
+    }
+
+    private async _clearBots() {
+        await this._client.clearBots(this._universe);
+
+        const ids = sortBy(values(this.state).map(b => b.id));
+        this.state = {};
+
+        this._onBotsRemoved.next(ids);
     }
 }

--- a/src/aux-common/partitions/MemoryBotClient.ts
+++ b/src/aux-common/partitions/MemoryBotClient.ts
@@ -18,6 +18,10 @@ export class MemoryBotClient implements BotClient {
         }
     }
 
+    async clearBots(universe: string) {
+        this.universes[universe] = {};
+    }
+
     async lookupBots(universe: string, tags: TagFilter[]): Promise<Bot[]> {
         let uni = this.universes[universe];
         if (!uni) {

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -59,6 +59,7 @@ import {
     superShout,
     botRemoved,
     botAdded,
+    clearSpace,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2292,6 +2293,14 @@ describe('AuxLibrary', () => {
             });
         });
 
+        describe('server.clearErrors()', () => {
+            it('should issue a ClearSpaceAction', () => {
+                const action = library.api.server.clearErrors();
+                const expected = clearSpace('error');
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
         describe('remote()', () => {
             it('should replace the original event in the queue', () => {
                 const action = library.api.remote(

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -60,6 +60,7 @@ import {
     botRemoved,
     botAdded,
     clearSpace,
+    loadBots,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2301,6 +2302,49 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
         });
+
+        describe('server.loadErrors()', () => {
+            it('should issue a LoadBotsAction for the given tag and bot ID', () => {
+                const action = library.api.server.loadErrors('test', 'abc');
+                const expected = loadBots('error', [
+                    {
+                        tag: 'auxError',
+                        value: true,
+                    },
+                    {
+                        tag: 'auxErrorBot',
+                        value: 'test',
+                    },
+                    {
+                        tag: 'auxErrorTag',
+                        value: 'abc',
+                    },
+                ]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support being passed a runtime bot', () => {
+                const action = library.api.server.loadErrors(bot1, 'abc');
+                const expected = loadBots('error', [
+                    {
+                        tag: 'auxError',
+                        value: true,
+                    },
+                    {
+                        tag: 'auxErrorBot',
+                        value: bot1.id,
+                    },
+                    {
+                        tag: 'auxErrorTag',
+                        value: 'abc',
+                    },
+                ]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
         describe('remote()', () => {
             it('should replace the original event in the queue', () => {
                 const action = library.api.remote(

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2294,9 +2294,9 @@ describe('AuxLibrary', () => {
             });
         });
 
-        describe('server.clearErrors()', () => {
+        describe('server.destroyErrors()', () => {
             it('should issue a ClearSpaceAction', () => {
-                const action = library.api.server.clearErrors();
+                const action = library.api.server.destroyErrors();
                 const expected = clearSpace('error');
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -61,6 +61,7 @@ import {
     botAdded,
     clearSpace,
     loadBots,
+    localFormAnimation,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2482,6 +2483,28 @@ describe('AuxLibrary', () => {
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
                 expect(action.action).toBe(original);
+            });
+        });
+
+        describe('experiment.localFormAnimation()', () => {
+            it('should emit a LocalFormAnimationAction', () => {
+                const action = library.api.experiment.localFormAnimation(
+                    bot1,
+                    'test'
+                );
+                const expected = localFormAnimation(bot1.id, 'test');
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support passing a bot ID directly', () => {
+                const action = library.api.experiment.localFormAnimation(
+                    'abc',
+                    'test'
+                );
+                const expected = localFormAnimation('abc', 'test');
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
     });

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -49,6 +49,7 @@ import {
     webhook as calcWebhook,
     superShout as calcSuperShout,
     clearSpace,
+    loadBots,
     BotAction,
     download,
     BotsState,
@@ -345,6 +346,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 loadFile,
                 saveFile,
                 clearErrors,
+                loadErrors,
             },
 
             action: {
@@ -1420,6 +1422,30 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      */
     function clearErrors() {
         return addAction(clearSpace('error'));
+    }
+
+    /**
+     * Loads the errors for the given bot and tag.
+     * @param bot The bot that the errors should be loaded for.
+     * @param tag The tag that the errors should be loaded for.
+     */
+    function loadErrors(bot: string | Bot, tag: string) {
+        return addAction(
+            loadBots('error', [
+                {
+                    tag: 'auxError',
+                    value: true,
+                },
+                {
+                    tag: 'auxErrorBot',
+                    value: getID(bot),
+                },
+                {
+                    tag: 'auxErrorTag',
+                    value: tag,
+                },
+            ])
+        );
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -46,6 +46,7 @@ import {
     loadFile as calcLoadFile,
     saveFile as calcSaveFile,
     reject as calcReject,
+    localFormAnimation as calcLocalFormAnimation,
     webhook as calcWebhook,
     superShout as calcSuperShout,
     clearSpace,
@@ -75,6 +76,7 @@ import {
     CREATE_ANY_ACTION_NAME,
     DESTROY_ACTION_NAME,
     RanOutOfEnergyError,
+    LocalFormAnimationAction,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import { BotFilterFunction } from '../Formulas/SandboxInterface';
@@ -352,6 +354,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             action: {
                 perform,
                 reject,
+            },
+
+            experiment: {
+                localFormAnimation,
             },
 
             math: {
@@ -1535,6 +1541,19 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function reject(action: any) {
         const event = calcReject(getOriginalObject(action));
         return addAction(event);
+    }
+
+    /**
+     * Plays the given animation on the given bot locally.
+     * Reverts back to the original animation when done playing.
+     * @param bot The bot.
+     * @param animation The animation to play.
+     */
+    function localFormAnimation(
+        bot: Bot | string,
+        animation: string | number
+    ): LocalFormAnimationAction {
+        return addAction(calcLocalFormAnimation(getID(bot), animation));
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -48,6 +48,7 @@ import {
     reject as calcReject,
     webhook as calcWebhook,
     superShout as calcSuperShout,
+    clearSpace,
     BotAction,
     download,
     BotsState,
@@ -343,6 +344,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 restoreHistoryMarkToUniverse,
                 loadFile,
                 saveFile,
+                clearErrors,
             },
 
             action: {
@@ -1411,6 +1413,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 ...(options || {}),
             })
         );
+    }
+
+    /**
+     * Clears all the errors in the universe.
+     */
+    function clearErrors() {
+        return addAction(clearSpace('error'));
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -345,7 +345,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 restoreHistoryMarkToUniverse,
                 loadFile,
                 saveFile,
-                clearErrors,
+                destroyErrors,
                 loadErrors,
             },
 
@@ -1418,9 +1418,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     }
 
     /**
-     * Clears all the errors in the universe.
+     * Destroys all the errors in the universe.
      */
-    function clearErrors() {
+    function destroyErrors() {
         return addAction(clearSpace('error'));
     }
 

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -44,7 +44,11 @@ describe('RuntimeBot', () => {
         );
 
         updateTagMock = jest.fn();
-        updateTagMock.mockReturnValue(RealtimeEditMode.Immediate);
+        updateTagMock.mockImplementation((bot, tag, value) => {
+            bot.values[tag] = value;
+            bot.tags[tag] = value;
+            return RealtimeEditMode.Immediate;
+        });
 
         getListenerMock = jest.fn(
             (bot: CompiledBot, tag: string) => bot.listeners[tag]
@@ -171,6 +175,40 @@ describe('RuntimeBot', () => {
             expect(script.raw.abc).not.toEqual(null);
             expect(script.changes.abc).toEqual(null);
         });
+
+        it('should Object.keys() for tags that were added after the bot was created', () => {
+            const keys1 = Object.keys(script.tags);
+            keys1.sort();
+
+            expect(keys1).toEqual(['abc', 'bool', 'different', 'ghi']);
+
+            script.tags.newTag = true;
+
+            const keys2 = Object.keys(script.tags);
+            keys2.sort();
+
+            expect(keys2).toEqual([
+                'abc',
+                'bool',
+                'different',
+                'ghi',
+                'newTag',
+            ]);
+
+            precalc.values.otherNewTag = false;
+
+            const keys3 = Object.keys(script.tags);
+            keys3.sort();
+
+            expect(keys3).toEqual([
+                'abc',
+                'bool',
+                'different',
+                'ghi',
+                'newTag',
+                'otherNewTag',
+            ]);
+        });
     });
 
     describe('raw', () => {
@@ -252,6 +290,40 @@ describe('RuntimeBot', () => {
             expect(script.tags.abc).not.toEqual(null);
             expect(script.raw.abc).not.toEqual(null);
             expect(script.changes.abc).toEqual(null);
+        });
+
+        it('should Object.keys() for tags that were added after the bot was created', () => {
+            const keys1 = Object.keys(script.raw);
+            keys1.sort();
+
+            expect(keys1).toEqual(['abc', 'bool', 'different', 'ghi']);
+
+            script.raw.newTag = true;
+
+            const keys2 = Object.keys(script.raw);
+            keys2.sort();
+
+            expect(keys2).toEqual([
+                'abc',
+                'bool',
+                'different',
+                'ghi',
+                'newTag',
+            ]);
+
+            precalc.tags.otherNewTag = false;
+
+            const keys3 = Object.keys(script.raw);
+            keys3.sort();
+
+            expect(keys3).toEqual([
+                'abc',
+                'bool',
+                'different',
+                'ghi',
+                'newTag',
+                'otherNewTag',
+            ]);
         });
     });
 

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -129,6 +129,17 @@ export function createRuntimeBot(
             }
             return true;
         },
+        ownKeys(target) {
+            const keys = Object.keys(bot.values);
+            return keys;
+        },
+        getOwnPropertyDescriptor(target, property) {
+            if (property === 'toJSON') {
+                return Reflect.getOwnPropertyDescriptor(target, property);
+            }
+
+            return Reflect.getOwnPropertyDescriptor(bot.values, property);
+        },
     });
     const rawProxy = new Proxy(rawTags, {
         get(target, key: string, proxy) {
@@ -163,6 +174,17 @@ export function createRuntimeBot(
                 changedRawTags[key] = value;
             }
             return true;
+        },
+        ownKeys(target) {
+            const keys = Object.keys(bot.tags);
+            return keys;
+        },
+        getOwnPropertyDescriptor(target, property) {
+            if (property === 'toJSON') {
+                return Reflect.getOwnPropertyDescriptor(target, property);
+            }
+
+            return Reflect.getOwnPropertyDescriptor(bot.tags, property);
         },
     });
 

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -364,6 +364,21 @@ export class PlayerGame extends Game {
         //     // })
         // );
 
+        this.playerSimulations.push(playerSim3D);
+        this.mainScene.add(playerSim3D);
+
+        //
+        // Create Inventory Simulation
+        //
+        const inventorySim3D = new InventorySimulation3D(this, sim);
+        inventorySim3D.init();
+        inventorySim3D.onBotAdded.addListener(this.onBotAdded.invoke);
+        inventorySim3D.onBotRemoved.addListener(this.onBotRemoved.invoke);
+        inventorySim3D.onBotUpdated.addListener(this.onBotUpdated.invoke);
+
+        this.inventorySimulations.push(inventorySim3D);
+        this.inventoryScene.add(inventorySim3D);
+
         this.subs.push(
             playerSim3D.simulation.localEvents.subscribe(e => {
                 if (e.type === 'go_to_dimension') {
@@ -395,21 +410,6 @@ export class PlayerGame extends Game {
                 }
             })
         );
-
-        this.playerSimulations.push(playerSim3D);
-        this.mainScene.add(playerSim3D);
-
-        //
-        // Create Inventory Simulation
-        //
-        const inventorySim3D = new InventorySimulation3D(this, sim);
-        inventorySim3D.init();
-        inventorySim3D.onBotAdded.addListener(this.onBotAdded.invoke);
-        inventorySim3D.onBotRemoved.addListener(this.onBotRemoved.invoke);
-        inventorySim3D.onBotUpdated.addListener(this.onBotUpdated.invoke);
-
-        this.inventorySimulations.push(inventorySim3D);
-        this.inventoryScene.add(inventorySim3D);
     }
 
     createAudio() {

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -6,6 +6,7 @@ import {
     calculateGridScale,
     isBotPointable,
     isBotFocusable,
+    LocalActions,
 } from '@casual-simulation/aux-common';
 import { AuxBot3DDecorator } from './AuxBot3DDecorator';
 import { DimensionGroup3D } from './DimensionGroup3D';
@@ -244,6 +245,16 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
             );
         }
         this._updatesInFrame = 0;
+    }
+
+    localEvent(event: LocalActions, calc: BotCalculationContext): void {
+        if (this.decorators) {
+            for (let decorator of this.decorators) {
+                if (decorator.localEvent) {
+                    decorator.localEvent(event, calc);
+                }
+            }
+        }
     }
 
     updateFrameUpdateList() {

--- a/src/aux-server/aux-web/shared/scene/AuxBot3DDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3DDecorator.ts
@@ -1,5 +1,8 @@
 import { AuxBot3D } from './AuxBot3D';
-import { BotCalculationContext } from '@casual-simulation/aux-common';
+import {
+    BotCalculationContext,
+    LocalActions,
+} from '@casual-simulation/aux-common';
 
 export interface AuxBot3DDecorator {
     bot3D: AuxBot3D;
@@ -7,6 +10,7 @@ export interface AuxBot3DDecorator {
     botUpdated(calc: BotCalculationContext): void;
     botRemoved(calc: BotCalculationContext): void;
     frameUpdate?(calc: BotCalculationContext): void;
+    localEvent?(event: LocalActions, calc: BotCalculationContext): void;
     dispose(): void;
 }
 

--- a/src/aux-server/aux-web/shared/scene/AuxBotVisualizer.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBotVisualizer.ts
@@ -1,4 +1,8 @@
-import { BotCalculationContext, Bot } from '@casual-simulation/aux-common';
+import {
+    BotCalculationContext,
+    Bot,
+    LocalActions,
+} from '@casual-simulation/aux-common';
 
 /**
  * Defines an interface for a visualizer for a bot.
@@ -22,6 +26,13 @@ export interface AuxBotVisualizer {
      * @param calc The calculation context.
      */
     frameUpdate(calc: BotCalculationContext): void;
+
+    /**
+     * Handles the given local event.
+     * @param event The event.
+     * @param calc The calculation context.
+     */
+    localEvent(event: LocalActions, calc: BotCalculationContext): void;
 
     /**
      * Disposes of all the resources this bot uses.

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -7,6 +7,7 @@ import {
     PrecalculatedBot,
     GLOBALS_BOT_ID,
     BotIndexEvent,
+    LocalActions,
 } from '@casual-simulation/aux-common';
 import { SubscriptionLike, Subject, Observable } from 'rxjs';
 import { tap, startWith } from 'rxjs/operators';
@@ -201,6 +202,11 @@ export abstract class Simulation3D extends Object3D
                 .pipe(tap(update => this._botsUpdated(update, false)))
                 .subscribe()
         );
+        this._subs.push(
+            this.simulation.localEvents
+                .pipe(tap(e => this._localEvent(e)))
+                .subscribe()
+        );
 
         this._subs.push(
             this.simulation.watcher
@@ -365,6 +371,16 @@ export abstract class Simulation3D extends Object3D
         }
 
         this._removeBotsFromGroups(groups, event.dimension, event.bot);
+    }
+
+    private _localEvent(e: LocalActions): void {
+        if (e.type === 'local_form_animation') {
+            const calc = this._currentContext;
+            const bots = this.findBotsById(e.botId);
+            for (let b of bots) {
+                b.localEvent(e, calc);
+            }
+        }
     }
 
     _onLoaded() {}

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -15,6 +15,7 @@ import {
     calculateStringTagValue,
     hasValue,
     isBotPointable,
+    LocalActions,
 } from '@casual-simulation/aux-common';
 import {
     Mesh,
@@ -144,6 +145,12 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         this._updateAnimation(animation);
     }
 
+    localEvent(event: LocalActions, calc: BotCalculationContext) {
+        if (event.type === 'local_form_animation') {
+            this._playAnimation(event.animation);
+        }
+    }
+
     private _needsUpdate(
         shape: string,
         subShape: string,
@@ -221,7 +228,59 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         }
     }
 
-    private _updateAnimation(animation: any, forceUpdate: boolean = false) {
+    private _playAnimation(animation: string | number) {
+        if (!this._animationMixer) {
+            return;
+        }
+
+        console.log('[BotShapeDecorator] Play Animation:', animation);
+
+        const clips = this._getClips(animation);
+
+        if (clips.length > 0) {
+            let previousTime = this._animationMixer.time;
+            this._animationMixer.stopAllAction();
+            this._animationMixer.setTime(0);
+
+            let clips = this._getClips(animation);
+            let startTimeOffset = 0;
+            let lastClip: AnimationAction;
+
+            if (clips.length === 1) {
+                const clip = clips[0];
+                clip.startAt(startTimeOffset);
+                clip.play();
+                clip.setLoop(LoopOnce, 1);
+                lastClip = clip;
+            } else if (clips.length > 0) {
+                for (let i = 0; i < clips.length; i++) {
+                    let clip = clips[i];
+                    const isLast: boolean = i === clips.length - 1;
+                    clip.startAt(startTimeOffset);
+                    clip.play();
+                    startTimeOffset += clip.getClip().duration;
+                    if (isLast) {
+                        lastClip = clip;
+                    }
+                    clip.setLoop(LoopOnce, 1);
+                }
+            }
+
+            const listener = () => {
+                console.log('[BotShapeDecorator] Finished Animation');
+                this._updateAnimation(this._animation, true, previousTime);
+                this._animationMixer.removeEventListener('finished', listener);
+            };
+
+            this._animationMixer.addEventListener('finished', listener);
+        }
+    }
+
+    private _updateAnimation(
+        animation: any,
+        forceUpdate: boolean = false,
+        startTime: number = 0
+    ) {
         if (this._animation === animation && !forceUpdate) {
             return;
         }
@@ -230,57 +289,76 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
         }
         this._animation = animation;
         this._animationMixer.stopAllAction();
+        this._animationMixer.setTime(startTime);
 
         const noAnimation = animation === false;
         if (noAnimation) {
         } else if (hasValue(this._animation)) {
-            let playing = false;
-            if (typeof this._animation === 'number') {
-                const index = Math.floor(this._animation);
-                if (index >= 0 && index < this._animClips.length) {
-                    this._animClips[index].play();
-                    playing = true;
-                }
-            } else if (Array.isArray(this._animation)) {
-                let startTime = this._animationMixer.time;
-                for (let i = 0; i < this._animation.length; i++) {
-                    const val = this._animation[i];
-                    let clip: AnimationAction;
-                    const isLast: boolean = i === this._animation.length - 1;
-                    if (typeof val === 'number') {
-                        if (val >= 0 && val < this._animClips.length) {
-                            clip = this._animClips[val];
-                        }
-                    } else if (hasValue(val)) {
-                        const name = val.toString();
-                        clip = this._animClipMap.get(name);
-                    }
+            let clips = this._getClips(this._animation);
 
-                    if (clip) {
-                        playing = true;
-                        clip.startAt(startTime);
-                        clip.play();
-                        startTime += clip.getClip().duration;
-                        if (isLast) {
-                            clip.setLoop(LoopRepeat, Infinity);
-                        } else {
-                            clip.setLoop(LoopOnce, 1);
-                        }
-                    }
-                }
-            }
-
-            if (!playing) {
-                const name = this._animation.toString();
-                const clip = this._animClipMap.get(name);
-                if (clip) {
+            let startTimeOffset = 0;
+            if (clips.length === 1) {
+                const clip = clips[0];
+                clip.startAt(startTimeOffset);
+                clip.play();
+            } else if (clips.length > 0) {
+                for (let i = 0; i < clips.length; i++) {
+                    let clip = clips[i];
+                    const isLast: boolean = i === clips.length - 1;
+                    clip.startAt(startTimeOffset);
                     clip.play();
-                    playing = true;
+                    startTimeOffset += clip.getClip().duration;
+                    if (isLast) {
+                        clip.setLoop(LoopRepeat, Infinity);
+                    } else {
+                        clip.setLoop(LoopOnce, 1);
+                    }
                 }
             }
         } else {
             this._animClips[0].play();
         }
+    }
+
+    private _getClips(animation: any): AnimationAction[] {
+        if (Array.isArray(animation)) {
+            let clips = [] as AnimationAction[];
+            for (let i = 0; i < animation.length; i++) {
+                const val = animation[i];
+                let clip: AnimationAction;
+                const isLast: boolean = i === animation.length - 1;
+                if (typeof val === 'number') {
+                    if (val >= 0 && val < this._animClips.length) {
+                        clip = this._animClips[val];
+                    }
+                } else if (hasValue(val)) {
+                    const name = val.toString();
+                    clip = this._animClipMap.get(name);
+                }
+
+                if (clip) {
+                    clips.push(clip);
+                }
+            }
+
+            return clips;
+        } else if (typeof animation === 'number') {
+            const index = Math.floor(animation);
+            if (index >= 0 && index < this._animClips.length) {
+                const clip = this._animClips[index];
+                if (clip) {
+                    return [clip];
+                }
+            }
+        } else if (hasValue(animation)) {
+            const name = animation.toString();
+            const clip = this._animClipMap.get(name);
+            if (clip) {
+                return [clip];
+            }
+        }
+
+        return [];
     }
 
     private _updateIframeHtml() {

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -36,6 +36,8 @@ import {
     SkinnedMesh,
     AnimationAction,
     MathUtils as ThreeMath,
+    LoopRepeat,
+    LoopOnce,
 } from 'three';
 import {
     createCube,
@@ -238,6 +240,33 @@ export class BotShapeDecorator extends AuxBot3DDecoratorBase
                 if (index >= 0 && index < this._animClips.length) {
                     this._animClips[index].play();
                     playing = true;
+                }
+            } else if (Array.isArray(this._animation)) {
+                let startTime = this._animationMixer.time;
+                for (let i = 0; i < this._animation.length; i++) {
+                    const val = this._animation[i];
+                    let clip: AnimationAction;
+                    const isLast: boolean = i === this._animation.length - 1;
+                    if (typeof val === 'number') {
+                        if (val >= 0 && val < this._animClips.length) {
+                            clip = this._animClips[val];
+                        }
+                    } else if (hasValue(val)) {
+                        const name = val.toString();
+                        clip = this._animClipMap.get(name);
+                    }
+
+                    if (clip) {
+                        playing = true;
+                        clip.startAt(startTime);
+                        clip.play();
+                        startTime += clip.getClip().duration;
+                        if (isLast) {
+                            clip.setLoop(LoopRepeat, Infinity);
+                        } else {
+                            clip.setLoop(LoopOnce, 1);
+                        }
+                    }
                 }
             }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -224,7 +224,9 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
         } else {
             let update = false;
             if (
-                ['billboard', 'billboardZ'].indexOf(this._orientationMode) >= 0
+                ['billboard', 'billboardTop', 'billboardFront'].indexOf(
+                    this._orientationMode
+                ) >= 0
             ) {
                 const cameraRig = this.bot3D.dimensionGroup.simulation3D.getMainCameraRig();
                 const cameraWorld = new Vector3();
@@ -246,21 +248,31 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
 
                 this._rotationObj.lookAt(cameraWorld);
 
-                // Rotate the object 90 degrees around its X axis
-                // so that the top of the bot is facing the camera.
-                const rotationOffset = new Quaternion().setFromAxisAngle(
-                    new Vector3(1, 0, 0),
-                    ThreeMath.degToRad(90)
-                );
-                this._rotationObj.quaternion.multiply(rotationOffset);
+                if (this._orientationMode !== 'billboardFront') {
+                    // Rotate the object 90 degrees around its X axis
+                    // so that the top of the bot is facing the camera.
+                    const rotationOffset = new Quaternion().setFromAxisAngle(
+                        new Vector3(1, 0, 0),
+                        ThreeMath.degToRad(90)
+                    );
+                    this._rotationObj.quaternion.multiply(rotationOffset);
+                }
 
                 update = true;
-                if (this._orientationMode === 'billboardZ') {
+                if (this._orientationMode === 'billboardTop') {
                     const euler = new Euler().setFromQuaternion(
                         this._rotationObj.quaternion,
                         'YXZ'
                     );
                     euler.x = ThreeMath.degToRad(90);
+                    euler.z = 0;
+                    this._rotationObj.setRotationFromEuler(euler);
+                } else if (this._orientationMode === 'billboardFront') {
+                    const euler = new Euler().setFromQuaternion(
+                        this._rotationObj.quaternion,
+                        'YXZ'
+                    );
+                    euler.x = 0;
                     euler.z = 0;
                     this._rotationObj.setRotationFromEuler(euler);
                 }

--- a/src/aux-server/server/mongodb/MongoDBBotStore.ts
+++ b/src/aux-server/server/mongodb/MongoDBBotStore.ts
@@ -37,6 +37,11 @@ export class MongoDBBotStore implements BotStore {
         return bots;
     }
 
+    async removeBots(namespace: string): Promise<void> {
+        const collection = await this._getCollection(namespace);
+        await collection.deleteMany({});
+    }
+
     private async _getCollection(namespace: string) {
         const collection = this._database.collection<Bot>(namespace);
 

--- a/src/aux-server/server/servers/BotHttpServer.ts
+++ b/src/aux-server/server/servers/BotHttpServer.ts
@@ -2,6 +2,7 @@ import express, { Response } from 'express';
 import { BotStore } from '../storage/BotStore';
 import { AddBotsRequest } from '../../shared/AddBotsRequest';
 import { LookupBotsRequest } from '../../shared/LookupBotsRequest';
+import { ClearBotsRequest } from '../../shared/ClearBotsRequest';
 import { asyncMiddleware } from '../utils';
 
 /**
@@ -44,6 +45,16 @@ export class BotHttpServer {
                     lookupBotsRequest.tags
                 );
                 res.send(bots);
+            })
+        );
+
+        this._app.post(
+            '/api/bots/clear',
+            asyncMiddleware(async (req, res) => {
+                // TODO: Add request validation
+                const lookupBotsRequest = req.body as ClearBotsRequest;
+                await this._store.removeBots(lookupBotsRequest.namespace);
+                res.sendStatus(204);
             })
         );
     }

--- a/src/aux-server/server/storage/BotStore.ts
+++ b/src/aux-server/server/storage/BotStore.ts
@@ -18,4 +18,10 @@ export interface BotStore {
      * @param tags The tags that the bots should have.
      */
     findBots(namespace: string, tags: TagFilter[]): Promise<Bot[]>;
+
+    /**
+     * Removes all the bots from the given namespace.
+     * @param namespace The namespace.
+     */
+    removeBots(namespace: string): Promise<void>;
 }

--- a/src/aux-server/shared/ClearBotsRequest.ts
+++ b/src/aux-server/shared/ClearBotsRequest.ts
@@ -1,0 +1,3 @@
+export interface ClearBotsRequest {
+    namespace: string;
+}

--- a/src/aux-vm-client/partitions/BotHttpClient.ts
+++ b/src/aux-vm-client/partitions/BotHttpClient.ts
@@ -23,6 +23,20 @@ export class BotHttpClient implements BotClient {
         }
     }
 
+    async clearBots(universe: string): Promise<void> {
+        const request = {
+            namespace: universe,
+        };
+        try {
+            const response = await axios.post(
+                `${this.host}/api/bots/clear`,
+                request
+            );
+        } catch (err) {
+            console.error('[BotHttpClient] Unable to clear bots:', err);
+        }
+    }
+
     async lookupBots(universe: string, tags: TagFilter[]): Promise<Bot[]> {
         const request = {
             namespace: universe,

--- a/src/aux-vm/vm/AuxHelper.spec.ts
+++ b/src/aux-vm/vm/AuxHelper.spec.ts
@@ -21,6 +21,7 @@ import {
     AuxRuntime,
     AuxPartitions,
     iteratePartitions,
+    clearSpace,
 } from '@casual-simulation/aux-common';
 import { AuxHelper } from './AuxHelper';
 import {
@@ -741,6 +742,37 @@ describe('AuxHelper', () => {
                         'error'
                     ),
                 });
+            });
+        });
+
+        describe('clear_space', () => {
+            it('should be able to clear a space', async () => {
+                let searchClient = new MemoryBotClient();
+                let error = createBotClientPartition({
+                    type: 'bot_client',
+                    universe: 'universe',
+                    client: searchClient,
+                });
+                helper = createHelper({
+                    shared: createMemoryPartition({
+                        type: 'memory',
+                        initialState: {},
+                    }),
+                    error: error,
+                });
+                helper.userId = userId;
+
+                await searchClient.addBots('universe', [
+                    createBot('test1', {
+                        abc: 'def',
+                    }),
+                ]);
+
+                await helper.transaction(clearSpace('error'));
+
+                await waitAsync();
+
+                expect(searchClient.universes['universe']).toEqual({});
             });
         });
 

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -575,6 +575,8 @@ export class AuxHelper extends BaseHelper<Bot> {
             return undefined;
         } else if (event.type === 'load_bots') {
             return this._partitionForBotType(event.space);
+        } else if (event.type === 'clear_space') {
+            return this._partitionForBotType(event.space);
         } else {
             return null;
         }


### PR DESCRIPTION
-   :boom: Breaking Changes

    -   Renamed the `billboardZ` auxOrientationMode option to `billboardTop`.

-   :rocket: Improvements

    -   Added the `server.loadErrors(bot, tag)` function to make loading error bots from the error space easy.
        -   `bot` is the bot or bot ID that the errors should be loaded for.
        -   `tag` is the tag that the errors should be loaded for.
    -   Added the `server.destroyErrors()` function to clear all the errors in the universe.
    -   Added the `billboardFront` auxOrientationMode option to billboard the front of a bot instead of its top.
    -   Added the ability to set `auxFormAnimation` to an array.
        -   When set, the list of animations will play in sequence.
        -   The last animation will loop forever until changed.
    -   Added the `experiment.localFormAnimation(bot, animation)` function to play an animation locally.
        -   It will interrupt and restore whichever animation is already playing on the bot.

-   :bug: Bug Fixes

    -   Fixed an issue where tags that were added via the sheet would not be recognized by the `getMod()` function.