### PR TITLE
Add the ability to return data from webhooks and use data portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
             -   `data` - The value that should be used as the body of the response.
             -   `headers` - An object that contains the HTTP headers that should be set on the response. (Optional)
             -   `status` - The numerical status code that should be set on the response. (Optional) If omitted, status code 200 will be used.
+    -   Added the `dataPortal`.
+        -   This is a special portal that only works on web requests and must be specified in the URL.
+        -   Setting it to a Bot ID will return the JSON of the bot with the given ID.
+        -   Setting it to a tag will return all the values corresponding to the given tag.
+        -   Using a tag with a common extension (like `.html`) will tag the data as the corresponding content type so that normal software know how to interpret the data.
 
 ## V1.1.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CasualOS Changelog
 
+## V1.1.16
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+    -   Added the ability to respond to webhooks by returning data from `@onWebhook`.
+        -   If the returned value is a string, then it will be used for the response.
+        -   If the returned value is an object, then it should have the following properties:
+            -   `data` - The value that should be used as the body of the response.
+            -   `headers` - An object that contains the HTTP headers that should be set on the response. (Optional)
+            -   `status` - The numerical status code that should be set on the response. (Optional) If omitted, status code 200 will be used.
+
 ## V1.1.15
 
 ### Date: 7/2/2020

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -830,6 +830,7 @@ let that: {
 ### `@onWebhook`
 
 A shout that is sent whenever a webhook is received.
+If data is returned, the first result will be used as the HTTP response.
 
 #### Arguments:
 ```typescript
@@ -838,6 +839,38 @@ let that: {
   url: string,
   data: any,
   headers: any
+};
+```
+
+#### Return Value:
+
+If an object is returned, it is expected to have the following form:
+
+```typescript
+let response: {
+    headers?: {
+        [key: string]: any
+    },
+    status?: number,
+    data: any,
+}
+```
+
+#### Examples:
+
+1. Return an arbitrary string of data.
+```typescript
+return 'hello from webhook!';
+```
+
+2. Return a response with a custom header.
+```typescript
+return {
+    headers: {
+        'Content-Type': 'text/plain',
+        MyCustomHeader: 'custom value'
+    },
+    data: 'hello from webhook!'
 };
 ```
 

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -856,6 +856,13 @@ let response: {
 }
 ```
 
+The `headers` property is an object that specifies the [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) that should be set on the response.
+Each property is a header name and the value is the value set on the header.
+
+The `status` property is the numerical [status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that should be set on the response. If omitted, then status code 200 will be used.
+
+The `data` property is the data that should be included in the response body.
+
 #### Examples:
 
 1. Return an arbitrary string of data.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1365,6 +1365,38 @@ This is similar to a Skype or Zoom call except that all data is encrypted and is
 
 Only available on the player bot.
 
+### `dataPortal`
+
+The data portal is a special portal that can be used in a web request to get bot data directly from the server.
+Similar to webhooks, you specify the story and data portal in the query string of the URL.
+
+If given a bot ID, then the bot will be returned as JSON.
+
+If no bot matches the given value, then it will be treated as a tag and all the values for the given tag will be returned.
+
+If the tag ends with a common extension (like `.html` or `.txt` or `.json`), then the returned data will be [tagged](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) with the corresponding [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
+This will let web browsers and other common software know what type of data they are dealing with and handle it correctly. (i.e. display a webpage)
+Alternatively, you can specify the `dataPortalContentType` query parameter to override the default content type.
+
+If there is only one tag and it ends with an extension like specified above then the content directly from the tag will be returned.
+
+#### Examples:
+
+1. Request the JSON of the Bot with the given ID:
+```
+https://auxplayer.com?story=my-story&dataPortal=bf68e5cc-993b-42fd-a142-a23de6d2cdcb
+```
+
+2. Request all the <TagLink tag='label'/> tags values.
+```
+https://auxplayer.com?story=my-story&dataPortal=label
+```
+
+3. Request a web page from the `test.html` tag.
+```
+https://auxplayer.com?story=my-story&dataPortal=test.html
+```
+
 ### `pagePortalConfigBot`
 
 <Badges>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,9 +7073,9 @@
 			"dev": true
 		},
 		"@types/mime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-			"integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+			"integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -18025,9 +18025,9 @@
 			}
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+			"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
 		},
 		"mime-db": {
 			"version": "1.37.0",
@@ -22962,6 +22962,13 @@
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.0",
 				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				}
 			}
 		},
 		"serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "@types/howler": "^2.1.2",
         "@types/inquirer": "^6.5.0",
         "@types/cli-progress": "3.4.2",
+        "@types/mime": "2.0.2",
         "babel-loader": "^8.0.4",
         "braces": "^2.3.2",
         "chai": "^4.2.0",

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -908,6 +908,11 @@ export const AUX_BOT_VERSION: number = 1;
 export const MEET_PORTAL: string = 'meetPortal';
 
 /**
+ * The name of the data portal.
+ */
+export const DATA_PORTAL: string = 'dataPortal';
+
+/**
  * The list of all portal tags.
  */
 export const KNOWN_PORTALS: string[] = [
@@ -950,6 +955,7 @@ export const KNOWN_TAGS: string[] = [
 
     MEET_PORTAL,
     `${MEET_PORTAL}ConfigBot`,
+    DATA_PORTAL,
 
     '_editingBot',
 

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -112,6 +112,7 @@
         "vue-material": "^1.0.0-beta-10.2",
         "vue-property-decorator": "^7.2.0",
         "vue-router": "^3.0.1",
-        "vue-shortkey": "^3.1.6"
+        "vue-shortkey": "^3.1.6",
+        "mime": "2.4.6"
     }
 }

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -7,7 +7,12 @@ import {
 } from '@casual-simulation/aux-common';
 import { Observable, Subject } from 'rxjs';
 import { wrap, proxy, Remote, expose, transfer } from 'comlink';
-import { AuxConfig, AuxVM, AuxUser } from '@casual-simulation/aux-vm';
+import {
+    AuxConfig,
+    AuxVM,
+    AuxUser,
+    ChannelActionResult,
+} from '@casual-simulation/aux-vm';
 import {
     AuxChannel,
     AuxStatic,
@@ -165,6 +170,23 @@ export class AuxVMImpl implements AuxVM {
     async sendEvents(events: BotAction[]): Promise<void> {
         if (!this._proxy) return null;
         return await this._proxy.sendEvents(events);
+    }
+
+    /**
+     * Executes a shout with the given event name on the given bot IDs with the given argument.
+     * Also dispatches any actions and errors that occur.
+     * Returns the results from the event.
+     * @param eventName The name of the event.
+     * @param botIds The IDs of the bots that the shout is being sent to.
+     * @param arg The argument to include in the shout.
+     */
+    async shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult> {
+        if (!this._proxy) return null;
+        return await this._proxy.shout(eventName, botIds, arg);
     }
 
     async formulaBatch(formulas: string[]): Promise<void> {

--- a/src/aux-vm-node/vm/AuxVMNode.ts
+++ b/src/aux-vm-node/vm/AuxVMNode.ts
@@ -2,6 +2,7 @@ import {
     AuxVM,
     AuxChannelErrorType,
     StoredAux,
+    ChannelActionResult,
 } from '@casual-simulation/aux-vm';
 import { Observable, Subject } from 'rxjs';
 import {
@@ -70,6 +71,14 @@ export class AuxVMNode implements AuxVM {
 
     sendEvents(events: BotAction[]): Promise<void> {
         return this._channel.sendEvents(events);
+    }
+
+    shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult> {
+        return this._channel.shout(eventName, botIds, arg);
     }
 
     formulaBatch(formulas: string[]): Promise<void> {

--- a/src/aux-vm/managers/BotHelper.ts
+++ b/src/aux-vm/managers/BotHelper.ts
@@ -25,6 +25,7 @@ import {
 } from '@casual-simulation/aux-common';
 import { BaseHelper } from './BaseHelper';
 import { AuxVM } from '../vm/AuxVM';
+import { ChannelActionResult } from '../vm';
 
 /**
  * Defines an class that contains a simple set of functions
@@ -164,6 +165,21 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
         const botIds = bots ? bots.map(f => f.id) : null;
         const actionData = action(eventName, botIds, this.userId, arg);
         await this._vm.sendEvents([actionData]);
+    }
+
+    /**
+     * Runs the given event on the given bots.
+     * @param eventName The name of the event to run.
+     * @param bots The bots that should be searched for handlers for the event name.
+     * @param arg The argument that should be passed to the event handlers.
+     */
+    async shout(
+        eventName: string,
+        bots: Bot[],
+        arg?: any
+    ): Promise<ChannelActionResult> {
+        const botIds = bots ? bots.map(f => f.id) : null;
+        return await this._vm.shout(eventName, botIds, arg);
     }
 
     /**

--- a/src/aux-vm/vm/AuxChannel.ts
+++ b/src/aux-vm/vm/AuxChannel.ts
@@ -3,6 +3,7 @@ import {
     BotAction,
     StateUpdatedEvent,
     BotDependentInfo,
+    ActionResult,
 } from '@casual-simulation/aux-common';
 import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
 import { AuxConfig } from './AuxConfig';
@@ -86,6 +87,20 @@ export interface AuxChannel {
     sendEvents(events: BotAction[]): Promise<void>;
 
     /**
+     * Executes a shout with the given event name on the given bot IDs with the given argument.
+     * Also dispatches any actions and errors that occur.
+     * Returns the results from the event.
+     * @param eventName The name of the event.
+     * @param botIds The IDs of the bots that the shout is being sent to.
+     * @param arg The argument to include in the shout.
+     */
+    shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult>;
+
+    /**
      * Runs the given list of formulas.
      * @param formulas The formulas.
      */
@@ -118,4 +133,16 @@ export interface AuxChannel {
      * Gets the list of tags that are in use.
      */
     getTags(): Promise<string[]>;
+}
+
+export interface ChannelActionResult {
+    /**
+     * The actions that were queued.
+     */
+    actions: BotAction[];
+
+    /**
+     * The results from the scripts that were run.
+     */
+    results: any[];
 }

--- a/src/aux-vm/vm/AuxVM.ts
+++ b/src/aux-vm/vm/AuxVM.ts
@@ -10,6 +10,7 @@ import { Initable } from '../managers/Initable';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { AuxUser } from '../AuxUser';
 import { StoredAux } from '../StoredAux';
+import { ChannelActionResult } from './AuxChannel';
 
 /**
  * Defines an interface for an AUX that is run inside a virtual machine.
@@ -62,6 +63,20 @@ export interface AuxVM extends Initable {
      * @param events The events to send to the simulation.
      */
     sendEvents(events: BotAction[]): Promise<void>;
+
+    /**
+     * Executes a shout with the given event name on the given bot IDs with the given argument.
+     * Also dispatches any actions and errors that occur.
+     * Returns the results from the event.
+     * @param eventName The name of the event.
+     * @param botIds The IDs of the bots that the shout is being sent to.
+     * @param arg The argument to include in the shout.
+     */
+    shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult>;
 
     /**
      * Runs the given list of formulas as actions in a batch.

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -600,6 +600,69 @@ describe('BaseAuxChannel', () => {
         });
     });
 
+    describe('shout()', () => {
+        it('should execute the given shout and return the results', async () => {
+            await channel.initAndWait();
+
+            await channel.sendEvents([
+                botAdded(
+                    createBot('test1', {
+                        getValue: `@return 99;`,
+                    })
+                ),
+                botAdded(
+                    createBot('test2', {
+                        getValue: `@player.toast("abc");`,
+                    })
+                ),
+            ]);
+
+            const result = await channel.shout('getValue');
+
+            expect(result).toEqual({
+                results: [99, undefined],
+                actions: [toast('abc')],
+            });
+        });
+
+        it('should unwrap all promises', async () => {
+            await channel.initAndWait();
+
+            await channel.sendEvents([
+                botAdded(
+                    createBot('test1', {
+                        getValue: `@return 99;`,
+                    })
+                ),
+                botAdded(
+                    createBot('test2', {
+                        getValue: `@player.toast("abc");`,
+                    })
+                ),
+                botAdded(
+                    createBot('test3', {
+                        getValue: `@await Promise.resolve(); return 'fun';`,
+                    })
+                ),
+            ]);
+
+            const result = await channel.shout('getValue');
+
+            expect(result).toEqual({
+                results: [99, undefined, 'fun'],
+                actions: [toast('abc')],
+            });
+        });
+
+        it('should fail when not initialized', async () => {
+            expect(channel.shout('getValue')).rejects.toEqual(
+                new Error(
+                    'Unable to execute a shout without being initialized.'
+                )
+            );
+        });
+    });
+
     describe('formulaBatch()', () => {
         it('should send remote events', async () => {
             await channel.initAndWait();

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -1,6 +1,6 @@
 import { Subject, SubscriptionLike } from 'rxjs';
 import { tap, first } from 'rxjs/operators';
-import { AuxChannel } from './AuxChannel';
+import { AuxChannel, ChannelActionResult } from './AuxChannel';
 import { AuxUser } from '../AuxUser';
 import {
     LocalActions,
@@ -276,6 +276,24 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         } else {
             this._eventBuffer.push(...events);
         }
+    }
+
+    async shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult> {
+        if (!this._runtime) {
+            throw new Error(
+                'Unable to execute a shout without being initialized.'
+            );
+        }
+        const result = this._runtime.shout(eventName, botIds, arg);
+
+        return {
+            actions: result.actions,
+            results: await Promise.all(result.results),
+        };
     }
 
     async formulaBatch(formulas: string[]): Promise<void> {

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -20,6 +20,7 @@ import values from 'lodash/values';
 import union from 'lodash/union';
 import { AuxUser } from '../../AuxUser';
 import { StoredAux } from '../../StoredAux';
+import { ChannelActionResult } from '../../vm';
 
 export class TestAuxVM implements AuxVM {
     private _stateUpdated: Subject<StateUpdatedEvent>;
@@ -66,6 +67,19 @@ export class TestAuxVM implements AuxVM {
         this._stateUpdated = new Subject<StateUpdatedEvent>();
         this.connectionStateChanged = new Subject<StatusUpdate>();
         this.onError = new Subject<AuxChannelErrorType>();
+    }
+
+    async shout(
+        eventName: string,
+        botIds?: string[],
+        arg?: any
+    ): Promise<ChannelActionResult> {
+        const result = this._runtime.shout(eventName, botIds, arg);
+
+        return {
+            actions: result.actions,
+            results: await Promise.all(result.results),
+        };
     }
 
     async setUser(user: AuxUser): Promise<void> {


### PR DESCRIPTION

### Changes:

-   :rocket: Improvements
    -   Added the ability to respond to webhooks by returning data from `@onWebhook`.
        -   If the returned value is a string, then it will be used for the response.
        -   If the returned value is an object, then it should have the following properties:
            -   `data` - The value that should be used as the body of the response.
            -   `headers` - An object that contains the HTTP headers that should be set on the response. (Optional)
            -   `status` - The numerical status code that should be set on the response. (Optional) If omitted, status code 200 will be used.
    -   Added the `dataPortal`.
        -   This is a special portal that only works on web requests and must be specified in the URL.
        -   Setting it to a Bot ID will return the JSON of the bot with the given ID.
        -   Setting it to a tag will return all the values corresponding to the given tag.
        -   Using a tag with a common extension (like `.html`) will tag the data as the corresponding content type so that normal software know how to interpret the data.