### PR TITLE
Add more ways to recover lost data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     -   Fixed an issue where all bots would appear to be in the `shared` space even though they were not.
     -   Fixed issues with loading on Servo-based browsers.
         -   The issues were mostly related to Servo having not implemented IndexedDB yet.
+    -   Fixed an issue where some temporary branches would show up in `server.stories()`.
 
 ## V1.1.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Changes:
 
+-   :rocket: Improvements
+    -   Added a reflog and sitelog for stories so that it is possible to track the history of a story branch and which sites have connected to it.
+        -   This will make it easier for us to recover from data loss issues in the future since we'll be able to lookup data like the last commit that a branch pointed at or which atoms were added to a branch.
 -   :bug: Bug Fixes
 
     -   Fixed an issue where all bots would appear to be in the `shared` space even though they were not.

--- a/src/aux-common/partitions/OtherPlayersPartition.spec.ts
+++ b/src/aux-common/partitions/OtherPlayersPartition.spec.ts
@@ -171,6 +171,7 @@ describe('OtherPlayersPartition', () => {
                         data: {
                             branch: 'testBranch-player-device1SessionId',
                             temporary: true,
+                            siteId: expect.any(String),
                         },
                     },
                 ]);
@@ -339,6 +340,7 @@ describe('OtherPlayersPartition', () => {
                         data: {
                             branch: 'testBranch-player-device1SessionId',
                             temporary: true,
+                            siteId: expect.any(String),
                         },
                     },
                     {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
@@ -181,6 +181,26 @@ describe('RemoteCausalRepoPartition', () => {
             ]);
         });
 
