### PR TITLE
Add listen tags for when bots are added, removed, and changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@
         -   `@onAnyBotsRemoved` is triggered on every bot whenever one or more bots are removed.
             -   `that` is an object with the following properties:
                 -   `botIDs` - The array of bot IDs that were removed.
+    -   Added the `@onBotChanged` and `@onAnyBotsChanged` listen tags.
+        -   These are triggered whenever a bot is changed in the local story.
+        -   Note that you will be notified whenever a bot is changed in the state even if it was changed by another player.
+        -   An example of this are bots in the `otherPlayers` space. You cannot update bots in this space but you will be notified via `@onBotChanged` and `@onAnyBotsChanged`.
+        -   `@onBotChanged` is triggered on the bot that was changed.
+            -   `that` is an object with the following properties:
+                -   `tags` - The list of tags that were changed on the bot.
+        -   `@onAnyBotsAdded` is triggered on every bot whenever one or more bots are added.
+            -   `that` is an array containing objects with the following properties:
+                -   `bot` - The bot that was updated.
+                -   `tags` - The tags that were changed on the bot.
 
 ## V1.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
     -   Improved the `server.markHistory()` function to return a promise that resolves once the history is saved.
     -   Improved the `server.restoreHistoryMark()` function to return a promise that resolves once the history is restored.
     -   Improved the `server.restoreHistoryMarkToStory()` function to return a promise that resolves once the history is restored.
+    -   Added the `@onBotAdded` and `@onAnyBotsAdded` listen tags.
+        -   These are triggered whenever a bot is added to the local story.
+        -   Note that this is different from `@onCreate` because you will be notified whenever a bot is added to the state even if it has already been created.
+        -   An example of this are bots in the `otherPlayers` space. You cannot create bots in this space but you will be notified via `@onBotAdded` and `@onAnyBotsAdded`.
+        -   `@onBotAdded` is triggered on the bot that was added. There is no `that`.
+        -   `@onAnyBotsAdded` is triggered on every bot whenever one or more bots are added.
+            -   `that` is an object with the following properties:
+                -   `bots` - The array of bots that were added.
 
 ## V1.1.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
         -   `@onAnyBotsAdded` is triggered on every bot whenever one or more bots are added.
             -   `that` is an object with the following properties:
                 -   `bots` - The array of bots that were added.
+    -   Added the `@onAnyBotsRemoved` listen tags.
+        -   These are triggered whenever a a bot is removed from the local story.
+        -   Note that this is different from `@onDestroy` because you will be notified whenever a bot is removed from the state even if it has not been explicitly destroyed.
+        -   An example of this are bots in the `otherPlayers` space. When another player disconnects no `@onDestroy` is fired but you will get a `@onAnyBotsRemoved`.
+        -   `@onAnyBotsRemoved` is triggered on every bot whenever one or more bots are removed.
+            -   `that` is an object with the following properties:
+                -   `botIDs` - The array of bot IDs that were removed.
 
 ## V1.1.17
 

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -341,7 +341,28 @@ A whisper that is sent when the bot is added to the local story.
 Unlike <TagLink tag='@onCreate'/>, this listen tag is triggered whenever the bot as been added to the current player's story, even if the bot has already been created.
 An example of this happening is when you first load a story. Even though all the bots have already been created, they still need to be added to the story in order for you to interact with them.
 
+Note that this listen tag is triggered after any pending scripts have finished running. This means that if a script creates multiple bots, `@onBotAdded` will be triggered after all the bots have been created.
+
 There is no `that` argument for this listen tag.
