### PR TITLE
Improved the player.showInputForTag() modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## V1.0.25
 
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Improved the `player.showInputForTag()` modal.
+        -   Removed the "Save" and "Cancel" buttons. The tag will be saved automatically.
+        -   Hid the modal title when none is provided in the options.
+        -   Made the text box in the modal auto-focus.
+        -   Made the show/hide animations happen quicker.
+
+## V1.0.25
+
 ### Date: 4/15/2020
 
 ### Changes:

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
@@ -160,3 +160,7 @@
 .input-dialog-color-tools {
     padding-bottom: 16px;
 }
+
+.input-dialog {
+    transition-duration: 0.1s, 0.1s;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
@@ -144,3 +144,19 @@
 .user-info {
     display: flex;
 }
+
+.input-dialog-content {
+    padding-bottom: 0;
+}
+
+.input-dialog-content .md-field {
+    margin-bottom: 20px;
+}
+
+.input-dialog .md-dialog-title {
+    margin-bottom: 0;
+}
+
+.input-dialog-color-tools {
+    padding-bottom: 16px;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -855,6 +855,20 @@ export default class PlayerApp extends Vue {
         }
     }
 
+    autoFocusInputDialog() {
+        // wait for the transition to finish
+        setTimeout(
+            () => {
+                const field = <Vue>this.$refs.inputModalField;
+                if (field) {
+                    field.$el.focus();
+                }
+            },
+            // 0.36 seconds (transition is 0.35 seconds)
+            1000 * 0.36
+        );
+    }
+
     async closeInputDialog() {
         if (this.showInputDialog) {
             await this._inputDialogSimulation.helper.action('onCloseInput', [

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -864,8 +864,8 @@ export default class PlayerApp extends Vue {
                     field.$el.focus();
                 }
             },
-            // 0.36 seconds (transition is 0.35 seconds)
-            1000 * 0.36
+            // 0.11 seconds (transition is 0.1 seconds)
+            1000 * 0.11
         );
     }
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -885,9 +885,7 @@ export default class PlayerApp extends Vue {
         await this._inputDialogSimulation.helper.action('onSaveInput', [
             this._inputDialogTarget,
         ]);
-        if (this.showInputDialog) {
-            await this.closeInputDialog();
-        }
+        await this.closeInputDialog();
     }
 
     private _updateColor(
@@ -911,7 +909,7 @@ export default class PlayerApp extends Vue {
         if (typeof options.title !== 'undefined') {
             this.inputDialogLabel = options.title;
         } else {
-            this.inputDialogLabel = tag;
+            this.inputDialogLabel = null; // tag;
         }
 
         if (typeof options.foregroundColor !== 'undefined') {

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -865,27 +865,27 @@ export default class PlayerApp extends Vue {
     }
 
     async saveInputDialog() {
-        if (this.showInputDialog) {
-            let value: any;
-            if (
-                this.inputDialogType === 'color' &&
-                typeof this.inputDialogInputValue === 'object'
-            ) {
-                value = this.inputDialogInputValue.hex;
-            } else {
-                value = this.inputDialogInputValue;
+        let value: any;
+        if (
+            this.inputDialogType === 'color' &&
+            typeof this.inputDialogInputValue === 'object'
+        ) {
+            value = this.inputDialogInputValue.hex;
+        } else {
+            value = this.inputDialogInputValue;
+        }
+        await this._inputDialogSimulation.helper.updateBot(
+            this._inputDialogTarget,
+            {
+                tags: {
+                    [this.inputDialogInput]: value,
+                },
             }
-            await this._inputDialogSimulation.helper.updateBot(
-                this._inputDialogTarget,
-                {
-                    tags: {
-                        [this.inputDialogInput]: value,
-                    },
-                }
-            );
-            await this._inputDialogSimulation.helper.action('onSaveInput', [
-                this._inputDialogTarget,
-            ]);
+        );
+        await this._inputDialogSimulation.helper.action('onSaveInput', [
+            this._inputDialogTarget,
+        ]);
+        if (this.showInputDialog) {
             await this.closeInputDialog();
         }
     }

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -101,7 +101,7 @@
 
             <md-dialog
                 :md-active.sync="showInputDialog"
-                @md-closed="closeInputDialog()"
+                @md-closed="saveInputDialog()"
                 :style="{
                     'background-color': inputDialogBackgroundColor,
                     color: inputDialogLabelColor,

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -102,6 +102,7 @@
             <md-dialog
                 :md-active.sync="showInputDialog"
                 @md-closed="saveInputDialog()"
+                @md-opened="autoFocusInputDialog()"
                 class="input-dialog"
                 :style="{
                     'background-color': inputDialogBackgroundColor,
@@ -117,6 +118,7 @@
                         <md-input
                             v-model="inputDialogInputValue"
                             @keyup.enter="saveInputDialog()"
+                            ref="inputModalField"
                             style="-webkit-text-fill-color: inherit;"
                             :style="{ color: inputDialogLabelColor }"
                         ></md-input>

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -102,13 +102,14 @@
             <md-dialog
                 :md-active.sync="showInputDialog"
                 @md-closed="saveInputDialog()"
+                class="input-dialog"
                 :style="{
                     'background-color': inputDialogBackgroundColor,
                     color: inputDialogLabelColor,
                 }"
             >
-                <md-dialog-title>{{ inputDialogLabel }}</md-dialog-title>
-                <md-dialog-content>
+                <md-dialog-title v-show="inputDialogLabel">{{ inputDialogLabel }}</md-dialog-title>
+                <md-dialog-content class="input-dialog-content">
                     <md-field>
                         <label :style="{ color: inputDialogLabelColor }">{{
                             inputDialogPlaceholder
@@ -120,7 +121,7 @@
                             :style="{ color: inputDialogLabelColor }"
                         ></md-input>
                     </md-field>
-                    <div v-if="inputDialogType === 'color'">
+                    <div class="input-dialog-color-tools" v-if="inputDialogType === 'color'">
                         <color-picker-swatches
                             v-if="inputDialogSubtype === 'swatch'"
                             :value="inputDialogInputValue"

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -143,12 +143,6 @@
                         ></color-picker-basic>
                     </div>
                 </md-dialog-content>
-                <md-dialog-actions>
-                    <md-button @click="closeInputDialog()" :style="{ color: inputDialogLabelColor }"
-                        >Cancel</md-button
-                    >
-                    <md-button @click="saveInputDialog()" class="md-primary">Save</md-button>
-                </md-dialog-actions>
             </md-dialog>
 
             <authorize :show="showAuthorize" @close="showAuthorize = false"></authorize>


### PR DESCRIPTION
-   :rocket: Improvements

    -   Improved the `player.showInputForTag()` modal.
        -   Removed the "Save" and "Cancel" buttons. The tag will be saved automatically.
        -   Hid the modal title when none is provided in the options.
        -   Made the text box in the modal auto-focus.
        -   Made the show/hide animations happen quicker.