### PR TITLE
Improve the meet portal positioning and add remote shouts/whispers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CasualOS Changelog
 
+## V1.1.14
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+
+    -   Improved how the meet portal, page portal, and sheet portal work together to make space for each other.
+    -   Added the `left` and `right` options for `meetPortalAnchorPoint`.
+    -   Changed the `top` and `bottom` options for `meetPortalAnchorPoint` to occupy half of the screen.
+
 ## V1.1.13
 
 ### Date: 6/25/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@
     -   Improved how the meet portal, page portal, and sheet portal work together to make space for each other.
     -   Added the `left` and `right` options for `meetPortalAnchorPoint`.
     -   Changed the `top` and `bottom` options for `meetPortalAnchorPoint` to occupy half of the screen.
+    -   Added the `server.players()` function to get the list of player IDs that are connected to the current story.
+        -   Returns a promise that resolves with the list of player IDs.
+    -   Added the `remoteWhisper(players, name, arg)` function to make sending messages to other players easy.
+        -   Takes the following arguments:
+            -   `players` is the player ID or list of player IDs that should receive the shout.
+            -   `name` is the name of the message.
+            -   `arg` is the data that should be included.
+        -   This will trigger a `@onRemoteWhisper` shout on all the specified players.
+    -   Added the `remoteShout(name, arg)` function to make sending messages to all players easy.
+        -   Takes the following arguments:
+            -   `name` is the name of the message.
+            -   `arg` is the data that should be included.
+    -   Added the `@onRemoteWhisper` listen tag that is shouted when a `remoteWhisper()` or `remoteShout()` is sent to the local player.
+
+        -   `that` is an object with the following properties: - `name` - The name of the shout that was sent. - `that` - The data which was sent. - `playerId` - The ID of the player that sent the shout.
 
 ## V1.1.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
             -   `that` - The data which was sent.
             -   `playerId` - The ID of the player that sent the shout.
 
+-   Bug Fixes
+    -   Fixed an issue that prevented using `lineStyle` in place of `auxLineStyle`.
+
 ## V1.1.13
 
 ### Date: 6/25/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@
             -   `name` is the name of the message.
             -   `arg` is the data that should be included.
     -   Added the `@onRemoteWhisper` listen tag that is shouted when a `remoteWhisper()` or `remoteShout()` is sent to the local player.
-
-        -   `that` is an object with the following properties: - `name` - The name of the shout that was sent. - `that` - The data which was sent. - `playerId` - The ID of the player that sent the shout.
+        -   `that` is an object with the following properties:
+            -   `name` - The name of the shout that was sent.
+            -   `that` - The data which was sent.
+            -   `playerId` - The ID of the player that sent the shout.
 
 ## V1.1.13
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -814,7 +814,7 @@ If you want to perform the action, you can use <ActionLink action='action.perfor
 The **first parameter** is the action to send.
 
 The **second parameter** is optional and is a object specifing which player to send the action to. If not specified, then the action is sent to the server player.
-If specified, then the action is sent to all players that match the given values.
+If specified, then the action is sent to all players that match the given values. If given a string, then the action is sent to the player with the matching ID.
 
 #### Examples:
 
@@ -829,9 +829,58 @@ const toastAction = player.toast('My message!');
 // Send the action to the other player
 // The toastAction will not be performed locally because
 // it is being sent to another player.
-remote(toastAction, {
-    session: otherPlayerBotId
-});
+remote(toastAction, otherPlayerBotId);
+```
+
+### `remoteWhisper(playerId, name, arg?)`
+
+Sends a <TagLink tag='@onRemoteWhisper'/> shout to the player with the given ID or players if given a list of IDs.
+This is useful for sending arbitrary messages to specific players.
+
+The **first parameter** is the player ID or list of player IDs that the shout should be sent to.
+
+The **second parameter** is the name of the event that is being sent. This is useful for telling the difference between different messages.
+
+The **third parameter** is optional and is the `that` argument to send with the shout. You do not need to specify this parameter if you do not want to.
+
+#### Examples:
+
+1. Send a "custom" message to another player.
+```typescript
+const otherPlayerBotId = "otherPlayerBotId";
+
+// The other player will receive a @onRemoteWhisper with 
+// that.name === "custom" and that.that === "Hello"
+remoteWhisper(otherPlayerBotId, "custom", "Hello");
+```
+
+2. Send a message to all other players.
+```typescript
+const players = await server.players();
+const playerId = getID(player.getBot());
+const otherPlayers = players.filter(id => id !== playerId);
+
+// All other players will receive a @onRemoteWhisper with
+// that.name === "custom" and that.that === "Hello"
+remoteWhisper(otherPlayers, "custom", "Hello");
+```
+
+### `remoteShout(name, arg?)`
+
+Sends a <TagLink tag='@onRemoteWhisper'/> shout to all the players in the current story.
+The listener will be triggered on all players connected to the story, including the local player.
+
+The **first parameter** is the name of the message that is being sent. This is useful for telling the difference between different messages.
+
+The **second parameter** is optional and is the `that` argument to send with the shout. You do not need to specify this parameter if you do not want to.
+
+#### Examples:
+
+1. Send a message to all players.
+```typescript
+// All players will receive a @onRemoteWhisper with
+// that.name === "custom" and that.that === "Hello"
+remoteShout("custom", "Hello");
 ```
 
 ### `action.perform(action)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2333,6 +2333,22 @@ const stories = await server.stories();
 player.toast("Stories " + stories.join(','));
 ```
 
+### `server.players()`
+
+Gets the list of player IDs that are connected to the current story.
+Returns a promise that resolves with the list of player IDs.
+
+The resolved list will always have at least one value that represents the current player.
+
+#### Examples
+
+1. Get the list of player IDs.
+```typescript
+const players = await server.players();
+
+player.toast("Players " + players.join(','));
+```
+
 ## Utility Actions
 
 ### `setTag(bot, tag, value)`

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -851,3 +851,43 @@ let that: {
   action: any
 };
 ```
