### PR TITLE
Add promises to the remaining async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   :rocket: Improvements
     -   Improved the `player.run()` function to return a promise that can be awaited to get the result of the script (or wait until the script has been executed).
     -   Improved the `server.loadErrors()` function to return a promise that can be awaited to get the list of bots that were loaded.
+    -   Improved the `server.destroyErrors()` function to return a promise that resolves once the error bots are destroyed.
 
 ## V1.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
     -   Improved the `player.run()` function to return a promise that can be awaited to get the result of the script (or wait until the script has been executed).
     -   Improved the `server.loadErrors()` function to return a promise that can be awaited to get the list of bots that were loaded.
     -   Improved the `server.destroyErrors()` function to return a promise that resolves once the error bots are destroyed.
+    -   Improved the `server.loadFile()` function to return a promise that resolves once the file is loaded.
+    -   Improved the `server.saveFile()` function to return a promise that resolves once the file is saved.
+    -   Improved the `server.setupStory()` function to return a promise that resolves once the story is setup.
+    -   Improved the `server.browseHistory()` function to return a promise that resolves once the history is loaded.
+    -   Improved the `server.markHistory()` function to return a promise that resolves once the history is saved.
+    -   Improved the `server.restoreHistoryMark()` function to return a promise that resolves once the history is restored.
+    -   Improved the `server.restoreHistoryMarkToStory()` function to return a promise that resolves once the history is restored.
 
 ## V1.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   :rocket: Improvements
     -   Improved the `player.run()` function to return a promise that can be awaited to get the result of the script (or wait until the script has been executed).
+    -   Improved the `server.loadErrors()` function to return a promise that can be awaited to get the list of bots that were loaded.
 
 ## V1.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CasualOS Changelog
 
+## V1.1.18
+
+### Date: TBD
+
+### Changes:
+
+-   :rocket: Improvements
+    -   Improved the `player.run()` function to return a promise that can be awaited to get the result of the script (or wait until the script has been executed).
+
 ## V1.1.17
 
 ### Date: 7/3/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2342,8 +2342,9 @@ let bots = await server.loadErrors(this, tagName);
 
 ### `server.destroyErrors()`
 
-
 Destroys all the error bots.
+
+Returns a promise that resolves once the bots are destroyed.
 
 #### Examples:
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2181,6 +2181,8 @@ await server.browseHistory();
 Marks the current state as a save point in history. This save point can be restored by using the <ActionLink action='server.restoreHistoryMark(mark)'/> action.
 Note that this only saves bots in the `shared` space. `local` and `tempLocal` bots are unaffected.
 
+Returns a promise that resolves when the history mark has been created.
+
 The **first parameter** are the options that should be used to mark the history point.
 It should be an object with the following properties:
 - `message` - The message that the new mark should have. Use this as a way to communicate what was special about this save point.
@@ -2189,7 +2191,7 @@ It should be an object with the following properties:
 
 1. Save the current state of the `shared` space.
 ```typescript
-server.markHistory({
+await server.markHistory({
     message: 'First Version of my AUX'
 });
 ```

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2327,6 +2327,8 @@ Finds bots by searching the error space for bots with the following tags:
 -   `errorBot` must be the ID of the bot that was specified.
 -   `errorTag` must be the tag that was specified.
 
+Returns a promise that resolves with the list of bots that were loaded.
+
 The **first parameter** is the Bot or Bot ID that the errors should be loaded for.
 
 The **second parameter** is the name of the tag that the errors should be loaded for.
@@ -2335,7 +2337,7 @@ The **second parameter** is the name of the tag that the errors should be loaded
 
 1. Load all errors that have occurred for this script:
 ```typescript
-server.loadErrors(this, tagName);
+let bots = await server.loadErrors(this, tagName);
 ```
 
 ### `server.destroyErrors()`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -986,6 +986,8 @@ Runs the given script.
 The script will be executed in a separate environment with no `bot`, `tags`, `this`, `data`, and `that` variables.
 This means that you need to use the <ActionLink action='getBot(...filters)'/> or <ActionLink action='getBots(...filters)'/> functions to read bot data.
 
+Returns a promise that resolves with the returned script value after it has been executed.
+
 The **first parameter** is the script that should be executed.
 
 #### Examples:
@@ -998,6 +1000,12 @@ player.run("player.toast('hello');");
 2. Run a script from the `#script` tag on the current bot.
 ```typescript
 player.run(tags.script);
+```
+
+3. Run a script and toast the result.
+```typescript
+const result = await player.run("return 594 + 391");
+player.toast(result);
 ```
 
 ### `player.replaceDragBot(botOrMod)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2102,6 +2102,8 @@ Sends an action to the server that will create the given story if it does not ex
 The new bot will only be added to the story if the story did not exist.
 The action is only executed if <TagLink tag='@onStoryAction'/> has been configured to perform events in `device` actions.
 
+Returns a promise that resolves when the story has been setup.
+
 The **first parameter** is the ID of the story that should be setup.
 
 The **second parameter** is optional and is the bot or mod that should be cloned into the new story. After the bot is created, <TagLink tag='@onCreate'/> will be triggered.
