### PR TITLE
Fixes and improvements for infinite loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CasualOS Changelog
 
+## V1.2.7
+
+#### Date: TBD
+
+### :boom: Breaking Changes
+
+-   Changed `@onListen` to only be sent to bots which have a listener for the shout/whisper.
+    -   Previously `@onListen` would be sent to all bots that were targeted by the shout/whisper.
+-   Changed `shout()` and `whisper()` to cost 1 energy point.
+    -   This helps prevent infinite loops.
+    -   The energy point is only deducted if a bot has a listener for the event.
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where `onBotAdded`, `onAnyBotsAdded`, `onAnyBotsRemoved`, `onBotChanged`, and `onAnyBotsChanged` would reset the energy counter.
+
 ## V1.2.6
 
 #### Date: 9/4/2020

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -243,7 +243,7 @@ let that = null;
 
 ### `@onListen`
 
-A whisper that is sent whenever a whisper or shout is sent to this bot.
+A whisper that is sent whenever this bot receives a whisper or shout.
 
 #### Arguments:
 ```typescript

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -132,6 +132,7 @@ import { shuffle } from 'lodash';
 import { decryptV1, keypair } from '@casual-simulation/crypto';
 import { CERTIFIED_SPACE } from '../aux-format-2/AuxWeaveReducer';
 import { tagValueHash } from '../aux-format-2';
+import { RanOutOfEnergyError } from './AuxResults';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid/v4');
@@ -5389,6 +5390,13 @@ describe('AuxLibrary', () => {
             };
             expect(onAnyListen4).toBeCalledWith(expected);
         });
+
+        it('should perform an energy check', () => {
+            context.energy = 1;
+            expect(() => {
+                library.api.shout('sayHello');
+            }).toThrowError(new RanOutOfEnergyError());
+        });
     });
 
     describe('whisper()', () => {
@@ -5568,6 +5576,13 @@ describe('AuxLibrary', () => {
                 expect(sayHello3).not.toBeCalled();
             }
         );
+
+        it('should perform an energy check', () => {
+            context.energy = 1;
+            expect(() => {
+                library.api.whisper(bot1, 'sayHello');
+            }).toThrowError(new RanOutOfEnergyError());
+        });
     });
 
     describe('player.inSheet()', () => {

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5345,13 +5345,12 @@ describe('AuxLibrary', () => {
             expect(context.errors).toEqual([new Error('abc')]);
         });
 
-        it('should send a onListen whisper to all the targeted bots', () => {
+        it('should send a onListen whisper to all the listening bots', () => {
             const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
             const sayHello2 = (bot2.listeners.sayHello = jest.fn(() => {
                 throw new Error('abc');
             }));
             const sayHello3 = (bot3.listeners.sayHello = jest.fn());
-            const sayHello4 = (bot4.listeners.sayHello = jest.fn());
             const onListen1 = (bot1.listeners.onListen = jest.fn(() => {}));
             const onListen2 = (bot2.listeners.onListen = jest.fn(() => {}));
             const onListen3 = (bot3.listeners.onListen = jest.fn());
@@ -5363,12 +5362,12 @@ describe('AuxLibrary', () => {
                 that: 123,
                 responses: [undefined, undefined, undefined] as any[],
                 targets: [bot1, bot2, bot3, bot4],
-                listeners: [bot1, bot3, bot4], // should exclude erroring listeners
+                listeners: [bot1, bot2, bot3], // should exclude erroring listeners
             };
             expect(onListen1).toBeCalledWith(expected);
             expect(onListen2).toBeCalledWith(expected);
             expect(onListen3).toBeCalledWith(expected);
-            expect(onListen4).toBeCalledWith(expected);
+            expect(onListen4).not.toBeCalledWith(expected);
         });
 
         it('should send a onAnyListen shout', () => {
@@ -5384,9 +5383,14 @@ describe('AuxLibrary', () => {
             const expected = {
                 name: 'sayHello',
                 that: 123,
-                responses: [undefined, undefined, undefined] as any[],
+                responses: [
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                ] as any[],
                 targets: [bot1, bot2, bot3, bot4],
-                listeners: [bot1, bot3, bot4], // should exclude erroring listeners
+                listeners: [bot1, bot2, bot3, bot4], // should exclude erroring listeners
             };
             expect(onAnyListen4).toBeCalledWith(expected);
         });
@@ -5540,7 +5544,6 @@ describe('AuxLibrary', () => {
             const sayHello2 = (bot2.listeners.sayHello = jest.fn(() => {
                 throw new Error('abc');
             }));
-            const sayHello3 = (bot3.listeners.sayHello = jest.fn());
             const sayHello4 = (bot4.listeners.sayHello = jest.fn());
             const onListen1 = (bot1.listeners.onListen = jest.fn(() => {}));
             const onListen2 = (bot2.listeners.onListen = jest.fn(() => {}));
@@ -5553,11 +5556,11 @@ describe('AuxLibrary', () => {
                 that: 123,
                 responses: [undefined, undefined] as any[],
                 targets: [bot1, bot2, bot3],
-                listeners: [bot1, bot3], // should exclude erroring listeners
+                listeners: [bot1, bot2], // should exclude erroring listeners
             };
             expect(onListen1).toBeCalledWith(expected);
             expect(onListen2).toBeCalledWith(expected);
-            expect(onListen3).toBeCalledWith(expected);
+            expect(onListen3).not.toBeCalledWith(expected);
             expect(onListen4).not.toBeCalled();
         });
 
@@ -5574,9 +5577,9 @@ describe('AuxLibrary', () => {
             const expected = {
                 name: 'sayHello',
                 that: 123,
-                responses: [undefined, undefined] as any[],
+                responses: [undefined, undefined, undefined] as any[],
                 targets: [bot1, bot2, bot3],
-                listeners: [bot1, bot3], // should exclude erroring listeners
+                listeners: [bot1, bot2, bot3], // should exclude erroring listeners
             };
             expect(onAnyListen4).toBeCalledWith(expected);
         });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5392,9 +5392,38 @@ describe('AuxLibrary', () => {
         });
 
         it('should perform an energy check', () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
             context.energy = 1;
             expect(() => {
                 library.api.shout('sayHello');
+            }).toThrowError(new RanOutOfEnergyError());
+        });
+
+        it('should only take 1 energy for multiple listeners', () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
+            const sayHello2 = (bot2.listeners.sayHello = jest.fn(() => {}));
+            const sayHello3 = (bot3.listeners.sayHello = jest.fn(() => {}));
+            context.energy = 2;
+            library.api.shout('sayHello');
+            expect(context.energy).toBe(1);
+        });
+
+        it('should not perform an energy check if there are no listeners', () => {
+            context.energy = 1;
+            library.api.shout('sayHello');
+            expect(context.energy).toBe(1);
+        });
+
+        it('should run out of energy when listeners shout to each other', () => {
+            const first = (bot1.listeners.first = jest.fn(() => {
+                library.api.shout('second');
+            }));
+            const second = (bot2.listeners.second = jest.fn(() => {
+                library.api.shout('first');
+            }));
+            context.energy = 20;
+            expect(() => {
+                library.api.shout('first');
             }).toThrowError(new RanOutOfEnergyError());
         });
     });
@@ -5578,9 +5607,37 @@ describe('AuxLibrary', () => {
         );
 
         it('should perform an energy check', () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
             context.energy = 1;
             expect(() => {
                 library.api.whisper(bot1, 'sayHello');
+            }).toThrowError(new RanOutOfEnergyError());
+        });
+
+        it('should only take 1 energy for multiple listeners', () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
+            const sayHello2 = (bot2.listeners.sayHello = jest.fn(() => {}));
+            context.energy = 2;
+            library.api.whisper([bot1, bot2], 'sayHello');
+            expect(context.energy).toBe(1);
+        });
+
+        it('should not perform an energy check if there are no listeners', () => {
+            context.energy = 1;
+            library.api.whisper(bot1, 'sayHello');
+            expect(context.energy).toBe(1);
+        });
+
+        it('should run out of energy when listeners shout to each other', () => {
+            const first = (bot1.listeners.first = jest.fn(() => {
+                library.api.whisper(bot2, 'second');
+            }));
+            const second = (bot2.listeners.second = jest.fn(() => {
+                library.api.whisper(bot1, 'first');
+            }));
+            context.energy = 20;
+            expect(() => {
+                library.api.whisper(bot1, 'first');
             }).toThrowError(new RanOutOfEnergyError());
         });
     });

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3730,6 +3730,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         arg?: any,
         sendListenEvents: boolean = true
     ) {
+        __energyCheck();
         let ids = !!bots
             ? bots.map(bot => {
                   return !!bot

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3770,12 +3770,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                     __energyCheck();
                 }
                 try {
-                    // TODO: Handle exceptions
-                    results.push(listener(arg));
-                    listeners.push(bot);
+                    const result = listener(arg);
+                    results.push(result);
                 } catch (ex) {
                     context.enqueueError(ex);
+                    results.push(undefined);
                 }
+                listeners.push(bot);
             }
         }
 
@@ -3787,7 +3788,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 targets,
                 listeners,
             };
-            event('onListen', targets, listenArg, false);
+            event('onListen', listeners, listenArg, false);
             event('onAnyListen', null, listenArg, false);
         }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3730,7 +3730,6 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         arg?: any,
         sendListenEvents: boolean = true
     ) {
-        __energyCheck();
         let ids = !!bots
             ? bots.map(bot => {
                   return !!bot
@@ -3746,6 +3745,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
         let targets = [] as RuntimeBot[];
         let listeners = [] as RuntimeBot[];
+        let checkedEnergy = false;
 
         for (let id of ids) {
             if (!id) {
@@ -3765,6 +3765,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
             let listener = bot.listeners[tag];
             if (listener) {
+                if (!checkedEnergy) {
+                    checkedEnergy = true;
+                    __energyCheck();
+                }
                 try {
                     // TODO: Handle exceptions
                     results.push(listener(arg));

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -703,6 +703,48 @@ describe('AuxRuntime', () => {
                     ],
                 ]);
             });
+
+            it('should not reset the context energy', async () => {
+                runtime.context.energy = 3;
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onBotAdded: `@player.toast("Added 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onBotAdded: `@player.toast("Added 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(2);
+            });
+
+            it('should not crash when running out of energy', async () => {
+                runtime.context.energy = 1;
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onBotAdded: `@player.toast("Added 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onBotAdded: `@player.toast("Added 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(0);
+            });
         });
 
         describe('onAnyBotsAdded', () => {
@@ -787,6 +829,48 @@ describe('AuxRuntime', () => {
                         }),
                     ],
                 ]);
