### PR TITLE
Add the auxLabelAlignment tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
             -   `text` - The text to share. (optional)
             -   `title` - The title of the document that is being shared. (optional)
     -   Added the `auxLabelAlignment` tag.
+        -   Note that this value affects menu bots as well.
         -   Possible values are:
             -   `center` - Aligns the text in the center of the label. (default)
             -   `left` - Aligns the text to the left of the label.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changes:
 
+-   :boom: Breaking Changes
+
+    -   The default label alignment for bots in the page portal has changed from `center` to `left`. It is now consistent across all portals.
+
 -   :rocket: Improvements
 
     -   Added the `player.share(options)` function.
@@ -18,8 +22,8 @@
     -   Added the `auxLabelAlignment` tag.
         -   Note that this value affects menu bots as well.
         -   Possible values are:
-            -   `center` - Aligns the text in the center of the label. (default)
-            -   `left` - Aligns the text to the left of the label.
+            -   `left` - Aligns the text to the left of the label. (default)
+            -   `center` - Aligns the text in the center of the label.
             -   `right` - Aligns the text to the right of the label.
 
 ## V1.0.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
             -   `url` - The URL to share. (optional)
             -   `text` - The text to share. (optional)
             -   `title` - The title of the document that is being shared. (optional)
+    -   Added the `auxLabelAlignment` tag.
+        -   Possible values are:
+            -   `center` - Aligns the text in the center of the label. (default)
+            -   `left` - Aligns the text to the left of the label.
+            -   `right` - Aligns the text to the right of the label.
 
 ## V1.0.26
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -368,11 +368,11 @@ The text alignment for the label.
 #### Possible values are:
 
 <PossibleValuesTable>
-  <PossibleValueCode value='center'>
-    The text is aligned around the center of the label. (default)
-  </PossibleValueCode>
   <PossibleValueCode value='left'>
-    The text is aligned on the left side of the label.
+    The text is aligned on the left side of the label. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='center'>
+    The text is aligned around the center of the label.
   </PossibleValueCode>
   <PossibleValueCode value='right'>
     The text is aligned on the right side of the label.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -361,6 +361,24 @@ The anchor position for the label.
   <LabelAnchorValues/>
 </PossibleValuesTable>
 
