### PR TITLE
Add the player.share() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CasualOS Changelog
 
+## V1.0.27
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Added the `player.share(options)` function.
+        -   This will trigger the device's social share capabilities to share the given URL or text.
+        -   Note that this only works on Android and iOS phones and only works in response to some user action like a click.
+        -   `options` is an object with at least one of the following properties:
+            -   `url` - The URL to share. (optional)
+            -   `text` - The text to share. (optional)
+            -   `title` - The title of the document that is being shared. (optional)
+
 ## V1.0.26
 
 ### Date: 4/21/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1067,10 +1067,10 @@ player.hideHtml();
 Shares the given URL or text via the device's social share capabilities.
 Returns a [Promise](https://web.dev/promises/) that resolves when sharing has succeeded or failed.
 
-The **first parameter** is an object with the following properties:
--   `url` - The URL that should be shared.
--   `text` - The text that should be shared.
--   `title` - The title of the document that is being shared.
+The **first parameter** is an object with at least one the following properties:
+-   `url` - The URL that should be shared. (optional)
+-   `text` - The text that should be shared. (optional)
+-   `title` - The title of the document that is being shared. (optional)
 
 #### Examples:
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1060,6 +1060,34 @@ Closes the HTML popup modal.
 player.hideHtml();
 ```
 
+### `player.share(options)`
+
+<FunctionCode name='share'/>
+
+Shares the given URL or text via the device's social share capabilities.
+Returns a [Promise](https://web.dev/promises/) that resolves when sharing has succeeded or failed.
+
+The **first parameter** is an object with the following properties:
+-   `url` - The URL that should be shared.
+-   `text` - The text that should be shared.
+-   `title` - The title of the document that is being shared.
+
+#### Examples:
+
+1. Share a URL.
+```typescript
+player.share({
+    url: 'https://example.com'
+});
+```
+
+2. Share some text.
+```typescript
+player.share({
+    text: 'abcdefghijklmnopqrstuvwxyz'
+});
+```
+
 ### `player.toast(message, duration?)`
 
 <FunctionCode name='toast'/>

--- a/src/aux-common/Formulas/formula-lib.ts
+++ b/src/aux-common/Formulas/formula-lib.ts
@@ -69,6 +69,7 @@ import {
     LoadBotsAction,
     ClearSpaceAction,
     LocalFormAnimationAction,
+    ShareAction,
 } from '../bots/BotEvents';
 import {
     calculateActionResultsUsingContext,
@@ -1982,6 +1983,35 @@ function exitFullscreenMode() {
 }
 
 /**
+ * Defines the options that a share action can have.
+ */
+export interface ShareOptions {
+    /**
+     * The title of the document being shared.
+     */
+    title?: string;
+
+    /**
+     * The text that should be shared.
+     */
+    text?: string;
+
+    /**
+     * The URL of the document being shared.
+     */
+    url?: string;
+}
+
+/**
+ * Shares some information via the device's social sharing functionality.
+ * @param options The options.
+ */
+function share(options: ShareOptions): ShareAction {
+    // Implemented in AuxLibrary
+    return null;
+}
+
+/**
  * Shows some HTML to the user.
  * @param html The HTML to show.
  */
@@ -2481,6 +2511,7 @@ const player = {
     showJoinCode,
     requestFullscreenMode,
     exitFullscreenMode,
+    share,
 
     openDevConsole,
 };

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -92,7 +92,8 @@ export type ExtraActions =
 export type AsyncActions =
     | AsyncResultAction
     | AsyncErrorAction
-    | ShowInputAction;
+    | ShowInputAction
+    | ShareAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1223,6 +1224,34 @@ export interface ExitFullscreenAction {
     type: 'exit_fullscreen_mode';
 }
 
+/**
+ * Defines the options that a share action can have.
+ */
+export interface ShareOptions {
+    /**
+     * The title of the document being shared.
+     */
+    title?: string;
+
+    /**
+     * The text that should be shared.
+     */
+    text?: string;
+
+    /**
+     * The URL of the document being shared.
+     */
+    url?: string;
+}
+
+/**
+ * Defines an event that shares the given information using the
+ * device's native social sharing capabilities.
+ */
+export interface ShareAction extends AsyncAction, ShareOptions {
+    type: 'share';
+}
+
 /**z
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
@@ -2067,5 +2096,18 @@ export function asyncError(taskId: number, error: any): AsyncErrorAction {
         type: 'async_error',
         taskId,
         error,
+    };
+}
+
+/**
+ * Creates an action that shares some data via the device's social share capabilities.
+ * @param options The options for sharing.
+ * @param taskId The ID of the task.
+ */
+export function share(options: ShareOptions, taskId?: number): ShareAction {
+    return {
+        type: 'share',
+        taskId,
+        ...options,
     };
 }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -63,6 +63,7 @@ import {
     loadBots,
     localFormAnimation,
     showInput,
+    share,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2162,6 +2163,24 @@ describe('AuxLibrary', () => {
                     bot2,
                 ]);
                 expect(result).toEqual(false);
+            });
+        });
+
+        describe('player.share()', () => {
+            it('should return a ShareAction', () => {
+                const promise: any = library.api.player.share({
+                    url: 'http://example.com',
+                    title: 'Example',
+                });
+                const expected = share(
+                    {
+                        url: 'http://example.com',
+                        title: 'Example',
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -50,6 +50,7 @@ import {
     localFormAnimation as calcLocalFormAnimation,
     webhook as calcWebhook,
     superShout as calcSuperShout,
+    share as calcShare,
     clearSpace,
     loadBots,
     BotAction,
@@ -81,6 +82,8 @@ import {
     AsyncAction,
     ORIGINAL_OBJECT,
     AsyncActions,
+    ShareOptions,
+    ShareAction,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import { BotFilterFunction } from '../Formulas/SandboxInterface';
@@ -337,6 +340,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 checkout,
                 playSound,
                 hasBotInInventory,
+                share,
                 inSheet,
             },
 
@@ -1314,6 +1318,16 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             return false;
         }
         return every(bots, f => getTag(f, inventoryDimension) === true);
+    }
+
+    /**
+     * Shares some information via the device's social sharing functionality.
+     * @param options The options.
+     */
+    function share(options: ShareOptions): Promise<void> {
+        const task = context.createTask();
+        const event = calcShare(options, task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the `player.share(options)` function.
        -   This will trigger the device's social share capabilities to share the given URL or text.
        -   Note that this only works on Android and iOS phones and only works in response to some user action like a click.
        -   `options` is an object with at least one of the following properties:
            -   `url` - The URL to share. (optional)
            -   `text` - The text to share. (optional)
            -   `title` - The title of the document that is being shared. (optional)