+            });
+
+            it('should not reset the context energy', async () => {
+                runtime.context.energy = 3;
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onAnyBotsAdded: `@player.toast("Added 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onAnyBotsAdded: `@player.toast("Added 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(2);
+            });
+
+            it('should not crash when running out of energy', async () => {
+                runtime.context.energy = 1;
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onAnyBotsAdded: `@player.toast("Added 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onAnyBotsAdded: `@player.toast("Added 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(0);
             });
         });
 
@@ -1052,6 +1136,50 @@ describe('AuxRuntime', () => {
                 await waitAsync();
 
                 expect(events).toEqual([[botRemoved('test1')]]);
+            });
+
+            it('should not reset the context energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                        onAnyBotsRemoved: `@player.toast(that.botIDs)`,
+                    }),
+                ]);
+
+                runtime.context.energy = 2;
+                runtime.botsRemoved(['test1', 'test2']);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(1);
+            });
+
+            it('should not crash when running out of energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                        onAnyBotsRemoved: `@player.toast(that.botIDs)`,
+                    }),
+                ]);
+
+                runtime.context.energy = 1;
+                runtime.botsRemoved(['test1', 'test2']);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(0);
             });
         });
     });
@@ -1672,6 +1800,86 @@ describe('AuxRuntime', () => {
                     ],
                 ]);
             });