+
+### `@onBotChanged`
+
+A whisper that is sent when a tag on the bot is updated.
+
+This listen tag is triggered whenever the bot has been updated in the current player's story, even if the bot was not updated locally.
+An example of this happening is when another player changes a tag in the sheet portal. Even though the change was made on their device, it will show up on the current device.
+
+Note that this listen tag is triggered after any pending scripts have finished running. This means that if a script updates the same tag multiple times, `@onBotChanged` will still only be triggered once.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The list of tags that were changed on the bot.
+     */
+    tags: string[]
+};
+```
 
 ### `@[groupName][stateName]OnEnter`
 
@@ -1022,6 +1043,8 @@ A shout that is sent when a list of bots is added to the current story.
 Unlike <TagLink tag='@onAnyCreate'/>, this listen tag is triggered whenever the bots have been added to the current player's story, even if the bots have already been created.
 An example of this happening is when you first load a story. Even though all the bots have already been created, they still need to be added to the story in order for you to interact with them.
 
+Note that this listen tag is triggered after any pending scripts have finished running. This means that if a script creates multiple bots, `@onAnyBotsAdded` will only be triggered once.
+
 #### Arguments:
 ```typescript
 let that: {
@@ -1039,6 +1062,8 @@ A shout that is sent when a list of bots is removed from the current story.
 Unlike <TagLink tag='@onDestroy'/>, this listen tag is triggered whenever the bots have been removed from the current player's story, even if the bots were not destroyed.
 An example of this happening is when another player disconnects. Even though their player bots were not destroyed, they still need to be removed from the story.
 
+Note that this listen tag is triggered after any pending scripts have finished running. This means that if a script deletes multiple bots, `@onAnyBotsRemoved` will only be triggered once.
+
 #### Arguments:
 ```typescript
 let that: {
@@ -1047,4 +1072,28 @@ let that: {
      */
     botIDs: string[];
 };
+```
+
+### `@onAnyBotsChanged`
+
+A shout that is sent when one or more tags are changed on a list of bots in the current story.
+
+This listen tag is triggered whenever the bots have been updated in the current player's story, even if the bots were not updated locally.
+An example of this happening is when another player changes a tag in the sheet portal. Even though the change was made on their device, it will show up on the current device.
+
+Note that this listen tag is triggered after any pending scripts have finished running. This means that if a script updates multiple bots, `@onAnyBotsChanged` will only be triggered once.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The bot that was updated.
+     */
+    bot: Bot,
+
+    /**
+     * The list of tags that were changed on the bot.
+     */
+    tags: string[]
+}[];
 ```

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -1019,7 +1019,7 @@ if (getID(player.getBot()) === 'server') {
 
 A shout that is sent when a list of bots is added to the current story.
 
-Unlike <TagLink tag='@onAnyCreate'/>, this listen tag is triggered whenever the bot as been added to the current player's story, even if the bot has already been created.
+Unlike <TagLink tag='@onAnyCreate'/>, this listen tag is triggered whenever the bots have been added to the current player's story, even if the bots have already been created.
 An example of this happening is when you first load a story. Even though all the bots have already been created, they still need to be added to the story in order for you to interact with them.
 
 #### Arguments:
@@ -1029,5 +1029,22 @@ let that: {
      * The array of bots that were added to the story.
      */
     bots: Bot[];
+};
+```
+
+### `@onAnyBotsRemoved`
+
+A shout that is sent when a list of bots is removed from the current story.
+
+Unlike <TagLink tag='@onDestroy'/>, this listen tag is triggered whenever the bots have been removed from the current player's story, even if the bots were not destroyed.
+An example of this happening is when another player disconnects. Even though their player bots were not destroyed, they still need to be removed from the story.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The array of bot IDs that were removed from the story.
+     */
+    botIDs: string[];
 };
 ```

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -334,6 +334,15 @@ let that: {
 };
 ```
 
+### `@onBotAdded`
+
+A whisper that is sent when the bot is added to the local story.
+
+Unlike <TagLink tag='@onCreate'/>, this listen tag is triggered whenever the bot as been added to the current player's story, even if the bot has already been created.
+An example of this happening is when you first load a story. Even though all the bots have already been created, they still need to be added to the story in order for you to interact with them.
+
+There is no `that` argument for this listen tag.
+
 ### `@[groupName][stateName]OnEnter`
 
 A whisper that is sent whenever the `[groupName]` tag is set to `[stateName]` via the <ActionLink action='changeState(bot, stateName, groupName?)'/> function.
@@ -1004,4 +1013,21 @@ if (getID(player.getBot()) === 'server') {
         label: 'Player Left: ' + that.playerId
     });
 }