@@ -2130,12 +2132,12 @@ if (that.action.type === 'device') {
 
 1. Create the "test" story:
 ```typescript
-server.setupStory("test");
+await server.setupStory("test");
 ```
 
 2. Create the "test" story with a bot inside it:
 ```typescript
-server.setupStory("test", {
+await server.setupStory("test", {
     "name": "bob",
     "color": "red"
 });
@@ -2143,7 +2145,7 @@ server.setupStory("test", {
 
 3. Create the "test" story with a bot that places a bot in the "abc" dimension:
 ```typescript
-server.setupStory("test", {
+await server.setupStory("test", {
     "onCreate": `@
         create({
             creator: null,
@@ -2251,6 +2253,8 @@ Note that on a Raspberry PI, all USB storage devices are mapped into the `/drive
 Loading a file from a USB drive is as simple as specifying the file name.
 If multiple USB drives are plugged in and have files with the same name, then the file from the USB drive in the smallest numbered port is used.
 
+Returns a promise that resolves with the data in the file.
+
 The **first parameter** is the path that the file should be loaded from. This is usually just the full name of the file to load. (name + file extension)
 
 The **second parameter** are the options that should be used for loading the file.
@@ -2276,6 +2280,12 @@ server.loadFile('/2/book.txt', {
 });
 ```
 
+3. Load a file named "book.txt" and toast the contents.
+```typescript
+const result = await server.loadFile('book.txt');
+player.toast(result.data);
+```
+
 ### `server.saveFile(path, data, options?)`
 
 
@@ -2285,6 +2295,8 @@ If the file already exists, then the options are used to determine if the file s
 Note that on a Raspberry PI, all USB storage devices are mapped into the `/drives` directory based on the port they were plugged into.
 Saving a file to a USB drive is as simple as specifying the file name.
 If multiple USB drives are plugged in and a drive is not specified, then the file will be saved to the first drive.
+
+Returns a promise that resolves when the file has been saved.
 
 The **first parameter** is the path that the file should be saved to. This is usually just the full name of the file to save. (name + file extension)
 
@@ -2308,10 +2320,19 @@ server.saveFile('book.txt', 'My memoirs', {
 
 2. Save a file named "book.txt" to drive `2` and trigger a `@onBookSaved` shout when it is loaded.
 ```typescript
-server.loadFile('/2/book.txt', 'My memoirs', {
+server.saveFile('/2/book.txt', 'My memoirs', {
     callbackShout: 'onBookSaved',
     overwriteExistingFile: true
 });
+```
+
+3. Save a file named "book.txt" and send a toast when it is finished.
+```typescript
+await server.saveFile('/2/book.txt', 'My memoirs', {
+    overwriteExistingFile: true
+});
+
+player.toast("File Saved!");
 ```
 
 ### `server.loadErrors(bot, tag)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2202,6 +2202,8 @@ await server.markHistory({
 Restores the current state to the state that was saved by the given mark.
 This will create a new mark with any unsaved changes and another mark with the state that was saved by the given mark.
 
+Returns a promise that resolves when the history mark has been restored.
+
 The **first parameter** is the bot or bot ID of the mark that should be restored. You can find available marks in the current story by using the <ActionLink action='server.browseHistory()'/> action.
 
 #### Examples:
@@ -2212,7 +2214,7 @@ The **first parameter** is the bot or bot ID of the mark that should be restored
 let mark = getBot(byTag("#history", true));
 
 // Restore the current state to the given mark.
-server.restoreHistoryMark(mark);
+await server.restoreHistoryMark(mark);
 ```
 
 ### `server.restoreHistoryMarkToStory(mark, story)`
@@ -2220,6 +2222,8 @@ server.restoreHistoryMark(mark);
 
 Restores the state in the given story to the state that was saved by the given mark.
 This will create a new mark with any unsaved changes in the story and another mark with the state that was saved by the given mark.
+
+Returns a promise that resolves when the history mark has been restored.
 
 The **first parameter** is the bot or bot ID of the mark that should be restored. You can find available marks in the current story by using the <ActionLink action='server.browseHistory()'/> action.
 
@@ -2233,7 +2237,7 @@ The **second parameter** is the story that the state should be restored to. If `
 let mark = getBot(byTag("#history", true));
 
 // Restore the current state to the given mark.
-server.restoreHistoryMarkToStory(mark, "test");
+await server.restoreHistoryMarkToStory(mark, "test");
 ```
 
 ### `server.shell(script)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2166,11 +2166,13 @@ Loads the `history` space into the current story.
 The `history` space is read-only and contains all the marks that have been created for the story.
 Each mark is a bot that is placed in the `#history` dimension.
 
+Returns a promise that resolves when the history bots are loaded.
+
 #### Examples:
 
 1. Load the `history` space.
 ```typescript
-server.browseHistory();
+await server.browseHistory();
 ```
 
 ### `server.markHistory(options)`

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -1152,7 +1152,7 @@ export interface RestoreHistoryMarkAction {
 /**
  * Defines an event that loads a space into the story.
  */
-export interface LoadSpaceAction {
+export interface LoadSpaceAction extends Partial<AsyncAction> {
     type: 'load_space';
 
     /**
@@ -2104,12 +2104,18 @@ export function restoreHistoryMark(
  * Loads a space into the story.
  * @param space The space to load.
  * @param config The config which specifies how the space should be loaded.
+ * @param taskId The ID of the async task.
  */
-export function loadSpace(space: BotSpace, config: any): LoadSpaceAction {
+export function loadSpace(
+    space: BotSpace,
+    config: any,
+    taskId?: number | string
+): LoadSpaceAction {
     return {
         type: 'load_space',
         space,
         config,
+        taskId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -128,6 +128,12 @@ export interface AsyncResultAction extends AsyncAction {
      * The result value.
      */
     result: any;
+
+    /**
+     * Whether to map any bots found in the result to their actual bot counterparts.
+     * Defaults to false.
+     */
+    mapBotsInResult?: boolean;
 }
 
 /**
@@ -2229,15 +2235,18 @@ export function localFormAnimation(
  * Creates an action that resolves an async task with the given result.
  * @param taskId The ID of the task.
  * @param result The result.
+ * @param mapBots Whether to map any bots found in the result to their actual counterparts.
  */
 export function asyncResult(
     taskId: number | string,
-    result: any
+    result: any,
+    mapBots?: boolean
 ): AsyncResultAction {
     return {
         type: 'async_result',
         taskId,
         result,
+        mapBotsInResult: mapBots,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -85,7 +85,6 @@ export type ExtraActions =
     | ShowJoinCodeAction
     | RequestFullscreenAction
     | ExitFullscreenAction
-    | LoadBotsAction
     | ClearSpaceAction
     | LocalFormAnimationAction
     | GetPlayerCountAction;
@@ -99,6 +98,7 @@ export type AsyncActions =
     | ShowInputAction
     | ShareAction
     | RunScriptAction
+    | LoadBotsAction
     | SendWebhookAction
     | UnlockSpaceAction
     | RemoteAction
@@ -1161,7 +1161,7 @@ export interface LoadSpaceAction {
 /**
  * Defines an event that loads bots from the given space that match the given tags and values.
  */
-export interface LoadBotsAction {
+export interface LoadBotsAction extends AsyncAction {
     type: 'load_bots';
 
     /**
@@ -2168,12 +2168,18 @@ export function exitFullscreen(): ExitFullscreenAction {
  * Requests that bots matching the given tags be loaded from the given space.
  * @param space The space that the bots should be loaded from.
  * @param tags The tags that should be on the loaded bots.
+ * @param taskId The ID of the async task for this action.
  */
-export function loadBots(space: BotSpace, tags: TagFilter[]): LoadBotsAction {
+export function loadBots(
+    space: BotSpace,
+    tags: TagFilter[],
+    taskId?: number | string
+): LoadBotsAction {
     return {
         type: 'load_bots',
         space: space,
         tags: tags,
+        taskId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -75,7 +75,6 @@ export type ExtraActions =
     | SetupChannelAction
     | SetClipboardAction
     | ShowChatBarAction
-    | RunScriptAction
     | ShowUploadAuxFileAction
     | MarkHistoryAction
     | BrowseHistoryAction
@@ -99,6 +98,7 @@ export type AsyncActions =
     | AsyncErrorAction
     | ShowInputAction
     | ShareAction
+    | RunScriptAction
     | SendWebhookAction
     | UnlockSpaceAction
     | RemoteAction
@@ -1082,7 +1082,7 @@ export interface ShowChatOptions {
 /**
  * Defines an event that executes a script.
  */
-export interface RunScriptAction {
+export interface RunScriptAction extends AsyncAction {
     type: 'run_script';
 
     /**
@@ -2002,11 +2002,16 @@ export function setClipboard(text: string): SetClipboardAction {
 /**
  * Creates a RunScriptAction.
  * @param script The script that should be executed.
+ * @param taskId The ID of the async task that this script represents.
  */
-export function runScript(script: string): RunScriptAction {
+export function runScript(
+    script: string,
+    taskId?: number | string
+): RunScriptAction {
     return {
         type: 'run_script',
         script,
+        taskId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -85,7 +85,6 @@ export type ExtraActions =
     | ShowJoinCodeAction
     | RequestFullscreenAction
     | ExitFullscreenAction
-    | ClearSpaceAction
     | LocalFormAnimationAction
     | GetPlayerCountAction;
 
@@ -99,6 +98,7 @@ export type AsyncActions =
     | ShareAction
     | RunScriptAction
     | LoadBotsAction
+    | ClearSpaceAction
     | SendWebhookAction
     | UnlockSpaceAction
     | RemoteAction
@@ -1197,7 +1197,7 @@ export interface TagFilter {
  * Only supported for the following spaces:
  * - error
  */
-export interface ClearSpaceAction {
+export interface ClearSpaceAction extends AsyncAction {
     type: 'clear_space';
 
     /**
@@ -2190,11 +2190,16 @@ export function loadBots(
  * - error
  *
  * @param space The space to clear.
+ * @param taskId The ID of the async task.
  */
-export function clearSpace(space: BotSpace): ClearSpaceAction {
+export function clearSpace(
+    space: BotSpace,
+    taskId?: number | string
+): ClearSpaceAction {
     return {
         type: 'clear_space',
         space: space,
+        taskId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -23,6 +23,8 @@ export type BotAction =
     | ExtraActions
     | AsyncActions
     | RemoteAction
+    | RemoteActionResult
+    | RemoteActionError
     | DeviceAction;
 
 /**

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -72,7 +72,6 @@ export type ExtraActions =
     | FinishCheckoutAction
     | PasteStateAction
     | ReplaceDragBotAction
-    | SetupChannelAction
     | SetClipboardAction
     | ShowChatBarAction
     | ShowUploadAuxFileAction
@@ -103,6 +102,7 @@ export type AsyncActions =
     | UnlockSpaceAction
     | LoadFileAction
     | SaveFileAction
+    | SetupChannelAction
     | RemoteAction
     | RemoteActionResult
     | RemoteActionError
@@ -1030,7 +1030,7 @@ export interface RejectAction {
 /**
  * Defines an event that creates a channel if it doesn't exist.
  */
-export interface SetupChannelAction {
+export interface SetupChannelAction extends AsyncAction {
     type: 'setup_story';
 
     /**
@@ -2000,15 +2000,20 @@ export function replaceDragBot(bot: Bot | BotTags): ReplaceDragBotAction {
  * Creates a channel if it doesn't exist and places the given bot in it.
  * @param channel The ID of the channel to setup.
  * @param botOrMod The bot that should be cloned into the new channel.
+ * @param taskId The ID of the async task.
  */
 export function setupStory(
     channel: string,
-    botOrMod?: Bot | BotTags
+    botOrMod?: Bot | BotTags,
+    taskId?: string | number,
+    playerId?: string
 ): SetupChannelAction {
     return {
         type: 'setup_story',
         channel,
         botOrMod,
+        taskId,
+        playerId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -55,8 +55,6 @@ export type ExtraActions =
     | UnloadStoryAction
     | SuperShoutAction
     | SendWebhookAction
-    | LoadFileAction
-    | SaveFileAction
     | GoToDimensionAction
     | GoToURLAction
     | PlaySoundAction
@@ -103,6 +101,8 @@ export type AsyncActions =
     | ClearSpaceAction
     | SendWebhookAction
     | UnlockSpaceAction
+    | LoadFileAction
+    | SaveFileAction
     | RemoteAction
     | RemoteActionResult
     | RemoteActionError
@@ -118,6 +118,12 @@ export interface AsyncAction extends Action {
      * The ID of the async task.
      */
     taskId: number | string;
+
+    /**
+     * The ID of the player that created this task.
+     * Set by remote action handlers when a task is recieved from a remote player.
+     */
+    playerId?: string;
 }
 
 /**
@@ -709,7 +715,7 @@ export interface WebhookOptions {
 /**
  * Defines an event that is used to load a file.
  */
-export interface LoadFileAction extends Action {
+export interface LoadFileAction extends AsyncAction {
     type: 'load_file';
 
     /**
@@ -736,7 +742,7 @@ export interface LoadFileOptions {
 /**
  * Defines an event that is used to save a file to a drive.
  */
-export interface SaveFileAction extends Action {
+export interface SaveFileAction extends AsyncAction {
     type: 'save_file';
 
     /**
@@ -1905,22 +1911,32 @@ export function webhook(
 /**
  * Creates a new LoadFileAction.
  * @param options The options.
+ * @param taskId The ID of the async task.
  */
-export function loadFile(options: LoadFileOptions): LoadFileAction {
+export function loadFile(
+    options: LoadFileOptions,
+    taskId?: number | string
+): LoadFileAction {
     return {
         type: 'load_file',
         options: options,
+        taskId,
     };
 }
 
 /**
  * Creates a new SaveFileAction.
  * @param options The options.
+ * @param taskId The ID of the async task.
  */
-export function saveFile(options: SaveFileOptions): SaveFileAction {
+export function saveFile(
+    options: SaveFileOptions,
+    taskId?: number | string
+): SaveFileAction {
     return {
         type: 'save_file',
         options: options,
+        taskId,
     };
 }
 

--- a/src/aux-common/partitions/AuxPartition.ts
+++ b/src/aux-common/partitions/AuxPartition.ts
@@ -4,6 +4,7 @@ import {
     RemoteAction,
     User,
     Action,
+    RemoteActions,
 } from '@casual-simulation/causal-trees';
 import { Observable, SubscriptionLike } from 'rxjs';
 
@@ -75,7 +76,7 @@ export interface AuxPartitionBase extends SubscriptionLike {
      * Sends the given events to the targeted device.
      * @param events The events to send.
      */
-    sendRemoteEvents?(events: RemoteAction[]): Promise<void>;
+    sendRemoteEvents?(events: RemoteActions[]): Promise<void>;
 
     /**
      * Sets the user that the partition should use.

--- a/src/aux-common/partitions/BotPartition.spec.ts
+++ b/src/aux-common/partitions/BotPartition.spec.ts
@@ -320,5 +320,31 @@ describe('BotPartition', () => {
             expect(removed).toEqual(['test1', 'test2']);
             expect(subject.state).toEqual({});
         });
+
+        it('should emit a async result when the bots are cleared', async () => {
+            await client.addBots('story', [
+                createBot('test2', {
+                    num: 123,
+                    test: true,
+                }),
+                createBot('test1', {
+                    abc: 'def',
+                    test: true,
+                }),
+                createBot('test3', {
+                    wrong: true,
+                    test: false,
+                }),
+            ]);
+
+            let events = [] as Action[];
+            subject.onEvents.subscribe(e => events.push(...e));
+
+            await subject.applyEvents([clearSpace(<any>'space', 99)]);
+
+            await waitAsync();
+
+            expect(events).toEqual([asyncResult(99, undefined)]);
+        });
     });
 });

--- a/src/aux-common/partitions/BotPartition.ts
+++ b/src/aux-common/partitions/BotPartition.ts
@@ -38,6 +38,7 @@ import {
     UpdateBotAction,
     Bot,
     BotsState,
+    asyncResult,
 } from '../bots';
 import values from 'lodash/values';
 
@@ -176,15 +177,19 @@ export class BotPartitionImpl implements BotPartition {
 
     private async _loadBots(event: LoadBotsAction) {
         const bots = await this._client.lookupBots(this._story, event.tags);
+        const sorted = sortBy(bots, b => b.id);
 
         if (bots.length > 0) {
-            const sorted = sortBy(bots, b => b.id);
             this.state = Object.assign({}, this.state);
             for (let bot of sorted) {
                 bot.space = <any>this.space;
                 this.state[bot.id] = bot;
             }
             this._onBotsAdded.next(sorted);
+        }
+
+        if (hasValue(event.taskId)) {
+            this._onEvents.next([asyncResult(event.taskId, sorted, true)]);
         }
     }
 

--- a/src/aux-common/partitions/BotPartition.ts
+++ b/src/aux-common/partitions/BotPartition.ts
@@ -39,6 +39,7 @@ import {
     Bot,
     BotsState,
     asyncResult,
+    ClearSpaceAction,
 } from '../bots';
 import values from 'lodash/values';
 
@@ -126,7 +127,7 @@ export class BotPartitionImpl implements BotPartition {
             if (e.type === 'load_bots') {
                 this._loadBots(e);
             } else if (e.type === 'clear_space') {
-                this._clearBots();
+                this._clearBots(e);
             }
         }
 
@@ -193,12 +194,16 @@ export class BotPartitionImpl implements BotPartition {
         }
     }
 
-    private async _clearBots() {
+    private async _clearBots(event: ClearSpaceAction) {
         await this._client.clearBots(this._story);
 
         const ids = sortBy(values(this.state).map(b => b.id));
         this.state = {};
 
         this._onBotsRemoved.next(ids);
+
+        if (hasValue(event.taskId)) {
+            this._onEvents.next([asyncResult(event.taskId, undefined)]);
+        }
     }
 }

--- a/src/aux-common/partitions/OtherPlayersPartition.ts
+++ b/src/aux-common/partitions/OtherPlayersPartition.ts
@@ -13,6 +13,7 @@ import {
     DeviceInfo,
     USERNAME_CLAIM,
     SESSION_ID_CLAIM,
+    RemoteActions,
 } from '@casual-simulation/causal-trees';
 import { CausalRepoClient } from '@casual-simulation/causal-trees/core2';
 import {
@@ -184,9 +185,9 @@ export class OtherPlayersPartitionImpl implements OtherPlayersPartition {
         return [];
     }
 
-    async sendRemoteEvents(events: RemoteAction[]): Promise<void> {
+    async sendRemoteEvents(events: RemoteActions[]): Promise<void> {
         for (let event of events) {
-            if (event.event.type === 'get_players') {
+            if (event.type === 'remote' && event.event.type === 'get_players') {
                 const action = <GetPlayersAction>event.event;
                 const connectedDevices = [...this._devices.values()];
                 const sessionIds = sortBy([

--- a/src/aux-common/partitions/ProxyBridgePartition.ts
+++ b/src/aux-common/partitions/ProxyBridgePartition.ts
@@ -5,6 +5,7 @@ import {
     RemoteAction,
     StatusUpdate,
     Action,
+    RemoteActions,
 } from '@casual-simulation/causal-trees';
 import { Bot, UpdatedBot, BotAction } from '../bots';
 import { Observable, Subscription } from 'rxjs';
@@ -57,7 +58,7 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
         return this._partition.applyEvents(events);
     }
 
-    async sendRemoteEvents(events: RemoteAction[]): Promise<void> {
+    async sendRemoteEvents(events: RemoteActions[]): Promise<void> {
         if (this._partition.sendRemoteEvents) {
             await this._partition.sendRemoteEvents(events);
         }

--- a/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -3,6 +3,7 @@ import {
     StatusUpdate,
     RemoteAction,
     Action,
+    RemoteActions,
 } from '@casual-simulation/causal-trees';
 import {
     CausalRepoClient,
@@ -135,13 +136,16 @@ export class RemoteCausalRepoHistoryPartitionImpl
         this._synced = false;
     }
 
-    async sendRemoteEvents(events: RemoteAction[]): Promise<void> {
+    async sendRemoteEvents(events: RemoteActions[]): Promise<void> {
         if (this._readOnly) {
             return;
         }
 
         for (let event of events) {
-            if (event.event.type === 'restore_history_mark') {
+            if (
+                event.type === 'remote' &&
+                event.event.type === 'restore_history_mark'
+            ) {
                 const restoreMark = <RestoreHistoryMarkAction>event.event;
                 const bot = this.state[restoreMark.mark];
                 if (!bot) {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.spec.ts
@@ -422,6 +422,41 @@ describe('RemoteCausalRepoPartition', () => {
                         },
                     ]);
                 });
+
+                it(`should delegate the task to the load_space action`, async () => {
+                    setupPartition({
+                        type: 'remote_causal_repo',
+                        branch: 'testBranch',
+                        host: 'testHost',
+                    });
+
+                    let events = [] as Action[];
+                    partition.onEvents.subscribe(e => events.push(...e));
+
+                    await partition.sendRemoteEvents([
+                        remote(
+                            <any>{
+                                type: 'browse_history',
+                            },
+                            undefined,
+                            undefined,
+                            99
+                        ),
+                    ]);
+
+                    expect(events).toEqual([
+                        {
+                            type: 'load_space',
+                            space: 'history',
+                            config: {
+                                type: 'causal_repo_history_client',
+                                branch: 'testBranch',
+                                client: expect.anything(),
+                            },
+                            taskId: 99,
+                        },
+                    ]);
+                });
             });
 
             describe('get_player_count', () => {

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -192,13 +192,15 @@ export class RemoteCausalRepoPartitionImpl
                     this._client.commit(this._branch, markHistory.message);
                 } else if (event.event.type === 'browse_history') {
                     this._onEvents.next([
-                        loadSpace('history', <
-                            CausalRepoHistoryClientPartitionConfig
-                        >{
-                            type: 'causal_repo_history_client',
-                            branch: this._branch,
-                            client: this._client,
-                        }),
+                        loadSpace(
+                            'history',
+                            <CausalRepoHistoryClientPartitionConfig>{
+                                type: 'causal_repo_history_client',
+                                branch: this._branch,
+                                client: this._client,
+                            },
+                            event.taskId
+                        ),
                     ]);
                 } else if (event.event.type === 'get_player_count') {
                     const action = <GetPlayerCountAction>event.event;

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -189,7 +189,24 @@ export class RemoteCausalRepoPartitionImpl
             if (event.type === 'remote') {
                 if (event.event.type === 'mark_history') {
                     const markHistory = <MarkHistoryAction>event.event;
-                    this._client.commit(this._branch, markHistory.message);
+                    this._client
+                        .commit(this._branch, markHistory.message)
+                        .subscribe(
+                            () => {
+                                if (hasValue(event.taskId)) {
+                                    this._onEvents.next([
+                                        asyncResult(event.taskId, undefined),
+                                    ]);
+                                }
+                            },
+                            err => {
+                                if (hasValue(event.taskId)) {
+                                    this._onEvents.next([
+                                        asyncError(event.taskId, err),
+                                    ]);
+                                }
+                            }
+                        );
                 } else if (event.event.type === 'browse_history') {
                     this._onEvents.next([
                         loadSpace(

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -1464,9 +1464,10 @@ describe('AuxLibrary', () => {
 
         describe('player.run()', () => {
             it('should emit a RunScriptAction', () => {
-                const action = library.api.player.run('abc');
-                expect(action).toEqual(runScript('abc'));
-                expect(context.actions).toEqual([runScript('abc')]);
+                const action: any = library.api.player.run('abc');
+                const expected = runScript('abc', context.tasks.size);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2478,9 +2478,9 @@ describe('AuxLibrary', () => {
 
         describe('server.destroyErrors()', () => {
             it('should issue a ClearSpaceAction', () => {
-                const action = library.api.server.destroyErrors();
-                const expected = clearSpace('error');
-                expect(action).toEqual(expected);
+                const action: any = library.api.server.destroyErrors();
+                const expected = clearSpace('error', context.tasks.size);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2451,28 +2451,52 @@ describe('AuxLibrary', () => {
 
         describe('server.loadFile()', () => {
             it('should issue a LoadFileAction in a remote event', () => {
-                const action = library.api.server.loadFile('path');
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.loadFile('path');
                 const expected = remote(
                     loadFile({
                         path: 'path',
-                    })
+                    }),
+                    undefined,
+                    undefined,
+                    'task1'
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.loadFile('path');
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 
         describe('server.saveFile()', () => {
             it('should issue a SaveFileAction in a remote event', () => {
-                const action = library.api.server.saveFile('path', 'data');
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.saveFile('path', 'data');
                 const expected = remote(
                     saveFile({
                         path: 'path',
                         data: 'data',
-                    })
+                    }),
+                    undefined,
+                    undefined,
+                    'task1'
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.saveFile('path', 'data');
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2487,42 +2487,53 @@ describe('AuxLibrary', () => {
 
         describe('server.loadErrors()', () => {
             it('should issue a LoadBotsAction for the given tag and bot ID', () => {
-                const action = library.api.server.loadErrors('test', 'abc');
-                const expected = loadBots('error', [
-                    {
-                        tag: 'error',
-                        value: true,
-                    },
-                    {
-                        tag: 'errorBot',
-                        value: 'test',
-                    },
-                    {
-                        tag: 'errorTag',
-                        value: 'abc',
-                    },
-                ]);
-                expect(action).toEqual(expected);
+                const action: any = library.api.server.loadErrors(
+                    'test',
+                    'abc'
+                );
+                const expected = loadBots(
+                    'error',
+                    [
+                        {
+                            tag: 'error',
+                            value: true,
+                        },
+                        {
+                            tag: 'errorBot',
+                            value: 'test',
+                        },
+                        {
+                            tag: 'errorTag',
+                            value: 'abc',
+                        },
+                    ],
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should support being passed a runtime bot', () => {
-                const action = library.api.server.loadErrors(bot1, 'abc');
-                const expected = loadBots('error', [
-                    {
-                        tag: 'error',
-                        value: true,
-                    },
-                    {
-                        tag: 'errorBot',
-                        value: bot1.id,
-                    },
-                    {
-                        tag: 'errorTag',
-                        value: 'abc',
-                    },
-                ]);
-                expect(action).toEqual(expected);
+                const action: any = library.api.server.loadErrors(bot1, 'abc');
+                const expected = loadBots(
+                    'error',
+                    [
+                        {
+                            tag: 'error',
+                            value: true,
+                        },
+                        {
+                            tag: 'errorBot',
+                            value: bot1.id,
+                        },
+                        {
+                            tag: 'errorTag',
+                            value: 'abc',
+                        },
+                    ],
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2423,7 +2423,8 @@ describe('AuxLibrary', () => {
 
         describe('server.markHistory()', () => {
             it('should emit a mark_history event', () => {
-                const action = library.api.server.markHistory({
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.markHistory({
                     message: 'testMark',
                 });
                 const expected = remote(
@@ -2431,10 +2432,21 @@ describe('AuxLibrary', () => {
                         message: 'testMark',
                     }),
                     undefined,
-                    false
+                    false,
+                    'task1'
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.markHistory({
+                    message: 'test',
+                });
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2475,22 +2475,52 @@ describe('AuxLibrary', () => {
 
         describe('server.restoreHistoryMark()', () => {
             it('should emit a restore_history_mark event', () => {
-                const action = library.api.server.restoreHistoryMark('mark');
-                const expected = remote(restoreHistoryMark('mark'));
-                expect(action).toEqual(expected);
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.restoreHistoryMark(
+                    'mark'
+                );
+                const expected = remote(
+                    restoreHistoryMark('mark'),
+                    undefined,
+                    undefined,
+                    'task1'
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.restoreHistoryMark('mark');
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 
         describe('server.restoreHistoryMarkToStory()', () => {
             it('should emit a restore_history_mark event', () => {
-                const action = library.api.server.restoreHistoryMarkToStory(
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.restoreHistoryMarkToStory(
                     'mark',
                     'story'
                 );
-                const expected = remote(restoreHistoryMark('mark', 'story'));
-                expect(action).toEqual(expected);
+                const expected = remote(
+                    restoreHistoryMark('mark', 'story'),
+                    undefined,
+                    undefined,
+                    'task1'
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.restoreHistoryMarkToStory('mark', 'story');
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2440,10 +2440,24 @@ describe('AuxLibrary', () => {
 
         describe('server.browseHistory()', () => {
             it('should emit a browse_history event', () => {
-                const action = library.api.server.browseHistory();
-                const expected = remote(browseHistory());
-                expect(action).toEqual(expected);
+                uuidMock.mockReturnValueOnce('task1');
+                const action: any = library.api.server.browseHistory();
+                const expected = remote(
+                    browseHistory(),
+                    undefined,
+                    undefined,
+                    'task1'
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            it('should create tasks that can be resolved from a remote', () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                library.api.server.browseHistory();
+
+                const task = context.tasks.get('uuid');
+                expect(task.allowRemoteResolution).toBe(true);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -897,7 +897,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param script The script that should be executed.
      */
     function run(script: string) {
-        return addAction(runScript(script));
+        const task = context.createTask();
+        const event = runScript(script, task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1512,7 +1512,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Destroys all the errors in the story.
      */
     function destroyErrors() {
-        return addAction(clearSpace('error'));
+        const task = context.createTask();
+        const event = clearSpace('error', task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1486,7 +1486,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      */
     function restoreHistoryMark(mark: Bot | string) {
         const id = getID(mark);
-        return remote(calcRestoreHistoryMark(id));
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            calcRestoreHistoryMark(id),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**
@@ -1496,7 +1503,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      */
     function restoreHistoryMarkToStory(mark: Bot | string, story: string) {
         const id = getID(mark);
-        return remote(calcRestoreHistoryMark(id, story));
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            calcRestoreHistoryMark(id, story),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1484,12 +1484,17 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param options The options.
      */
     function loadFile(path: string, options?: LoadFileOptions) {
-        return remote(
+        const task = context.createTask(true, true);
+        const event = calcRemote(
             calcLoadFile({
                 path: path,
                 ...(options || {}),
-            })
+            }),
+            undefined,
+            undefined,
+            task.taskId
         );
+        return addAsyncAction(task, event);
     }
 
     /**
@@ -1499,13 +1504,18 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param options The options to use.
      */
     function saveFile(path: string, data: string, options?: SaveFileOptions) {
-        return remote(
+        const task = context.createTask(true, true);
+        const event = calcRemote(
             calcSaveFile({
                 path: path,
                 data: data,
                 ...(options || {}),
-            })
+            }),
+            undefined,
+            undefined,
+            task.taskId
         );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1520,9 +1520,11 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param bot The bot that the errors should be loaded for.
      * @param tag The tag that the errors should be loaded for.
      */
-    function loadErrors(bot: string | Bot, tag: string) {
-        return addAction(
-            loadBots('error', [
+    function loadErrors(bot: string | Bot, tag: string): Promise<Bot[]> {
+        const task = context.createTask();
+        const event = loadBots(
+            'error',
+            [
                 {
                     tag: 'error',
                     value: true,
@@ -1535,8 +1537,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                     tag: 'errorTag',
                     value: tag,
                 },
-            ])
+            ],
+            task.taskId
         );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1456,7 +1456,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * });
      */
     function markHistory(options: MarkHistoryOptions) {
-        return remote(calcMarkHistory(options), undefined, false);
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            calcMarkHistory(options),
+            undefined,
+            false,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1463,7 +1463,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Loads the "history" space into the story.
      */
     function browseHistory() {
-        return remote(calcBrowseHistory());
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            calcBrowseHistory(),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1383,7 +1383,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param botOrMod The bot or mod that should be cloned into the new story.
      */
     function setupStory(story: string, botOrMod?: Mod) {
-        return remote(calcSetupStory(story, context.unwrapBot(botOrMod)));
+        const task = context.createTask(true, true);
+        const event = calcRemote(
+            calcSetupStory(story, context.unwrapBot(botOrMod)),
+            undefined,
+            undefined,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2608,7 +2608,7 @@ declare global {
          * @param story The story.
          * @param botOrMod The bot or mod that should be cloned into the new story.
          */
-        setupStory(story: string, botOrMod?: Mod): SetupChannelAction;
+        setupStory(story: string, botOrMod?: Mod): Promise<void>;
     
         /**
          * Executes the given shell script on the server.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2716,7 +2716,7 @@ declare global {
         /**
          * Loads the "history" space into the story.
          */
-        browseHistory(): BrowseHistoryAction;
+        browseHistory(): Promise<void>;
     
         /**
          * Restores the current state to the given mark.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -839,6 +839,15 @@ declare interface LoadFileOptions {
 }
 
 /**
+ * The data returned from loading a file.
+ */
+declare interface LoadFileResult {
+    path: string;
+    url: string;
+    data: string | Buffer;
+}
+
+/**
  * Defines an event that is used to save a file to a drive.
  */
 declare interface SaveFileAction extends Action {
@@ -873,6 +882,14 @@ declare interface SaveFileOptions {
      * Whether to overwrite existing files.
      */
     overwriteExistingFile?: boolean;
+}
+
+/**
+ * The data returned from saving a file.
+ */
+declare interface SaveFileResult {
+    path: string;
+    url: string;
 }
 
 /**
@@ -2656,14 +2673,14 @@ declare global {
          * @param path The path of the file.
          * @param options The options.
          */
-        loadFile(path: string, options?: LoadFileOptions): RemoteAction;
+        loadFile(path: string, options?: LoadFileOptions): Promise<LoadFileResult>;
     
         /**
          * Saves a file on the server at the given path.
          * @param path The path of the file.
          * @param options The options.
          */
-        saveFile(path: string, data: string, options?: SaveFileOptions): RemoteAction;
+        saveFile(path: string, data: string, options?: SaveFileOptions): Promise<SaveFileResult>;
     
         /**
          * Finishes the checkout process by charging the payment fee to the user.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2613,7 +2613,7 @@ declare global {
         /**
          * Clears all the errors in the story.
          */
-        destroyErrors(): ClearSpaceAction;
+        destroyErrors(): Promise<void>;
     
         /**
          * Loads the errors for the given bot and tag.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2620,7 +2620,7 @@ declare global {
          * @param bot The bot that the errors should be loaded for.
          * @param tag The tag that the errors should be loaded for.
          */
-        loadErrors(bot: string | Bot, tag: string): LoadBotsAction;
+        loadErrors(bot: string | Bot, tag: string): Promise<Bot[]>;
 
         /**
          * Gets the number of players that are viewing the current story.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1163,7 +1163,7 @@ declare interface ShowChatOptions {
 /**
  * Defines an event that executes a script.
  */
-declare interface RunScriptAction {
+declare interface RunScriptAction extends AsyncAction {
     type: 'run_script';
 
     /**
@@ -2409,7 +2409,7 @@ declare global {
          * Enqueues the given script to execute after this script is done running.
          * @param script The script that should be executed.
          */
-        run(script: string): RunScriptAction;
+        run(script: string): Promise<any>;
 
         /**
          * Downloads the given list of bots.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2722,7 +2722,7 @@ declare global {
          * Restores the current state to the given mark.
          * @param mark The bot or bot ID that represents the mark that should be restored.
          */
-        restoreHistoryMark(mark: Bot | string): RestoreHistoryMarkAction;
+        restoreHistoryMark(mark: Bot | string): Promise<void>;
     
         /**
          * Restores the current state to the given mark.
@@ -2732,7 +2732,7 @@ declare global {
         restoreHistoryMarkToStory(
             mark: Bot | string,
             story: string
-        ): RestoreHistoryMarkAction;
+        ): Promise<void>;
     };
 
     /**

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -9433,7 +9433,12 @@ describe('original action tests', () => {
             const result = calculateActionResults(state, botAction);
 
             expect(result.actions).toEqual([
-                remote(restoreHistoryMark('mark')),
+                remote(
+                    restoreHistoryMark('mark'),
+                    undefined,
+                    undefined,
+                    'uuid-0'
+                ),
             ]);
         });
     });
@@ -9455,11 +9460,16 @@ describe('original action tests', () => {
             const result = calculateActionResults(state, botAction);
 
             expect(result.actions).toEqual([
-                remote(<RestoreHistoryMarkAction>{
-                    type: 'restore_history_mark',
-                    mark: 'mark',
-                    story: 'story',
-                }),
+                remote(
+                    <RestoreHistoryMarkAction>{
+                        type: 'restore_history_mark',
+                        mark: 'mark',
+                        story: 'story',
+                    },
+                    undefined,
+                    undefined,
+                    'uuid-0'
+                ),
             ]);
         });
     });

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -1533,6 +1533,43 @@ describe('AuxRuntime', () => {
             expect(events.slice(1)).toEqual([[], [toast('abc')]]);
         });
 
+        it('should support mapping bots in async actions results', async () => {
+            runtime.botsAdded([
+                createBot('test1', {
+                    abc: 'def',
+                }),
+            ]);
+
+            runtime.process([
+                runScript(
+                    'player.showInput().then(result => player.toast(result.tags.abc))'
+                ),
+            ]);
+
+            await waitAsync();
+
+            expect(events).toEqual([
+                [showInput(undefined, undefined, expect.any(Number))],
+            ]);
+
+            const taskId = (<any>events[0][0]).taskId as number;
+
+            runtime.process([
+                asyncResult(
+                    taskId,
+                    {
+                        id: 'test1',
+                        tags: {},
+                    },
+                    true
+                ),
+            ]);
+
+            await waitAsync();
+
+            expect(events.slice(1)).toEqual([[], [toast('def')]]);
+        });
+
         it('should support rejecting async actions', async () => {
             runtime.process([
                 runScript(

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -1627,6 +1627,26 @@ describe('AuxRuntime', () => {
 
             expect(events).toEqual([[toast('abc')]]);
         });
+
+        it('should resolve run_script tasks', async () => {
+            const result = runtime.execute(
+                'return await player.run("return 123");'
+            );
+
+            runtime.process(result.actions);
+
+            expect(await result.result).toBe(123);
+        });
+
+        it('should unwrap async run_script tasks', async () => {
+            const result = runtime.execute(
+                'return await player.run("return Promise.resolve(123);");'
+            );
+
+            runtime.process(result.actions);
+
+            expect(await result.result).toBe(123);
+        });
     });
 
     describe('execute()', () => {
@@ -7575,7 +7595,7 @@ describe('original action tests', () => {
             const botAction = action('test', ['thisBot']);
             const result = calculateActionResults(state, botAction);
 
-            expect(result.actions).toEqual([runScript('abc')]);
+            expect(result.actions).toEqual([runScript('abc', 1)]);
         });
     });
 

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -9192,7 +9192,10 @@ describe('original action tests', () => {
                         createBot('thisBot', {
                             test: '@server.setupStory("channel", this)',
                         })
-                    )
+                    ),
+                    undefined,
+                    undefined,
+                    'uuid-0'
                 ),
             ]);
         });

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -9387,7 +9387,8 @@ describe('original action tests', () => {
                         message: 'testMark',
                     }),
                     undefined,
-                    false
+                    false,
+                    'uuid-0'
                 ),
             ]);
         });

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -9409,7 +9409,9 @@ describe('original action tests', () => {
             const botAction = action('test', ['thisBot'], 'userBot');
             const result = calculateActionResults(state, botAction);
 
-            expect(result.actions).toEqual([remote(browseHistory())]);
+            expect(result.actions).toEqual([
+                remote(browseHistory(), undefined, undefined, 'uuid-0'),
+            ]);
         });
     });
 

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -7173,7 +7173,10 @@ describe('original action tests', () => {
                 remote(
                     loadFile({
                         path: 'path',
-                    })
+                    }),
+                    undefined,
+                    undefined,
+                    'uuid-0'
                 ),
             ]);
         });

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -98,6 +98,10 @@ export class AuxRuntime
     private _library: AuxLibrary;
     private _editModeProvider: AuxRealtimeEditModeProvider;
 
+    get context() {
+        return this._globalContext;
+    }
+
     /**
      * Creates a new AuxRuntime using the given library factory.
      * @param libraryFactory

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -304,6 +304,13 @@ export class AuxRuntime
         } else if (action.type === 'run_script') {
             const result = this._execute(action.script, false);
             this.process(result.actions);
+            if (hasValue(action.taskId)) {
+                this._globalContext.resolveTask(
+                    action.taskId,
+                    result.result,
+                    false
+                );
+            }
         } else if (action.type === 'apply_state') {
             const events = breakIntoIndividualEvents(this.currentState, action);
             this.process(events);

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -315,11 +315,11 @@ export class AuxRuntime
             const events = breakIntoIndividualEvents(this.currentState, action);
             this.process(events);
         } else if (action.type === 'async_result') {
-            this._globalContext.resolveTask(
-                action.taskId,
-                action.result,
-                false
-            );
+            const value =
+                action.mapBotsInResult === true
+                    ? this._mapBotsToRuntimeBots(action.result)
+                    : action.result;
+            this._globalContext.resolveTask(action.taskId, value, false);
         } else if (action.type === 'async_error') {
             this._globalContext.rejectTask(action.taskId, action.error, false);
         } else if (action.type === 'device_result') {

--- a/src/aux-server/server/modules/FilesModule2.spec.ts
+++ b/src/aux-server/server/modules/FilesModule2.spec.ts
@@ -269,7 +269,7 @@ describe('FilesModule2', () => {
                     remoteResult(
                         {
                             path: '/drives/newFile.txt',
-                            url: '/drives//newFile.txt',
+                            url: expect.any(String),
                         },
                         {
                             sessionId: 'player1',
@@ -415,7 +415,7 @@ describe('FilesModule2', () => {
                     remoteResult(
                         {
                             path: '/drives/file1.txt',
-                            url: '/drives/\\test\\storage-dir\\0\\file1.txt',
+                            url: expect.any(String),
                             data: 'abc',
                         },
                         {

--- a/src/aux-server/server/modules/FilesModule2.spec.ts
+++ b/src/aux-server/server/modules/FilesModule2.spec.ts
@@ -1,12 +1,26 @@
-import { saveFile, loadFile } from '@casual-simulation/aux-common';
+import {
+    saveFile,
+    loadFile,
+    MemoryPartition,
+} from '@casual-simulation/aux-common';
 import { waitAsync } from '@casual-simulation/aux-common/test/TestHelpers';
 import { nodeSimulationWithConfig } from '@casual-simulation/aux-vm-node';
 import { Subscription } from 'rxjs';
-import { AuxConfig, AuxUser, Simulation } from '@casual-simulation/aux-vm';
+import {
+    AuxConfig,
+    AuxUser,
+    Simulation,
+    AuxChannel,
+} from '@casual-simulation/aux-vm';
 import fs from 'fs';
 import { FilesModule2 } from './FilesModule2';
 import mockFs from 'mock-fs';
 import uuid from 'uuid/v4';
+import {
+    Action,
+    remoteResult,
+    remoteError,
+} from '@casual-simulation/causal-trees';
 let dateNowMock = (Date.now = jest.fn());
 
 console.log = jest.fn();
@@ -17,6 +31,8 @@ jest.mock('uuid/v4');
 
 describe('FilesModule2', () => {
     let simulation: Simulation;
+    let channel: AuxChannel;
+    let memory: MemoryPartition;
     let user: AuxUser;
     let config: AuxConfig;
     let subject: FilesModule2;
@@ -55,6 +71,9 @@ describe('FilesModule2', () => {
 
         simulation = nodeSimulationWithConfig(user, 'admin', config);
         await simulation.init();
+
+        channel = (<any>simulation)._vm.channel;
+        memory = (<any>channel)._partitions.shared;
 
         subject = new FilesModule2('/test/storage-dir');
         sub = await subject.setup(simulation);
@@ -225,6 +244,76 @@ describe('FilesModule2', () => {
 
                 expect(exists).toBe(true);
             });
+
+            it('should send an async result when done if the event has a task id and player id', async () => {
+                let remoteEvents = [] as Action[];
+
+                memory.sendRemoteEvents = async events => {
+                    remoteEvents.push(...events);
+                };
+
+                await simulation.helper.transaction({
+                    type: 'save_file',
+                    options: {
+                        path: '/drives/newFile.txt',
+                        data: 'test',
+                        callbackShout: 'callback',
+                    },
+                    taskId: 'task1',
+                    playerId: 'player1',
+                });
+
+                await waitAsync();
+
+                expect(remoteEvents).toEqual([
+                    remoteResult(
+                        {
+                            path: '/drives/newFile.txt',
+                            url: '/drives//newFile.txt',
+                        },
+                        {
+                            sessionId: 'player1',
+                        },
+                        'task1'
+                    ),
+                ]);
+            });
+
+            it('should send an async error when done if the event has a task id and player id', async () => {
+                let remoteEvents = [] as Action[];
+
+                memory.sendRemoteEvents = async events => {
+                    remoteEvents.push(...events);
+                };
+
+                fs.writeFileSync('/test/storage-dir/0/newFile.txt', 'abc');
+
+                await simulation.helper.transaction({
+                    type: 'save_file',
+                    options: {
+                        path: '/drives/newFile.txt',
+                        data: 'test',
+                        callbackShout: 'callback',
+                    },
+                    taskId: 'task1',
+                    playerId: 'player1',
+                });
+
+                await waitAsync();
+
+                expect(remoteEvents).toEqual([
+                    remoteError(
+                        {
+                            path: '/drives/newFile.txt',
+                            error: 'file_already_exists',
+                        },
+                        {
+                            sessionId: 'player1',
+                        },
+                        'task1'
+                    ),
+                ]);
+            });
         });
 
         describe('load_file', () => {
@@ -302,6 +391,71 @@ describe('FilesModule2', () => {
                 const bot = simulation.helper.botsState['callback'];
                 const tags = bot.tags;
                 expect(tags['err']).toBe('file_does_not_exist');
+            });
+
+            it('should send an async result with the file', async () => {
+                let remoteEvents = [] as Action[];
+
+                memory.sendRemoteEvents = async events => {
+                    remoteEvents.push(...events);
+                };
+
+                await simulation.helper.transaction({
+                    type: 'load_file',
+                    options: {
+                        path: '/drives/file1.txt',
+                    },
+                    taskId: 'task1',
+                    playerId: 'player1',
+                });
+
+                await waitAsync();
+
+                expect(remoteEvents).toEqual([
+                    remoteResult(
+                        {
+                            path: '/drives/file1.txt',
+                            url: '/drives/\\test\\storage-dir\\0\\file1.txt',
+                            data: 'abc',
+                        },
+                        {
+                            sessionId: 'player1',
+                        },
+                        'task1'
+                    ),
+                ]);
+            });
+
+            it('should send an async error if the file doesnt exist', async () => {
+                let remoteEvents = [] as Action[];
+
+                memory.sendRemoteEvents = async events => {
+                    remoteEvents.push(...events);
+                };
+
+                await simulation.helper.transaction({
+                    type: 'load_file',
+                    options: {
+                        path: '/drives/not_exists.txt',
+                    },
+                    taskId: 'task1',
+                    playerId: 'player1',
+                });
+
+                await waitAsync();
+
+                expect(remoteEvents).toEqual([
+                    remoteError(
+                        {
+                            path: '/drives/not_exists.txt',
+                            error: 'file_does_not_exist',
+                        },
+                        {
+                            sessionId: 'player1',
+                        },
+                        'task1'
+                    ),
+                ]);
             });
         });
     });

--- a/src/aux-vm/vm/AuxHelper.spec.ts
+++ b/src/aux-vm/vm/AuxHelper.spec.ts
@@ -38,6 +38,9 @@ import {
     ADD_ATOMS,
     atom,
     atomId,
+    remoteResult,
+    RemoteActions,
+    remoteError,
 } from '@casual-simulation/causal-trees';
 import uuid from 'uuid/v4';
 import {
@@ -645,7 +648,7 @@ describe('AuxHelper', () => {
         });
 
         it('should emit remote events that are sent via transaction()', async () => {
-            let events: RemoteAction[] = [];
+            let events: RemoteActions[] = [];
             helper.remoteEvents.subscribe(e => events.push(...e));
 
             await helper.transaction(remote(toast('test')));
@@ -653,8 +656,26 @@ describe('AuxHelper', () => {
             expect(events).toEqual([remote(toast('test'))]);
         });
 
+        it('should emit remote_result events that are sent via transaction()', async () => {
+            let events: RemoteActions[] = [];
+            helper.remoteEvents.subscribe(e => events.push(...e));
+
+            await helper.transaction(remoteResult('test'));
+
+            expect(events).toEqual([remoteResult('test')]);
+        });
+
+        it('should emit remote_error events that are sent via transaction()', async () => {
+            let events: RemoteActions[] = [];
+            helper.remoteEvents.subscribe(e => events.push(...e));
+
+            await helper.transaction(remoteError('test'));
+
+            expect(events).toEqual([remoteError('test')]);
+        });
+
         it('should not batch remote events that have allowBatching set to false', async () => {
-            let events: RemoteAction[][] = [];
+            let events: RemoteActions[][] = [];
             helper.remoteEvents.subscribe(e => events.push(e));
 
             await helper.transaction(

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -31,7 +31,12 @@ import {
     AsyncActions,
     asyncError,
 } from '@casual-simulation/aux-common';
-import { RemoteAction, DeviceAction } from '@casual-simulation/causal-trees';
+import {
+    RemoteAction,
+    DeviceAction,
+    RemoteActionResult,
+    RemoteActions,
+} from '@casual-simulation/causal-trees';
 import { Subject } from 'rxjs';
 import union from 'lodash/union';
 import sortBy from 'lodash/sortBy';
@@ -52,7 +57,7 @@ export class AuxHelper extends BaseHelper<Bot> {
     private _partitions: AuxPartitions;
     private _runtime: AuxRuntime;
     private _localEvents: Subject<LocalActions[]>;
-    private _remoteEvents: Subject<RemoteAction[]>;
+    private _remoteEvents: Subject<RemoteActions[]>;
     private _deviceEvents: Subject<DeviceAction[]>;
     private _partitionStates: Map<string, BotsState>;
     private _stateCache: Map<string, BotsState>;
@@ -464,6 +469,10 @@ export class AuxHelper extends BaseHelper<Bot> {
     private _partitionForEvent(event: BotAction): AuxPartition {
         if (event.type === 'remote') {
             return null;
+        } else if (event.type === 'remote_result') {
+            return null;
+        } else if (event.type === 'remote_error') {
+            return null;
         } else if (event.type === 'device') {
             return null;
         } else if (event.type === 'add_bot') {
@@ -523,12 +532,16 @@ export class AuxHelper extends BaseHelper<Bot> {
     }
 
     private _sendOtherEvents(events: BotAction[]) {
-        let remoteEvents: RemoteAction[] = [];
+        let remoteEvents: RemoteActions[] = [];
         let localEvents: LocalActions[] = [];
         let deviceEvents: DeviceAction[] = [];
 
         for (let event of events) {
-            if (event.type === 'remote') {
+            if (
+                event.type === 'remote' ||
+                event.type === 'remote_result' ||
+                event.type === 'remote_error'
+            ) {
                 remoteEvents.push(event);
             } else if (event.type === 'device') {
                 deviceEvents.push(event);

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -569,6 +569,7 @@ describe('BaseAuxChannel', () => {
                         type: 'run_script',
                         script:
                             'create({ value: "fun" }); let bot = create({ space: "random", value: 123 }); player.toast(bot)',
+                        taskId: null,
                     },
                 ]);
 

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -725,9 +725,9 @@ describe('BaseAuxChannel', () => {
         it('should send remote events', async () => {
             await channel.initAndWait();
 
-            await channel.formulaBatch(['server.browseHistory()']);
+            await channel.formulaBatch(['remote(player.toast("abc"))']);
 
-            expect(channel.remoteEvents).toEqual([remote(browseHistory())]);
+            expect(channel.remoteEvents).toEqual([remote(toast('abc'))]);
         });
     });
 

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -17,6 +17,9 @@ import {
     BotSpace,
     realtimeStrategyToRealtimeEditMode,
     AuxPartitionRealtimeEditModeProvider,
+    LoadSpaceAction,
+    hasValue,
+    asyncResult,
 } from '@casual-simulation/aux-common';
 import { AuxHelper } from './AuxHelper';
 import { AuxConfig, buildVersionNumber } from './AuxConfig';
@@ -518,7 +521,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     protected _handleLocalEvents(e: LocalActions[]) {
         for (let event of e) {
             if (event.type === 'load_space') {
-                this._loadPartition(event.space, event.config);
+                this._loadPartition(event.space, event.config, event);
             }
         }
         this._onLocalEvents.next(e);
@@ -528,11 +531,18 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._onDeviceEvents.next(e);
     }
 
-    protected async _loadPartition(space: string, config: PartitionConfig) {
+    protected async _loadPartition(
+        space: string,
+        config: PartitionConfig,
+        event: LoadSpaceAction
+    ) {
         if (space in this._partitions) {
             console.log(
                 `[BaseAuxChannel] Cannot load partition for "${space}" since the space is already occupied`
             );
+            if (hasValue(event.taskId)) {
+                this.sendEvents([asyncResult(event.taskId, null)]);
+            }
             return;
         }
 
@@ -546,6 +556,20 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._subs.push(
             ...this._getCleanupSubscriptionsForPartition(partition)
         );
+
+        if (hasValue(event.taskId)) {
+            // Wait for initial connection
+            partition.onStatusUpdated
+                .pipe(
+                    first(
+                        status =>
+                            status.type === 'sync' && status.synced === true
+                    )
+                )
+                .subscribe(() => {
+                    this.sendEvents([asyncResult(event.taskId, null)]);
+                });
+        }
 
         partition.connect();
 

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -27,6 +27,7 @@ import {
     RemoteAction,
     DeviceInfo,
     Action,
+    RemoteActions,
 } from '@casual-simulation/causal-trees';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { StatusHelper } from './StatusHelper';
@@ -345,7 +346,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
      * Sends the given list of remote events to their destinations.
      * @param events The events.
      */
-    protected async _sendRemoteEvents(events: RemoteAction[]): Promise<void> {
+    protected async _sendRemoteEvents(events: RemoteActions[]): Promise<void> {
         for (let [, partition] of iteratePartitions(this._partitions)) {
             if (partition.sendRemoteEvents) {
                 await partition.sendRemoteEvents(events);

--- a/src/causal-tree-server/CausalRepoServer.spec.ts
+++ b/src/causal-tree-server/CausalRepoServer.spec.ts
@@ -49,6 +49,7 @@ import {
     UNWATCH_BRANCH_DEVICES,
     BRANCHES_STATUS,
     COMMIT_CREATED,
+    RESTORED,
 } from '@casual-simulation/causal-trees/core2';
 import { waitAsync } from './test/TestHelpers';
 import { Subject } from 'rxjs';
@@ -2775,6 +2776,12 @@ describe('CausalRepoServer', () => {
                         branch: 'testBranch',
                         atoms: [a3],
                         removedAtoms: [a4.hash, a5.hash],
+                    },
+                },
+                {
+                    name: RESTORED,
+                    data: {
+                        branch: 'testBranch',
                     },
                 },
             ]);

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -65,6 +65,7 @@ import {
     UNWATCH_BRANCH_DEVICES,
     BRANCHES_STATUS,
     COMMIT_CREATED,
+    RESTORED,
 } from '@casual-simulation/causal-trees/core2';
 import { ConnectionServer, Connection } from './ConnectionServer';
 import { devicesForEvent } from './DeviceManagerHelpers';
@@ -256,6 +257,7 @@ export class CausalRepoServer {
                             false
                         );
                         if (!repo) {
+                            // TODO: Send an error event to the device
                             return;
                         }
 
@@ -364,6 +366,10 @@ export class CausalRepoServer {
 
                         this._sendCommits(event.branch, [newCommit]);
                         this._sendDiff(current, after, event.branch);
+
+                        sendToDevices([device], RESTORED, {
+                            branch: event.branch,
+                        });
                     },
                     [SEND_EVENT]: async event => {
                         const info = infoForBranch(event.branch);

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -64,6 +64,7 @@ import {
     WATCH_BRANCH_DEVICES,
     UNWATCH_BRANCH_DEVICES,
     BRANCHES_STATUS,
+    COMMIT_CREATED,
 } from '@casual-simulation/causal-trees/core2';
 import { ConnectionServer, Connection } from './ConnectionServer';
 import { devicesForEvent } from './DeviceManagerHelpers';
@@ -260,6 +261,9 @@ export class CausalRepoServer {
 
                         if (repo.hasChanges()) {
                             await this._commitToRepo(event, repo);
+                            sendToDevices([device], COMMIT_CREATED, {
+                                branch: event.branch,
+                            });
                         }
                     },
                     [WATCH_COMMITS]: async branch => {

--- a/src/causal-trees/core/Event.ts
+++ b/src/causal-trees/core/Event.ts
@@ -3,7 +3,6 @@ import { DeviceInfo } from './DeviceInfo';
 /**
  * Defines an interface that represents an event.
  * That is, a time-ordered action in a channel.
- * @deprecated
  */
 export interface Action {
     /**
@@ -59,6 +58,11 @@ export interface DeviceSelector {
      */
     broadcast?: boolean;
 }
+
+export type RemoteActions =
+    | RemoteAction
+    | RemoteActionResult
+    | RemoteActionError;
 
 /**
  * An event that is used to send events from this device to a remote device.

--- a/src/causal-trees/core2/CausalRepoClient.ts
+++ b/src/causal-trees/core2/CausalRepoClient.ts
@@ -60,6 +60,7 @@ import {
     RemoteAction,
     DeviceActionResult,
     DeviceActionError,
+    RemoteActions,
 } from '../core/Event';
 import { DeviceInfo, SESSION_ID_CLAIM } from '../core/DeviceInfo';
 import { SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION } from 'constants';
@@ -454,7 +455,7 @@ export class CausalRepoClient {
      * @param branch The branch.
      * @param action The action.
      */
-    sendEvent(branch: string, action: RemoteAction) {
+    sendEvent(branch: string, action: RemoteActions) {
         this._client.send(SEND_EVENT, {
             branch: branch,
             action: action,

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -73,6 +73,11 @@ export const CHECKOUT = 'repo/checkout';
 export const RESTORE = 'repo/restore';
 
 /**
+ * The name of the event which notifies that a branch was restored.
+ */
+export const RESTORED = 'repo/restored';
+
+/**
  * The name of the event which notifies that a commit was added.
  */
 export const ADD_COMMITS = 'repo/add_commits';
@@ -271,6 +276,16 @@ export interface RestoreEvent {
      * The hash of the commit to restore.
      */
     commit: string;
+}
+
+/**
+ * Defines an event which indicates that a commit was restored to a branch.
+ */
+export interface RestoredEvent {
+    /**
+     * The branch to restore.
+     */
+    branch: string;
 }
 
 /**

--- a/src/causal-trees/core2/CausalRepoEvents.ts
+++ b/src/causal-trees/core2/CausalRepoEvents.ts
@@ -48,6 +48,11 @@ export const ADD_ATOMS = 'repo/add_atoms';
 export const COMMIT = 'repo/commit';
 
 /**
+ * The name of the event which notifies that a requested commit was created.
+ */
+export const COMMIT_CREATED = 'repo/commit_created';
+
+/**
  * The name of the event which starts watching commits made to a branch.
  */
 export const WATCH_COMMITS = 'repo/watch_commits';
@@ -211,6 +216,16 @@ export interface CommitEvent {
      * The commit message.
      */
     message: string;
+}
+
+/**
+ * Defines an event which indicates that a commit was created on a branch.
+ */
+export interface CommitCreatedEvent {
+    /**
+     * The branch that was committed.
+     */
+    branch: string;
 }
 
 /**


### PR DESCRIPTION
### Changes:

-   :rocket: Improvements
    -   Improved the `player.run()` function to return a promise that can be awaited to get the result of the script (or wait until the script has been executed).
    -   Improved the `server.loadErrors()` function to return a promise that can be awaited to get the list of bots that were loaded.
    -   Improved the `server.destroyErrors()` function to return a promise that resolves once the error bots are destroyed.
    -   Improved the `server.loadFile()` function to return a promise that resolves once the file is loaded.
    -   Improved the `server.saveFile()` function to return a promise that resolves once the file is saved.
    -   Improved the `server.setupStory()` function to return a promise that resolves once the story is setup.
    -   Improved the `server.browseHistory()` function to return a promise that resolves once the history is loaded.
    -   Improved the `server.markHistory()` function to return a promise that resolves once the history is saved.
    -   Improved the `server.restoreHistoryMark()` function to return a promise that resolves once the history is restored.
    -   Improved the `server.restoreHistoryMarkToStory()` function to return a promise that resolves once the history is restored.