+
+            it('should not reset the context energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onBotChanged: `@player.toast("Changed 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onBotChanged: `@player.toast("Changed 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                runtime.context.energy = 3;
+
+                runtime.botsUpdated([
+                    {
+                        bot: createBot('test1', {
+                            abc: 'def1',
+                            onBotChanged: `@player.toast("Changed 1!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                    {
+                        bot: createBot('test2', {
+                            abc: 'ghi1',
+                            onBotChanged: `@player.toast("Changed 2!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                ]);
+
+                await waitAsync();
+
+                // One separate shout per individual bot listener
+                expect(runtime.context.energy).toBe(1);
+            });
+
+            it('should not crash when running out of energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onBotChanged: `@player.toast("Changed 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onBotChanged: `@player.toast("Changed 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                runtime.context.energy = 1;
+
+                runtime.botsUpdated([
+                    {
+                        bot: createBot('test1', {
+                            abc: 'def1',
+                            onBotChanged: `@player.toast("Changed 1!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                    {
+                        bot: createBot('test2', {
+                            abc: 'ghi1',
+                            onBotChanged: `@player.toast("Changed 2!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                ]);
+
+                await waitAsync();
+
+                // One separate shout per individual bot listener
+                expect(runtime.context.energy).toBe(0);
+            });
         });
 
         describe('onAnyBotsChanged', () => {
@@ -1764,6 +1972,85 @@ describe('AuxRuntime', () => {
                         }),
                     ],
                 ]);
+            });
+
+            it('should not reset the context energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onAnyBotsChanged: `@player.toast("Changed 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onAnyBotsChanged: `@player.toast("Changed 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                runtime.context.energy = 2;
+
+                runtime.botsUpdated([
+                    {
+                        bot: createBot('test1', {
+                            abc: 'def1',
+                            onAnyBotsChanged: `@player.toast("Changed 1!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                    {
+                        bot: createBot('test2', {
+                            abc: 'ghi1',
+                            onAnyBotsChanged: `@player.toast("Changed 2!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                ]);
+
+                await waitAsync();
+
+                // One shout for all listeners
+                expect(runtime.context.energy).toBe(1);
+            });
+
+            it('should not crash when running out of energy', async () => {
+                runtime.botsAdded([
+                    createBot('test1', {
+                        abc: 'def',
+                        onAnyBotsChanged: `@player.toast("Changed 1!")`,
+                    }),
+                    createBot('test2', {
+                        abc: 'ghi',
+                        onAnyBotsChanged: `@player.toast("Changed 2!")`,
+                    }),
+                    createBot('test3', {
+                        abc: '999',
+                    }),
+                ]);
+
+                runtime.context.energy = 1;
+
+                runtime.botsUpdated([
+                    {
+                        bot: createBot('test1', {
+                            abc: 'def1',
+                            onAnyBotsChanged: `@player.toast("Changed 1!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                    {
+                        bot: createBot('test2', {
+                            abc: 'ghi1',
+                            onAnyBotsChanged: `@player.toast("Changed 2!")`,
+                        }),
+                        tags: ['abc'],
+                    },
+                ]);
+
+                await waitAsync();
+
+                expect(runtime.context.energy).toBe(0);
             });
         });
 

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -309,7 +309,7 @@ export class AuxRuntime
             );
             this.process(result.actions);
         } else if (action.type === 'run_script') {
-            const result = this._execute(action.script, false);
+            const result = this._execute(action.script, false, false);
             this.process(result.actions);
             if (hasValue(action.taskId)) {
                 this._globalContext.resolveTask(
@@ -378,20 +378,25 @@ export class AuxRuntime
         eventName: string,
         botIds: string[],
         arg: any,
-        batch: boolean
+        batch: boolean,
+        resetEnergy: boolean = true
     ): ActionResult {
         try {
             arg = this._mapBotsToRuntimeBots(arg);
         } catch (err) {
             arg = err;
         }
-        const { result, actions, errors } = this._batchScriptResults(() => {
-            const results = hasValue(botIds)
-                ? this._library.api.whisper(botIds, eventName, arg)
-                : this._library.api.shout(eventName, arg);
+        const { result, actions, errors } = this._batchScriptResults(
+            () => {
+                const results = hasValue(botIds)
+                    ? this._library.api.whisper(botIds, eventName, arg)
+                    : this._library.api.shout(eventName, arg);
 
-            return results;
-        }, batch);
+                return results;
+            },
+            batch,
+            resetEnergy
+        );
 
         return {
             actions,
@@ -406,10 +411,10 @@ export class AuxRuntime
      * @param script The script to run.
      */
     execute(script: string) {
-        return this._execute(script, true);
+        return this._execute(script, true, true);
     }
 
-    private _execute(script: string, batch: boolean) {
+    private _execute(script: string, batch: boolean, resetEnergy: boolean) {
         let fn: () => any;
 
         try {
@@ -434,13 +439,17 @@ export class AuxRuntime
             };
         }
 
-        return this._batchScriptResults(() => {
-            try {
-                return fn();
-            } catch (ex) {
-                this._globalContext.enqueueError(ex);
-            }
-        }, batch);
+        return this._batchScriptResults(
+            () => {
+                try {
+                    return fn();
+                } catch (ex) {
+                    this._globalContext.enqueueError(ex);
+                }
+            },
+            batch,
+            resetEnergy
+        );
     }
 
     /**
@@ -507,10 +516,30 @@ export class AuxRuntime
         this._updateDependentBots(changes, update, newBotIDs);
 
         if (update.addedBots.length > 0) {
-            this.shout(ON_BOT_ADDED_ACTION_NAME, update.addedBots);
-            this.shout(ON_ANY_BOTS_ADDED_ACTION_NAME, null, {
-                bots: newBots.map(([bot, precalc]) => bot),
-            });
+            try {
+                this._shout(
+                    ON_BOT_ADDED_ACTION_NAME,
+                    update.addedBots,
+                    undefined,
+                    true,
+                    false
+                );
+                this._shout(
+                    ON_ANY_BOTS_ADDED_ACTION_NAME,
+                    null,
+                    {
+                        bots: newBots.map(([bot, precalc]) => bot),
+                    },
+                    true,
+                    false
+                );
+            } catch (err) {
+                if (!(err instanceof RanOutOfEnergyError)) {
+                    throw err;
+                } else {
+                    console.warn(err);
+                }
+            }
         }
 
         return update;
@@ -542,9 +571,23 @@ export class AuxRuntime
         this._updateDependentBots(changes, update, new Set());
 
         if (botIds.length > 0) {
-            this.shout(ON_ANY_BOTS_REMOVED_ACTION_NAME, null, {
-                botIDs: botIds,
-            });
+            try {
+                this._shout(
+                    ON_ANY_BOTS_REMOVED_ACTION_NAME,
+                    null,
+                    {
+                        botIDs: botIds,
+                    },
+                    true,
+                    false
+                );
+            } catch (err) {
+                if (!(err instanceof RanOutOfEnergyError)) {
+                    throw err;
+                } else {
+                    console.warn(err);
+                }
+            }
         }
 
         return update;
@@ -613,12 +656,32 @@ export class AuxRuntime
         const changes = this._dependencies.updateBots(updates);
         this._updateDependentBots(changes, update, new Set());
 
-        for (let update of updates) {
-            this.shout(ON_BOT_CHANGED_ACTION_NAME, [update.bot.id], {
-                tags: update.tags,
-            });
+        try {
+            for (let update of updates) {
+                this._shout(
+                    ON_BOT_CHANGED_ACTION_NAME,
+                    [update.bot.id],
+                    {
+                        tags: update.tags,
+                    },
+                    true,
+                    false
+                );
+            }
+            this._shout(
+                ON_ANY_BOTS_CHANGED_ACTION_NAME,
+                null,
+                updates,
+                true,
+                false
+            );
+        } catch (err) {
+            if (!(err instanceof RanOutOfEnergyError)) {
+                throw err;
+            } else {
+                console.warn(err);
+            }
         }
-        this.shout(ON_ANY_BOTS_CHANGED_ACTION_NAME, null, updates);
 
         return update;
     }
@@ -689,10 +752,11 @@ export class AuxRuntime
 
     private _batchScriptResults<T>(
         callback: () => T,
-        batch: boolean
+        batch: boolean,
+        resetEnergy: boolean
     ): { result: T; actions: BotAction[]; errors: ScriptError[] } {
         return this._zone.run(() => {
-            const results = this._calculateScriptResults(callback);
+            const results = this._calculateScriptResults(callback, resetEnergy);
 
             if (batch) {
                 this._actionBatch.push(...results.actions);
@@ -704,10 +768,13 @@ export class AuxRuntime
     }
 
     private _calculateScriptResults<T>(
-        callback: () => T
+        callback: () => T,
+        resetEnergy: boolean
     ): { result: T; actions: BotAction[]; errors: ScriptError[] } {
         this._globalContext.playerBot = this.userBot;
-        this._globalContext.energy = DEFAULT_ENERGY;
+        if (resetEnergy) {
+            this._globalContext.energy = DEFAULT_ENERGY;
+        }
         const result = callback();
 
         const actions = this._processUnbatchedActions();


### PR DESCRIPTION
### :boom: Breaking Changes

-   Changed `@onListen` to only be sent to bots which have a listener for the shout/whisper.
    -   Previously `@onListen` would be sent to all bots that were targeted by the shout/whisper.
-   Changed `shout()` and `whisper()` to cost 1 energy point.
    -   This helps prevent infinite loops.
    -   The energy point is only deducted if a bot has a listener for the event.

### :bug: Bug Fixes

-   Fixed an issue where `onBotAdded`, `onAnyBotsAdded`, `onAnyBotsRemoved`, `onBotChanged`, and `onAnyBotsChanged` would reset the energy counter.