+```
+
+### `@onAnyBotsAdded`
+
+A shout that is sent when a list of bots is added to the current story.
+
+Unlike <TagLink tag='@onAnyCreate'/>, this listen tag is triggered whenever the bot as been added to the current player's story, even if the bot has already been created.
+An example of this happening is when you first load a story. Even though all the bots have already been created, they still need to be added to the story in order for you to interact with them.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The array of bots that were added to the story.
+     */
+    bots: Bot[];
+};
 ```

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -905,6 +905,11 @@ export const ON_BOT_ADDED_ACTION_NAME = 'onBotAdded';
 export const ON_ANY_BOTS_ADDED_ACTION_NAME = 'onAnyBotsAdded';
 
 /**
+ * The name of the event that is triggered when any bot is removed from the local simulation.
+ */
+export const ON_ANY_BOTS_REMOVED_ACTION_NAME = 'onAnyBotsRemoved';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -1141,6 +1146,7 @@ export const KNOWN_TAGS: string[] = [
 
     ON_BOT_ADDED_ACTION_NAME,
     ON_ANY_BOTS_ADDED_ACTION_NAME,
+    ON_ANY_BOTS_REMOVED_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -895,6 +895,16 @@ export const ON_REMOTE_PLAYER_UNSUBSCRIBED_ACTION_NAME: string =
     'onRemotePlayerUnsubscribed';
 
 /**
+ * The name of the event that is triggered when a bot is added to the local simulation.
+ */
+export const ON_BOT_ADDED_ACTION_NAME = 'onBotAdded';
+
+/**
+ * The name of the event that is triggered when any bot is added to the local simulation.
+ */
+export const ON_ANY_BOTS_ADDED_ACTION_NAME = 'onAnyBotsAdded';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -910,6 +910,16 @@ export const ON_ANY_BOTS_ADDED_ACTION_NAME = 'onAnyBotsAdded';
 export const ON_ANY_BOTS_REMOVED_ACTION_NAME = 'onAnyBotsRemoved';
 
 /**
+ * The name of the event that is triggered when a bot is changed.
+ */
+export const ON_BOT_CHANGED_ACTION_NAME = 'onBotChanged';
+
+/**
+ * The name of the event that is triggered when any bot is changed in the local simulation.
+ */
+export const ON_ANY_BOTS_CHANGED_ACTION_NAME = 'onAnyBotsChanged';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -1147,6 +1157,9 @@ export const KNOWN_TAGS: string[] = [
     ON_BOT_ADDED_ACTION_NAME,
     ON_ANY_BOTS_ADDED_ACTION_NAME,
     ON_ANY_BOTS_REMOVED_ACTION_NAME,
+
+    ON_BOT_CHANGED_ACTION_NAME,
+    ON_ANY_BOTS_CHANGED_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1138,6 +1138,9 @@ export const KNOWN_TAGS: string[] = [
 
     ON_REMOTE_PLAYER_SUBSCRIBED_ACTION_NAME,
     ON_REMOTE_PLAYER_UNSUBSCRIBED_ACTION_NAME,
+
+    ON_BOT_ADDED_ACTION_NAME,
+    ON_ANY_BOTS_ADDED_ACTION_NAME,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/partitions/MemoryPartition.ts
+++ b/src/aux-common/partitions/MemoryPartition.ts
@@ -182,7 +182,7 @@ class MemoryPartitionImpl implements MemoryPartition {
                 if (update) {
                     update.bot = newBot;
                     update.tags = union(update.tags, changedTags);
-                } else {
+                } else if (changedTags.length > 0) {
                     updated.set(event.id, {
                         bot: newBot,
                         tags: changedTags,

--- a/src/aux-common/partitions/test/PartitionTests.ts
+++ b/src/aux-common/partitions/test/PartitionTests.ts
@@ -298,6 +298,30 @@ export function testPartitionImplementation(
             expect(updated).toEqual([]);
         });
 
+        it('should ignore updates that set tag values to the same value that it is currently at', async () => {
+            const bot = createBot('test', {
+                abc: 'def',
+                example: 123,
+            });
+
+            // Run the bot added and updated
+            // events in separate batches
+            // because partitions may combine the events
+            await partition.applyEvents([botAdded(bot)]);
+
+            await partition.applyEvents([
+                botUpdated('test', {
+                    tags: {
+                        abc: 'def',
+                    },
+                }),
+            ]);
+
+            await waitAsync();
+
+            expect(updated).toEqual([]);
+        });
+
         it('should only report tags that changed', async () => {
             const bot = createBot('test', {
                 abc: 'def',

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -29,6 +29,7 @@ import {
     breakIntoIndividualEvents,
     ON_BOT_ADDED_ACTION_NAME,
     ON_ANY_BOTS_ADDED_ACTION_NAME,
+    ON_ANY_BOTS_REMOVED_ACTION_NAME,
 } from '../bots';
 import { Observable, Subject, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -533,6 +534,12 @@ export class AuxRuntime
 
         const changes = this._dependencies.removeBots(botIds);
         this._updateDependentBots(changes, update, new Set());
+
+        if (botIds.length > 0) {
+            this.shout(ON_ANY_BOTS_REMOVED_ACTION_NAME, null, {
+                botIDs: botIds,
+            });
+        }
 
         return update;
     }

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -30,6 +30,8 @@ import {
     ON_BOT_ADDED_ACTION_NAME,
     ON_ANY_BOTS_ADDED_ACTION_NAME,
     ON_ANY_BOTS_REMOVED_ACTION_NAME,
+    ON_BOT_CHANGED_ACTION_NAME,
+    ON_ANY_BOTS_CHANGED_ACTION_NAME,
 } from '../bots';
 import { Observable, Subject, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -582,6 +584,13 @@ export class AuxRuntime
         const changes = this._dependencies.updateBots(updates);
         this._updateDependentBots(changes, update, new Set());
 
+        for (let update of updates) {
+            this.shout(ON_BOT_CHANGED_ACTION_NAME, [update.bot.id], {
+                tags: update.tags,
+            });
+        }
+        this.shout(ON_ANY_BOTS_CHANGED_ACTION_NAME, null, updates);
+
         return update;
     }
 
@@ -1019,6 +1028,12 @@ export class AuxRuntime
                     this._transformBotsToRuntimeBots(result, value, key),
                 { [ORIGINAL_OBJECT]: value }
             );
+        } else if (
+            hasValue(value) &&
+            Array.isArray(value) &&
+            !(value instanceof ArrayBuffer)
+        ) {
+            return value.map(v => this._mapBotsToRuntimeBots(v));
         }
 
         return value;

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -27,6 +27,8 @@ import {
     getBotSpace,
     ON_ACTION_ACTION_NAME,
     breakIntoIndividualEvents,
+    ON_BOT_ADDED_ACTION_NAME,
+    ON_ANY_BOTS_ADDED_ACTION_NAME,
 } from '../bots';
 import { Observable, Subject, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -143,6 +145,10 @@ export class AuxRuntime
 
                 this._actionBatch = [];
                 this._errorBatch = [];
+
+                if (actions.length <= 0 && errors.length <= 0) {
+                    return;
+                }
 
                 // Schedule a new micro task to
                 // run at a later time with the actions.
@@ -492,6 +498,13 @@ export class AuxRuntime
 
         const changes = this._dependencies.addBots(bots);
         this._updateDependentBots(changes, update, newBotIDs);
+
+        if (update.addedBots.length > 0) {
+            this.shout(ON_BOT_ADDED_ACTION_NAME, update.addedBots);
+            this.shout(ON_ANY_BOTS_ADDED_ACTION_NAME, null, {
+                bots: newBots.map(([bot, precalc]) => bot),
+            });
+        }
 
         return update;
     }


### PR DESCRIPTION
### Changes:

-   :rocket: Improvements
    -   Added the `@onBotAdded` and `@onAnyBotsAdded` listen tags.
        -   These are triggered whenever a bot is added to the local story.
        -   Note that this is different from `@onCreate` because you will be notified whenever a bot is added to the state even if it has already been created.
        -   An example of this are bots in the `otherPlayers` space. You cannot create bots in this space but you will be notified via `@onBotAdded` and `@onAnyBotsAdded`.
        -   `@onBotAdded` is triggered on the bot that was added. There is no `that`.
        -   `@onAnyBotsAdded` is triggered on every bot whenever one or more bots are added.
            -   `that` is an object with the following properties:
                -   `bots` - The array of bots that were added.
    -   Added the `@onAnyBotsRemoved` listen tags.
        -   These are triggered whenever a a bot is removed from the local story.
        -   Note that this is different from `@onDestroy` because you will be notified whenever a bot is removed from the state even if it has not been explicitly destroyed.
        -   An example of this are bots in the `otherPlayers` space. When another player disconnects no `@onDestroy` is fired but you will get a `@onAnyBotsRemoved`.
        -   `@onAnyBotsRemoved` is triggered on every bot whenever one or more bots are removed.
            -   `that` is an object with the following properties:
                -   `botIDs` - The array of bot IDs that were removed.
    -   Added the `@onBotChanged` and `@onAnyBotsChanged` listen tags.
        -   These are triggered whenever a bot is changed in the local story.
        -   Note that you will be notified whenever a bot is changed in the state even if it was changed by another player.
        -   An example of this are bots in the `otherPlayers` space. You cannot update bots in this space but you will be notified via `@onBotChanged` and `@onAnyBotsChanged`.
        -   `@onBotChanged` is triggered on the bot that was changed.
            -   `that` is an object with the following properties:
                -   `tags` - The list of tags that were changed on the bot.
        -   `@onAnyBotsAdded` is triggered on every bot whenever one or more bots are added.
            -   `that` is an array containing objects with the following properties:
                -   `bot` - The bot that was updated.
                -   `tags` - The tags that were changed on the bot.