+
+### `@onRemoteWhisper`
+
+A shout that is sent whenever a message is received from another player.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The name of the message.
+     */
+    name: string,
+
+    /**
+     * The argument that was included in the message.
+     */
+    that: any,
+
+    /**
+     * The ID of the player that sent the message.
+     */
+    playerId: string
+};
+```
+
+#### Examples:
+
+1. Show a toast when a "custom" message is received.
+```typescript
+if (that.name === "custom") {
+    player.toast("Got message from " + that.playerId + " with " + that.that);
+}
+```
+
+2. Send a message back to the player that sent the message.
+```typescript
+if (that.name === "hello") {
+    remoteWhisper(that.playerId, "hi");
+}
+```

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1175,6 +1175,12 @@ Overrides any conflicting properties set by <TagLink tag='meetPortalStyle'/>.
   <PossibleValueCode value='bottomLeft'>
     The meet portal will occupy the bottom-left corner of the screen.
   </PossibleValueCode>
+  <PossibleValueCode value='left'>
+    The meet portal will occupy the left side of the screen.
+  </PossibleValueCode>
+  <PossibleValueCode value='right'>
+    The meet portal will occupy the right side of the screen.
+  </PossibleValueCode>
   <PossibleValueCode value='[top, right, bottom, left]'>
     The meet portal will use the given values for the CSS [top](https://developer.mozilla.org/en-US/docs/Web/CSS/top),
     [right](https://developer.mozilla.org/en-US/docs/Web/CSS/right), [left](https://developer.mozilla.org/en-US/docs/Web/CSS/left),

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -135,10 +135,10 @@ The mode that controls how a bot can be dragged.
     The bot cannot be dragged.
   </PossibleValueCode>
   <PossibleValueCode value='moveOnly'>
-    The bot can be moved anywhere within the dimension it is currently in but not moved to another dimension. (only applies to AUXPlayer)
+    The bot can be moved anywhere within the dimension it is currently in but not moved to another dimension.
   </PossibleValueCode>
   <PossibleValueCode value='pickupOnly'>
-    The bot can be moved to another dimension but not within the dimension it is currently in. (only applies to AUXPlayer)
+    The bot can be moved to another dimension but not within the dimension it is currently in.
   </PossibleValueCode>
 </PossibleValuesTable>
 
@@ -194,16 +194,16 @@ Bots that are focusable can receive focus events like <TagLink tag='@onFocusEnte
 
 ### `destroyable`
 
-Whether the bot is able to be destroyed in AUXPlayer. The bot can still be destroyed in Channel Designer.
+Whether the bot is able to be destroyed.
 
 #### Possible values are:
 
 <PossibleValuesTable>
   <PossibleValueCode value='true'>
-    The bot will allow destruction events to occur outside Channel Designer. (default)
+    The bot will be able to be destroyed. (default)
   </PossibleValueCode>
   <PossibleValueCode value='false'>
-    The bot will not allow destruction events to occur to it outside of Channel Designer.
+    The bot will not be able to be destroyed.
   </PossibleValueCode>
 </PossibleValuesTable>
 
@@ -849,7 +849,7 @@ These tags are used to configure portals.
   <VideoBadge url='https://youtu.be/mbUHq94OGEg' />
 </Badges>
 
-The color of the background of the portal in AUXPlayer.
+The color of the background of the portal.
 
 #### Possible values are:
 <PossibleValuesTable>
@@ -861,15 +861,15 @@ The color of the background of the portal in AUXPlayer.
 
 ### `portalLocked`
 
-Determines if the portal can be loaded in AUXPlayer.
+Determines if the portal can be loaded.
 
 #### Possible values are:
 <PossibleValuesTable>
   <PossibleValueCode value='true'>
-    The portal can be loaded in AUXPlayer. (Default)
+    The portal can be loaded. (Default)
   </PossibleValueCode>
   <PossibleValueCode value='false'>
-    The portal cannot be loaded in AUXPlayer.
+    The portal cannot be loaded.
   </PossibleValueCode>
 </PossibleValuesTable>
 
@@ -1296,7 +1296,7 @@ It also means that putting `inventoryPortal=myDimension` into the query string w
   <UserBotBadge/>
 </Badges>
 
-The story that is loaded into auxPlayer.
+The story that is loaded into CasualOS.
 
 ### `pagePortal`
 
@@ -1304,7 +1304,7 @@ The story that is loaded into auxPlayer.
   <UserBotBadge/>
 </Badges>
 
-The dimension that is loaded into the "page" portal in auxPlayer.
+The dimension that is loaded into the "page" portal in CasualOS.
 Only available on the player bot.
 
 ### `sheetPortal`
@@ -1313,7 +1313,7 @@ Only available on the player bot.
   <UserBotBadge/>
 </Badges>
 
-The dimension that is loaded into the "sheet" portal in auxPlayer.
+The dimension that is loaded into the "sheet" portal in CasualOS.
 Only available on the player bot.
 
 ### `inventoryPortal`
@@ -1322,7 +1322,7 @@ Only available on the player bot.
   <UserBotBadge/>
 </Badges>
 
-The dimension that is loaded into the "inventory" portal in auxPlayer.
+The dimension that is loaded into the "inventory" portal in CasualOS.
 Only available on the player bot.
 
 ### `menuPortal`
@@ -1331,7 +1331,7 @@ Only available on the player bot.
   <UserBotBadge/>
 </Badges>
 
-The dimension that is loaded into the "menu" portal in auxPlayer.
+The dimension that is loaded into the "menu" portal in CasualOS.
 Only available on the player bot.
 
 ### `leftWristPortal`
@@ -1362,6 +1362,134 @@ The [Jitsi Meet](https://meet.jit.si/) room code of the meeting that should be j
 This will join the current tab to the meeting and provide audiovisual communication between everyone that is joined.
 
 This is similar to a Skype or Zoom call except that all data is encrypted and is deleted once you are done with it. Check out the Jitsi Meet privacy policy [here](https://jitsi.org/meet-jit-si-privacy/).
+
+Only available on the player bot.
+
+### `pagePortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='pagePortal'>page portal</TagLink>.
+
+Supports the following tags:
+
+- <TagLink tag='portalColor'/>
+- <TagLink tag='portalLocked'/>
+- <TagLink tag='portalPannable'/>
+- <TagLink tag='portalPannableMinX'/>
+- <TagLink tag='portalPannableMaxX'/>
+- <TagLink tag='portalPannableMinY'/>
+- <TagLink tag='portalPannableMaxY'/>
+- <TagLink tag='portalRotatable'/>
+- <TagLink tag='portalPlayerRotationX'/>
+- <TagLink tag='portalPlayerRotationY'/>
+- <TagLink tag='portalZoomable'/>
+- <TagLink tag='portalGridScale'/>
+- <TagLink tag='portalSurfaceScale'/>
+- <TagLink tag='portalPointerDragMode'/>
+- <TagLink tag='portalShowFocusPoint'/>
+- <TagLink tag='portalDisableCanvasTransparency'/>
+
+Only available on the player bot.
+
+### `sheetPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='sheetPortal'>sheet portal</TagLink>.
+
+Currently not used. Only available on the player bot.
+
+### `inventoryPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='inventoryPortal'>inventory portal</TagLink>.
+
+Supports the following tags:
+
+- <TagLink tag='portalColor'/>
+- <TagLink tag='portalLocked'/>
+- <TagLink tag='portalPannable'/>
+- <TagLink tag='portalPannableMinX'/>
+- <TagLink tag='portalPannableMaxX'/>
+- <TagLink tag='portalPannableMinY'/>
+- <TagLink tag='portalPannableMaxY'/>
+- <TagLink tag='portalRotatable'/>
+- <TagLink tag='portalPlayerRotationX'/>
+- <TagLink tag='portalPlayerRotationY'/>
+- <TagLink tag='portalZoomable'/>
+- <TagLink tag='portalGridScale'/>
+- <TagLink tag='portalSurfaceScale'/>
+- <TagLink tag='portalPointerDragMode'/>
+- <TagLink tag='inventoryPortalHeight'/>
+- <TagLink tag='inventoryPortalResizable'/>
+
+Only available on the player bot.
+
+### `menuPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='menuPortal'>menu portal</TagLink>.
+
+Currently not used. Only available on the player bot.
+
+### `leftWristPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='leftWristPortal'>left wrist portal</TagLink>.
+
+Supports the following tags:
+
+- <TagLink tag='portalGridScale'/>
+- <TagLink tag='portalSurfaceScale'/>
+- <TagLink tag='wristPortalHeight'/>
+- <TagLink tag='wristPortalWidth'/>
+
+Only available on the player bot.
+
+### `rightWristPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='rightWristPortal'>right wrist portal</TagLink>.
+
+Supports the following tags:
+
+- <TagLink tag='portalGridScale'/>
+- <TagLink tag='portalSurfaceScale'/>
+- <TagLink tag='wristPortalHeight'/>
+- <TagLink tag='wristPortalWidth'/>
+
+Only available on the player bot.
+
+### `meetPortalConfigBot`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The ID of the bot that should be used to configure the <TagLink tag='meetPortal'>meet portal</TagLink>.
+
+Supports the following tags:
+
+- <TagLink tag='meetPortalVisible'/>
+- <TagLink tag='meetPortalAnchorPoint'/>
+- <TagLink tag='meetPortalStyle'/>
 
 Only available on the player bot.
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -752,6 +752,11 @@ export const ON_SHOUT_ACTION_NAME: string = 'onListen';
 export const ON_ACTION_ACTION_NAME: string = 'onStoryAction';
 
 /**
+ * The name of the event that is triggered when a remote whisper is executed.
+ */
+export const ON_REMOTE_WHISPER_ACTION_NAME: string = 'onRemoteWhisper';
+
+/**
  * The name of the event that is triggered when a channel becomes synced.
  */
 export const ON_STORY_STREAMING_ACTION_NAME: string = 'onStoryStreaming';