+        it('should send a WATCH_BRANCH event to the server', async () => {
+            setupPartition({
+                type: 'remote_causal_repo',
+                branch: 'testBranch',
+                host: 'testHost',
+            });
+
+            partition.connect();
+
+            expect(connection.sentMessages).toEqual([
+                {
+                    name: WATCH_BRANCH,
+                    data: {
+                        branch: 'testBranch',
+                        siteId: partition.tree.site.id,
+                    },
+                },
+            ]);
+        });
+
         describe('remote events', () => {
             it('should send the remote event to the server', async () => {
                 await partition.sendRemoteEvents([
@@ -902,6 +922,7 @@ describe('RemoteCausalRepoPartition', () => {
                         name: WATCH_BRANCH,
                         data: {
                             branch: 'testBranch',
+                            siteId: partition.tree.site.id,
                         },
                     },
                 ]);
@@ -1029,6 +1050,7 @@ describe('RemoteCausalRepoPartition', () => {
                         name: WATCH_BRANCH,
                         data: {
                             branch: 'testBranch',
+                            siteId: partition.tree.site.id,
                             temporary: true,
                         },
                     },

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -92,6 +92,10 @@ export class RemoteCausalRepoPartitionImpl
 
     private: boolean;
 
+    get tree() {
+        return this._tree;
+    }
+
     get realtimeStrategy(): AuxPartitionRealtimeStrategy {
         return this._static ? 'delayed' : 'immediate';
     }
@@ -363,6 +367,7 @@ export class RemoteCausalRepoPartitionImpl
                 .watchBranch({
                     branch: this._branch,
                     temporary: this._temporary,
+                    siteId: this._tree.site.id,
                 })
                 .subscribe(event => {
                     if (!this._synced) {

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -37,6 +37,7 @@ import {
     DEVICE_ID_CLAIM,
     SESSION_ID_CLAIM,
     deviceInfoFromUser,
+    sitelog,
 } from '@casual-simulation/causal-trees';
 import {
     CausalRepoServer,
@@ -889,10 +890,14 @@ export class Server {
         const objectsCollection = db.collection('objects');
         const headsCollection = db.collection('heads');
         const indexesCollection = db.collection('indexes');
+        const reflogCollection = db.collection('reflog');
+        const sitelogCollection = db.collection('sitelog');
         const mongoStore = new MongoDBRepoStore(
             objectsCollection,
             headsCollection,
-            indexesCollection
+            indexesCollection,
+            reflogCollection,
+            sitelogCollection
         );
         await mongoStore.init();
 

--- a/src/aux-vm-node/managers/AuxCausalRepoManager.spec.ts
+++ b/src/aux-vm-node/managers/AuxCausalRepoManager.spec.ts
@@ -163,6 +163,26 @@ describe('AuxCausalRepoManager', () => {
         });
     });
 
+    it('should not try loading the branch if a disconnected event is received without a corresponding connection event', async () => {
+        manager.init();
+        connection.connect();
+        await waitAsync();
+
+        deviceDisconnected.next({
+            branch: 'abc',
+            device: device1Info,
+        });
+        await waitAsync();
+
+        expect(connection.sentMessages).not.toContainEqual({
+            name: WATCH_BRANCH,
+            data: {
+                branch: 'abc',
+                siteId: expect.any(String),
+            },
+        });
+    });
+
     it('should call setup() on each of the modules when a branch is loaded', async () => {
         manager.init();
         connection.connect();

--- a/src/aux-vm-node/managers/AuxCausalRepoManager.spec.ts
+++ b/src/aux-vm-node/managers/AuxCausalRepoManager.spec.ts
@@ -110,6 +110,7 @@ describe('AuxCausalRepoManager', () => {
                 name: WATCH_BRANCH,
                 data: {
                     branch: 'abc',
+                    siteId: expect.any(String),
                 },
             },
         ]);
@@ -153,6 +154,7 @@ describe('AuxCausalRepoManager', () => {
             name: WATCH_BRANCH,
             data: {
                 branch: 'abc',
+                siteId: expect.any(String),
             },
         });
         expect(connection.sentMessages).toContainEqual({

--- a/src/aux-vm-node/managers/AuxCausalRepoManager.ts
+++ b/src/aux-vm-node/managers/AuxCausalRepoManager.ts
@@ -58,7 +58,7 @@ export class AuxCausalRepoManager {
             return;
         }
 
-        let info = await this._loadBranch(branch.branch);
+        let info = await this._loadBranch(branch.branch, true);
         const id = device.claims[SESSION_ID_CLAIM];
         info.connections.add(id);
 
@@ -72,7 +72,10 @@ export class AuxCausalRepoManager {
             return;
         }
 
-        let info = await this._loadBranch(branch);
+        let info = await this._loadBranch(branch, false);
+        if (!info) {
+            return;
+        }
         const id = device.claims[SESSION_ID_CLAIM];
         info.connections.delete(id);
 
@@ -95,9 +98,14 @@ export class AuxCausalRepoManager {
         }
     }
 
-    private async _loadBranch(branch: string) {
+    /**
+     * Loads a simulation for the given branch.
+     * @param branch The branch to load.
+     * @param allowLoadingFresh Whether to allow loading a new simulation. If false and the branch is not already loaded, then null will be returned.
+     */
+    private async _loadBranch(branch: string, allowLoadingFresh: boolean) {
         let info = this._branches.get(branch);
-        if (!info) {
+        if (!info && allowLoadingFresh) {
             const sim = nodeSimulationForBranch(
                 this._user,
                 this._client,

--- a/src/causal-tree-cli/migrate/mongodb.ts
+++ b/src/causal-tree-cli/migrate/mongodb.ts
@@ -41,11 +41,15 @@ export async function mongoConnectionInfo(
     const objectsCollection = db.collection('objects');
     const headsCollection = db.collection('heads');
     const indexesCollection = db.collection('indexes');
+    const reflogCollection = db.collection('reflog');
+    const sitelogCollection = db.collection('sitelog');
 
     const mongoStore = new MongoDBRepoStore(
         objectsCollection,
         headsCollection,
-        indexesCollection
+        indexesCollection,
+        reflogCollection,
+        sitelogCollection
     );
     await mongoStore.init();
     return mongoStore;

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -258,6 +258,38 @@ describe('CausalRepoServer', () => {
             ]);
         });
 
+        it('should log the site ID to the branch if specified', async () => {
+            server.init();
+
+            const device = new MemoryConnection(device1Info);
+            const addAtoms = new Subject<AddAtomsEvent>();
+            device.events.set(ADD_ATOMS, addAtoms);
+
+            const joinBranch = new Subject<WatchBranchEvent>();
+            device.events.set(WATCH_BRANCH, joinBranch);
+
+            connections.connection.next(device);
+
+            await waitAsync();
+
+            joinBranch.next({
+                branch: 'testBranch',
+                siteId: 'testSite',
+            });
+
+            await waitAsync();
+
+            const log = await store.getSitelog('testBranch');
+            expect(log).toEqual([
+                {
+                    type: 'sitelog',
+                    branch: 'testBranch',
+                    site: 'testSite',
+                    time: expect.any(Date),
+                },
+            ]);
+        });
+
         describe('temp', () => {
             it('should load the branch without persistent data if the branch is temporary', async () => {
                 server.init();

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -384,6 +384,32 @@ describe('CausalRepoServer', () => {
                     },
                 ]);
             });
+
+            it('should not log the site ID to the branch if specified', async () => {
+                server.init();
+
+                const device = new MemoryConnection(device1Info);
+                const addAtoms = new Subject<AddAtomsEvent>();
+                device.events.set(ADD_ATOMS, addAtoms);
+
+                const joinBranch = new Subject<WatchBranchEvent>();
+                device.events.set(WATCH_BRANCH, joinBranch);
+
+                connections.connection.next(device);
+
+                await waitAsync();
+
+                joinBranch.next({
+                    branch: 'testBranch',
+                    siteId: 'testSite',
+                    temporary: true,
+                });
+
+                await waitAsync();
+
+                const log = await store.getSitelog('testBranch');
+                expect(log).toEqual([]);
+            });
         });
     });
 

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -410,6 +410,32 @@ describe('CausalRepoServer', () => {
                 const log = await store.getSitelog('testBranch');
                 expect(log).toEqual([]);
             });
+
+            it('should not create a branch', async () => {
+                server.init();
+
+                const device = new MemoryConnection(device1Info);
+                const addAtoms = new Subject<AddAtomsEvent>();
+                device.events.set(ADD_ATOMS, addAtoms);
+
+                const joinBranch = new Subject<WatchBranchEvent>();
+                device.events.set(WATCH_BRANCH, joinBranch);
+
+                connections.connection.next(device);
+
+                await waitAsync();
+
+                joinBranch.next({
+                    branch: 'testBranch',
+                    siteId: 'testSite',
+                    temporary: true,
+                });
+
+                await waitAsync();
+
+                const branches = await store.getBranches('testBranch');
+                expect(branches).toEqual([]);
+            });
         });
     });
 

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -123,7 +123,7 @@ export class CausalRepoServer {
                         if (!this._branches.has(branch)) {
                             this._branches.set(branch, event);
                         }
-                        if (event.siteId) {
+                        if (!event.temporary && event.siteId) {
                             await this._store.logSite(
                                 event.branch,
                                 event.siteId

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -123,6 +123,12 @@ export class CausalRepoServer {
                         if (!this._branches.has(branch)) {
                             this._branches.set(branch, event);
                         }
+                        if (event.siteId) {
+                            await this._store.logSite(
+                                event.branch,
+                                event.siteId
+                            );
+                        }
                         const repo = await this._getOrLoadRepo(
                             branch,
                             true,

--- a/src/causal-tree-store-mongodb/MongoDBRepoStore.ts
+++ b/src/causal-tree-store-mongodb/MongoDBRepoStore.ts
@@ -204,7 +204,7 @@ export class MongoDBRepoStore implements CausalRepoStore {
      * @param head The branch to save.
      */
     async saveBranch(head: CausalRepoBranch): Promise<void> {
-        await this._heads.updateOne(
+        const result = await this._heads.updateOne(
             { name: head.name },
             {
                 $set: head,
@@ -213,8 +213,10 @@ export class MongoDBRepoStore implements CausalRepoStore {
                 upsert: true,
             }
         );
-        const ref = reflog(head);
-        await this._reflog.insertOne(ref);
+        if (result.modifiedCount > 0 || result.upsertedCount > 0) {
+            const ref = reflog(head);
+            await this._reflog.insertOne(ref);
+        }
     }
 
     /**

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -153,6 +153,11 @@ export interface WatchBranchEvent {
     branch: string;
 
     /**
+     * The ID of the site that is watching the branch.
+     */
+    siteId?: string;
+
+    /**
      * Whether the branch should be temporary.
      * That is, if the branch data should not be loaded from the database
      * and everything should be deleted once all the watchers have left.

--- a/src/causal-trees/core2/CausalRepoObject.ts
+++ b/src/causal-trees/core2/CausalRepoObject.ts
@@ -30,6 +30,54 @@ export interface CausalRepoBranch {
 }
 
 /**
+ * Defines a reflog.
+ * That is, a record that records where a ref (i.e. branch) was pointing at a given moment in time.
+ * Useful for recovering old states that a branch was at if it was reset to an unrelated commit.
+ */
+export interface CausalRepoReflog {
+    type: 'reflog';
+
+    /**
+     * The name of the branch that this log entry represents.
+     */
+    branch: string;
+
+    /**
+     * The hash that the branch pointed to.
+     */
+    hash: string;
+
+    /**
+     * The time that the reflog was created at.
+     */
+    time: Date;
+}
+
+/**
+ * Defines a sitelog.
+ * That is, a record that records when a site connected to a branch.
+ * Useful for recovering a list of atoms that have been created for a branch if the branch has not been saved.
+ */
+export interface CausalRepoSitelog {
+    type: 'sitelog';
+
+    /**
+     * The name of the branch that this log entry represents.
+     */
+    branch: string;
+
+    /**
+     * The ID of the site that connected to the branch.
+     */
+    site: string;
+
+    /**
+     * The time that the sitelog was created at.
+     */
+    time: Date;
+}
+
+/**
  * Defines information about an index in a causal repo.
  */
 export interface CausalRepoIndex {
@@ -117,6 +165,32 @@ export function branch(
         return repoBranch(name, ref);
     }
     return repoBranch(name, getObjectHash(ref));
+}
+
+/**
+ * Creates a reflog for the given branch.
+ * @param head The branch.
+ */
+export function reflog(head: CausalRepoBranch): CausalRepoReflog {
+    return {
+        type: 'reflog',
+        branch: head.name,
+        hash: head.hash,
+        time: new Date(),
+    };
+}
+
+/**
+ * Creates a sitelog for the given branch.
+ * @param branch The branch.
+ */
+export function sitelog(branch: string, site: string): CausalRepoSitelog {
+    return {
+        type: 'sitelog',
+        branch: branch,
+        site: site,
+        time: new Date(),
+    };
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoStore.ts
+++ b/src/causal-trees/core2/CausalRepoStore.ts
@@ -2,6 +2,8 @@ import {
     CausalRepoObject,
     CausalRepoBranch,
     CausalRepoIndex,
+    CausalRepoReflog,
+    CausalRepoSitelog,
 } from './CausalRepoObject';
 
 /**
@@ -23,6 +25,7 @@ export interface CausalBranchStore {
 
     /**
      * Saves/updates the given head to the given repo.
+     * The old branch will be saved as a ref.
      * @param head The branch to save.
      */
     saveBranch(head: CausalRepoBranch): Promise<void>;
@@ -32,6 +35,29 @@ export interface CausalBranchStore {
      * @param head The branch to delete.
      */
     deleteBranch(head: CausalRepoBranch): Promise<void>;
+
+    /**
+     * Gets the reflog for the given branch.
+     * Useful for recovering references to old commits.
+     * The returned reflog list will be sorted from most recent to least recent.
+     * @param branch The name of the branch.
+     */
+    getReflog(branch: string): Promise<CausalRepoReflog[]>;
+
+    /**
+     * Gets the sitelog for the given branch.
+     * Useful for recovering a list of atoms that have been added to the given branch.
+     * The returned sitelog list will be sorted from most recent to least recent.
+     * @param branch The name of the branch.
+     */
+    getSitelog(branch: string): Promise<CausalRepoSitelog[]>;
+
+    /**
+     * Logs that the given site connected to the given branch.
+     * @param branch The name of the branch.
+     * @param site The site.
+     */
+    logSite(branch: string, site: string): Promise<CausalRepoSitelog>;
 }
 
 /**
@@ -98,6 +124,18 @@ export class CombinedCausalRepoStore implements CausalRepoStore {
         if (objects.storeIndex) {
             this.storeIndex = this._storeIndex;
         }
+    }
+
+    getReflog(branch: string): Promise<CausalRepoReflog[]> {
+        return this._branches.getReflog(branch);
+    }
+
+    getSitelog(branch: string): Promise<CausalRepoSitelog[]> {
+        return this._branches.getSitelog(branch);
+    }
+
+    logSite(branch: string, site: string): Promise<CausalRepoSitelog> {
+        return this._branches.logSite(branch, site);
     }
 
     loadIndex: (

--- a/src/causal-trees/core2/test/CausalRepoStoreTests.ts
+++ b/src/causal-trees/core2/test/CausalRepoStoreTests.ts
@@ -81,6 +81,37 @@ export default function causalRepoStoreTests(
             expect(branches).toEqual([b4, b3]);
         });
 
+        it('should create a reflog for the saved branch', async () => {
+            const b1 = repoBranch('my-repo/master', 'hash1');
+
+            await store.saveBranch(b1);
+
+            const b2 = repoBranch('my-repo/master', 'hash2');
+
+            await store.saveBranch(b2);
+
+            let branches = await store.getBranches('my-repo');
+
+            expect(branches).toEqual([b2]);
+
+            let reflog = await store.getReflog('my-repo/master');
+
+            expect(reflog).toEqual([
+                {
+                    type: 'reflog',
+                    branch: 'my-repo/master',
+                    hash: 'hash2',
+                    time: expect.any(Date),
+                },
+                {
+                    type: 'reflog',
+                    branch: 'my-repo/master',
+                    hash: 'hash1',
+                    time: expect.any(Date),
+                },
+            ]);
+        });
+
         it('should be able to delete branches', async () => {
             const b1 = repoBranch('my-repo/master', 'hash1');
             const b2 = repoBranch('my-repo/other', 'hash2');
@@ -121,6 +152,29 @@ export default function causalRepoStoreTests(
 
             // should be sorted by name
             expect(branches).toEqual([b4, b3, b1, b2]);
+        });
+    });
+
+    describe('sitelog', () => {
+        it('should be able to log that a site was connected to a branch', async () => {
+            await store.logSite('test', 'abc1');
+            await store.logSite('test', 'abc2');
+
+            const log = await store.getSitelog('test');
+            expect(log).toEqual([
+                {
+                    type: 'sitelog',
+                    branch: 'test',
+                    site: 'abc2',
+                    time: expect.any(Date),
+                },
+                {
+                    type: 'sitelog',
+                    branch: 'test',
+                    site: 'abc1',
+                    time: expect.any(Date),
+                },
+            ]);
         });
     });
 


### PR DESCRIPTION
-   :rocket: Improvements
    -   Added a reflog and sitelog for stories so that it is possible to track the history of a story branch and which sites have connected to it.
        -   This will make it easier for us to recover from data loss issues in the future since we'll be able to lookup data like the last commit that a branch pointed at or which atoms were added to a branch.