+### `auxLabelAlignment`
+
+The text alignment for the label.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='center'>
+    The text is aligned around the center of the label. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='left'>
+    The text is aligned on the left side of the label.
+  </PossibleValueCode>
+  <PossibleValueCode value='right'>
+    The text is aligned on the right side of the label.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `auxScale`
 
 <Badges>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -125,6 +125,7 @@ export interface BotTags {
     ['auxLabelSize']?: unknown;
     ['auxLabelSizeMode']?: 'auto' | null;
     ['auxLabelPosition']?: BotLabelAnchor | null | string;
+    ['auxLabelAlignment']?: BotLabelAlignment | null | string;
     ['auxListening']?: unknown;
     ['auxForm']?: BotShape;
     ['auxFormAnimation']?: string;
@@ -302,6 +303,11 @@ export type BotLabelAnchor =
     | 'floating';
 
 /**
+ * Defines the possible label alignment types.
+ */
+export type BotLabelAlignment = 'center' | 'left' | 'right';
+
+/**
  * Defines the possible bot orientation modes.
  */
 export type BotOrientationMode =
@@ -356,6 +362,11 @@ export const DEFAULT_BOT_SHAPE: BotShape = 'cube';
  * The default bot label anchor.
  */
 export const DEFAULT_LABEL_ANCHOR: BotLabelAnchor = 'top';
+
+/**
+ * The default bot label alignment.
+ */
+export const DEFAULT_LABEL_ALIGNMENT: BotLabelAlignment = 'center';
 
 /**
  * The default bot orientation mode.
@@ -905,6 +916,7 @@ export const KNOWN_TAGS: string[] = [
     'auxLabelSize',
     'auxLabelSizeMode',
     'auxLabelPosition',
+    'auxLabelAlignment',
     'auxListening',
     'auxScale',
     'auxScaleX',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -366,7 +366,7 @@ export const DEFAULT_LABEL_ANCHOR: BotLabelAnchor = 'top';
 /**
  * The default bot label alignment.
  */
-export const DEFAULT_LABEL_ALIGNMENT: BotLabelAlignment = 'center';
+export const DEFAULT_LABEL_ALIGNMENT: BotLabelAlignment = 'left';
 
 /**
  * The default bot orientation mode.

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -34,6 +34,8 @@ import {
     PortalPointerDragMode,
     DEFAULT_PORTAL_POINTER_DRAG_MODE,
     BotLOD,
+    BotLabelAlignment,
+    DEFAULT_LABEL_ALIGNMENT,
 } from './Bot';
 
 import {
@@ -1250,6 +1252,26 @@ export function getBotTagAnchor(
         return anchor;
     }
     return DEFAULT_LABEL_ANCHOR;
+}
+
+/**
+ * Gets the text alignment for the bot's label.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function getBotLabelAlignment(
+    calc: BotCalculationContext,
+    bot: Bot
+): BotLabelAlignment {
+    const anchor: BotLabelAlignment = calculateBotValue(
+        calc,
+        bot,
+        'auxLabelAlignment'
+    );
+    if (anchor === 'center' || anchor === 'left' || anchor === 'right') {
+        return anchor;
+    }
+    return DEFAULT_LABEL_ALIGNMENT;
 }
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -60,6 +60,7 @@ import {
     getAnchorPointOffset,
     isBotPointable,
     isBotFocusable,
+    getBotLabelAlignment,
 } from '../BotCalculations';
 import {
     Bot,
@@ -4375,6 +4376,45 @@ export function botCalculationContextTests(
             const anchor = getBotLabelAnchor(calc, bot);
 
             expect(anchor).toBe('front');
+        });
+    });
+
+    describe('getBotLabelAlignment()', () => {
+        it('should default to center', () => {
+            const bot = createBot('bot');
+
+            const calc = createCalculationContext([bot]);
+            const anchor = getBotLabelAlignment(calc, bot);
+
+            expect(anchor).toBe('center');
+        });
+
+        const cases = [
+            ['center', 'center'],
+            ['left', 'left'],
+            ['right', 'right'],
+            ['abc', 'center'],
+        ];
+        it.each(cases)('given %s it should return %s', (anchor, expected) => {
+            const bot = createBot('bot', {
+                auxLabelAlignment: anchor,
+            });
+
+            const calc = createCalculationContext([bot]);
+            const a = getBotLabelAlignment(calc, bot);
+
+            expect(a).toBe(expected);
+        });
+
+        it('should support formulas', () => {
+            const bot = createBot('bot', {
+                auxLabelAlignment: '="left"',
+            });
+
+            const calc = createCalculationContext([bot]);
+            const anchor = getBotLabelAlignment(calc, bot);
+
+            expect(anchor).toBe('left');
         });
     });
 

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -4380,20 +4380,20 @@ export function botCalculationContextTests(
     });
 
     describe('getBotLabelAlignment()', () => {
-        it('should default to center', () => {
+        it('should default to left', () => {
             const bot = createBot('bot');
 
             const calc = createCalculationContext([bot]);
             const anchor = getBotLabelAlignment(calc, bot);
 
-            expect(anchor).toBe('center');
+            expect(anchor).toBe('left');
         });
 
         const cases = [
             ['center', 'center'],
             ['left', 'left'],
             ['right', 'right'],
-            ['abc', 'center'],
+            ['abc', 'left'],
         ];
         it.each(cases)('given %s it should return %s', (anchor, expected) => {
             const bot = createBot('bot', {
@@ -4408,13 +4408,13 @@ export function botCalculationContextTests(
 
         it('should support formulas', () => {
             const bot = createBot('bot', {
-                auxLabelAlignment: '="left"',
+                auxLabelAlignment: '="right"',
             });
 
             const calc = createCalculationContext([bot]);
             const anchor = getBotLabelAlignment(calc, bot);
 
-            expect(anchor).toBe('left');
+            expect(anchor).toBe('right');
         });
     });
 

--- a/src/aux-server/aux-web/aux-player/ItemDimension.ts
+++ b/src/aux-server/aux-web/aux-player/ItemDimension.ts
@@ -156,7 +156,14 @@ export class ItemDimension implements SubscriptionLike {
         for (let update of updates.updatedBots) {
             if (this._botItemMap.has(update.bot.id)) {
                 let item = this._botItemMap.get(update.bot.id);
-                item.bot = update.bot;
+
+                // We make a new item to force change detection
+                // in Vue.js for menus.
+                let newItem = {
+                    ...item,
+                    bot: update.bot,
+                };
+                this._botItemMap.set(update.bot.id, newItem);
                 hasUpdate = true;
             }
         }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -2,4 +2,5 @@
     overflow-wrap: break-word;
     white-space: normal;
     font-size: 16px;
+    flex: 1 1 auto;
 }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -38,6 +38,7 @@ export default class MenuBot extends Vue {
         } else {
             this.label = '';
             this.labelColor = '#000';
+            this.labelAlign = 'center';
             this.backgroundColor = '#FFF';
         }
     }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -7,6 +7,8 @@ import {
     calculateFormattedBotValue,
     calculateBotValue,
     isFormula,
+    BotLabelAlignment,
+    getBotLabelAlignment,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../shared/AppManager';
 import { DimensionItem } from '../DimensionItem';
@@ -22,6 +24,7 @@ export default class MenuBot extends Vue {
 
     label: string = '';
     labelColor: string = '#000';
+    labelAlign: BotLabelAlignment = 'center';
     backgroundColor: string = '#FFF';
 
     @Watch('item')
@@ -31,6 +34,7 @@ export default class MenuBot extends Vue {
             const calc = simulation.helper.createContext();
             this._updateLabel(calc, item.bot);
             this._updateColor(calc, item.bot);
+            this._updateAlignment(calc, item.bot);
         } else {
             this.label = '';
             this.labelColor = '#000';
@@ -76,6 +80,10 @@ export default class MenuBot extends Vue {
         } else {
             this.label = '';
         }
+    }
+
+    private _updateAlignment(calc: BotCalculationContext, bot: Bot) {
+        this.labelAlign = getBotLabelAlignment(calc, bot);
     }
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -5,7 +5,11 @@
         :style="{ 'background-color': backgroundColor }"
         @click="click()"
     >
-        <div class="menu-bot-text" v-show="label" :style="{ color: labelColor }">
+        <div
+            class="menu-bot-text"
+            v-show="label"
+            :style="{ color: labelColor, 'text-align': labelAlign }"
+        >
             {{ label }}
         </div>
     </md-list-item>

--- a/src/aux-server/aux-web/shared/scene/Text3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Text3D.ts
@@ -21,7 +21,10 @@ import createBMFont, {
     TextGeometryOptions,
 } from 'three-bmfont-text';
 import { calculateAnchorPosition, buildSRGBColor } from './SceneUtils';
-import { BotLabelAnchor } from '@casual-simulation/aux-common';
+import {
+    BotLabelAnchor,
+    BotLabelAlignment,
+} from '@casual-simulation/aux-common';
 import { DebugObjectManager } from './debugobjectmanager/DebugObjectManager';
 
 var sdfShader = require('three-bmfont-text/shaders/sdf');
@@ -236,8 +239,9 @@ export class Text3D extends Object3D {
     /**
      * Set the text to display with this 3d text.
      * @param text the text to display.
+     * @param alignment The alignment to set.
      */
-    public setText(text: string) {
+    public setText(text: string, alignment?: BotLabelAlignment) {
         // Ignore if the text is already set to provided value.
         if (this._unprocessedText === text) return;
 
@@ -250,7 +254,10 @@ export class Text3D extends Object3D {
 
             // Text has value, enable the mesh and update the geometry.
             this.visible = true;
-            this._geometry.update(text.toString());
+            this._geometry.update(<any>(<Partial<TextGeometryOptions>>{
+                text: text.toString(),
+                align: alignment || 'center',
+            }));
             this.updateBoundingBox();
         } else {
             // Disable the text's rendering.

--- a/src/aux-server/aux-web/shared/scene/decorators/LabelDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/LabelDecorator.ts
@@ -9,6 +9,7 @@ import {
     getBotLabelAnchor,
     BotLabelAnchor,
     getBotScale,
+    getBotLabelAlignment,
 } from '@casual-simulation/aux-common';
 import { Text3D } from '../Text3D';
 import { Color, Vector3, Box3, PerspectiveCamera } from 'three';
@@ -45,6 +46,7 @@ export class LabelDecorator extends AuxBot3DDecoratorBase
         let label = this.bot3D.bot.tags['auxLabel'];
 
         const anchor = getBotLabelAnchor(calc, this.bot3D.bot);
+        const alignment = getBotLabelAlignment(calc, this.bot3D.bot);
 
         let botWidth = calculateNumericalTagValue(
             calc,
@@ -84,9 +86,9 @@ export class LabelDecorator extends AuxBot3DDecoratorBase
                     this.bot3D.bot,
                     'auxLabel'
                 );
-                this.text3D.setText(calculatedValue);
+                this.text3D.setText(calculatedValue, alignment);
             } else {
-                this.text3D.setText(<string>label);
+                this.text3D.setText(<string>label, alignment);
             }
 
             // Update auto size mode.


### PR DESCRIPTION
-   :boom: Breaking Changes

    -   The default label alignment for bots in the page portal has changed from `center` to `left`. It is now consistent across all portals.
-   :rocket: Improvements

    -   Added the `auxLabelAlignment` tag.
        -   Possible values are:
            -   `center` - Aligns the text in the center of the label.
            -   `left` - Aligns the text to the left of the label.  (default)
            -   `right` - Aligns the text to the right of the label.