### PR TITLE
Add the player.showInput() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
         -   Hid the modal title when none is provided in the options.
         -   Made the text box in the modal auto-focus.
         -   Made the show/hide animations happen quicker.
+    -   Added the `player.showInput(value, options)` function.
+        -   Shows an input modal but without requiring a bot and a tag.
+        -   Returns a [Promise](https://web.dev/promises/) that resolves with the final value when the input modal is closed.
+        -   The function accepts two arguments:
+            -   `value` is a string containing the value that should
+            -   `options` is an object that takes the same properties that the options for `player.showInputForTag()` takes.
     -   Improved Builder to support opening a single bot in a new tab and changed its hover label from "menu" to "|||".
 
 ## V1.0.25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
         -   The function accepts two arguments:
             -   `value` is a string containing the value that should
             -   `options` is an object that takes the same properties that the options for `player.showInputForTag()` takes.
+    -   Added the ability to use the [`await` keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) in scripts.
+        -   `await` tells the system to wait for a promise to finish before continuing.
+        -   This makes it easier to write scripts which deal with tasks that take a while to complete.
     -   Improved Builder to support opening a single bot in a new tab and changed its hover label from "menu" to "|||".
 
 ## V1.0.25

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1359,37 +1359,33 @@ The **third parameter** is optional and is the possible cusomization options for
 
 1. Show a basic text input modal and displays a toast message with the input value.
 ```typescript
-player.showInput().then(value => {
-    player.toast(value);
-});
+const value = await player.showInput();
+player.toast(value);
 ```
 
 2. Show a text input modal with a placeholder.
 ```typescript
-player.showInput(null, {
+const name = await player.showInput(null, {
     placeholder: 'Enter a name'
-}).then(name => {
-    player.toast(name);
 });
+player.toast(name);
 ```
 
 3. Show a input modal with a custom title.
 ```typescript
-player.showInput('My Name', {
+const name = await player.showInput('My Name', {
     title: 'Edit name'
-}).then(name => {
-    player.toast(name);
 });
+player.toast(name);
 ```
 
 4. Show a color input modal with a custom title.
 ```typescript
-player.showInput('green', {
+const color = await player.showInput('green', {
     type: 'color',
     title: 'Enter a custom color'
-}).then(name => {
-    player.toast(name);
 });
+player.toast(name);
 ```
 
 ### `player.showInputForTag(bot, tag, options?)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1341,6 +1341,57 @@ Closes the Barcode popup modal.
 player.hideBarcode();
 ```
 
+### `player.showInput(value?, options?)`
+
+<FunctionCode name='showInput'/>
+
+Shows an input modal with the given value and options.
+When shown, the player will be able to change the value.
+
+Returns a [Promise](https://web.dev/promises/) that resolves with the final value when the user is finished editing.
+This function is similar to <ActionLink action='player.showInputForTag(bot, tag, options?)'/> except it doesn't require a bot and a tag.
+
+The **first parameter** is optional  and is the value that should be shown in the input modal,
+
+The **third parameter** is optional and is the possible cusomization options for the input modal.
+
+#### Examples:
+
+1. Show a basic text input modal and displays a toast message with the input value.
+```typescript
+player.showInput().then(value => {
+    player.toast(value);
+});
+```
+
+2. Show a text input modal with a placeholder.
+```typescript
+player.showInput(null, {
+    placeholder: 'Enter a name'
+}).then(name => {
+    player.toast(name);
+});
+```
+
+3. Show a input modal with a custom title.
+```typescript
+player.showInput('My Name', {
+    title: 'Edit name'
+}).then(name => {
+    player.toast(name);
+});
+```
+
+4. Show a color input modal with a custom title.
+```typescript
+player.showInput('green', {
+    type: 'color',
+    title: 'Enter a custom color'
+}).then(name => {
+    player.toast(name);
+});
+```
+
 ### `player.showInputForTag(bot, tag, options?)`
 
 <FunctionCode name='showInputForTag'/>

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -1127,6 +1127,26 @@ function showInputForTag(
 }
 
 /**
+ * Shows an input box. Returns a promise that resolves with the new value.
+ *
+ * @param currentValue The value that the input box should be prefilled with.
+ * @param options The options that indicate how the input box should be customized.
+ *
+ * @example
+ * // Show an input box.
+ * const result = await player.showInput({
+ *    title: "Change the label",
+ *    type: "text"
+ * });
+ */
+function showInput(
+    currentValue?: any,
+    options?: Partial<ShowInputOptions>
+): Promise<any> {
+    return null;
+}
+
+/**
  * Shows a checkout screen that lets the user purchase something.
  *
  * @param options The options for the payment box.
@@ -2441,6 +2461,7 @@ const player = {
     getCurrentUniverse,
     getDimensionalDepth,
     showInputForTag,
+    showInput,
     checkout,
     replaceDragBot,
     setClipboard,

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -8,7 +8,7 @@ import {
 import { clamp } from '../utils';
 import { hasValue } from './BotCalculations';
 
-export type LocalActions = BotActions | ExtraActions;
+export type LocalActions = BotActions | ExtraActions | AsyncActions;
 
 /**
  * Defines a union type for all the possible events that can be emitted from a bots channel.
@@ -17,6 +17,7 @@ export type BotAction =
     | BotActions
     | TransactionAction
     | ExtraActions
+    | AsyncActions
     | RemoteAction
     | DeviceAction;
 
@@ -84,6 +85,48 @@ export type ExtraActions =
     | LoadBotsAction
     | ClearSpaceAction
     | LocalFormAnimationAction;
+
+/**
+ * Defines a set of possible async action types.
+ */
+export type AsyncActions =
+    | AsyncResultAction
+    | AsyncErrorAction
+    | ShowInputAction;
+
+/**
+ * Defines an interface for actions that represent asynchronous tasks.
+ */
+export interface AsyncAction extends Action {
+    /**
+     * The ID of the async task.
+     */
+    taskId: number;
+}
+
+/**
+ * Defines an action that supplies a result for an AsyncRequestAction.
+ */
+export interface AsyncResultAction extends AsyncAction {
+    type: 'async_result';
+
+    /**
+     * The result value.
+     */
+    result: any;
+}
+
+/**
+ * Defines an action that supplies an error for an AsyncRequestAction.
+ */
+export interface AsyncErrorAction extends AsyncAction {
+    type: 'async_error';
+
+    /**
+     * The error.
+     */
+    error: any;
+}
 
 /**
  * Defines a bot event that indicates a bot was added to the state.
@@ -732,6 +775,23 @@ export interface ShowInputForTagAction extends Action {
      * The tag that should be edited on the bot.
      */
     tag: string;
+
+    /**
+     * The options for the input box.
+     */
+    options: Partial<ShowInputOptions>;
+}
+
+/**
+ * Defines an event that is used to show an input box.
+ */
+export interface ShowInputAction extends AsyncAction {
+    type: 'show_input';
+
+    /**
+     * The value that should be in the input box.
+     */
+    currentValue?: any;
 
     /**
      * The options for the input box.
@@ -1528,6 +1588,25 @@ export function showInputForTag(
 }
 
 /**
+ * Creates a new ShowInputAction.
+ * @param currentValue The value that the input should be prefilled with.
+ * @param options The options for the input.
+ * @param taskId The ID of the async task.
+ */
+export function showInput(
+    currentValue?: any,
+    options?: Partial<ShowInputOptions>,
+    taskId?: number
+): ShowInputAction {
+    return {
+        type: 'show_input',
+        taskId,
+        currentValue,
+        options: options || {},
+    };
+}
+
+/**
  * Creates a new SetForcedOfflineAction event.
  * @param offline Whether the connection should be offline.
  */
@@ -1962,5 +2041,31 @@ export function localFormAnimation(
         type: 'local_form_animation',
         botId,
         animation,
+    };
+}
+
+/**
+ * Creates an action that resolves an async task with the given result.
+ * @param taskId The ID of the task.
+ * @param result The result.
+ */
+export function asyncResult(taskId: number, result: any): AsyncResultAction {
+    return {
+        type: 'async_result',
+        taskId,
+        result,
+    };
+}
+
+/**
+ * Creates an action that resolves an async task with the given error.
+ * @param taskId The ID of the task.
+ * @param error The error.
+ */
+export function asyncError(taskId: number, error: any): AsyncErrorAction {
+    return {
+        type: 'async_error',
+        taskId,
+        error,
     };
 }

--- a/src/aux-common/runtime/AuxGlobalContext.spec.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.spec.ts
@@ -9,6 +9,7 @@ import {
 } from './test/TestScriptBotFactory';
 import { RanOutOfEnergyError, createBot, botAdded, botRemoved } from '../bots';
 import { RealtimeEditMode } from './RuntimeBot';
+import { waitAsync } from '../test/TestHelpers';
 
 describe('AuxGlobalContext', () => {
     let context: AuxGlobalContext;
@@ -135,6 +136,50 @@ describe('AuxGlobalContext', () => {
             expect(() => {
                 context.enqueueError(err);
             }).toThrow(err);
+        });
+    });
+
+    describe('createTask()', () => {
+        it('should increment task IDs', () => {
+            const t1 = context.createTask();
+            const t2 = context.createTask();
+            const t3 = context.createTask();
+
+            expect(t1.taskId).toBe(1);
+            expect(t2.taskId).toBe(2);
+            expect(t3.taskId).toBe(3);
+        });
+    });
+
+    describe('resolveTask()', () => {
+        it('should be able to resolve a created task', async () => {
+            const fn = jest.fn();
+            const t1 = context.createTask();
+            t1.promise.then(fn);
+
+            context.resolveTask(t1.taskId, 'abc');
+            context.resolveTask(t1.taskId, 'def');
+
+            await waitAsync();
+
+            expect(fn).toBeCalledWith('abc');
+            expect(fn).not.toBeCalledWith('def');
+        });
+    });
+
+    describe('rejectTask()', () => {
+        it('should be able to reject a created task', async () => {
+            const fn = jest.fn();
+            const t1 = context.createTask();
+            t1.promise.catch(fn);
+
+            context.rejectTask(t1.taskId, 'abc');
+            context.rejectTask(t1.taskId, 'def');
+
+            await waitAsync();
+
+            expect(fn).toBeCalledWith('abc');
+            expect(fn).not.toBeCalledWith('def');
         });
     });
 });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -62,6 +62,7 @@ import {
     clearSpace,
     loadBots,
     localFormAnimation,
+    showInput,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2001,6 +2002,47 @@ describe('AuxLibrary', () => {
                         foregroundColor: 'green',
                     }),
                 ]);
+            });
+        });
+
+        describe('player.showInput()', () => {
+            it('should emit a ShowInputAction', () => {
+                const promise: any = library.api.player.showInput();
+                const expected = showInput(
+                    undefined,
+                    undefined,
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support passing the current value', () => {
+                const promise: any = library.api.player.showInput('abc');
+                const expected = showInput(
+                    'abc',
+                    undefined,
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support passing extra options', () => {
+                const promise: any = library.api.player.showInput('abc', {
+                    backgroundColor: 'red',
+                    foregroundColor: 'green',
+                });
+                const expected = showInput(
+                    'abc',
+                    {
+                        backgroundColor: 'red',
+                        foregroundColor: 'green',
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1208,7 +1208,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      *
      * @example
      * // Show an input box.
-     * player.showInputForTag({
+     * const result = await player.showInput({
      *    title: "Change the label",
      *    type: "text"
      * });

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1,4 +1,4 @@
-import { AuxGlobalContext } from './AuxGlobalContext';
+import { AuxGlobalContext, AsyncTask } from './AuxGlobalContext';
 import {
     hasValue,
     trimTag,
@@ -29,6 +29,7 @@ import {
     showBarcode as calcShowBarcode,
     importAUX as calcImportAUX,
     showInputForTag as calcShowInputForTag,
+    showInput as calcShowInput,
     replaceDragBot as calcReplaceDragBot,
     goToDimension as calcGoToDimension,
     goToURL as calcGoToURL,
@@ -77,6 +78,9 @@ import {
     DESTROY_ACTION_NAME,
     RanOutOfEnergyError,
     LocalFormAnimationAction,
+    AsyncAction,
+    ORIGINAL_OBJECT,
+    AsyncActions,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import { BotFilterFunction } from '../Formulas/SandboxInterface';
@@ -325,6 +329,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 getPortalDimension,
                 getDimensionalDepth,
                 showInputForTag,
+                showInput,
                 goToDimension,
                 goToURL,
                 openURL,
@@ -1193,6 +1198,28 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const id = typeof bot === 'string' ? bot : bot.id;
         const event = calcShowInputForTag(id, trimTag(tag), options);
         return addAction(event);
+    }
+
+    /**
+     * Shows an input box. Returns a promise that resolves with the new value.
+     *
+     * @param currentValue The value that the input box should be prefilled with.
+     * @param options The options that indicate how the input box should be customized.
+     *
+     * @example
+     * // Show an input box.
+     * player.showInputForTag({
+     *    title: "Change the label",
+     *    type: "text"
+     * });
+     */
+    function showInput(
+        currentValue?: any,
+        options?: Partial<ShowInputOptions>
+    ) {
+        const task = context.createTask();
+        const event = calcShowInput(currentValue, options, task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**
@@ -2150,6 +2177,16 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function addAction<T extends BotAction>(action: T) {
         context.enqueueAction(action);
         return action;
+    }
+
+    function addAsyncAction<T extends AsyncActions>(
+        task: AsyncTask,
+        action: T
+    ) {
+        addAction(action);
+        let promise = task.promise;
+        (<any>promise)[ORIGINAL_OBJECT] = action;
+        return promise;
     }
 
     function getDownloadState(state: BotsState) {

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -1426,6 +1426,29 @@ describe('AuxRuntime', () => {
 
             expect(events.slice(1)).toEqual([[], [toast('abc')]]);
         });
+
+        it('should support using await for async actions', async () => {
+            runtime.process([
+                runScript(
+                    `const result = await player.showInput();
+                     player.toast(result);`
+                ),
+            ]);
+
+            await waitAsync();
+
+            expect(events).toEqual([
+                [showInput(undefined, undefined, expect.any(Number))],
+            ]);
+
+            const taskId = (<any>events[0][0]).taskId as number;
+
+            runtime.process([asyncResult(taskId, 'abc')]);
+
+            await waitAsync();
+
+            expect(events.slice(1)).toEqual([[], [toast('abc')]]);
+        });
     });
 
     describe('execute()', () => {

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -319,8 +319,9 @@ export class AuxRuntime
             const events = breakIntoIndividualEvents(this.currentState, action);
             this.process(events);
         } else if (action.type === 'async_result') {
-            // const actions =
             this._globalContext.resolveTask(action.taskId, action.result);
+        } else if (action.type === 'async_error') {
+            this._globalContext.rejectTask(action.taskId, action.error);
         } else {
             this._actionBatch.push(action);
         }

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -318,6 +318,9 @@ export class AuxRuntime
         } else if (action.type === 'apply_state') {
             const events = breakIntoIndividualEvents(this.currentState, action);
             this.process(events);
+        } else if (action.type === 'async_result') {
+            // const actions =
+            this._globalContext.resolveTask(action.taskId, action.result);
         } else {
             this._actionBatch.push(action);
         }

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
@@ -119,14 +119,6 @@
     color: var(--md-theme-default-text-primary-on-background-variant, #777);
 }
 
-.color-picker-advanced {
-    margin: auto;
-}
-
-.color-picker-basic.vc-compact {
-    width: 245px;
-}
-
 .username-label {
     flex: 1;
 }
@@ -143,24 +135,4 @@
 
 .user-info {
     display: flex;
-}
-
-.input-dialog-content {
-    padding-bottom: 0;
-}
-
-.input-dialog-content .md-field {
-    margin-bottom: 20px;
-}
-
-.input-dialog .md-dialog-title {
-    margin-bottom: 0;
-}
-
-.input-dialog-color-tools {
-    padding-bottom: 16px;
-}
-
-.input-dialog {
-    transition-duration: 0.1s, 0.1s;
 }

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -13,6 +13,7 @@
             </md-toolbar>
             <checkout></checkout>
             <bot-sheet></bot-sheet>
+            <show-input></show-input>
 
             <md-dialog :md-active.sync="showQRCode" class="qr-code-dialog">
                 <div class="qr-code-container">
@@ -98,55 +99,6 @@
                 v-bind:md-content="alertDialogOptions.body"
                 v-bind:md-confirm-text="alertDialogOptions.confirmText"
             />
-
-            <md-dialog
-                :md-active.sync="showInputDialog"
-                @md-closed="saveInputDialog()"
-                @md-opened="autoFocusInputDialog()"
-                class="input-dialog"
-                :style="{
-                    'background-color': inputDialogBackgroundColor,
-                    color: inputDialogLabelColor,
-                }"
-            >
-                <md-dialog-title v-show="inputDialogLabel">{{ inputDialogLabel }}</md-dialog-title>
-                <md-dialog-content class="input-dialog-content">
-                    <md-field>
-                        <label :style="{ color: inputDialogLabelColor }">{{
-                            inputDialogPlaceholder
-                        }}</label>
-                        <md-input
-                            v-model="inputDialogInputValue"
-                            @keyup.enter="saveInputDialog()"
-                            ref="inputModalField"
-                            style="-webkit-text-fill-color: inherit;"
-                            :style="{ color: inputDialogLabelColor }"
-                        ></md-input>
-                    </md-field>
-                    <div class="input-dialog-color-tools" v-if="inputDialogType === 'color'">
-                        <color-picker-swatches
-                            v-if="inputDialogSubtype === 'swatch'"
-                            :value="inputDialogInputValue"
-                            @input="updateInputDialogColor"
-                            :disableAlpha="true"
-                        ></color-picker-swatches>
-                        <color-picker-advanced
-                            v-else-if="inputDialogSubtype === 'advanced'"
-                            :value="inputDialogInputValue"
-                            @input="updateInputDialogColor"
-                            class="color-picker-advanced"
-                            :disableAlpha="true"
-                        ></color-picker-advanced>
-                        <color-picker-basic
-                            v-else
-                            :value="inputDialogInputValue"
-                            @input="updateInputDialogColor"
-                            class="color-picker-basic"
-                            :disableAlpha="true"
-                        ></color-picker-basic>
-                    </div>
-                </md-dialog-content>
-            </md-dialog>
 
             <authorize :show="showAuthorize" @close="showAuthorize = false"></authorize>
 

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.css
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.css
@@ -1,0 +1,27 @@
+.input-dialog-content {
+    padding-bottom: 0;
+}
+
+.input-dialog-content .md-field {
+    margin-bottom: 20px;
+}
+
+.input-dialog .md-dialog-title {
+    margin-bottom: 0;
+}
+
+.input-dialog-color-tools {
+    padding-bottom: 16px;
+}
+
+.input-dialog {
+    transition-duration: 0.1s, 0.1s;
+}
+
+.color-picker-advanced {
+    margin: auto;
+}
+
+.color-picker-basic.vc-compact {
+    width: 245px;
+}

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.ts
@@ -1,0 +1,208 @@
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { Subscription } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { appManager } from '../../AppManager';
+import { Simulation } from '@casual-simulation/aux-vm';
+import { wrapHtmlWithSandboxContentSecurityPolicy } from '../../../shared/SharedUtils';
+import {
+    ShowInputType,
+    ShowInputSubtype,
+    ShowInputOptions,
+    BotCalculationContext,
+    calculateFormattedBotValue,
+    Bot,
+    ShowInputForTagAction,
+} from '@casual-simulation/aux-common';
+import { Swatches, Chrome, Compact } from 'vue-color';
+
+@Component({
+    components: {
+        'color-picker-swatches': Swatches,
+        'color-picker-advanced': Chrome,
+        'color-picker-basic': Compact,
+    },
+})
+export default class ShowInputModal extends Vue {
+    private _sub: Subscription;
+    private _simulationSubs: Map<Simulation, Subscription>;
+
+    inputDialogLabel: string = '';
+    inputDialogPlaceholder: string = '';
+    inputDialogInput: string = '';
+    inputDialogType: ShowInputType = 'text';
+    inputDialogSubtype: ShowInputSubtype = 'basic';
+    inputDialogInputValue: any = '';
+    inputDialogLabelColor: string = '#000';
+    inputDialogBackgroundColor: string = '#FFF';
+    showInputDialog: boolean = false;
+
+    private _inputDialogTarget: Bot = null;
+    private _inputDialogSimulation: Simulation = null;
+
+    created() {
+        this._sub = new Subscription();
+        this._simulationSubs = new Map();
+
+        this._sub.add(
+            appManager.simulationManager.simulationAdded
+                .pipe(tap(sim => this._simulationAdded(sim)))
+                .subscribe()
+        );
+        this._sub.add(
+            appManager.simulationManager.simulationRemoved
+                .pipe(tap(sim => this._simulationRemoved(sim)))
+                .subscribe()
+        );
+    }
+
+    beforeDestroy() {
+        this._sub.unsubscribe();
+    }
+
+    private _simulationAdded(sim: Simulation): void {
+        let sub = new Subscription();
+        this._sub.add(sub);
+
+        sub.add(
+            sim.localEvents.subscribe(e => {
+                if (e.type === 'show_input_for_tag') {
+                    setTimeout(() => {
+                        this._showInputDialog(sim, e);
+                    });
+                }
+            })
+        );
+    }
+
+    private _simulationRemoved(sim: Simulation): void {
+        const sub = this._simulationSubs.get(sim);
+        if (sub) {
+            sub.unsubscribe();
+        }
+        this._simulationSubs.delete(sim);
+    }
+
+    private _showInputDialog(
+        simulation: Simulation,
+        event: ShowInputForTagAction
+    ) {
+        const calc = simulation.helper.createContext();
+        const bot = simulation.helper.botsState[event.botId];
+        this._updateLabel(calc, bot, event.tag, event.options);
+        this._updateColor(calc, bot, event.options);
+        this._updateInput(calc, bot, event.tag, event.options);
+        this._inputDialogSimulation = simulation;
+        this.showInputDialog = true;
+    }
+
+    updateInputDialogColor(newColor: any) {
+        if (typeof newColor === 'object') {
+            this.inputDialogInputValue = newColor.hex;
+        } else {
+            this.inputDialogInputValue = newColor;
+        }
+    }
+
+    autoFocusInputDialog() {
+        // wait for the transition to finish
+        setTimeout(
+            () => {
+                const field = <Vue>this.$refs.inputModalField;
+                if (field) {
+                    field.$el.focus();
+                }
+            },
+            // 0.11 seconds (transition is 0.1 seconds)
+            1000 * 0.11
+        );
+    }
+
+    async closeInputDialog() {
+        if (this.showInputDialog) {
+            await this._inputDialogSimulation.helper.action('onCloseInput', [
+                this._inputDialogTarget,
+            ]);
+            this.showInputDialog = false;
+        }
+    }
+
+    async saveInputDialog() {
+        let value: any;
+        if (
+            this.inputDialogType === 'color' &&
+            typeof this.inputDialogInputValue === 'object'
+        ) {
+            value = this.inputDialogInputValue.hex;
+        } else {
+            value = this.inputDialogInputValue;
+        }
+        await this._inputDialogSimulation.helper.updateBot(
+            this._inputDialogTarget,
+            {
+                tags: {
+                    [this.inputDialogInput]: value,
+                },
+            }
+        );
+        await this._inputDialogSimulation.helper.action('onSaveInput', [
+            this._inputDialogTarget,
+        ]);
+        await this.closeInputDialog();
+    }
+
+    private _updateColor(
+        calc: BotCalculationContext,
+        bot: Bot,
+        options: Partial<ShowInputOptions>
+    ) {
+        if (typeof options.backgroundColor !== 'undefined') {
+            this.inputDialogBackgroundColor = options.backgroundColor;
+        } else {
+            this.inputDialogBackgroundColor = '#FFF';
+        }
+    }
+
+    private _updateLabel(
+        calc: BotCalculationContext,
+        bot: Bot,
+        tag: string,
+        options: Partial<ShowInputOptions>
+    ) {
+        if (typeof options.title !== 'undefined') {
+            this.inputDialogLabel = options.title;
+        } else {
+            this.inputDialogLabel = null; // tag;
+        }
+
+        if (typeof options.foregroundColor !== 'undefined') {
+            this.inputDialogLabelColor = options.foregroundColor;
+        } else {
+            this.inputDialogLabelColor = '#000';
+        }
+    }
+
+    private _updateInput(
+        calc: BotCalculationContext,
+        bot: Bot,
+        tag: string,
+        options: Partial<ShowInputOptions>
+    ) {
+        this.inputDialogInput = tag;
+        this.inputDialogType = options.type || 'text';
+        this.inputDialogSubtype = options.subtype || 'basic';
+        this._inputDialogTarget = bot;
+        this.inputDialogInputValue =
+            calculateFormattedBotValue(
+                calc,
+                this._inputDialogTarget,
+                this.inputDialogInput
+            ) || '';
+
+        if (typeof options.placeholder !== 'undefined') {
+            this.inputDialogPlaceholder = options.placeholder;
+        } else {
+            this.inputDialogPlaceholder = this.inputDialogInput;
+        }
+    }
+}

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
@@ -1,0 +1,54 @@
+<template>
+    <div>
+        <md-dialog
+            :md-active.sync="showInputDialog"
+            @md-closed="saveInputDialog()"
+            @md-opened="autoFocusInputDialog()"
+            class="input-dialog"
+            :style="{
+                'background-color': inputDialogBackgroundColor,
+                color: inputDialogLabelColor,
+            }"
+        >
+            <md-dialog-title v-show="inputDialogLabel">{{ inputDialogLabel }}</md-dialog-title>
+            <md-dialog-content class="input-dialog-content">
+                <md-field>
+                    <label :style="{ color: inputDialogLabelColor }">{{
+                        inputDialogPlaceholder
+                    }}</label>
+                    <md-input
+                        v-model="inputDialogInputValue"
+                        @keyup.enter="saveInputDialog()"
+                        ref="inputModalField"
+                        style="-webkit-text-fill-color: inherit;"
+                        :style="{ color: inputDialogLabelColor }"
+                    ></md-input>
+                </md-field>
+                <div class="input-dialog-color-tools" v-if="inputDialogType === 'color'">
+                    <color-picker-swatches
+                        v-if="inputDialogSubtype === 'swatch'"
+                        :value="inputDialogInputValue"
+                        @input="updateInputDialogColor"
+                        :disableAlpha="true"
+                    ></color-picker-swatches>
+                    <color-picker-advanced
+                        v-else-if="inputDialogSubtype === 'advanced'"
+                        :value="inputDialogInputValue"
+                        @input="updateInputDialogColor"
+                        class="color-picker-advanced"
+                        :disableAlpha="true"
+                    ></color-picker-advanced>
+                    <color-picker-basic
+                        v-else
+                        :value="inputDialogInputValue"
+                        @input="updateInputDialogColor"
+                        class="color-picker-basic"
+                        :disableAlpha="true"
+                    ></color-picker-basic>
+                </div>
+            </md-dialog-content>
+        </md-dialog>
+    </div>
+</template>
+<script src="./ShowInputModal.ts"></script>
+<style src="./ShowInputModal.css" scoped></style>

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
@@ -6,41 +6,39 @@
             @md-opened="autoFocusInputDialog()"
             class="input-dialog"
             :style="{
-                'background-color': inputDialogBackgroundColor,
-                color: inputDialogLabelColor,
+                'background-color': backgroundColor,
+                color: labelColor,
             }"
         >
-            <md-dialog-title v-show="inputDialogLabel">{{ inputDialogLabel }}</md-dialog-title>
+            <md-dialog-title v-show="currentLabel">{{ currentLabel }}</md-dialog-title>
             <md-dialog-content class="input-dialog-content">
                 <md-field>
-                    <label :style="{ color: inputDialogLabelColor }">{{
-                        inputDialogPlaceholder
-                    }}</label>
+                    <label :style="{ color: labelColor }">{{ currentPlaceholder }}</label>
                     <md-input
-                        v-model="inputDialogInputValue"
+                        v-model="currentValue"
                         @keyup.enter="saveInputDialog()"
                         ref="inputModalField"
                         style="-webkit-text-fill-color: inherit;"
-                        :style="{ color: inputDialogLabelColor }"
+                        :style="{ color: labelColor }"
                     ></md-input>
                 </md-field>
-                <div class="input-dialog-color-tools" v-if="inputDialogType === 'color'">
+                <div class="input-dialog-color-tools" v-if="currentType === 'color'">
                     <color-picker-swatches
-                        v-if="inputDialogSubtype === 'swatch'"
-                        :value="inputDialogInputValue"
+                        v-if="currentSubtype === 'swatch'"
+                        :value="currentValue"
                         @input="updateInputDialogColor"
                         :disableAlpha="true"
                     ></color-picker-swatches>
                     <color-picker-advanced
-                        v-else-if="inputDialogSubtype === 'advanced'"
-                        :value="inputDialogInputValue"
+                        v-else-if="currentSubtype === 'advanced'"
+                        :value="currentValue"
                         @input="updateInputDialogColor"
                         class="color-picker-advanced"
                         :disableAlpha="true"
                     ></color-picker-advanced>
                     <color-picker-basic
                         v-else
-                        :value="inputDialogInputValue"
+                        :value="currentValue"
                         @input="updateInputDialogColor"
                         class="color-picker-basic"
                         :disableAlpha="true"


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the `player.showInput(value, options)` function.
        -   Shows an input modal but without requiring a bot and a tag.
        -   Returns a [Promise](https://web.dev/promises/) that resolves with the final value when the input modal is closed.
        -   The function accepts two arguments:
            -   `value` is a string containing the value that should
            -   `options` is an object that takes the same properties that the options for `player.showInputForTag()` takes.
    -   Added the ability to use the [`await` keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) in scripts.
        -   `await` tells the system to wait for a promise to finish before continuing.
        -   This makes it easier to write scripts which deal with tasks that take a while to complete.