### PR TITLE
Add functions to allow requesting metadata from the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 
     -   Renamed all the history tags no not have the `aux` prefix.
 
+-   :rocket: Improvements
+
+    -   Added the `server.storyPlayerCount()` function.
+        -   Returns a promise that resolves with the number of players currently connected to the current story.
+        -   Optionally accepts a parameter which indicates the story to check.
+    -   Added the `server.totalPlayerCount()` function.
+        -   Returns a promise that resolves with the total number of players connected to the server.
+
 -   :bug: Bug Fixes
     -   Removed the globals bot tags from the documentation since they no longer exist.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 ### Changes:
 
 -   :boom: Breaking Changes
+
     -   Renamed all the history tags no not have the `aux` prefix.
+
+-   :bug: Bug Fixes
+    -   Removed the globals bot tags from the documentation since they no longer exist.
 
 ## V1.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
         -   Optionally accepts a parameter which indicates the story to check.
     -   Added the `server.totalPlayerCount()` function.
         -   Returns a promise that resolves with the total number of players connected to the server.
+    -   Added the `server.stories()` function.
+        -   Returns a promise that resolves with the list of stories that are on the server.
 
 -   :bug: Bug Fixes
     -   Removed the globals bot tags from the documentation since they no longer exist.

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2246,7 +2246,6 @@ server.loadFile('/2/book.txt', 'My memoirs', {
 
 ### `server.loadErrors(bot, tag)`
 
-
 Loads the errors for the given bot and tag.
 Note that the bots don't load immediately. They will automatically be added to the story state once they have been loaded.
 
@@ -2279,6 +2278,31 @@ Destroys all the error bots.
 1. Destroy all the error bots in this story:
 ```typescript
 server.destroyErrors();
+```
+
+### `server.storyPlayerCount(story?)`
+
+Gets the number of players that are viewing the current story.
+Optionally takes a parameter which is the story that the number of players should be retrieved for. If omitted, then the current story will be checked.
+Returns a promise that resolves with the number of active players.
+
+The **first parameter** is optional and is the name of the story that the number of players should be retrieved for.
+If not specified, then the current story <ActionLink action="player.getCurrentStory()">current story</ActionLink> will be used.
+
+#### Examples
+
+1. Get the number of players in the current story.
+```typescript
+const numberOfPlayers = await server.storyPlayerCount();
+
+player.toast("Number of Players: " + numberOfPlayers);
+```
+
+2. Get the number of players in the `test` story.
+```typescript
+const numberOfPlayers = await server.storyPlayerCount('test');
+
+player.toast("Number of Players: " + numberOfPlayers);
 ```
 
 ## Utility Actions

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2319,6 +2319,20 @@ const numberOfPlayers = await server.totalPlayerCount();
 player.toast("Number of Players: " + numberOfPlayers);
 ```
 
+### `server.stories()`
+
+Gets the list of stories that are stored on the server.
+Returns a promise that resolves with the list of story names.
+
+#### Examples
+
+1. Get the number of players on the server.
+```typescript
+const stories = await server.stories();
+
+player.toast("Stories " + stories.join(','));
+```
+
 ## Utility Actions
 
 ### `setTag(bot, tag, value)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2305,6 +2305,20 @@ const numberOfPlayers = await server.storyPlayerCount('test');
 player.toast("Number of Players: " + numberOfPlayers);
 ```
 
+### `server.totalPlayerCount()`
+
+Gets the number of players that are connected to the server.
+Returns a promise that resolves with the number of active players.
+
+#### Examples
+
+1. Get the number of players on the server.
+```typescript
+const numberOfPlayers = await server.totalPlayerCount();
+
+player.toast("Number of Players: " + numberOfPlayers);
+```
+
 ## Utility Actions
 
 ### `setTag(bot, tag, value)`

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -52,9 +52,11 @@ export const ListenTagLink = ({tag}) => (
   </a>
 );
 
-export const ActionLink = ({action}) => (
+export const ActionLink = ({action, children}) => (
   <a href={useBaseUrl('docs/actions') + '#' + action.replace(/[\.\(\)\,\?]/g, '').replace(/\s/g, '-').toLowerCase()}>
-    <NormalCode>{action}</NormalCode>
+  {children ? children : (
+      <NormalCode>{action}</NormalCode>
+  )}
   </a>
 );
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1120,60 +1120,6 @@ The number of grid spaces that the wrist portal should have in the X direction.
   </PossibleValue>
 </PossibleValuesTable>
 
-## Channel Config Tags
-
-These tags are set on the config bot and affect the entire story.
-
-### `auxSceneColor`
-
-The color of the scene background. This value applies to both Channel Designer and AUXPlayer.
-The value can be overridden on a per-dimension basis in AUXPlayer by using the <TagLink tag='portalColor'/> tag.
-
-#### Possible values are:
-<PossibleValuesTable>
-  <PossibleValueCode value='#263238'>
-    (default)
-  </PossibleValueCode>
-  <AnyColorValues/>
-</PossibleValuesTable>
-
-### `auxSceneUserPlayerColor`
-
-The color of other users that are in AUXPlayer.
-
-#### Possible values are:
-<PossibleValuesTable>
-  <PossibleValueCode value='#DDDD00'>
-    (default)
-  </PossibleValueCode>
-  <AnyColorValues/>
-</PossibleValuesTable>
-
-### `auxSceneUserBuilderColor`
-
-The color of other users that are in Channel Designer.
-
-#### Possible values are:
-<PossibleValuesTable>
-  <PossibleValueCode value='#00D000'>
-    (default)
-  </PossibleValueCode>
-  <AnyColorValues/>
-</PossibleValuesTable>
-
-### `auxInventoryHeight`
-
-Sets the initial height of the inventory viewport for all dimension.
-
-This value is overridden by <TagLink tag='auxDimensionInventoryHeight'/>.
-
-#### Possible values are:
-<PossibleValuesTable>
-  <PossibleValue value='Numbers >= 1 and <= 10'>
-    The number of bots that the inventory should be able to accommodate vertically. (Default is 1)
-  </PossibleValue>
-</PossibleValuesTable>
-
 ## History Tags
 
 History tags are tags that are automatically applied to bots in the `history` space.

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -88,7 +88,8 @@ export type ExtraActions =
     | ExitFullscreenAction
     | LoadBotsAction
     | ClearSpaceAction
-    | LocalFormAnimationAction;
+    | LocalFormAnimationAction
+    | GetPlayerCountAction;
 
 /**
  * Defines a set of possible async action types.
@@ -759,6 +760,19 @@ export interface SaveFileOptions {
      * Whether to overwrite existing files.
      */
     overwriteExistingFile?: boolean;
+}
+
+/**
+ * Defines an event that is used to get the player count.
+ */
+export interface GetPlayerCountAction extends Action {
+    type: 'get_player_count';
+
+    /**
+     * The story that the player count should be retrieved for.
+     * If omitted, then the total player count will be returned.
+     */
+    story?: string;
 }
 
 /**
@@ -1881,6 +1895,23 @@ export function saveFile(options: SaveFileOptions): SaveFileAction {
         type: 'save_file',
         options: options,
     };
+}
+
+/**
+ * Creates a new GetPlayerCountAction.
+ * @param story The story that the player count should be retrieved for.
+ */
+export function getPlayerCount(story?: string): GetPlayerCountAction {
+    if (hasValue(story)) {
+        return {
+            type: 'get_player_count',
+            story,
+        };
+    } else {
+        return {
+            type: 'get_player_count',
+        };
+    }
 }
 
 /**

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -776,6 +776,13 @@ export interface GetPlayerCountAction extends Action {
 }
 
 /**
+ * Defines an event that is used to get the list of stories on the server.
+ */
+export interface GetStoriesAction extends Action {
+    type: 'get_stories';
+}
+
+/**
  * Defines an event that is used to send the player to a dimension.
  */
 export interface GoToDimensionAction extends Action {
@@ -1912,6 +1919,15 @@ export function getPlayerCount(story?: string): GetPlayerCountAction {
             type: 'get_player_count',
         };
     }
+}
+
+/**
+ * Creates a new GetStoriesAction.
+ */
+export function getStories(): GetStoriesAction {
+    return {
+        type: 'get_stories',
+    };
 }
 
 /**

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -4,6 +4,10 @@ import {
     DeviceAction,
     RemoteAction,
     DeviceSelector,
+    RemoteActionResult,
+    RemoteActionError,
+    DeviceActionResult,
+    DeviceActionError,
 } from '@casual-simulation/causal-trees';
 import { clamp } from '../utils';
 import { hasValue } from './BotCalculations';
@@ -95,7 +99,13 @@ export type AsyncActions =
     | ShowInputAction
     | ShareAction
     | SendWebhookAction
-    | UnlockSpaceAction;
+    | UnlockSpaceAction
+    | RemoteAction
+    | RemoteActionResult
+    | RemoteActionError
+    | DeviceAction
+    | DeviceActionResult
+    | DeviceActionError;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -104,7 +114,7 @@ export interface AsyncAction extends Action {
     /**
      * The ID of the async task.
      */
-    taskId: number;
+    taskId: number | string;
 }
 
 /**
@@ -1656,7 +1666,7 @@ export function showInputForTag(
 export function showInput(
     currentValue?: any,
     options?: Partial<ShowInputOptions>,
-    taskId?: number
+    taskId?: number | string
 ): ShowInputAction {
     return {
         type: 'show_input',
@@ -1842,7 +1852,7 @@ export function finishCheckout(
  */
 export function webhook(
     options: WebhookOptions,
-    taskId?: number
+    taskId?: number | string
 ): SendWebhookAction {
     return {
         type: 'send_webhook',
@@ -2106,7 +2116,7 @@ export function clearSpace(space: BotSpace): ClearSpaceAction {
 export function unlockSpace(
     space: BotSpace,
     password: string,
-    taskId?: number
+    taskId?: number | string
 ): UnlockSpaceAction {
     return {
         type: 'unlock_space',
@@ -2137,7 +2147,10 @@ export function localFormAnimation(
  * @param taskId The ID of the task.
  * @param result The result.
  */
-export function asyncResult(taskId: number, result: any): AsyncResultAction {
+export function asyncResult(
+    taskId: number | string,
+    result: any
+): AsyncResultAction {
     return {
         type: 'async_result',
         taskId,
@@ -2150,7 +2163,10 @@ export function asyncResult(taskId: number, result: any): AsyncResultAction {
  * @param taskId The ID of the task.
  * @param error The error.
  */
-export function asyncError(taskId: number, error: any): AsyncErrorAction {
+export function asyncError(
+    taskId: number | string,
+    error: any
+): AsyncErrorAction {
     return {
         type: 'async_error',
         taskId,
@@ -2163,7 +2179,10 @@ export function asyncError(taskId: number, error: any): AsyncErrorAction {
  * @param options The options for sharing.
  * @param taskId The ID of the task.
  */
-export function share(options: ShareOptions, taskId?: number): ShareAction {
+export function share(
+    options: ShareOptions,
+    taskId?: number | string
+): ShareAction {
     return {
         type: 'share',
         taskId,

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -3,6 +3,7 @@ import {
     StatusUpdate,
     RemoteAction,
     Action,
+    USERNAME_CLAIM,
 } from '@casual-simulation/causal-trees';
 import {
     Atom,
@@ -181,9 +182,12 @@ export class RemoteCausalRepoPartitionImpl
             } else if (event.event.type === 'get_player_count') {
                 const action = <GetPlayerCountAction>event.event;
                 this._client.devices(action.story).subscribe(
-                    devices => {
+                    e => {
+                        const devices = e.devices.filter(
+                            d => d.claims[USERNAME_CLAIM] !== 'Server'
+                        );
                         this._onEvents.next([
-                            asyncResult(event.taskId, devices.devices.length),
+                            asyncResult(event.taskId, devices.length),
                         ]);
                     },
                     err => {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -200,7 +200,10 @@ export class RemoteCausalRepoPartitionImpl
                 this._client.branches().subscribe(
                     e => {
                         this._onEvents.next([
-                            asyncResult(event.taskId, e.branches),
+                            asyncResult(
+                                event.taskId,
+                                e.branches.filter(b => !b.startsWith('$'))
+                            ),
                         ]);
                     },
                     err => {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -34,6 +34,7 @@ import {
     asyncError,
     asyncResult,
     GetPlayerCountAction,
+    GetStoriesAction,
 } from '../bots';
 import flatMap from 'lodash/flatMap';
 import {
@@ -188,6 +189,18 @@ export class RemoteCausalRepoPartitionImpl
                         );
                         this._onEvents.next([
                             asyncResult(event.taskId, devices.length),
+                        ]);
+                    },
+                    err => {
+                        this._onEvents.next([asyncError(event.taskId, err)]);
+                    }
+                );
+            } else if (event.event.type === 'get_stories') {
+                const action = <GetStoriesAction>event.event;
+                this._client.branches().subscribe(
+                    e => {
+                        this._onEvents.next([
+                            asyncResult(event.taskId, e.branches),
                         ]);
                     },
                     err => {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -32,6 +32,7 @@ import {
     loadSpace,
     asyncError,
     asyncResult,
+    GetPlayerCountAction,
 } from '../bots';
 import flatMap from 'lodash/flatMap';
 import {
@@ -177,6 +178,18 @@ export class RemoteCausalRepoPartitionImpl
                         client: this._client,
                     }),
                 ]);
+            } else if (event.event.type === 'get_player_count') {
+                const action = <GetPlayerCountAction>event.event;
+                this._client.devices(action.story).subscribe(
+                    devices => {
+                        this._onEvents.next([
+                            asyncResult(event.taskId, devices.devices.length),
+                        ]);
+                    },
+                    err => {
+                        this._onEvents.next([asyncError(event.taskId, err)]);
+                    }
+                );
             } else {
                 this._client.sendEvent(this._branch, event);
             }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -63,6 +63,7 @@ import {
     showInput,
     share,
     unlockSpace,
+    getPlayerCount,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2518,6 +2519,58 @@ describe('AuxLibrary', () => {
                 ]);
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('server.storyPlayerCount()', () => {
+            let player: RuntimeBot;
+
+            beforeEach(() => {
+                player = createDummyRuntimeBot(
+                    'player',
+                    {
+                        story: 'channel',
+                    },
+                    'tempLocal'
+                );
+                addToContext(context, player);
+                context.playerBot = player;
+            });
+
+            it('should emit a remote action with a get_player_count action', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.storyPlayerCount();
+                const expected = remote(
+                    getPlayerCount('channel'),
+                    undefined,
+                    undefined,
+                    'uuid'
+                );
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept a custom story ID', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.storyPlayerCount('test');
+                const expected = remote(
+                    getPlayerCount('test'),
+                    undefined,
+                    undefined,
+                    'uuid'
+                );
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.storyPlayerCount('test');
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2574,6 +2574,44 @@ describe('AuxLibrary', () => {
             });
         });
 
+        describe('server.totalPlayerCount()', () => {
+            it('should emit a remote action with a get_player_count action', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.totalPlayerCount();
+                const expected = remote(
+                    getPlayerCount(),
+                    undefined,
+                    undefined,
+                    'uuid'
+                );
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept a custom story ID', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.totalPlayerCount();
+                const expected = remote(
+                    getPlayerCount(),
+                    undefined,
+                    undefined,
+                    'uuid'
+                );
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.totalPlayerCount();
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
+            });
+        });
+
         describe('remote()', () => {
             it('should replace the original event in the queue', () => {
                 const action = library.api.remote(

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -64,6 +64,7 @@ import {
     share,
     unlockSpace,
     getPlayerCount,
+    getStories,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2589,11 +2590,21 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
-            it('should accept a custom story ID', () => {
+            it('should create tasks that can be resolved from a remote', () => {
                 uuidMock.mockReturnValueOnce('uuid');
-                const action: any = library.api.server.totalPlayerCount();
+                library.api.server.totalPlayerCount();
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
+            });
+        });
+
+        describe('server.stories()', () => {
+            it('should emit a remote action with a get_stories action', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.stories();
                 const expected = remote(
-                    getPlayerCount(),
+                    getStories(),
                     undefined,
                     undefined,
                     'uuid'
@@ -2605,7 +2616,7 @@ describe('AuxLibrary', () => {
 
             it('should create tasks that can be resolved from a remote', () => {
                 uuidMock.mockReturnValueOnce('uuid');
-                library.api.server.totalPlayerCount();
+                library.api.server.stories();
 
                 const task = context.tasks.get('uuid');
                 expect(task.allowRemoteResolution).toBe(true);

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -365,6 +365,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 destroyErrors,
                 loadErrors,
                 storyPlayerCount,
+                totalPlayerCount,
             },
 
             action: {
@@ -1534,6 +1535,20 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const actualStory = hasValue(story) ? story : getCurrentStory();
         const event = calcRemote(
             getPlayerCount(actualStory),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the total number of players that are connected to the server.
+     */
+    function totalPlayerCount(): Promise<number> {
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            getPlayerCount(),
             undefined,
             undefined,
             task.taskId

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -81,6 +81,7 @@ import {
     ShareOptions,
     unlockSpace,
     getPlayerCount,
+    getStories,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -366,6 +367,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 loadErrors,
                 storyPlayerCount,
                 totalPlayerCount,
+                stories,
             },
 
             action: {
@@ -1549,6 +1551,20 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const task = context.createTask(true, true);
         const event = calcRemote(
             getPlayerCount(),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the list of stories that are on the server.
+     */
+    function stories(): Promise<string[]> {
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            getStories(),
             undefined,
             undefined,
             task.taskId

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -80,6 +80,7 @@ import {
     AsyncActions,
     ShareOptions,
     unlockSpace,
+    getPlayerCount,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -363,6 +364,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 saveFile,
                 destroyErrors,
                 loadErrors,
+                storyPlayerCount,
             },
 
             action: {
@@ -1521,6 +1523,22 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 },
             ])
         );
+    }
+
+    /**
+     * Gets the number of players that are viewing the current story.
+     * @param story The story to get the statistics for. If omitted, then the current story is used.
+     */
+    function storyPlayerCount(story?: string): Promise<number> {
+        const task = context.createTask(true, true);
+        const actualStory = hasValue(story) ? story : getCurrentStory();
+        const event = calcRemote(
+            getPlayerCount(actualStory),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2600,6 +2600,11 @@ declare global {
          * Gets the total number of players that are connected to the server.
          */
         totalPlayerCount(): Promise<number>;
+
+        /**
+         * Gets the list of stories that are on the server.
+         */
+        stories(): Promise<string[]>;
     
         /**
          * Loads a file from the server at the given path.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2589,6 +2589,12 @@ declare global {
          * @param tag The tag that the errors should be loaded for.
          */
         loadErrors(bot: string | Bot, tag: string): LoadBotsAction;
+
+        /**
+         * Gets the number of players that are viewing the current story.
+         * @param story The story to get the statistics for. If omitted, then the current story is used.
+         */
+        storyPlayerCount(story?: string): Promise<number>;
     
         /**
          * Loads a file from the server at the given path.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2595,6 +2595,11 @@ declare global {
          * @param story The story to get the statistics for. If omitted, then the current story is used.
          */
         storyPlayerCount(story?: string): Promise<number>;
+
+        /**
+         * Gets the total number of players that are connected to the server.
+         */
+        totalPlayerCount(): Promise<number>;
     
         /**
          * Loads a file from the server at the given path.

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -308,9 +308,17 @@ export class AuxRuntime
             const events = breakIntoIndividualEvents(this.currentState, action);
             this.process(events);
         } else if (action.type === 'async_result') {
-            this._globalContext.resolveTask(action.taskId, action.result);
+            this._globalContext.resolveTask(
+                action.taskId,
+                action.result,
+                false
+            );
         } else if (action.type === 'async_error') {
-            this._globalContext.rejectTask(action.taskId, action.error);
+            this._globalContext.rejectTask(action.taskId, action.error, false);
+        } else if (action.type === 'device_result') {
+            this._globalContext.resolveTask(action.taskId, action.result, true);
+        } else if (action.type === 'device_error') {
+            this._globalContext.rejectTask(action.taskId, action.error, true);
         } else {
             this._actionBatch.push(action);
         }

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.ts
@@ -41,7 +41,7 @@ export default class ShowInputModal extends Vue {
 
     private _currentTag: string = '';
     private _currentBot: Bot = null;
-    private _currentTask: number = null;
+    private _currentTask: number | string = null;
     private _inputDialogSimulation: Simulation = null;
 
     created() {

--- a/src/aux-vm-node/modules/AdminModule2.ts
+++ b/src/aux-vm-node/modules/AdminModule2.ts
@@ -6,7 +6,12 @@ import {
 } from '@casual-simulation/causal-trees';
 import { Subscription } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
-import { ShellAction, LocalActions } from '@casual-simulation/aux-common';
+import {
+    ShellAction,
+    LocalActions,
+    BotActions,
+    BotAction,
+} from '@casual-simulation/aux-common';
 import { exec } from 'child_process';
 
 /**

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -402,7 +402,11 @@ export class AuxHelper extends BaseHelper<Bot> {
             }
             if (typeof partition === 'undefined') {
                 console.warn('[AuxHelper] No partition for event', event);
-                if ('taskId' in event) {
+                if (
+                    'taskId' in event &&
+                    event.type !== 'remote' &&
+                    event.type !== 'device'
+                ) {
                     events.push(
                         asyncError(
                             event.taskId,

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -58,6 +58,7 @@ import {
     UNWATCH_DEVICES,
     UNWATCH_COMMITS,
     GET_BRANCH,
+    DEVICES,
 } from '@casual-simulation/causal-trees/core2';
 import { ConnectionServer, Connection } from './ConnectionServer';
 import { devicesForEvent } from './DeviceManagerHelpers';
@@ -395,6 +396,21 @@ export class CausalRepoServer {
 
                         conn.send(BRANCHES, {
                             branches: branches.map(b => b.name),
+                        });
+                    },
+                    [DEVICES]: async branch => {
+                        let devices: DeviceConnection<any>[];
+                        if (typeof branch !== 'undefined' && branch !== null) {
+                            const info = infoForBranch(branch);
+                            devices = this._deviceManager.getConnectedDevices(
+                                info
+                            );
+                        } else {
+                            devices = this._deviceManager.connectedDevices;
+                        }
+
+                        conn.send(DEVICES, {
+                            devices: devices.map(d => d.extra.device),
                         });
                     },
                     [UNWATCH_BRANCHES]: async () => {},

--- a/src/causal-tree-server/DeviceManagerHelpers.spec.ts
+++ b/src/causal-tree-server/DeviceManagerHelpers.spec.ts
@@ -27,7 +27,7 @@ describe('DeviceManagerHelpers', () => {
 
                 expect(
                     isEventForDevice(
-                        {
+                        <any>{
                             type: 'remote',
                             event: null,
                             username: eventUsername,
@@ -57,7 +57,7 @@ describe('DeviceManagerHelpers', () => {
 
                 expect(
                     isEventForDevice(
-                        {
+                        <any>{
                             type: 'remote',
                             event: null,
                             sessionId: eventSessionId,
@@ -87,7 +87,7 @@ describe('DeviceManagerHelpers', () => {
 
                 expect(
                     isEventForDevice(
-                        {
+                        <any>{
                             type: 'remote',
                             event: null,
                             deviceId: eventDeviceId,

--- a/src/causal-tree-server/DeviceManagerHelpers.ts
+++ b/src/causal-tree-server/DeviceManagerHelpers.ts
@@ -6,6 +6,7 @@ import {
     USERNAME_CLAIM,
     SESSION_ID_CLAIM,
     DEVICE_ID_CLAIM,
+    DeviceSelector,
 } from '@casual-simulation/causal-trees';
 import { DeviceChannelConnection } from './DeviceChannelConnection';
 import { DeviceManager } from './DeviceManager';
@@ -38,14 +39,14 @@ export function connectDeviceChannel<TExtra>(
 }
 
 export function devicesForEvent(
-    event: RemoteAction,
+    event: DeviceSelector,
     devices: (readonly [DeviceConnection<any>, DeviceInfo])[]
 ): DeviceConnection<any>[] {
     return devices.filter(d => isEventForDevice(event, d[1])).map(d => d[0]);
 }
 
 export function isEventForDevice(
-    event: RemoteAction,
+    event: DeviceSelector,
     device: DeviceInfo
 ): boolean {
     if (event.username === device.claims[USERNAME_CLAIM]) {

--- a/src/causal-trees/core/Event.ts
+++ b/src/causal-trees/core/Event.ts
@@ -28,6 +28,11 @@ export interface DeviceAction extends Action {
      * The event.
      */
     event: Action;
+
+    /**
+     * The ID of the task that this action was sent with.
+     */
+    taskId?: number | string;
 }
 
 /**
@@ -67,6 +72,89 @@ export interface RemoteAction extends Action, DeviceSelector {
      * break ordering with respect to bot actions. Defaults to true.
      */
     allowBatching?: boolean;
+
+    /**
+     * The ID of the task.
+     */
+    taskId?: number | string;
+}
+
+/**
+ * An event that is used to respond to remote actions with some arbitrary data.
+ */
+export interface RemoteActionResult extends Action, DeviceSelector {
+    type: 'remote_result';
+
+    /**
+     * The data that is included in the result.
+     */
+    result?: any;
+
+    /**
+     * The ID of the task that this is a result for.
+     */
+    taskId: number | string;
+}
+
+/**
+ * An event that is used to response to remote actions with an error.
+ */
+export interface RemoteActionError extends Action, DeviceSelector {
+    type: 'remote_error';
+
+    /**
+     * The error that occurred.
+     */
+    error: any;
+
+    /**
+     * The ID of the task that this is a result for.
+     */
+    taskId: number | string;
+}
+
+/**
+ * An event that is used to respond to remote actions with some arbitrary data.
+ */
+export interface DeviceActionResult extends Action {
+    type: 'device_result';
+
+    /**
+     * The data that is included in the result.
+     */
+    result: any;
+
+    /**
+     * The ID of the task that this is a result for.
+     */
+    taskId: number | string;
+
+    /**
+     * The device which sent the event.
+     */
+    device: DeviceInfo;
+}
+
+/**
+ * An event that is used to respond to remote actions with an error.
+ */
+export interface DeviceActionError extends Action {
+    type: 'device_error';
+
+    /**
+     * The error that is included in the result.
+     */
+    error: any;
+
+    /**
+     * The ID of the task that this is a result for.
+     */
+    taskId: number | string;
+
+    /**
+     * The device which sent the event.
+     */
+    device: DeviceInfo;
 }
 
 /**
@@ -76,16 +164,57 @@ export interface RemoteAction extends Action, DeviceSelector {
  * @param allowBatching Whether this action is allowed to be batched with other remote actions.
  *                      Batching will preserve ordering between remote actions but may
  *                      break ordering with respect to bot actions. Defaults to true.
+ * @param taskId The ID of the task that this remote action represents.
  */
 export function remote(
     event: Action,
     selector?: DeviceSelector,
-    allowBatching?: boolean
+    allowBatching?: boolean,
+    taskId?: number | string
 ): RemoteAction {
     return {
         type: 'remote',
         event: event,
         allowBatching,
+        taskId,
+        ...selector,
+    };
+}
+
+/**
+ * Creates a new remote event that represents a result to an async task.
+ * @param result The result data.
+ * @param selector The selector that should be used to determine which devices this event should be sent to.
+ * @param taskId The ID of the task that this remote action represents.
+ */
+export function remoteResult(
+    result: any,
+    selector?: DeviceSelector,
+    taskId?: number | string
+): RemoteActionResult {
+    return {
+        type: 'remote_result',
+        result,
+        taskId,
+        ...selector,
+    };
+}
+
+/**
+ * Creates a new remote event that represents an error result to an async task.
+ * @param result The result data.
+ * @param selector The selector that should be used to determine which devices this event should be sent to.
+ * @param taskId The ID of the task that this remote action represents.
+ */
+export function remoteError(
+    error: any,
+    selector?: DeviceSelector,
+    taskId?: number | string
+): RemoteActionError {
+    return {
+        type: 'remote_error',
+        error,
+        taskId,
         ...selector,
     };
 }
@@ -93,12 +222,56 @@ export function remote(
 /**
  * Creates a new device event.
  * @param info The info about the device that is sending the event.
- * @param event The event that is being sent.
+ * @param data The data included in the result.
+ * @param taskId The ID of the task that this device action represents.
  */
-export function device(info: DeviceInfo, event: Action): DeviceAction {
+export function device(
+    info: DeviceInfo,
+    event: Action,
+    taskId?: number | string
+): DeviceAction {
     return {
         type: 'device',
         device: info,
         event: event,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new device event that represents the result of an async task.
+ * @param info The info about the device that is sending the event.
+ * @param result The result data included in the result.
+ * @param taskId The ID of the task that this device action represents.
+ */
+export function deviceResult(
+    info: DeviceInfo,
+    result: any,
+    taskId?: number | string
+): DeviceActionResult {
+    return {
+        type: 'device_result',
+        device: info,
+        result,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new device event that represents an error of an async task.
+ * @param info The info about the device that is sending the event.
+ * @param error The error data included in the result.
+ * @param taskId The ID of the task that this device action represents.
+ */
+export function deviceError(
+    info: DeviceInfo,
+    error: any,
+    taskId?: number | string
+): DeviceActionError {
+    return {
+        type: 'device_error',
+        device: info,
+        error,
+        taskId,
     };
 }

--- a/src/causal-trees/core2/CausalRepoClient.ts
+++ b/src/causal-trees/core2/CausalRepoClient.ts
@@ -46,6 +46,8 @@ import {
     RestoreEvent,
     RESTORE,
     GET_BRANCH,
+    DEVICES,
+    DevicesEvent,
 } from './CausalRepoEvents';
 import { Atom } from './Atom2';
 import {
@@ -280,6 +282,21 @@ export class CausalRepoClient {
             }),
             switchMap(connected =>
                 merge(this._client.event<BranchesEvent>(BRANCHES).pipe(first()))
+            )
+        );
+    }
+
+    /**
+     * Requests a list of devices that are currently connected.
+     * @param branch The branch that the devices should be retrieved from.
+     */
+    devices(branch?: string) {
+        return this._whenConnected().pipe(
+            tap(connected => {
+                this._client.send(DEVICES, branch);
+            }),
+            switchMap(connected =>
+                merge(this._client.event<DevicesEvent>(DEVICES).pipe(first()))
             )
         );
     }

--- a/src/causal-trees/core2/CausalRepoClient.ts
+++ b/src/causal-trees/core2/CausalRepoClient.ts
@@ -48,7 +48,12 @@ import {
     GET_BRANCH,
 } from './CausalRepoEvents';
 import { Atom } from './Atom2';
-import { DeviceAction, RemoteAction } from '../core/Event';
+import {
+    DeviceAction,
+    RemoteAction,
+    DeviceActionResult,
+    DeviceActionError,
+} from '../core/Event';
 
 /**
  * Defines a client for a causal repo.
@@ -405,7 +410,7 @@ export interface ClientAtomsReceived {
 
 export interface ClientEvent {
     type: 'event';
-    action: DeviceAction;
+    action: DeviceAction | DeviceActionResult | DeviceActionError;
 }
 
 export type ClientWatchBranchEvents =

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -129,6 +129,11 @@ export const BRANCH_INFO = 'repo/branch_info';
 export const BRANCHES = 'repo/branches';
 
 /**
+ * The name of the event which gets all the devices.
+ */
+export const DEVICES = 'repo/devices';
+
+/**
  * Defines an event which indicates that atoms should be added for the given branch.
  */
 export interface AddAtomsEvent {
@@ -290,6 +295,10 @@ export interface BranchDoesNotExistInfo {
 
 export interface BranchesEvent {
     branches: string[];
+}
+
+export interface DevicesEvent {
+    devices: DeviceInfo[];
 }
 
 export interface LoadBranchEvent {

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -1,6 +1,13 @@
 import { Atom } from './Atom2';
 import { DeviceInfo } from '../core/DeviceInfo';
-import { RemoteAction, DeviceAction } from '../core/Event';
+import {
+    RemoteAction,
+    DeviceAction,
+    DeviceActionResult,
+    RemoteActionResult,
+    RemoteActionError,
+    DeviceActionError,
+} from '../core/Event';
 import { CausalRepoCommit } from './CausalRepoObject';
 
 /**
@@ -213,7 +220,7 @@ export interface SendRemoteActionEvent {
     /**
      * The action to send.
      */
-    action: RemoteAction;
+    action: RemoteAction | RemoteActionResult | RemoteActionError;
 }
 
 /**
@@ -221,7 +228,7 @@ export interface SendRemoteActionEvent {
  */
 export interface ReceiveDeviceActionEvent {
     branch: string;
-    action: DeviceAction;
+    action: DeviceAction | DeviceActionResult | DeviceActionError;
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoSession.ts
+++ b/src/causal-trees/core2/CausalRepoSession.ts
@@ -51,6 +51,7 @@ export interface CausalRepoMessageHandlerTypes {
     'repo/unwatch_devices': void;
     'repo/branch_info': string;
     'repo/branches': void;
+    'repo/devices': string;
     'repo/commit': CommitEvent;
     'repo/watch_commits': string;
     'repo/unwatch_commits': string;
@@ -117,6 +118,10 @@ export interface CausalRepoSession extends GenericSession {
      * Gets an observable for events that request a list of available branches.
      */
     event(name: 'repo/branches'): Observable<void>;
+    /**
+     * Gets an observable for events that request a list of connected devices.
+     */
+    event(name: 'repo/devices'): Observable<string>;
     /**
      * Gets an observable for events which make a commit for a branch.
      */


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the `server.storyPlayerCount()` function.
        -   Returns a promise that resolves with the number of players currently connected to the current story.
        -   Optionally accepts a parameter which indicates the story to check.
    -   Added the `server.totalPlayerCount()` function.
        -   Returns a promise that resolves with the total number of players connected to the server.
    -   Added the `server.stories()` function.
        -   Returns a promise that resolves with the list of stories that are on the server.
-   :bug: Bug Fixes
    -   Removed the globals bot tags from the documentation since they no longer exist.