### PR TITLE
Add the ability to start and join Jitsi Meet meetings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@
     -   Added the `meetPortal`.
         -   This is a special portal that, instead of loading bots, loads a [Jitsi Meet](https://meet.jit.si/) meeting with the given room code.
         -   All rooms are publicly accessible (but not searchable), so longer room codes will be more private.
+        -   You can use the `meetPortalConfigBot` option to reference the bot that should be used to configure the meet portal.
+        -   The following options are available:
+            -   `meetPortalVisible` - Whether the meet portal should be visible. This allows you to be joined to a meet while keeping your screen on the page portal. (Defaults to true)
+            -   `meetPortalAnchorPoint` - The anchor point that the meet portal should use. Possible options are:
+                -   `fullscreen` - The meet portal should take the entire screen. (Default)
+                -   `top` - The meet portal should take the top of the screen.
+                -   `topRight` - The meet portal should take the top-right corner of the screen.
+                -   `topLeft` - The meet portal should take the top-left corner of the screen.
+                -   `bottom` - The meet portal should take the bottom of the screen.
+                -   `bottomRight` - The meet portal should take the bottom-right corner of the screen.
+                -   `bottomLeft` - The meet portal should take the bottom-left corner of the screen.
+                -   `[top, right, bottom, left]` - The meet portal should use the given values for the CSS top, right, bottom, and left properties respectively.
+            -   `meetPortalStyle` - The CSS style that should be applied to the meet portal container.
+                -   Should be a JavaScript object.
+                -   Each property on the object will map directly to a CSS property.
+                -   Useful for moving the meet portal to arbitrary positions.
 
 -   :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
     -   Fixed an issue where the Hololens 2 would not be able to enter AR/VR because a controller's (hand) position would sometimes be null.
     -   Fixed an issue where loading without a story would create a new random story but then immediately unload it.
     -   Fixed an issue where local bots from other stories would be loaded if the current story name happened to be a prefix of the other story name.
+    -   Fixed the input modal background.
+    -   Fixed the TypeScript definitions for the `player.showInput()` function.
 
 ## V1.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
     -   Fixed an issue where the Hololens 2 would not be able to enter AR/VR because a controller's (hand) position would sometimes be null.
     -   Fixed an issue where loading without a story would create a new random story but then immediately unload it.
+    -   Fixed an issue where local bots from other stories would be loaded if the current story name happened to be a prefix of the other story name.
 
 ## V1.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Changes:
 
+-   :rocket: Improvements
+
+    -   Added the `meetPortal`.
+        -   This is a special portal that, instead of loading bots, loads a [Jitsi Meet](https://meet.jit.si/) meeting with the given room code.
+        -   All rooms are publicly accessible (but not searchable), so longer room codes will be more private.
+
 -   :bug: Bug Fixes
 
     -   Fixed an issue where the Hololens 2 would not be able to enter AR/VR because a controller's (hand) position would sometimes be null.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1132,6 +1132,87 @@ The number of grid spaces that the wrist portal should have in the X direction.
   </PossibleValue>
 </PossibleValuesTable>
 
+### `meetPortalVisible`
+
+Whether the meet portal should be visible.
+This is useful for hiding the meet portal while still in a meeting.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The meet portal will be visible. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The meet portal will be hidden.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `meetPortalAnchorPoint`
+
+The position on the screen that the meet portal should be anchored to.
+Overrides any conflicting properties set by <TagLink tag='meetPortalStyle'/>.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='fullscreen'>
+    The meet portal will occupy the entire screen. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='top'>
+    The meet portal will occupy the top of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='topRight'>
+    The meet portal will occupy the top-right corner of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='topLeft'>
+    The meet portal will occupy the top-left corner of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='bottom'>
+    The meet portal will occupy the bottom of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='bottomRight'>
+    The meet portal will occupy the bottom-right corner of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='bottomLeft'>
+    The meet portal will occupy the bottom-left corner of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='[top, right, bottom, left]'>
+    The meet portal will use the given values for the CSS [top](https://developer.mozilla.org/en-US/docs/Web/CSS/top),
+    [right](https://developer.mozilla.org/en-US/docs/Web/CSS/right), [left](https://developer.mozilla.org/en-US/docs/Web/CSS/left),
+    and [bottom](https://developer.mozilla.org/en-US/docs/Web/CSS/bottom) properties of the container.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `meetPortalStyle`
+
+The custom [CSS styles](https://developer.mozilla.org/en-US/docs/Web/CSS) that should be applied to the meet portal container.
+This is useful for positioning the meet portal in ways that are not possible using <TagLink tag='meetPortalAnchorPoint'/>.
+Overridden by conflicting properties set by <TagLink tag='meetPortalAnchorPoint'/>.
+
+When setting this tag via the sheet, it is useful to utilize formulas to ensure that the resulting value is considered an object.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    No special styling. (Default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Object'>
+    The properties of the object will be applied as special styling to the meet portal container.
+  </PossibleValue>
+</PossibleValuesTable>
+
+#### Examples
+
+1. Put the meet portal in the center of the screen.
+Note that we wrap the curly braces in parenthesis to tell JavaScript that we want the curly braces to be intepreted as an [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) instead of as a [block](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block).
+```
+=({
+    top: "10%",
+    bottom: "10%",
+    left: "10%",
+    right: "10%",
+})
+```
+
 ## History Tags
 
 History tags are tags that are automatically applied to bots in the `history` space.
@@ -1272,6 +1353,10 @@ Only available on the player bot.
 </Badges>
 
 The [Jitsi Meet](https://meet.jit.si/) room code of the meeting that should be joined.
+This will join the current tab to the meeting and provide audiovisual communication between everyone that is joined.
+
+This is similar to a Skype or Zoom call except that all data is encrypted and is deleted once you are done with it. Check out the Jitsi Meet privacy policy [here](https://jitsi.org/meet-jit-si-privacy/).
+
 Only available on the player bot.
 
 ## Hidden Tags

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1265,6 +1265,15 @@ Only available on the player bot.
 The dimension that is loaded onto the right controller near the wrist when in VR.
 Only available on the player bot.
 
+### `meetPortal`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The [Jitsi Meet](https://meet.jit.si/) room code of the meeting that should be joined.
+Only available on the player bot.
+
 ## Hidden Tags
 
 Hidden tags are tags that are hidden in the sheet by default.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -331,6 +331,12 @@ export type BotAnchorPoint =
  */
 export type MeetPortalAnchorPoint =
     | 'fullscreen'
+    | 'top'
+    | 'topRight'
+    | 'topLeft'
+    | 'bottom'
+    | 'bottomRight'
+    | 'bottomLeft'
     | [number | string]
     | [number | string, number | string]
     | [number | string, number | string, number | string]

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -327,6 +327,16 @@ export type BotAnchorPoint =
     | [number, number, number];
 
 /**
+ * Defines the possible meet portal anchor points.
+ */
+export type MeetPortalAnchorPoint =
+    | 'fullscreen'
+    | [number | string]
+    | [number | string, number | string]
+    | [number | string, number | string, number | string]
+    | [number | string, number | string, number | string, number | string];
+
+/**
  * Defines the possible portal raycast modes.
  */
 export type PortalPointerDragMode = 'grid' | 'world';
@@ -511,6 +521,12 @@ export const DEFAULT_WRIST_PORTAL_WIDTH = 6;
  * The default grid scale for wrist portals.
  */
 export const DEFAULT_WRIST_PORTAL_GRID_SCALE = 0.025;
+
+/**
+ * The default anchor point for the meet portal.
+ */
+export const DEFAULT_MEET_PORTAL_ANCHOR_POINT: MeetPortalAnchorPoint =
+    'fullscreen';
 
 /**
  * The default bot LOD.
@@ -935,6 +951,9 @@ export const KNOWN_TAGS: string[] = [
     'inventoryPortalResizable',
     'wristPortalHeight',
     'wristPortalWidth',
+    'meetPortalAnchorPoint',
+    'meetPortalVisible',
+    'meetPortalStyle',
 
     'color',
     'creator',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -83,6 +83,7 @@ export type PortalType =
     | 'menu'
     | 'sheet'
     | 'stories'
+    | 'meet'
     | string;
 
 export interface ScriptTags extends PrecalculatedTags {
@@ -861,6 +862,11 @@ export const ON_ANY_FOCUS_EXIT_ACTION_NAME: string = 'onAnyFocusExit';
 export const AUX_BOT_VERSION: number = 1;
 
 /**
+ * The name of the meet portal.
+ */
+export const MEET_PORTAL: string = 'meetPortal';
+
+/**
  * The list of all portal tags.
  */
 export const KNOWN_PORTALS: string[] = [
@@ -870,12 +876,17 @@ export const KNOWN_PORTALS: string[] = [
     'menuPortal',
     'leftWristPortal',
     'rightWristPortal',
+    MEET_PORTAL,
 ];
 
 /**
  * The list of portal tags that should always be represented in the query string.
  */
-export const QUERY_PORTALS: string[] = ['pagePortal', 'sheetPortal'];
+export const QUERY_PORTALS: string[] = [
+    'pagePortal',
+    'sheetPortal',
+    MEET_PORTAL,
+];
 
 /*
  * The list of all tags that have existing functionality in casual sim
@@ -895,6 +906,10 @@ export const KNOWN_TAGS: string[] = [
     'menuPortalConfigBot',
     'leftWristPortalConfigBot',
     'rightWristPortalConfigBot',
+
+    MEET_PORTAL,
+    `${MEET_PORTAL}ConfigBot`,
+
     '_editingBot',
 
     'portalColor',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -37,6 +37,8 @@ import {
     DEFAULT_LABEL_ALIGNMENT,
     BotScaleMode,
     DEFAULT_SCALE_MODE,
+    MeetPortalAnchorPoint,
+    DEFAULT_MEET_PORTAL_ANCHOR_POINT,
 } from './Bot';
 
 import { BotCalculationContext, cacheFunction } from './BotCalculationContext';
@@ -1339,6 +1341,89 @@ export function getAnchorPointOffset(
             z: -z,
         };
     }
+}
+
+const possibleMeetPortalAnchorPoints = new Set(['fullscreen'] as const);
+
+/**
+ * Gets the meet portal anchor point for the given bot.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function getBotMeetPortalAnchorPoint(
+    calc: BotCalculationContext,
+    bot: Bot
+): MeetPortalAnchorPoint {
+    const mode = <MeetPortalAnchorPoint>(
+        calculateBotValue(calc, bot, 'auxMeetPortalAnchorPoint')
+    );
+
+    if (Array.isArray(mode)) {
+        if (mode.every(v => ['string', 'number'].indexOf(typeof v) >= 0)) {
+            let result = mode.slice(0, 4);
+            while (result.length < 4) {
+                result.push(0);
+            }
+            return result as MeetPortalAnchorPoint;
+        }
+    } else if (possibleMeetPortalAnchorPoints.has(mode)) {
+        return mode;
+    }
+    return DEFAULT_MEET_PORTAL_ANCHOR_POINT;
+}
+
+/**
+ * Gets the anchor point offset for the bot in AUX coordinates.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function getBotMeetPortalAnchorPointOffset(
+    calc: BotCalculationContext,
+    bot: Bot
+): {
+    top: string;
+    right: string;
+    bottom: string;
+    left: string;
+} {
+    const point = getBotMeetPortalAnchorPoint(calc, bot);
+    return calculateMeetPortalAnchorPointOffset(point);
+}
+
+/**
+ * Calculates the CSS style for the given meet portal anchor point.
+ */
+export function calculateMeetPortalAnchorPointOffset(
+    anchorPoint: MeetPortalAnchorPoint
+): {
+    top: string;
+    right: string;
+    bottom: string;
+    left: string;
+} {
+    if (typeof anchorPoint === 'string') {
+        return {
+            top: '0px',
+            right: '0px',
+            bottom: '0px',
+            left: '0px',
+        };
+    } else {
+        const [top, right, bottom, left] = anchorPoint;
+        return {
+            top: stringOrPx(top),
+            right: stringOrPx(right),
+            bottom: stringOrPx(bottom),
+            left: stringOrPx(left),
+        };
+    }
+}
+
+function stringOrPx(value: string | number): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    return `${value}px`;
 }
 
 const lodTags = new Set([

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1343,7 +1343,15 @@ export function getAnchorPointOffset(
     }
 }
 
-const possibleMeetPortalAnchorPoints = new Set(['fullscreen'] as const);
+const possibleMeetPortalAnchorPoints = new Set([
+    'fullscreen',
+    'top',
+    'topRight',
+    'topLeft',
+    'bottom',
+    'bottomRight',
+    'bottomLeft',
+] as const);
 
 /**
  * Gets the meet portal anchor point for the given bot.
@@ -1381,10 +1389,14 @@ export function getBotMeetPortalAnchorPointOffset(
     calc: BotCalculationContext,
     bot: Bot
 ): {
-    top: string;
-    right: string;
-    bottom: string;
-    left: string;
+    top?: string;
+    right?: string;
+    bottom?: string;
+    left?: string;
+    height?: string;
+    width?: string;
+    'min-height'?: string;
+    'min-width'?: string;
 } {
     const point = getBotMeetPortalAnchorPoint(calc, bot);
     return calculateMeetPortalAnchorPointOffset(point);
@@ -1396,18 +1408,76 @@ export function getBotMeetPortalAnchorPointOffset(
 export function calculateMeetPortalAnchorPointOffset(
     anchorPoint: MeetPortalAnchorPoint
 ): {
-    top: string;
-    right: string;
-    bottom: string;
-    left: string;
+    top?: string;
+    right?: string;
+    bottom?: string;
+    left?: string;
+    height?: string;
+    width?: string;
+    'min-height'?: string;
+    'min-width'?: string;
 } {
     if (typeof anchorPoint === 'string') {
-        return {
-            top: '0px',
-            right: '0px',
-            bottom: '0px',
-            left: '0px',
-        };
+        if (anchorPoint === 'top') {
+            return {
+                top: '0px',
+                height: '25%',
+                'min-height': '250px',
+                left: '0px',
+                right: '0px',
+            };
+        } else if (anchorPoint === 'topRight') {
+            return {
+                top: '25px',
+                height: '25%',
+                'min-height': '250px',
+                width: '25%',
+                'min-width': '250px',
+                right: '25px',
+            };
+        } else if (anchorPoint === 'topLeft') {
+            return {
+                top: '25px',
+                height: '25%',
+                'min-height': '250px',
+                width: '25%',
+                'min-width': '250px',
+                left: '25px',
+            };
+        } else if (anchorPoint === 'bottom') {
+            return {
+                bottom: '0px',
+                height: '25%',
+                'min-height': '250px',
+                left: '0px',
+                right: '0px',
+            };
+        } else if (anchorPoint === 'bottomRight') {
+            return {
+                bottom: '25px',
+                height: '25%',
+                'min-height': '250px',
+                width: '25%',
+                'min-width': '250px',
+                right: '25px',
+            };
+        } else if (anchorPoint === 'bottomLeft') {
+            return {
+                bottom: '25px',
+                height: '25%',
+                'min-height': '250px',
+                width: '25%',
+                'min-width': '250px',
+                left: '25px',
+            };
+        } else {
+            return {
+                top: '0px',
+                right: '0px',
+                bottom: '0px',
+                left: '0px',
+            };
+        }
     } else {
         const [top, right, bottom, left] = anchorPoint;
         return {

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -56,6 +56,8 @@ import {
     isBotFocusable,
     getBotLabelAlignment,
     getBotScaleMode,
+    getBotMeetPortalAnchorPoint,
+    getBotMeetPortalAnchorPointOffset,
 } from '../BotCalculations';
 import {
     Bot,
@@ -984,6 +986,49 @@ export function botCalculationContextTests(
         });
     });
 
+    describe('getMeetPortalAnchorPoint()', () => {
+        const cases = [
+            ['fullscreen', 'fullscreen'],
+            ['[1]', [1, 0, 0, 0]],
+            ['[1, 2]', [1, 2, 0, 0]],
+            ['[1, 2, 3]', [1, 2, 3, 0]],
+            ['[1, 2, 3, 4]', [1, 2, 3, 4]],
+            ['[1, 2, 3, 4, 5]', [1, 2, 3, 4]],
+            ['[a]', ['a', 0, 0, 0]],
+            ['[a, b]', ['a', 'b', 0, 0]],
+            ['[a, b, c]', ['a', 'b', 'c', 0]],
+            ['[a, b, c, d]', ['a', 'b', 'c', 'd']],
+            ['[a, b, c, d, e]', ['a', 'b', 'c', 'd']],
+        ];
+        const tagCases = ['auxMeetPortalAnchorPoint', 'meetPortalAnchorPoint'];
+
+        describe.each(tagCases)('%s', (tag: string) => {
+            it.each(cases)(
+                'should support %s',
+                (mode: string, expected: any) => {
+                    const bot = createBot('test', {
+                        [tag]: <any>mode,
+                    });
+
+                    const calc = createPrecalculatedContext([bot]);
+
+                    expect(getBotMeetPortalAnchorPoint(calc, bot)).toEqual(
+                        expected
+                    );
+                }
+            );
+        });
+
+        it('should default to fullscreen', () => {
+            const bot = createBot();
+
+            const calc = createPrecalculatedContext([bot]);
+            const shape = getBotMeetPortalAnchorPoint(calc, bot);
+
+            expect(shape).toBe('fullscreen');
+        });
+    });
+
     describe('getAnchorPointOffset()', () => {
         const cases = [
             ['center', { x: 0, y: 0, z: 0 }],
@@ -1010,6 +1055,54 @@ export function botCalculationContextTests(
                     const calc = createPrecalculatedContext([bot]);
 
                     expect(getAnchorPointOffset(calc, bot)).toEqual(expected);
+                }
+            );
+        });
+
+        it('should default to bottom', () => {
+            const bot = createBot();
+
+            const calc = createPrecalculatedContext([bot]);
+            const offset = getAnchorPointOffset(calc, bot);
+
+            expect(offset).toEqual({
+                x: 0,
+                y: 0,
+                z: 0.5,
+            });
+        });
+    });
+
+    describe('getMeetPortalAnchorPointOffset()', () => {
+        const cases = [
+            [
+                'fullscreen',
+                { top: '0px', bottom: '0px', left: '0px', right: '0px' },
+            ],
+            [
+                '[1, 2, 3]',
+                { top: '1px', bottom: '3px', left: '0px', right: '2px' },
+            ],
+            [
+                '[1%, 2%, 3%]',
+                { top: '1%', bottom: '3%', left: '0px', right: '2%' },
+            ],
+        ];
+        const tagCases = ['auxMeetPortalAnchorPoint', 'meetPortalAnchorPoint'];
+
+        describe.each(tagCases)('%s', (tag: string) => {
+            it.each(cases)(
+                'should support %s',
+                (mode: string, expected: any) => {
+                    const bot = createBot('test', {
+                        [tag]: <any>mode,
+                    });
+
+                    const calc = createPrecalculatedContext([bot]);
+
+                    expect(
+                        getBotMeetPortalAnchorPointOffset(calc, bot)
+                    ).toEqual(expected);
                 }
             );
         });

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -989,6 +989,12 @@ export function botCalculationContextTests(
     describe('getMeetPortalAnchorPoint()', () => {
         const cases = [
             ['fullscreen', 'fullscreen'],
+            ['top', 'top'],
+            ['topRight', 'topRight'],
+            ['topLeft', 'topLeft'],
+            ['bottom', 'bottom'],
+            ['bottomRight', 'bottomRight'],
+            ['bottomLeft', 'bottomLeft'],
             ['[1]', [1, 0, 0, 0]],
             ['[1, 2]', [1, 2, 0, 0]],
             ['[1, 2, 3]', [1, 2, 3, 0]],
@@ -1086,6 +1092,71 @@ export function botCalculationContextTests(
             [
                 '[1%, 2%, 3%]',
                 { top: '1%', bottom: '3%', left: '0px', right: '2%' },
+            ],
+
+            [
+                'top',
+                {
+                    top: '0px',
+                    height: '25%',
+                    'min-height': '250px',
+                    left: '0px',
+                    right: '0px',
+                },
+            ],
+            [
+                'topRight',
+                {
+                    top: '25px',
+                    height: '25%',
+                    'min-height': '250px',
+                    width: '25%',
+                    'min-width': '250px',
+                    right: '25px',
+                },
+            ],
+            [
+                'topLeft',
+                {
+                    top: '25px',
+                    height: '25%',
+                    'min-height': '250px',
+                    width: '25%',
+                    'min-width': '250px',
+                    left: '25px',
+                },
+            ],
+            [
+                'bottom',
+                {
+                    bottom: '0px',
+                    height: '25%',
+                    'min-height': '250px',
+                    left: '0px',
+                    right: '0px',
+                },
+            ],
+            [
+                'bottomRight',
+                {
+                    bottom: '25px',
+                    height: '25%',
+                    'min-height': '250px',
+                    width: '25%',
+                    'min-width': '250px',
+                    right: '25px',
+                },
+            ],
+            [
+                'bottomLeft',
+                {
+                    bottom: '25px',
+                    height: '25%',
+                    'min-height': '250px',
+                    width: '25%',
+                    'min-width': '250px',
+                    left: '25px',
+                },
             ],
         ];
         const tagCases = ['auxMeetPortalAnchorPoint', 'meetPortalAnchorPoint'];

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2490,7 +2490,7 @@ declare global {
         showInput(
             currentValue?: any,
             options?: Partial<ShowInputOptions>
-        ): Promise<ShowInputAction>;
+        ): Promise<string>;
 
         /**
          * Shows a checkout screen that lets the user purchase something.

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -59,6 +59,7 @@ import BotSheet from '../../shared/vue-components/BotSheet/BotSheet';
 import { BotRenderer, getRenderer } from '../../shared/scene/BotRenderer';
 import UploadFiles from '../../shared/vue-components/UploadFiles/UploadFiles';
 import ShowInputModal from '../../shared/vue-components/ShowInputModal/ShowInputModal';
+import MeetPortal from '../../shared/vue-components/MeetPortal/MeetPortal';
 
 @Component({
     components: {
@@ -74,6 +75,7 @@ import ShowInputModal from '../../shared/vue-components/ShowInputModal/ShowInput
         'bot-sheet': BotSheet,
         'upload-files': UploadFiles,
         'show-input': ShowInputModal,
+        'meet-portal': MeetPortal,
         console: Console,
         tagline: Tagline,
         checkout: Checkout,

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -14,6 +14,7 @@
             <checkout></checkout>
             <bot-sheet></bot-sheet>
             <show-input></show-input>
+            <meet-portal></meet-portal>
 
             <md-dialog :md-active.sync="showQRCode" class="qr-code-dialog">
                 <div class="qr-code-container">

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
@@ -1,0 +1,93 @@
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { EventEmitter } from 'events';
+import { Prop } from 'vue-property-decorator';
+
+declare var JitsiMeetExternalAPI: {
+    new (domain: string, options: JitsiMeetExternalAPIOptions): JitsiApi;
+};
+
+@Component({})
+export default class JitsiMeet extends Vue {
+    /**
+     * The domain used to build the conference URL.
+     */
+    @Prop({
+        default: 'meet.jit.si',
+    })
+    domain: string;
+
+    /**
+     * The options that should be used to join Jitsi.
+     */
+    @Prop({
+        default: {},
+    })
+    options: JitsiMeetExternalAPIOptions;
+
+    private _jitsiApi: JitsiApi;
+
+    mounted() {
+        this._loadScript('https://meet.jit.si/external_api.js', () => {
+            if (!JitsiMeetExternalAPI)
+                throw new Error('Jitsi Meet API not loaded');
+            this._embedJitsiWidget();
+        });
+    }
+
+    beforeDestroy() {
+        this._removeJitsiWidget();
+    }
+
+    executeCommand(command: string, ...value: any[]) {
+        this._jitsiApi.executeCommand(command, ...value);
+    }
+
+    private _embedJitsiWidget() {
+        const options = {
+            ...this.options,
+            parentNode: this.$refs.jitsiContainer as Element,
+        };
+        this._jitsiApi = new JitsiMeetExternalAPI(
+            this.domain,
+            options
+        ) as JitsiApi;
+    }
+
+    private _removeJitsiWidget() {
+        if (this._jitsiApi) this._jitsiApi.dispose();
+    }
+
+    private _loadScript(src: string, cb: () => any) {
+        const scriptEl = document.createElement('script');
+        scriptEl.src = src;
+        scriptEl.async = true;
+        document.querySelector('head').appendChild(scriptEl);
+        scriptEl.addEventListener('load', cb);
+    }
+}
+
+interface JitsiMeetExternalAPIOptions {
+    roomName?: string;
+    userInfo?: JitsiParticipant;
+    invitees?: JitsiParticipant[];
+    devices?: any;
+    onload?: () => void;
+    width?: number | string;
+    height?: number | string;
+    parentNode?: Element;
+    configOverwrite?: any;
+    interfaceConfigOverwrite?: any;
+    noSSL?: boolean;
+    jwt?: any;
+}
+
+interface JitsiParticipant {
+    email: string;
+    displayName: string;
+}
+
+interface JitsiApi extends EventEmitter {
+    executeCommand(command: string, ...args: any): void;
+    dispose(): void;
+}

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
@@ -52,6 +52,10 @@ export default class JitsiMeet extends Vue {
             this.domain,
             options
         ) as JitsiApi;
+
+        this._jitsiApi.on('readyToClose', () => {
+            this.$emit('closed');
+        });
     }
 
     private _removeJitsiWidget() {

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.vue
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.vue
@@ -1,0 +1,4 @@
+<template>
+    <div ref="jitsiContainer" style="height: 100%; width: 100%;"></div>
+</template>
+<script src="./JitsiMeet.ts"></script>

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/LICENSE
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 MYCURE Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/README.md
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/README.md
@@ -1,0 +1,156 @@
+# vue-jitsi-meet ![Deploy](https://github.com/mycurelabs/vue-jitsi-meet/workflows/Deploy/badge.svg)
+
+_Forked from https://github.com/mycurelabs/vue-jitsi-meet_
+
+Vue component for Jitsi Meet Web Integration via IFrame.
+
+> **NOTE:** Always refer to the official [Jitsi Meet IFrame API Docs](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe).
+
+# Installation
+
+**YARN**
+
+```bash
+$ yarn add @mycure/vue-jitsi-meet
+```
+
+**NPM**
+
+```bash
+$ npm install @mycure/vue-jitsi-meet
+```
+
+# Props
+
+| Prop    | Type   | Description                                                                                                                   |
+| ------- | ------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| domain  | String | The jitsi server domain                                                                                                       |
+| options | Object | Jitsi [Options](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#api--new-jitsimeetexternalapidomain-options) |
+
+# Usage
+
+```vue
+<template>
+    <vue-jitsi-meet
+        ref="jitsiRef"
+        domain="meet.jit.si"
+        :options="jitsiOptions"
+    ></vue-jitsi-meet>
+</template>
+
+<script>
+import { JitsiMeet } from '@mycure/vue-jitsi-meet';
+export default {
+    components: {
+        VueJitsiMeet: JitsiMeet,
+    },
+    computed: {
+        jitsiOptions() {
+            return {
+                roomName: 'some-room-name',
+                noSSL: false,
+                userInfo: {
+                    email: 'user@email.com',
+                    displayName: '',
+                },
+                configOverwrite: {
+                    enableNoisyMicDetection: false,
+                },
+                interfaceConfigOverwrite: {
+                    SHOW_JITSI_WATERMARK: false,
+                    SHOW_WATERMARK_FOR_GUESTS: false,
+                    SHOW_CHROME_EXTENSION_BANNER: false,
+                },
+                onload: this.onIFrameLoad,
+            };
+        },
+    },
+    methods: {
+        onIFrameLoad() {
+            // do stuff
+        },
+    },
+};
+</script>
+```
+
+# Domain, and Options
+
+This plugin supports all options available in the [Jitsi IFrame API Documentation](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#api--new-jitsimeetexternalapidomain-options).
+
+**Usage**
+
+Just bind the jitsi option object to the `options` property.
+
+```html
+<vue-jitsi-meet domain="meet.jit.si" :options="options" />
+```
+
+# Events
+
+**Methods**
+
+> `addEventListener(eventName, handler)`
+
+To create an event, you must specify a `ref` in the JitsiMeet component. This `ref` is required to access the methods in the JitMeet component.
+
+```html
+<vue-jitsi-meet ref="jitsiRef" :options="jitsiOptions" />
+```
+
+```javascript
+...
+computed: {
+  jitsiOptions () {
+    return {
+      ...
+      onload: this.onIFrameLoad
+    };
+  },
+},
+methods: {
+  // Setup events after the IFrame onload event
+  onIFrameLoad () {
+    this.$refs.jitsiRef.addEventListener('participantJoined', this.onParticipantJoined);
+  },
+  onParticipantJoined (e) {
+    // do stuff
+  },
+}
+...
+```
+
+# Execute Command
+
+[Commands Documentation](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#controlling-the-embedded-jitsi-meet-conference);
+
+**Methods**
+
+> `executeCommand(commandName, arg1, arg2, ...args)`
+
+Control the embedded JitsiMeet conference using the `executeCommand` method. Similar to the [events](#events), this can also be achieved using `ref`.
+
+```html
+<vue-jitsi-meet ref="jitsiRef" :options="jitsiOptions" />
+```
+
+```javascript
+...
+computed: {
+  jitsiOptions () {
+    return {
+      ...
+      onload: this.onIFrameLoad
+    };
+  },
+},
+methods: {
+  // Execute commands after the IFrame onload event
+  // or at any given action by the user.
+  onIFrameLoad () {
+    // This will load the 'The display name' value using the `displayName` command.
+    this.$refs.jitsiRef.executeCommand('displayName', 'The display name');
+  },
+}
+...
+```

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
@@ -6,5 +6,5 @@
     right: 0;
     width: 100%;
     height: 100%;
-    z-index: 1;
+    z-index: 3;
 }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
@@ -1,0 +1,10 @@
+.meet-portal {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
@@ -1,10 +1,8 @@
 .meet-portal {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
     z-index: 3;
+}
+
+.meet-portal.invisible {
+    display: none;
 }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -8,6 +8,7 @@ import {
     MEET_PORTAL,
     PrecalculatedBot,
     calculateBotValue,
+    calculateStringTagValue,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../AppManager';
 import { SubscriptionLike, Subscription, Observable } from 'rxjs';
@@ -66,6 +67,16 @@ export default class MeetPortal extends Vue {
         }
     }
 
+    onClose() {
+        if (this._currentSim) {
+            this._currentSim.helper.updateBot(this._currentSim.helper.userBot, {
+                tags: {
+                    [MEET_PORTAL]: null,
+                },
+            });
+        }
+    }
+
     private _onSimulationAdded(sim: BrowserSimulation) {
         let sub = new Subscription();
         this._simulations.set(sim, sub);
@@ -97,7 +108,7 @@ export default class MeetPortal extends Vue {
     }
 
     private _onUserBotUpdated(sim: BrowserSimulation, user: PrecalculatedBot) {
-        const portal = calculateBotValue(null, user, MEET_PORTAL);
+        const portal = calculateStringTagValue(null, user, MEET_PORTAL, null);
         if (hasValue(portal)) {
             this._portals.set(sim, portal);
         } else {

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -1,0 +1,127 @@
+import Vue, { ComponentOptions } from 'vue';
+import Component from 'vue-class-component';
+import { Provide, Prop, Inject, Watch } from 'vue-property-decorator';
+import {
+    Bot,
+    hasValue,
+    BotTags,
+    MEET_PORTAL,
+    PrecalculatedBot,
+    calculateBotValue,
+} from '@casual-simulation/aux-common';
+import { appManager } from '../../AppManager';
+import { SubscriptionLike, Subscription, Observable } from 'rxjs';
+import JitsiMeet from '../JitsiMeet/JitsiMeet';
+import { Simulation } from '@casual-simulation/aux-vm';
+import { tap } from 'rxjs/operators';
+import {
+    BotManager,
+    watchPortalConfigBot,
+    BrowserSimulation,
+    userBotChanged,
+} from '@casual-simulation/aux-vm-browser';
+
+@Component({
+    components: {
+        'jitsi-meet': JitsiMeet,
+    },
+})
+export default class MeetPortal extends Vue {
+    private _sub: Subscription;
+    private _simulations: Map<Simulation, Subscription> = new Map();
+    private _portals: Map<Simulation, string> = new Map();
+
+    private _currentSim: Simulation;
+
+    currentMeet: string = null;
+    get hasPortal(): boolean {
+        return hasValue(this.currentMeet);
+    }
+
+    constructor() {
+        super();
+    }
+
+    created() {
+        this._sub = new Subscription();
+        this._simulations = new Map();
+        this._portals = new Map();
+
+        this._sub.add(
+            appManager.simulationManager.simulationAdded
+                .pipe(tap(sim => this._onSimulationAdded(sim)))
+                .subscribe()
+        );
+        this._sub.add(
+            appManager.simulationManager.simulationRemoved
+                .pipe(tap(sim => this._onSimulationRemoved(sim)))
+                .subscribe()
+        );
+    }
+
+    beforeDestroy() {
+        if (this._sub) {
+            this._sub.unsubscribe();
+            this._sub = null;
+        }
+    }
+
+    private _onSimulationAdded(sim: BrowserSimulation) {
+        let sub = new Subscription();
+        this._simulations.set(sim, sub);
+
+        sub.add(
+            userBotChanged(sim)
+                .pipe(tap(user => this._onUserBotUpdated(sim, user)))
+                .subscribe()
+        );
+        sub.add(
+            watchPortalConfigBot(sim, MEET_PORTAL)
+                .pipe(
+                    tap(bot => {
+                        // TODO: Update options
+                    })
+                )
+                .subscribe()
+        );
+    }
+
+    private _onSimulationRemoved(sim: BrowserSimulation) {
+        const sub = this._simulations.get(sim);
+        if (sub) {
+            sub.unsubscribe();
+        }
+        this._simulations.delete(sim);
+        this._portals.delete(sim);
+        this._updateCurrentPortal();
+    }
+
+    private _onUserBotUpdated(sim: BrowserSimulation, user: PrecalculatedBot) {
+        const portal = calculateBotValue(null, user, MEET_PORTAL);
+        if (hasValue(portal)) {
+            this._portals.set(sim, portal);
+        } else {
+            this._portals.delete(sim);
+        }
+        this._updateCurrentPortal();
+    }
+
+    /**
+     * Updates the current simulation and portal.
+     */
+    private _updateCurrentPortal() {
+        // If the current sim still exists, then keep it.
+        if (this._currentSim && this._portals.has(this._currentSim)) {
+            return;
+        }
+
+        // Use the first meet
+        this._currentSim = null;
+        this.currentMeet = null;
+        for (let [sim, meet] of this._portals) {
+            this._currentSim = sim;
+            this.currentMeet = meet;
+            break;
+        }
+    }
+}

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -1,5 +1,10 @@
 <template>
-    <div v-if="hasPortal" class="meet-portal">
+    <div
+        v-if="hasPortal"
+        class="meet-portal"
+        :class="{ invisible: !portalVisible }"
+        :style="extraStyle"
+    >
         <jitsi-meet :options="{ roomName: currentMeet }" @closed="onClose"></jitsi-meet>
     </div>
 </template>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="hasPortal" class="meet-portal">
-        <jitsi-meet :options="{ roomName: currentMeet }"></jitsi-meet>
+        <jitsi-meet :options="{ roomName: currentMeet }" @closed="onClose"></jitsi-meet>
     </div>
 </template>
 <script src="./MeetPortal.ts"></script>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -1,0 +1,7 @@
+<template>
+    <div v-if="hasPortal" class="meet-portal">
+        <jitsi-meet :options="{ roomName: currentMeet }"></jitsi-meet>
+    </div>
+</template>
+<script src="./MeetPortal.ts"></script>
+<style src="./MeetPortal.css" scoped></style>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -1,0 +1,133 @@
+import {
+    isDimensionLocked,
+    DEFAULT_PORTAL_ZOOMABLE,
+    DEFAULT_PORTAL_PANNABLE,
+    hasValue,
+    calculateBotValue,
+    BotCalculationContext,
+    PrecalculatedBot,
+    calculateGridScale,
+    calculateBooleanTagValue,
+    calculateNumericalTagValue,
+    DEFAULT_PORTAL_ROTATABLE,
+    PortalPointerDragMode,
+    DEFAULT_PORTAL_POINTER_DRAG_MODE,
+    calculatePortalPointerDragMode,
+    getBotMeetPortalAnchorPointOffset,
+    DEFAULT_MEET_PORTAL_ANCHOR_POINT,
+    calculateMeetPortalAnchorPointOffset,
+} from '@casual-simulation/aux-common';
+import { Color } from 'three';
+import {
+    BrowserSimulation,
+    watchPortalConfigBot,
+} from '@casual-simulation/aux-vm-browser';
+import { tap } from 'rxjs/operators';
+import { SubscriptionLike, Subscription, Subject, Observable } from 'rxjs';
+import { merge } from 'lodash';
+
+/**
+ * Defines a class that is able to watch dimension confic bots and update values.
+ */
+export class MeetPortalConfig implements SubscriptionLike {
+    private _sub: Subscription;
+    private _portalTag: string;
+    private _visible: boolean;
+    private _style: Object;
+    private _updated: Subject<void>;
+
+    /**
+     * Gets whether the portal should be visible.
+     */
+    get visible(): boolean {
+        if (hasValue(this._visible)) {
+            return this._visible;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Gets the CSS style that should be applied.
+     */
+    get style(): Object {
+        if (hasValue(this._style)) {
+            return this._style;
+        }
+        return calculateMeetPortalAnchorPointOffset(
+            DEFAULT_MEET_PORTAL_ANCHOR_POINT
+        );
+    }
+
+    unsubscribe(): void {
+        this._sub.unsubscribe();
+    }
+
+    get closed(): boolean {
+        return this._sub.closed;
+    }
+
+    get portalTag() {
+        return this._portalTag;
+    }
+
+    get onUpdated(): Observable<void> {
+        return this._updated;
+    }
+
+    constructor(portalTag: string, simulation: BrowserSimulation) {
+        this._portalTag = portalTag;
+        this._updated = new Subject();
+        this._sub = watchPortalConfigBot(simulation, portalTag)
+            .pipe(
+                tap(update => {
+                    const bot = update;
+
+                    if (bot) {
+                        const calc = simulation.helper.createContext();
+                        this._updatePortalValues(calc, bot, portalTag);
+                    } else {
+                        this._clearPortalValues();
+                    }
+                })
+            )
+            .subscribe();
+    }
+
+    protected _clearPortalValues() {
+        this._visible = null;
+        this._style = null;
+        this._updated.next();
+    }
+
+    protected _updatePortalValues(
+        calc: BotCalculationContext,
+        bot: PrecalculatedBot,
+        portalTag: string
+    ) {
+        this._visible = calculateBooleanTagValue(
+            calc,
+            bot,
+            'auxMeetPortalVisible',
+            null
+        );
+        this._style = calculateBotValue(calc, bot, 'meetPortalStyle');
+        if (typeof this._style !== 'object') {
+            this._style = null;
+        }
+        const anchorPoint = calculateBotValue(
+            calc,
+            bot,
+            'auxMeetPortalAnchorPoint'
+        );
+
+        if (hasValue(anchorPoint)) {
+            if (!this._style) {
+                this._style = {};
+            }
+            const offset = getBotMeetPortalAnchorPointOffset(calc, bot);
+            merge(this._style, offset);
+        }
+        this._updated.next();
+    }
+}

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.css
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.css
@@ -18,6 +18,10 @@
     transition-duration: 0.1s, 0.1s;
 }
 
+.input-dialog .md-dialog-title {
+    display: inline-block;
+}
+
 .color-picker-advanced {
     margin: auto;
 }

--- a/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/ShowInputModal/ShowInputModal.vue
@@ -5,46 +5,50 @@
             @md-closed="saveInputDialog()"
             @md-opened="autoFocusInputDialog()"
             class="input-dialog"
-            :style="{
-                'background-color': backgroundColor,
-                color: labelColor,
-            }"
         >
-            <md-dialog-title v-show="currentLabel">{{ currentLabel }}</md-dialog-title>
-            <md-dialog-content class="input-dialog-content">
-                <md-field>
-                    <label :style="{ color: labelColor }">{{ currentPlaceholder }}</label>
-                    <md-input
-                        v-model="currentValue"
-                        @keyup.enter="saveInputDialog()"
-                        ref="inputModalField"
-                        style="-webkit-text-fill-color: inherit;"
-                        :style="{ color: labelColor }"
-                    ></md-input>
-                </md-field>
-                <div class="input-dialog-color-tools" v-if="currentType === 'color'">
-                    <color-picker-swatches
-                        v-if="currentSubtype === 'swatch'"
-                        :value="currentValue"
-                        @input="updateInputDialogColor"
-                        :disableAlpha="true"
-                    ></color-picker-swatches>
-                    <color-picker-advanced
-                        v-else-if="currentSubtype === 'advanced'"
-                        :value="currentValue"
-                        @input="updateInputDialogColor"
-                        class="color-picker-advanced"
-                        :disableAlpha="true"
-                    ></color-picker-advanced>
-                    <color-picker-basic
-                        v-else
-                        :value="currentValue"
-                        @input="updateInputDialogColor"
-                        class="color-picker-basic"
-                        :disableAlpha="true"
-                    ></color-picker-basic>
-                </div>
-            </md-dialog-content>
+            <div
+                class="input-dialog-container"
+                :style="{
+                    'background-color': backgroundColor,
+                    color: labelColor,
+                }"
+            >
+                <md-dialog-title v-show="currentLabel">{{ currentLabel }}</md-dialog-title>
+                <md-dialog-content class="input-dialog-content">
+                    <md-field>
+                        <label :style="{ color: labelColor }">{{ currentPlaceholder }}</label>
+                        <md-input
+                            v-model="currentValue"
+                            @keyup.enter="saveInputDialog()"
+                            ref="inputModalField"
+                            style="-webkit-text-fill-color: inherit;"
+                            :style="{ color: labelColor }"
+                        ></md-input>
+                    </md-field>
+                    <div class="input-dialog-color-tools" v-if="currentType === 'color'">
+                        <color-picker-swatches
+                            v-if="currentSubtype === 'swatch'"
+                            :value="currentValue"
+                            @input="updateInputDialogColor"
+                            :disableAlpha="true"
+                        ></color-picker-swatches>
+                        <color-picker-advanced
+                            v-else-if="currentSubtype === 'advanced'"
+                            :value="currentValue"
+                            @input="updateInputDialogColor"
+                            class="color-picker-advanced"
+                            :disableAlpha="true"
+                        ></color-picker-advanced>
+                        <color-picker-basic
+                            v-else
+                            :value="currentValue"
+                            @input="updateInputDialogColor"
+                            class="color-picker-basic"
+                            :disableAlpha="true"
+                        ></color-picker-basic>
+                    </div>
+                </md-dialog-content>
+            </div>
         </md-dialog>
     </div>
 </template>

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.ts
@@ -145,7 +145,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
         let events = [] as AddBotAction[];
         for (let i = 0; i < localStorage.length; i++) {
             const key = localStorage.key(i);
-            if (key.startsWith(this.namespace)) {
+            if (key.startsWith(this.namespace + '/')) {
                 // it is a bot
                 events.push(botAdded(getStoredBot(key)));
             }
@@ -243,7 +243,7 @@ function storedBotUpdated(
     namespace: string
 ): Observable<AddBotAction | RemoveBotAction | UpdateBotAction> {
     return storageUpdated().pipe(
-        filter(e => e.key.startsWith(namespace)),
+        filter(e => e.key.startsWith(namespace + '/')),
         map(e => {
             const newBot: Bot = JSON.parse(e.newValue) || null;
             const oldBot: Bot = JSON.parse(e.oldValue) || null;


### PR DESCRIPTION
-   :rocket: Improvements

    -   Added the `meetPortal`.
        -   This is a special portal that, instead of loading bots, loads a [Jitsi Meet](https://meet.jit.si/) meeting with the given room code.
        -   All rooms are publicly accessible (but not searchable), so longer room codes will be more private.
        -   You can use the `meetPortalConfigBot` option to reference the bot that should be used to configure the meet portal.
        -   The following options are available:
            -   `meetPortalVisible` - Whether the meet portal should be visible. This allows you to be joined to a meet while keeping your screen on the page portal. (Defaults to true)
            -   `meetPortalAnchorPoint` - The anchor point that the meet portal should use. Possible options are:
                -   `fullscreen` - The meet portal should take the entire screen. (Default)
                -   `top` - The meet portal should take the top of the screen.
                -   `topRight` - The meet portal should take the top-right corner of the screen.
                -   `topLeft` - The meet portal should take the top-left corner of the screen.
                -   `bottom` - The meet portal should take the bottom of the screen.
                -   `bottomRight` - The meet portal should take the bottom-right corner of the screen.
                -   `bottomLeft` - The meet portal should take the bottom-left corner of the screen.
                -   `[top, right, bottom, left]` - The meet portal should use the given values for the CSS top, right, bottom, and left properties respectively.
            -   `meetPortalStyle` - The CSS style that should be applied to the meet portal container.
                -   Should be a JavaScript object.
                -   Each property on the object will map directly to a CSS property.
                -   Useful for moving the meet portal to arbitrary positions.

-   :bug: Bug Fixes

    -   Fixed an issue where local bots from other stories would be loaded if the current story name happened to be a prefix of the other story name.
    -   Fixed the input modal background.
    -   Fixed the TypeScript definitions for the `player.showInput()` function.