@@ -1082,6 +1087,7 @@ export const KNOWN_TAGS: string[] = [
     'onWebhook',
     'onAnyListen',
     'onListen',
+    ON_REMOTE_WHISPER_ACTION_NAME,
     ON_ACTION_ACTION_NAME,
     ON_RUN_ACTION_NAME,
     ON_CHAT_TYPING_ACTION_NAME,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -337,6 +337,8 @@ export type MeetPortalAnchorPoint =
     | 'bottom'
     | 'bottomRight'
     | 'bottomLeft'
+    | 'left'
+    | 'right'
     | [number | string]
     | [number | string, number | string]
     | [number | string, number | string, number | string]

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1351,6 +1351,8 @@ const possibleMeetPortalAnchorPoints = new Set([
     'bottom',
     'bottomRight',
     'bottomLeft',
+    'left',
+    'right',
 ] as const);
 
 /**
@@ -1421,7 +1423,7 @@ export function calculateMeetPortalAnchorPointOffset(
         if (anchorPoint === 'top') {
             return {
                 top: '0px',
-                height: '25%',
+                height: '50%',
                 'min-height': '250px',
                 left: '0px',
                 right: '0px',
@@ -1447,7 +1449,7 @@ export function calculateMeetPortalAnchorPointOffset(
         } else if (anchorPoint === 'bottom') {
             return {
                 bottom: '0px',
-                height: '25%',
+                height: '50%',
                 'min-height': '250px',
                 left: '0px',
                 right: '0px',
@@ -1469,6 +1471,24 @@ export function calculateMeetPortalAnchorPointOffset(
                 width: '25%',
                 'min-width': '250px',
                 left: '25px',
+            };
+        } else if (anchorPoint === 'left') {
+            return {
+                bottom: '25px',
+                height: '100%',
+                'min-height': '250px',
+                width: '50%',
+                'min-width': '250px',
+                left: '0px',
+            };
+        } else if (anchorPoint === 'right') {
+            return {
+                bottom: '25px',
+                height: '100%',
+                'min-height': '250px',
+                width: '50%',
+                'min-width': '250px',
+                right: '0px',
             };
         } else {
             return {

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -783,6 +783,13 @@ export interface GetStoriesAction extends Action {
 }
 
 /**
+ * Defines an event that is used to get the list of players on the server.
+ */
+export interface GetPlayersAction extends Action {
+    type: 'get_players';
+}
+
+/**
  * Defines an event that is used to send the player to a dimension.
  */
 export interface GoToDimensionAction extends Action {
@@ -1927,6 +1934,15 @@ export function getPlayerCount(story?: string): GetPlayerCountAction {
 export function getStories(): GetStoriesAction {
     return {
         type: 'get_stories',
+    };
+}
+
+/**
+ * Creates a new GetPlayersAction.
+ */
+export function getPlayers(): GetPlayersAction {
+    return {
+        type: 'get_players',
     };
 }
 

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -1098,7 +1098,7 @@ export function botCalculationContextTests(
                 'top',
                 {
                     top: '0px',
-                    height: '25%',
+                    height: '50%',
                     'min-height': '250px',
                     left: '0px',
                     right: '0px',
@@ -1130,7 +1130,7 @@ export function botCalculationContextTests(
                 'bottom',
                 {
                     bottom: '0px',
-                    height: '25%',
+                    height: '50%',
                     'min-height': '250px',
                     left: '0px',
                     right: '0px',
@@ -1156,6 +1156,28 @@ export function botCalculationContextTests(
                     width: '25%',
                     'min-width': '250px',
                     left: '25px',
+                },
+            ],
+            [
+                'left',
+                {
+                    bottom: '25px',
+                    height: '100%',
+                    'min-height': '250px',
+                    width: '50%',
+                    'min-width': '250px',
+                    left: '0px',
+                },
+            ],
+            [
+                'right',
+                {
+                    bottom: '25px',
+                    height: '100%',
+                    'min-height': '250px',
+                    width: '50%',
+                    'min-width': '250px',
+                    right: '0px',
                 },
             ],
         ];

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
@@ -42,6 +42,7 @@ import {
     getPlayerCount,
     getStories,
     BotActions,
+    getPlayers,
 } from '../bots';
 import { AuxOpType, bot, tag, value, AuxCausalTree } from '../aux-format-2';
 import { RemoteCausalRepoPartitionConfig } from './AuxPartitionConfig';
@@ -525,6 +526,36 @@ describe('RemoteCausalRepoPartition', () => {
                     expect(events).toEqual([
                         asyncResult('task1', ['abc', 'def']),
                     ]);
+                });
+            });
+
+            describe('get_players', () => {
+                it('should not send a get_players event to the server', async () => {
+                    setupPartition({
+                        type: 'remote_causal_repo',
+                        branch: 'testBranch',
+                        host: 'testHost',
+                    });
+                    partition.connect();
+
+                    await partition.sendRemoteEvents([
+                        remote(getPlayers(), undefined, undefined, 'task1'),
+                    ]);
+
+                    await waitAsync();
+
+                    expect(connection.sentMessages).not.toContainEqual({
+                        name: SEND_EVENT,
+                        data: {
+                            branch: 'testBranch',
+                            action: remote(
+                                getPlayers(),
+                                undefined,
+                                undefined,
+                                'task1'
+                            ),
+                        },
+                    });
                 });
             });
         });

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
@@ -44,6 +44,7 @@ import {
     BotActions,
     getPlayers,
     action,
+    ON_REMOTE_WHISPER_ACTION_NAME,
 } from '../bots';
 import { AuxOpType, bot, tag, value, AuxCausalTree } from '../aux-format-2';
 import { RemoteCausalRepoPartitionConfig } from './AuxPartitionConfig';
@@ -587,7 +588,7 @@ describe('RemoteCausalRepoPartition', () => {
                     await waitAsync();
 
                     expect(events).toEqual([
-                        action('onRemoteWhisper', null, null, {
+                        action(ON_REMOTE_WHISPER_ACTION_NAME, null, null, {
                             name: 'eventName',
                             that: { abc: 'def' },
                             playerId: 'info1SessionId',
@@ -620,7 +621,7 @@ describe('RemoteCausalRepoPartition', () => {
                     await waitAsync();
 
                     expect(events).toEqual([
-                        action('onRemoteWhisper', null, null, {
+                        action(ON_REMOTE_WHISPER_ACTION_NAME, null, null, {
                             name: 'eventName',
                             that: { abc: 'def' },
                             playerId: 'info1SessionId',

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -39,6 +39,7 @@ import {
     GetStoriesAction,
     action,
     ShoutAction,
+    ON_REMOTE_WHISPER_ACTION_NAME,
 } from '../bots';
 import flatMap from 'lodash/flatMap';
 import {
@@ -391,14 +392,19 @@ export class RemoteCausalRepoPartitionImpl
                             const remoteAction = event.action
                                 .event as ShoutAction;
                             this._onEvents.next([
-                                action('onRemoteWhisper', null, null, {
-                                    name: remoteAction.eventName,
-                                    that: remoteAction.argument,
-                                    playerId:
-                                        event.action.device.claims[
-                                            SESSION_ID_CLAIM
-                                        ],
-                                }),
+                                action(
+                                    ON_REMOTE_WHISPER_ACTION_NAME,
+                                    null,
+                                    null,
+                                    {
+                                        name: remoteAction.eventName,
+                                        that: remoteAction.argument,
+                                        playerId:
+                                            event.action.device.claims[
+                                                SESSION_ID_CLAIM
+                                            ],
+                                    }
+                                ),
                             ]);
                         } else {
                             this._onEvents.next([event.action]);

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -217,6 +217,10 @@ export class RemoteCausalRepoPartitionImpl
                         this._onEvents.next([asyncError(event.taskId, err)]);
                     }
                 );
+            } else if (event.event.type === 'get_players') {
+                // Do nothing for get_players since it will be handled by the OtherPlayersPartition.
+                // TODO: Make this mechanism more extensible so that we don't have to hardcode for each time
+                //       we do this type of logic.
             } else {
                 this._client.sendEvent(this._branch, event);
             }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -65,6 +65,7 @@ import {
     unlockSpace,
     getPlayerCount,
     getStories,
+    getPlayers,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2617,6 +2618,30 @@ describe('AuxLibrary', () => {
             it('should create tasks that can be resolved from a remote', () => {
                 uuidMock.mockReturnValueOnce('uuid');
                 library.api.server.stories();
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
+            });
+        });
+
+        describe('server.players()', () => {
+            it('should emit a remote action with a get_players action', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                const action: any = library.api.server.players();
+                const expected = remote(
+                    getPlayers(),
+                    undefined,
+                    undefined,
+                    'uuid'
+                );
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.players();
 
                 const task = context.tasks.get('uuid');
                 expect(task.allowRemoteResolution).toBe(true);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -66,6 +66,7 @@ import {
     getPlayerCount,
     getStories,
     getPlayers,
+    action,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2677,6 +2678,80 @@ describe('AuxLibrary', () => {
                 });
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should use the given player ID as the session ID', () => {
+                const action = library.api.remote(
+                    library.api.player.toast('abc'),
+                    'abc'
+                );
+                const expected = remote(toast('abc'), {
+                    sessionId: 'abc',
+                });
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support multiple selectors to send the same event to multiple places', () => {
+                const action = library.api.remote(
+                    library.api.player.toast('abc'),
+                    [
+                        'abc',
+                        {
+                            session: 's',
+                            username: 'u',
+                            device: 'd',
+                        },
+                    ]
+                );
+                const expected = [
+                    remote(toast('abc'), {
+                        sessionId: 'abc',
+                    }),
+                    remote(toast('abc'), {
+                        sessionId: 's',
+                        username: 'u',
+                        deviceId: 'd',
+                    }),
+                ];
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual(expected);
+            });
+        });
+
+        describe('remoteWhisper()', () => {
+            it('should send a remote action with a @onPlayerWhisper shout', () => {
+                const actions = library.api.remoteWhisper(
+                    'playerId',
+                    'eventName'
+                );
+
+                const expected = remote(
+                    action('eventName', null, null, undefined),
+                    {
+                        sessionId: 'playerId',
+                    }
+                );
+                expect(actions).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support multiple player IDs', () => {
+                const actions = library.api.remoteWhisper(
+                    ['playerId1', 'playerId2'],
+                    'eventName'
+                );
+
+                const expected = [
+                    remote(action('eventName', null, null, undefined), {
+                        sessionId: 'playerId1',
+                    }),
+                    remote(action('eventName', null, null, undefined), {
+                        sessionId: 'playerId2',
+                    }),
+                ];
+                expect(actions).toEqual(expected);
+                expect(context.actions).toEqual(expected);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2692,6 +2692,20 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
+            it('should be able to broadcast to all players', () => {
+                const action = library.api.remote(
+                    library.api.player.toast('abc'),
+                    {
+                        broadcast: true,
+                    }
+                );
+                const expected = remote(toast('abc'), {
+                    broadcast: true,
+                });
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
             it('should support multiple selectors to send the same event to multiple places', () => {
                 const action = library.api.remote(
                     library.api.player.toast('abc'),
@@ -2720,7 +2734,7 @@ describe('AuxLibrary', () => {
         });
 
         describe('remoteWhisper()', () => {
-            it('should send a remote action with a @onPlayerWhisper shout', () => {
+            it('should send a remote action with a shout', () => {
                 const actions = library.api.remoteWhisper(
                     'playerId',
                     'eventName'
@@ -2752,6 +2766,21 @@ describe('AuxLibrary', () => {
                 ];
                 expect(actions).toEqual(expected);
                 expect(context.actions).toEqual(expected);
+            });
+        });
+
+        describe('remoteShout()', () => {
+            it('should send a remote action with a shout', () => {
+                const actions = library.api.remoteShout('eventName');
+
+                const expected = remote(
+                    action('eventName', null, null, undefined),
+                    {
+                        broadcast: true,
+                    }
+                );
+                expect(actions).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -82,6 +82,7 @@ import {
     unlockSpace,
     getPlayerCount,
     getStories,
+    getPlayers,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -368,6 +369,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 storyPlayerCount,
                 totalPlayerCount,
                 stories,
+                players,
             },
 
             action: {
@@ -1565,6 +1567,20 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const task = context.createTask(true, true);
         const event = calcRemote(
             getStories(),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the list of player IDs that are connected to the story.
+     */
+    function players(): Promise<string[]> {
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            getPlayers(),
             undefined,
             undefined,
             task.taskId

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -135,6 +135,7 @@ export interface SessionSelector {
     username?: string;
     device?: string;
     session?: string;
+    broadcast?: boolean;
 }
 
 /**
@@ -294,6 +295,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
             remote,
             remoteWhisper,
+            remoteShout,
             webhook,
 
             __energyCheck,
@@ -1651,6 +1653,21 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         return remote(action(name, null, null, arg), playerId);
     }
 
+    /**
+     * Sends the given shout to all players.
+     * The other players will recieve an onRemoteWhisper event for this whisper.
+     *
+     * In effect, this allows players to communicate with each other by sending arbitrary events.
+     *
+     * @param name The name of the event.
+     * @param arg The optional argument to include in the whisper.
+     */
+    function remoteShout(name: string, arg?: any) {
+        return remote(action(name, null, null, arg), {
+            broadcast: true,
+        });
+    }
+
     function webhook(options: WebhookOptions) {
         const task = context.createTask();
         const event = calcWebhook(<any>options, task.taskId);
@@ -2406,6 +2423,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                   sessionId: selector.session,
                   username: selector.username,
                   deviceId: selector.device,
+                  broadcast: selector.broadcast,
               }
             : undefined;
     }

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2605,6 +2605,11 @@ declare global {
          * Gets the list of stories that are on the server.
          */
         stories(): Promise<string[]>;
+
+        /**
+         * Gets the list of player IDs that are connected to the story.
+         */
+        players(): Promise<string[]>;
     
         /**
          * Loads a file from the server at the given path.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1879,9 +1879,21 @@ declare global {
      */
     function remote(
         event: BotAction,
-        selector?: SessionSelector,
+        selector?: SessionSelector | string | (SessionSelector | string)[],
         allowBatching?: boolean
-    ): RemoteAction;
+    ): RemoteAction | RemoteAction[];
+
+    /**
+     * Sends the given shout to the given player or list of players.
+     * The other players will recieve an onRemoteWhisper event for this whisper.
+     * 
+     * In effect, this allows players to communicate with each other by sending arbitrary events.
+     * 
+     * @param playerId The ID of the other player or players to whisper to.
+     * @param name The name of the event.
+     * @param arg The optional argument to include in the whisper.
+     */
+    function remoteWhisper(playerId: string | string[], name: string, arg?: any): RemoteAction | RemoteAction[];
 
     /**
      * Gets the first bot which matches all of the given filters.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1526,6 +1526,7 @@ declare interface SessionSelector {
     username?: string;
     device?: string;
     session?: string;
+    broadcast?: boolean;
 }
 
 declare interface BotTags {
@@ -1894,6 +1895,20 @@ declare global {
      * @param arg The optional argument to include in the whisper.
      */
     function remoteWhisper(playerId: string | string[], name: string, arg?: any): RemoteAction | RemoteAction[];
+
+    /**
+     * Sends the given shout to all players.
+     * The other players will recieve an onRemoteWhisper event for this whisper.
+     *
+     * In effect, this allows players to communicate with each other by sending arbitrary events.
+     *
+     * @param name The name of the event.
+     * @param arg The optional argument to include in the whisper.
+     */
+    function remoteShout(
+        name: string,
+        arg?: any
+    ): RemoteAction;
 
     /**
      * Gets the first bot which matches all of the given filters.

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.css
@@ -10,8 +10,11 @@
     top: 16px;
 }
 
-.app-content {
-    padding: 16px;
+#app-game-container {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .synced-checkmark {

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -1,20 +1,25 @@
 <template>
     <div id="app">
         <load-app>
+            <meet-portal>
+                <md-toolbar v-if="showChatBar">
+                    <div class="md-toolbar-section-start">
+                        <bot-chat
+                            ref="chatBar"
+                            :prefill="chatBarPrefill"
+                            :placeholder="chatBarPlaceholder"
+                        ></bot-chat>
+                    </div>
+                </md-toolbar>
+                <bot-sheet></bot-sheet>
+                <md-content id="app-game-container">
+                    <router-view></router-view>
+                </md-content>
+            </meet-portal>
+
             <upload-files></upload-files>
-            <md-toolbar v-if="showChatBar">
-                <div class="md-toolbar-section-start">
-                    <bot-chat
-                        ref="chatBar"
-                        :prefill="chatBarPrefill"
-                        :placeholder="chatBarPlaceholder"
-                    ></bot-chat>
-                </div>
-            </md-toolbar>
             <checkout></checkout>
-            <bot-sheet></bot-sheet>
             <show-input></show-input>
-            <meet-portal></meet-portal>
 
             <md-dialog :md-active.sync="showQRCode" class="qr-code-dialog">
                 <div class="qr-code-container">
@@ -124,10 +129,6 @@
             <html-modal></html-modal>
             <clipboard-modal></clipboard-modal>
             <upload-story-modal></upload-story-modal>
-
-            <md-content class="app-content">
-                <router-view></router-view>
-            </md-content>
         </load-app>
     </div>
 </template>

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
@@ -13,10 +13,6 @@ html.ar-app .webxr-sessions canvas {
     top: 0px !important;
 }
 
-.game-container {
-    margin: -16px;
-}
-
 .toolbar {
     position: absolute;
     bottom: 0.75vh;

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
@@ -2,25 +2,6 @@
     margin-top: 0;
 }
 
-.game-view {
-    position: fixed;
-    top: 0px;
-}
-
-/* @media(min-width: 1024px) {
-    .info-card {
-        max-width: 66%;
-    }
-} */
-
-.info-card {
-    /* margin: -16px; */
-}
-
-/* .info-card .md-card-content .bot-table {
-    margin: 0 -16px;
-} */
-
 .info-card .md-card-content {
     max-height: 500px;
     overflow-y: auto;

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -1,6 +1,11 @@
 <template>
     <div>
-        <game-view v-if="!isLoading" class="game-view" :debug="debug">
+        <game-view
+            v-if="!isLoading"
+            class="game-view"
+            :debug="debug"
+            containerId="app-game-container"
+        >
             <div class="ui-container"></div>
         </game-view>
     </div>

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -64,9 +64,31 @@ export class PlayerGame extends Game {
 
     inventoryHeightOverride: number = null;
 
-    private sliderLeft: Element;
-    private sliderRight: Element;
-    private menuElement: Element;
+    private _sliderLeft: Element;
+    private _sliderRight: Element;
+    private _menuElement: Element;
+
+    private get sliderLeft() {
+        if (!this._sliderLeft) {
+            this._sliderLeft = document.querySelector('.slider-hiddenLeft');
+        }
+        return this._sliderLeft;
+    }
+
+    private get sliderRight() {
+        if (!this._sliderRight) {
+            this._sliderRight = document.querySelector('.slider-hiddenRight');
+        }
+        return this._sliderRight;
+    }
+
+    private get menuElement() {
+        if (!this._menuElement) {
+            this._menuElement = document.querySelector('.toolbar.menu');
+        }
+        return this._menuElement;
+    }
+
     private sliderPressed: boolean = false;
 
     setupDelay: boolean = false;
@@ -645,18 +667,6 @@ export class PlayerGame extends Game {
 
         // if there is no existing height set by the slider then
         if (this.inventoryHeightOverride === null) {
-            // get a new reference to the slider object in the html
-            if (this.sliderLeft === undefined)
-                this.sliderLeft = document.querySelector('.slider-hiddenLeft');
-
-            if (this.sliderRight === undefined)
-                this.sliderRight = document.querySelector(
-                    '.slider-hiddenRight'
-                );
-
-            if (this.menuElement === undefined)
-                this.menuElement = document.querySelector('.toolbar.menu');
-
             let invOffsetHeight = 40;
 
             if (window.innerWidth <= 700) {
@@ -765,12 +775,6 @@ export class PlayerGame extends Game {
 
     private _hideInventory() {
         this.inventoryViewport.setScale(null, 0);
-        if (this.sliderLeft === undefined)
-            this.sliderLeft = document.querySelector('.slider-hiddenLeft');
-        if (this.sliderRight === undefined)
-            this.sliderRight = document.querySelector('.slider-hiddenRight');
-        if (this.menuElement === undefined)
-            this.menuElement = document.querySelector('.toolbar.menu');
         (<HTMLElement>this.sliderLeft).style.display = 'none';
         (<HTMLElement>this.sliderRight).style.display = 'none';
         (<HTMLElement>this.menuElement).style.bottom =
@@ -780,12 +784,6 @@ export class PlayerGame extends Game {
     }
 
     private _showInventory() {
-        if (this.sliderLeft === undefined)
-            this.sliderLeft = document.querySelector('.slider-hiddenLeft');
-        if (this.sliderRight === undefined)
-            this.sliderRight = document.querySelector('.slider-hiddenRight');
-        if (this.menuElement === undefined)
-            this.menuElement = document.querySelector('.toolbar.menu');
         (<HTMLElement>this.sliderLeft).style.display = 'block';
         (<HTMLElement>this.sliderRight).style.display = 'block';
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
@@ -264,6 +264,9 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
         }
 
         let style = this.bot3D.bot.tags['auxLineStyle'];
+        if (!hasValue(style)) {
+            style = this.bot3D.bot.tags['lineStyle'];
+        }
         let styleValue: string;
 
         if (isFormula(style)) {

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.css
@@ -6,3 +6,9 @@
 .meet-portal.invisible {
     display: none;
 }
+
+.other-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -44,6 +44,41 @@ export default class MeetPortal extends Vue {
         return hasValue(this.currentMeet);
     }
 
+    // The override options for the config
+    // that the Jitsi Iframe should use.
+    // See https://github.com/jitsi/jitsi-meet/blob/master/config.js for options
+    get config() {
+        return {
+            // Start with the video feed muted
+            // Unlike startAudioOnly, this will let people unmute their
+            // video feed to show it.
+            startWithVideoMuted: true,
+        };
+    }
+
+    // The override options for the interface config
+    // that the Jitsi Iframe should use.
+    // See https://github.com/jitsi/jitsi-meet/blob/master/interface_config.js for options
+    // Note that not all options will work due to the settings whitelist (https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/config/interfaceConfigWhitelist.js).
+    // Also note that meet.jit.si uses a custom whitelist that prevents disabling the watermarks and branding.
+    // The settings below are specified for the future if/when we get our own Jitsi deployment.
+    get interfaceConfig() {
+        return {
+            // Disable the mobile app promo screen
+            MOBILE_APP_PROMO: false,
+
+            // Don't show the chrome extension promo
+            SHOW_CHROME_EXTENSION_BANNER: false,
+
+            // Don't show the watermark
+            filStripOnly: false,
+            SHOW_BRAND_WATERMARK: false,
+            SHOW_JITSI_WATERMARK: false,
+            SHOW_WATERMARK_FOR_GUESTS: false,
+            SHOW_POWERED_BY: false,
+        };
+    }
+
     constructor() {
         super();
     }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -23,6 +23,7 @@ import {
     userBotChanged,
 } from '@casual-simulation/aux-vm-browser';
 import { MeetPortalConfig } from './MeetPortalConfig';
+import { EventBus } from '../../EventBus';
 
 @Component({
     components: {
@@ -105,6 +106,21 @@ export default class MeetPortal extends Vue {
         };
     }
 
+    /**
+     * The HTML element that contains the meet iframe.
+     */
+    get portalElement(): HTMLElement {
+        return <HTMLElement>this.$refs.portalContainer;
+    }
+
+    /**
+     * The HTML element that contains the other elements that should be repositioned when
+     * the meet portal is open.
+     */
+    get othersElement(): HTMLElement {
+        return <HTMLElement>this.$refs.otherContainer;
+    }
+
     constructor() {
         super();
     }
@@ -115,6 +131,8 @@ export default class MeetPortal extends Vue {
         this._portals = new Map();
         this.extraStyle = calculateMeetPortalAnchorPointOffset('fullscreen');
         this.portalVisible = true;
+
+        window.addEventListener('resize', e => this._resize());
 
         this._sub.add(
             appManager.simulationManager.simulationAdded
@@ -143,6 +161,78 @@ export default class MeetPortal extends Vue {
                 },
             });
         }
+    }
+
+    private _resize(): any {
+        if (!this.portalElement || !this.othersElement) {
+            return;
+        }
+        setTimeout(() => {
+            const portalRect = this.portalElement.getBoundingClientRect();
+
+            // Calculate whether to fill space not taken or whether to fill behind
+            if (
+                portalRect.top !== 0 &&
+                portalRect.bottom !== window.innerHeight &&
+                portalRect.left !== 0 &&
+                portalRect.right !== window.innerWidth
+            ) {
+                // If the portal is not attached to a side of the screen then fill behind
+                this.othersElement.style.height = null;
+                this.othersElement.style.width = null;
+                this.othersElement.style.top = null;
+                this.othersElement.style.bottom = null;
+                this.othersElement.style.left = null;
+                this.othersElement.style.right = null;
+                return;
+            }
+
+            const portalSize = this._calculateSize(this.portalElement);
+            const heightRatio = portalSize.height / window.innerHeight;
+            const widthRatio = portalSize.width / window.innerWidth;
+
+            // Calculate whether to fill the rest of the height or width
+            if (widthRatio > heightRatio) {
+                this.othersElement.style.height =
+                    window.innerHeight - portalSize.height + 'px';
+                this.othersElement.style.width = null;
+
+                // Calculate whether to fill above or below
+                if (portalRect.top < window.innerHeight - portalRect.bottom) {
+                    // The meet portal is on the top so place the others on the bottom
+                    this.othersElement.style.top = null;
+                    this.othersElement.style.bottom = '0px';
+                } else {
+                    // the meet portal is on the bottom so place the others on the top
+                    this.othersElement.style.top = '0px';
+                    this.othersElement.style.bottom = null;
+                }
+            } else {
+                this.othersElement.style.height = null;
+                this.othersElement.style.width =
+                    window.innerWidth - portalSize.width + 'px';
+
+                // Calculate whether to fill left or right
+                if (portalRect.left < window.innerWidth - portalRect.right) {
+                    // The meet portal is on the left so place the others on the right
+                    this.othersElement.style.left = null;
+                    this.othersElement.style.right = '0px';
+                } else {
+                    // the meet portal is on the right so place the others on the left
+                    this.othersElement.style.left = '0px';
+                    this.othersElement.style.right = null;
+                }
+            }
+
+            EventBus.$emit('resize');
+        }, 100);
+    }
+
+    private _calculateSize(element: HTMLElement) {
+        const width = element.offsetWidth;
+        const height = element.offsetHeight;
+
+        return { width, height };
     }
 
     private _onSimulationAdded(sim: BrowserSimulation) {
@@ -224,9 +314,16 @@ export default class MeetPortal extends Vue {
     }
 
     private _updateConfig() {
+        if (!this.currentMeet) {
+            this.extraStyle = {};
+            this.portalVisible = true;
+            this._resize();
+            return;
+        }
         if (this._currentConfig) {
             this.portalVisible = this._currentConfig.visible;
             this.extraStyle = this._currentConfig.style;
+            this._resize();
         } else {
             this.portalVisible = true;
             this.extraStyle = calculateMeetPortalAnchorPointOffset(

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -76,6 +76,32 @@ export default class MeetPortal extends Vue {
             SHOW_JITSI_WATERMARK: false,
             SHOW_WATERMARK_FOR_GUESTS: false,
             SHOW_POWERED_BY: false,
+
+            // Disable some settings sections
+            SETTINGS_SECTIONS: ['devices', 'language', 'moderator', 'profile'],
+            TOOLBAR_BUTTONS: [
+                'microphone',
+                'camera',
+                'hangup',
+                'closedcaptions',
+                'desktop',
+                'chat',
+                'recording',
+                'livestreaming',
+                'sharedvideo',
+                'settings',
+                'filmstrip',
+                'feedback',
+                'tileview',
+                'videobackgroundblur',
+                'download',
+                'help',
+                'mute-everyone',
+                'security',
+            ],
+
+            // Hide the "invite more people" header since we want them to share the CausalOS link.
+            HIDE_INVITE_MORE_HEADER: true,
         };
     }
 

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -5,7 +5,14 @@
         :class="{ invisible: !portalVisible }"
         :style="extraStyle"
     >
-        <jitsi-meet :options="{ roomName: currentMeet }" @closed="onClose"></jitsi-meet>
+        <jitsi-meet
+            :options="{
+                roomName: currentMeet,
+                interfaceConfigOverwrite: interfaceConfig,
+                configOverwrite: config,
+            }"
+            @closed="onClose"
+        ></jitsi-meet>
     </div>
 </template>
 <script src="./MeetPortal.ts"></script>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -1,18 +1,24 @@
 <template>
-    <div
-        v-if="hasPortal"
-        class="meet-portal"
-        :class="{ invisible: !portalVisible }"
-        :style="extraStyle"
-    >
-        <jitsi-meet
-            :options="{
-                roomName: currentMeet,
-                interfaceConfigOverwrite: interfaceConfig,
-                configOverwrite: config,
-            }"
-            @closed="onClose"
-        ></jitsi-meet>
+    <div class="meet-portal-container">
+        <div
+            ref="portalContainer"
+            class="meet-portal"
+            :class="{ invisible: !portalVisible }"
+            :style="extraStyle"
+        >
+            <jitsi-meet
+                v-if="hasPortal"
+                :options="{
+                    roomName: currentMeet,
+                    interfaceConfigOverwrite: interfaceConfig,
+                    configOverwrite: config,
+                }"
+                @closed="onClose"
+            ></jitsi-meet>
+        </div>
+        <div ref="otherContainer" class="other-container">
+            <slot></slot>
+        </div>
     </div>
 </template>
 <script src="./MeetPortal.ts"></script>

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -117,10 +117,17 @@ export class CausalRepoServer {
 
                 handleEvents(conn, {
                     [WATCH_BRANCH]: async event => {
+                        if (!event) {
+                            console.log(
+                                '[CasualRepoServer] Trying to watch branch with a null event!'
+                            );
+                            return;
+                        }
                         const branch = event.branch;
                         const info = infoForBranch(branch);
                         await this._deviceManager.joinChannel(device, info);
-                        if (!this._branches.has(branch)) {
+                        let currentBranch = this._branches.get(branch);
+                        if (!currentBranch) {
                             this._branches.set(branch, event);
                         }
                         if (!event.temporary && event.siteId) {
@@ -427,12 +434,15 @@ export class CausalRepoServer {
 
                         const branches = this._repos.keys();
                         for (let branch of branches) {
+                            const branchEvent = this._branches.get(branch);
+                            if (!branchEvent) {
+                                continue;
+                            }
                             const branchInfo = infoForBranch(branch);
                             const devices = this._deviceManager.getConnectedDevices(
                                 branchInfo
                             );
                             for (let device of devices) {
-                                const branchEvent = this._branches.get(branch);
                                 conn.send(DEVICE_CONNECTED_TO_BRANCH, {
                                     branch: branchEvent,
                                     device: device.extra.device,
@@ -452,8 +462,11 @@ export class CausalRepoServer {
                         const devices = this._deviceManager.getConnectedDevices(
                             branchInfo
                         );
+                        const branchEvent = this._branches.get(branch);
+                        if (!branchEvent) {
+                            return;
+                        }
                         for (let device of devices) {
-                            const branchEvent = this._branches.get(branch);
                             conn.send(DEVICE_CONNECTED_TO_BRANCH, {
                                 branch: branchEvent,
                                 device: device.extra.device,
@@ -566,6 +579,11 @@ export class CausalRepoServer {
             } connected to branch: ${branch}`
         );
         const branchEvent = this._branches.get(branch);
+        if (!branchEvent) {
+            throw new Error(
+                'Unable to send connected to branch event because the branch does not exist!'
+            );
+        }
         const event = {
             branch: branchEvent,
             device: device.extra.device,

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -365,7 +365,9 @@ export class CausalRepoServer {
                         if (
                             event.action.deviceId ||
                             event.action.sessionId ||
-                            event.action.username
+                            event.action.username ||
+                            (typeof event.action.broadcast !== 'undefined' &&
+                                event.action.broadcast !== null)
                         ) {
                             finalAction = event.action;
                         } else if (this.defaultDeviceSelector) {

--- a/src/causal-tree-server/DeviceManagerHelpers.ts
+++ b/src/causal-tree-server/DeviceManagerHelpers.ts
@@ -49,6 +49,9 @@ export function isEventForDevice(
     event: DeviceSelector,
     device: DeviceInfo
 ): boolean {
+    if (event.broadcast === true) {
+        return true;
+    }
     if (event.username === device.claims[USERNAME_CLAIM]) {
         return true;
     } else if (event.sessionId === device.claims[SESSION_ID_CLAIM]) {

--- a/src/causal-trees/core/Event.ts
+++ b/src/causal-trees/core/Event.ts
@@ -53,6 +53,11 @@ export interface DeviceSelector {
      * The username of the user that the event should be sent to.
      */
     username?: string;
+
+    /**
+     * Whether the event should be broadcast to all users.
+     */
+    broadcast?: boolean;
 }
 
 /**


### PR DESCRIPTION
-   :rocket: Improvements

    -   Improved how the meet portal, page portal, and sheet portal work together to make space for each other.
    -   Added the `left` and `right` options for `meetPortalAnchorPoint`.
    -   Changed the `top` and `bottom` options for `meetPortalAnchorPoint` to occupy half of the screen.
    -   Added the `server.players()` function to get the list of player IDs that are connected to the current story.
        -   Returns a promise that resolves with the list of player IDs.
    -   Added the `remoteWhisper(players, name, arg)` function to make sending messages to other players easy.
        -   Takes the following arguments:
            -   `players` is the player ID or list of player IDs that should receive the shout.
            -   `name` is the name of the message.
            -   `arg` is the data that should be included.
        -   This will trigger a `@onRemoteWhisper` shout on all the specified players.
    -   Added the `remoteShout(name, arg)` function to make sending messages to all players easy.
        -   Takes the following arguments:
            -   `name` is the name of the message.
            -   `arg` is the data that should be included.
    -   Added the `@onRemoteWhisper` listen tag that is shouted when a `remoteWhisper()` or `remoteShout()` is sent to the local player.
        -   `that` is an object with the following properties:
            -   `name` - The name of the shout that was sent.
            -   `that` - The data which was sent.
            -   `playerId` - The ID of the player that sent the shout.
-   Bug Fixes
    -   Fixed an issue that prevented using `lineStyle` in place of `auxLineStyle`.