### PR TITLE
Add the player.bufferSound() and player.cancelSound() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 -   Added the tag portal.
     -   The tag portal is similar to the sheet portal but it shows only the multiline editor for the specified bot ID and tag.
     -   Set the `tagPortal` tag on the player bot to a string with a Bot ID and a tag name separated by a period (`.`).
+-   Improved `player.playSound(url)` to return a promise that resolves with a sound ID.
+    -   This sound ID can be used with `player.cancelSound(soundID)` to stop the sound from playing.
+-   Added the `player.bufferSound(url)` and `player.cancelSound(soundID)` functions.
+    -   `player.bufferSound(url)` can be used to pre-load a sound so that there will be no delay when using `player.playSound()`.
+        -   Returns a promise that resolves once the sound has been loaded.
+    -   `player.cancelSound(soundID)` can be used to stop a sound that is already playing.
+        -   Returns a promise that resolves once the sound has been canceled.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2108,8 +2108,10 @@ player.openDevConsole();
 
 ### `player.playSound(url)`
 
-
 Loads and plays the audio (MP3, WAV, etc.) from the given URL.
+
+Returns a promise that resolves with the ID of the sound when the sound starts playing.
+The sound ID can then be used with <ActionLink action='player.cancelSound(soundID)'/> to stop the sound.
 
 The **first parameter** is the [URL](https://en.wikipedia.org/wiki/URL) of the audio/music/sound clip that should be played.
 
@@ -2118,6 +2120,37 @@ The **first parameter** is the [URL](https://en.wikipedia.org/wiki/URL) of the a
 1. Play a MP3 file from another website.
 ```typescript
 player.playSound("https://www.testsounds.com/track06.mp3");
+```
+
+### `player.bufferSound(url)`
+
+Loads the audio from the given URL without playing it.
+Returns a promise that resolves once the sound has been loaded.
+
+This is useful for pre-loading a sound so that there will be no delay when playing it with <ActionLink action='player.playSound(url)'/>.
+
+The **first parameter** is the [URL](https://en.wikipedia.org/wiki/URL) of the audio/music/sound clip that should be loaded.
+
+#### Examples:
+
+1. Pre-load a MP3 fiel from another website.
+```typescript
+player.bufferSound("https://www.testsounds.com/track06.mp3");
+```
+
+### `player.cancelSound(soundID)`
+
+Cancels the sound with the given ID.
+Returns a promise that resolves once the sound has been canceled.
+
+The **first parameter** is the ID of the sound that was returned from <ActionLink action='player.playSound(url)'/>.
+
+#### Examples:
+
+1. Cancel a sound that is playing.
+```typescript
+const id = await player.playSound("https://www.testsounds.com/track06.mp3");
+player.cancelSound(id);
 ```
 
 ### `player.isInDimension(dimension)`

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -129,7 +129,8 @@ export type AsyncActions =
     | RemoteActionError
     | DeviceAction
     | DeviceActionResult
-    | DeviceActionError;
+    | DeviceActionError
+    | BufferSoundAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1009,6 +1010,18 @@ export interface PlaySoundAction extends Action {
 
     /**
      * The URL to open.
+     */
+    url: string;
+}
+
+/**
+ * Defines an event that is used to pre-load a sound from the given URL.
+ */
+export interface BufferSoundAction extends AsyncAction {
+    type: 'buffer_sound';
+
+    /**
+     * The URL to buffer.
      */
     url: string;
 }
@@ -2095,6 +2108,22 @@ export function playSound(url: string): PlaySoundAction {
     return {
         type: 'play_sound',
         url: url,
+    };
+}
+
+/**
+ * Creates a new BufferSoundAction.
+ * @param url The URL of the sound to play.
+ * @param taskId The ID of the async task.
+ */
+export function bufferSound(
+    url: string,
+    taskId?: string | number
+): BufferSoundAction {
+    return {
+        type: 'buffer_sound',
+        url: url,
+        taskId,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -61,7 +61,6 @@ export type ExtraActions =
     | SendWebhookAction
     | GoToDimensionAction
     | GoToURLAction
-    | PlaySoundAction
     | OpenURLAction
     | ImportAUXAction
     | ShowInputForTagAction
@@ -130,7 +129,9 @@ export type AsyncActions =
     | DeviceAction
     | DeviceActionResult
     | DeviceActionError
-    | BufferSoundAction;
+    | PlaySoundAction
+    | BufferSoundAction
+    | CancelSoundAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1005,13 +1006,19 @@ export interface OpenURLAction extends Action {
 /**
  * Defines an event that is used to play a sound from the given url.
  */
-export interface PlaySoundAction extends Action {
+export interface PlaySoundAction extends AsyncAction {
     type: 'play_sound';
 
     /**
      * The URL to open.
      */
     url: string;
+
+    /**
+     * The ID of the sound.
+     */
+    // NOTE: ID is capitalized to be consistent with the getID() API
+    soundID: number | string;
 }
 
 /**
@@ -1024,6 +1031,18 @@ export interface BufferSoundAction extends AsyncAction {
      * The URL to buffer.
      */
     url: string;
+}
+
+/**
+ * Defines an event that is used to cancel a sound that is playing.
+ */
+export interface CancelSoundAction extends AsyncAction {
+    type: 'cancel_sound';
+
+    /**
+     * The ID of the sound.
+     */
+    soundID: number | string;
 }
 
 /**
@@ -2103,11 +2122,19 @@ export function openURL(url: string): OpenURLAction {
 /**
  * Creates a new PlaySoundAction.
  * @param url The URL of the sound to play.
+ * @param soundID The ID of the sound.
+ * @param taskId The ID of the task.
  */
-export function playSound(url: string): PlaySoundAction {
+export function playSound(
+    url: string,
+    soundID: string | number,
+    taskId?: string | number
+): PlaySoundAction {
     return {
         type: 'play_sound',
         url: url,
+        soundID,
+        taskId,
     };
 }
 
@@ -2123,6 +2150,22 @@ export function bufferSound(
     return {
         type: 'buffer_sound',
         url: url,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new CancelSoundAction.
+ * @param soundId The ID of the sound to cancel.
+ * @param taskId The ID of the async task.
+ */
+export function cancelSound(
+    soundID: number | string,
+    taskId?: string | number
+): CancelSoundAction {
+    return {
+        type: 'cancel_sound',
+        soundID,
         taskId,
     };
 }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -86,6 +86,7 @@ import {
     revokeCertificate,
     setSpacePassword,
     bufferSound,
+    cancelSound,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2265,9 +2266,14 @@ describe('AuxLibrary', () => {
 
         describe('player.playSound()', () => {
             it('should emit a PlaySoundEvent', () => {
-                const action = library.api.player.playSound('abc');
-                expect(action).toEqual(playSound('abc'));
-                expect(context.actions).toEqual([playSound('abc')]);
+                const promise: any = library.api.player.playSound('abc');
+                const expected = playSound(
+                    'abc',
+                    context.tasks.size,
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 
@@ -2275,6 +2281,25 @@ describe('AuxLibrary', () => {
             it('should emit a BufferSoundEvent', () => {
                 const promise: any = library.api.player.bufferSound('abc');
                 const expected = bufferSound('abc', context.tasks.size);
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('player.cancelSound()', () => {
+            it('should emit a CancelSoundEvent', () => {
+                const promise: any = library.api.player.cancelSound(1);
+                const expected = cancelSound(1, context.tasks.size);
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should be able to take a PlaySoundEvent', () => {
+                const event = {
+                    [ORIGINAL_OBJECT]: playSound('abc', 1),
+                };
+                const promise: any = library.api.player.cancelSound(event);
+                const expected = cancelSound(1, context.tasks.size);
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -85,6 +85,7 @@ import {
     signTag,
     revokeCertificate,
     setSpacePassword,
+    bufferSound,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2267,6 +2268,15 @@ describe('AuxLibrary', () => {
                 const action = library.api.player.playSound('abc');
                 expect(action).toEqual(playSound('abc'));
                 expect(context.actions).toEqual([playSound('abc')]);
+            });
+        });
+
+        describe('player.bufferSound()', () => {
+            it('should emit a BufferSoundEvent', () => {
+                const promise: any = library.api.player.bufferSound('abc');
+                const expected = bufferSound('abc', context.tasks.size);
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -36,6 +36,7 @@ import {
     openURL as calcOpenURL,
     checkout as calcCheckout,
     playSound as calcPlaySound,
+    bufferSound as calcBufferSound,
     setupStory as calcSetupStory,
     shell as calcShell,
     backupToGithub as calcBackupToGithub,
@@ -381,6 +382,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 openDevConsole,
                 checkout,
                 playSound,
+                bufferSound,
                 hasBotInInventory,
                 share,
                 inSheet,
@@ -1409,12 +1411,27 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     /**
      *   Play given url's audio
      * @example
-     * // Send the player to the "welcome" dimension.
+     * // Play a cow "moo"
      * player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
      */
     function playSound(url: string) {
         const event = calcPlaySound(url);
         return addAction(event);
+    }
+
+    /**
+     * Preloads the audio for the given URL.
+     * Returns a promise that resolves when the audio has finished loading.
+     * @param url The URl to preload.
+     *
+     * @example
+     * // Preload a cow "moo"
+     * player.bufferSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+     */
+    function bufferSound(url: string) {
+        const task = context.createTask();
+        const event = calcBufferSound(url, task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -37,6 +37,7 @@ import {
     checkout as calcCheckout,
     playSound as calcPlaySound,
     bufferSound as calcBufferSound,
+    cancelSound as calcCancelSound,
     setupStory as calcSetupStory,
     shell as calcShell,
     backupToGithub as calcBackupToGithub,
@@ -383,6 +384,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 checkout,
                 playSound,
                 bufferSound,
+                cancelSound,
                 hasBotInInventory,
                 share,
                 inSheet,
@@ -1409,14 +1411,17 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     }
 
     /**
-     *   Play given url's audio
+     * Play given url's audio.
+     * Returns a promise that resolves once the sound starts playing.
+     *
      * @example
      * // Play a cow "moo"
      * player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
      */
     function playSound(url: string) {
-        const event = calcPlaySound(url);
-        return addAction(event);
+        const task = context.createTask();
+        const event = calcPlaySound(url, task.taskId, task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**
@@ -1431,6 +1436,26 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function bufferSound(url: string) {
         const task = context.createTask();
         const event = calcBufferSound(url, task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Cancels the sound with the given ID.
+     * Returns a promise that resolves when the audio has been canceled.
+     * @param soundId The ID of the sound that is being canceled.
+     *
+     * @example
+     * // Play and cancel a sound
+     * const id = await player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+     * player.cancelSound(id);
+     */
+    function cancelSound(soundId: number | string | object) {
+        const task = context.createTask();
+        const id =
+            typeof soundId === 'object'
+                ? getOriginalObject(soundId).soundID
+                : soundId;
+        const event = calcCancelSound(id, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -181,7 +181,6 @@ declare type ExtraActions =
     | SaveFileAction
     | GoToDimensionAction
     | GoToURLAction
-    | PlaySoundAction
     | OpenURLAction
     | ImportAUXAction
     | ShowInputForTagAction
@@ -227,7 +226,9 @@ declare type AsyncActions =
     | RevokeCertificateAction
     | UnlockSpaceAction
     | SetSpacePasswordAction
-    | BufferSoundAction;
+    | BufferSoundAction
+    | PlaySoundAction
+    | CancelSoundAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1071,13 +1072,18 @@ declare interface OpenURLAction extends Action {
 /**
  * Defines an event that is used to play a sound from the given url.
  */
-declare interface PlaySoundAction extends Action {
+declare interface PlaySoundAction extends AsyncAction {
     type: 'play_sound';
 
     /**
      * The URL to open.
      */
     url: string;
+
+    /**
+     * The ID of the sound.
+     */
+    soundID: number | string;
 }
 
 /**
@@ -1090,6 +1096,18 @@ export interface BufferSoundAction extends AsyncAction {
      * The URL to buffer.
      */
     url: string;
+}
+
+/**
+ * Defines an event that is used to cancel a sound that is playing.
+ */
+export interface CancelSoundAction extends AsyncAction {
+    type: 'cancel_sound';
+
+    /**
+     * The ID of the sound.
+     */
+    soundID: number;
 }
 
 /**
@@ -2466,14 +2484,15 @@ declare global {
         toast(message: string | number | boolean | object | Array<any> | null, duration?: number): ShowToastAction;
 
         /**
-         * Play the given url's audio
+         * Play the given url's audio.
+         * Returns a promise that resolves when the sound starts playing.
          * @param url The URL to play.
          * 
          * @example
          * // Play a cow "moo"
          * player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
          */
-        playSound(url: string): PlaySoundAction;
+        playSound(url: string): Promise<void>;
 
         /**
          * Preloads the audio for the given URL.
@@ -2485,6 +2504,18 @@ declare global {
          * player.bufferSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
          */
         bufferSound(url: string): Promise<void>;
+
+        /**
+         * Cancels the sound with the given ID.
+         * Returns a promise that resolves when the audio has been canceled.
+         * @param soundId The ID of the sound that is being canceled.
+         *
+         * @example
+         * // Play and cancel a sound
+         * const id = await player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+         * player.cancelSound(id);
+         */
+        cancelSound(soundId: number): Promise<void>;
 
         /**
          * Shows a QR Code that contains a link to a story and dimension.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -226,7 +226,8 @@ declare type AsyncActions =
     | SignTagAction
     | RevokeCertificateAction
     | UnlockSpaceAction
-    | SetSpacePasswordAction;
+    | SetSpacePasswordAction
+    | BufferSoundAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1075,6 +1076,18 @@ declare interface PlaySoundAction extends Action {
 
     /**
      * The URL to open.
+     */
+    url: string;
+}
+
+/**
+ * Defines an event that is used to pre-load a sound from the given URL.
+ */
+export interface BufferSoundAction extends AsyncAction {
+    type: 'buffer_sound';
+
+    /**
+     * The URL to buffer.
      */
     url: string;
 }
@@ -2453,12 +2466,25 @@ declare global {
         toast(message: string | number | boolean | object | Array<any> | null, duration?: number): ShowToastAction;
 
         /**
-         *   Play given url's audio
+         * Play the given url's audio
+         * @param url The URL to play.
+         * 
          * @example
-         * // Send the player to the "welcome" dimension.
+         * // Play a cow "moo"
          * player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
          */
         playSound(url: string): PlaySoundAction;
+
+        /**
+         * Preloads the audio for the given URL.
+         * Returns a promise that resolves when the audio has finished loading.
+         * @param url The URl to preload.
+         * 
+         * @example
+         * // Preload a cow "moo"
+         * player.bufferSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+         */
+        bufferSound(url: string): Promise<void>;
 
         /**
          * Shows a QR Code that contains a link to a story and dimension.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2485,7 +2485,7 @@ declare global {
 
         /**
          * Play the given url's audio.
-         * Returns a promise that resolves when the sound starts playing.
+         * Returns a promise that resolves with the sound ID when the sound starts playing.
          * @param url The URL to play.
          * 
          * @example
@@ -2508,14 +2508,14 @@ declare global {
         /**
          * Cancels the sound with the given ID.
          * Returns a promise that resolves when the audio has been canceled.
-         * @param soundId The ID of the sound that is being canceled.
+         * @param soundID The ID of the sound that is being canceled.
          *
          * @example
          * // Play and cancel a sound
          * const id = await player.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
          * player.cancelSound(id);
          */
-        cancelSound(soundId: number): Promise<void>;
+        cancelSound(soundID: number): Promise<void>;
 
         /**
          * Shows a QR Code that contains a link to a story and dimension.

--- a/src/aux-server/aux-web/shared/scene/GameAudio.ts
+++ b/src/aux-server/aux-web/shared/scene/GameAudio.ts
@@ -9,17 +9,52 @@ export class GameAudio {
     //  * It is a map of URLs to their elements.
     //  */
     // private _cache = new Map<string, HTMLMediaElement>();
+    private _playingSounds: Map<number | string, Howl>;
+
+    constructor() {
+        this._playingSounds = new Map();
+    }
 
     /**
      * Plays the audio from the given URL.
      * @param url The URL.
      */
-    playFromUrl(url: string) {
-        const sound = new Howl({
-            src: url,
+    playFromUrl(url: string, soundId: number | string): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            const sound = new Howl({
+                src: url,
+                onplay: () => {
+                    resolve();
+                },
+                onend: () => {
+                    this._playingSounds.delete(soundId);
+                },
+                onstop: () => {
+                    this._playingSounds.delete(soundId);
+                },
+                onloaderror: () => {
+                    this._playingSounds.delete(soundId);
+                    reject(new Error('Unable to play audio for: ' + url));
+                },
+                onplayerror: () => {
+                    this._playingSounds.delete(soundId);
+                    reject(new Error('Unable to play audio for: ' + url));
+                },
+            });
+            this._playingSounds.set(soundId, sound);
+            sound.play();
         });
+    }
 
-        sound.play();
+    /**
+     * Stops playing the sound with the given ID.
+     * @param soundId The ID of the sound to stop.
+     */
+    cancelSound(soundId: number | string): void {
+        const sound = this._playingSounds.get(soundId);
+        if (sound) {
+            sound.stop();
+        }
     }
 
     /**

--- a/src/aux-server/aux-web/shared/scene/GameAudio.ts
+++ b/src/aux-server/aux-web/shared/scene/GameAudio.ts
@@ -22,6 +22,28 @@ export class GameAudio {
         sound.play();
     }
 
+    /**
+     * Preloads the audio from the given URL.
+     * Returns a promise that resolves when the audio is loaded.
+     * @param url The URL.
+     */
+    bufferFromUrl(url: string): Promise<void> {
+        const sound = new Howl({
+            src: url,
+            preload: true,
+        });
+
+        return new Promise((resolve, reject) => {
+            sound.once('load', () => {
+                resolve();
+            });
+
+            sound.once('loaderror', () => {
+                reject(new Error('Unable to load audio from: ' + url));
+            });
+        });
+    }
+
     // private _getMediaElement(url: string) {
     //     let element = this._cache.get(url);
     //     if(!element) {

--- a/src/aux-server/aux-web/shared/scene/GameAudio.ts
+++ b/src/aux-server/aux-web/shared/scene/GameAudio.ts
@@ -28,18 +28,16 @@ export class GameAudio {
      * @param url The URL.
      */
     bufferFromUrl(url: string): Promise<void> {
-        const sound = new Howl({
-            src: url,
-            preload: true,
-        });
-
         return new Promise((resolve, reject) => {
-            sound.once('load', () => {
-                resolve();
-            });
-
-            sound.once('loaderror', () => {
-                reject(new Error('Unable to load audio from: ' + url));
+            const sound = new Howl({
+                src: url,
+                preload: true,
+                onload: () => {
+                    resolve();
+                },
+                onloaderror: () => {
+                    reject(new Error('Unable to load audio from: ' + url));
+                },
             });
         });
     }

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -807,19 +807,28 @@ export class CausalRepoServer {
     }
 
     private async _commitToRepo(event: CommitEvent, repo: CausalRepo) {
-        console.log(
-            `[CausalRepoServer] [${event.branch}] Committing with message '${
-                event.message
-            }'...`
-        );
-        const commit = await repo.commit(event.message);
-        if (commit) {
-            await this._stage.clearStage(event.branch);
-            console.log(`[CausalRepoServer] [${event.branch}] Committed.`);
-            this._sendCommits(event.branch, [commit]);
-        } else {
+        try {
             console.log(
-                `[CausalRepoServer] [${event.branch}] No Commit Created.`
+                `[CausalRepoServer] [${
+                    event.branch
+                }] Committing with message '${event.message}'...`
+            );
+            const commit = await repo.commit(event.message);
+            if (commit) {
+                await this._stage.clearStage(event.branch);
+                console.log(`[CausalRepoServer] [${event.branch}] Committed.`);
+                this._sendCommits(event.branch, [commit]);
+            } else {
+                console.log(
+                    `[CausalRepoServer] [${event.branch}] No Commit Created.`
+                );
+            }
+        } catch (err) {
+            console.error(
+                `[CausalRepoServer] [${
+                    event.branch
+                }] Unable to commit to branch.`,
+                err
             );
         }
     }
@@ -936,7 +945,7 @@ export class CausalRepoServer {
                 }
             } catch (err) {
                 console.error(
-                    `[CausalRepoServer] [${branch}] Unable to commit to branch.`,
+                    `[CausalRepoServer] [${branch}] Unable to commit to branch during unload.`,
                     err
                 );
             }

--- a/src/causal-tree-server/CausalRepoServer.ts
+++ b/src/causal-tree-server/CausalRepoServer.ts
@@ -916,19 +916,28 @@ export class CausalRepoServer {
         const repo = await this._repoPromises.get(branch);
         this._repoPromises.delete(branch);
         if (repo && repo.repo.hasChanges()) {
-            console.log(
-                `[CausalRepoServer] [${branch}] Committing before unloading...`
-            );
-            const c = await repo.repo.commit(`Save ${branch} before unload`);
-
-            if (c) {
+            try {
                 console.log(
-                    `[CausalRepoServer] [${branch}] [${c.hash}] Committed!`
+                    `[CausalRepoServer] [${branch}] Committing before unloading...`
                 );
-                await this._stage.clearStage(branch);
-            } else {
-                console.log(
-                    `[CausalRepoServer] [${branch}] No commit created due to no changes.`
+                const c = await repo.repo.commit(
+                    `Save ${branch} before unload`
+                );
+
+                if (c) {
+                    console.log(
+                        `[CausalRepoServer] [${branch}] [${c.hash}] Committed!`
+                    );
+                    await this._stage.clearStage(branch);
+                } else {
+                    console.log(
+                        `[CausalRepoServer] [${branch}] No commit created due to no changes.`
+                    );
+                }
+            } catch (err) {
+                console.error(
+                    `[CausalRepoServer] [${branch}] Unable to commit to branch.`,
+                    err
                 );
             }
         }


### PR DESCRIPTION
-   Improved `player.playSound(url)` to return a promise that resolves with a sound ID.
    -   This sound ID can be used with `player.cancelSound(soundID)` to stop the sound from playing.
-   Added the `player.bufferSound(url)` and `player.cancelSound(soundID)` functions.
    -   `player.bufferSound(url)` can be used to pre-load a sound so that there will be no delay when using `player.playSound()`.
        -   Returns a promise that resolves once the sound has been loaded.
    -   `player.cancelSound(soundID)` can be used to stop a sound that is already playing.
        -   Returns a promise that resolves once the sound has been canceled.