### PR TITLE
Tween Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### :bug: Bug Fixes
 
 -   Fixed an issue where `onBotAdded`, `onAnyBotsAdded`, `onAnyBotsRemoved`, `onBotChanged`, and `onAnyBotsChanged` would reset the energy counter.
+-   Fixed an issue where `experiment.localPositionTween()` and `experiment.localRotationTween()` may not execute if triggered during `@onCreate()`.
 
 ## V1.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 -   Changed `shout()` and `whisper()` to cost 1 energy point.
     -   This helps prevent infinite loops.
     -   The energy point is only deducted if a bot has a listener for the event.
+-   Changed `experiment.localPositionTween()` and `experiment.localRotationTween()` to take an options object as the 4th parameter instead of the easing options.
+    -   This options object is able to accept easing and duration values.
+    -   See the docs for examples.
 
 ### :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
 -   Changed `shout()` and `whisper()` to cost 1 energy point.
     -   This helps prevent infinite loops.
     -   The energy point is only deducted if a bot has a listener for the event.
--   Changed `experiment.localPositionTween()` and `experiment.localRotationTween()` to take an options object as the 4th parameter instead of the easing options.
+-   Changed `experiment.localPositionTween()` and `experiment.localRotationTween()` to take different arguments and return a promise.
+    -   the 4th parameter is now an options object instead of the easing options.
     -   This options object is able to accept easing and duration values.
+    -   Additionally the functions now return promises.
     -   See the docs for examples.
 
 ### :bug: Bug Fixes

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4269,7 +4269,7 @@ experiment.localPositionTween(
     });
 ```
 
-1. Tween the bot over 5 seconds.
+2. Tween the bot over 5 seconds.
 ```typescript
 experiment.localPositionTween(
     this,
@@ -4282,7 +4282,7 @@ experiment.localPositionTween(
     });
 ```
 
-2. Tween the bot with quadratic easing.
+3. Tween the bot with quadratic easing.
 ```typescript
 experiment.localPositionTween(
     this,
@@ -4381,7 +4381,7 @@ experiment.localRotationTween(
     });
 ```
 
-2. Tween the bot with quadratic easing.
+3. Tween the bot with quadratic easing.
 ```typescript
 experiment.localRotationTween(
     this,

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4214,29 +4214,44 @@ Note that the tween will only work if the given dimension is currently in the pa
 
 The **third parameter** is the position that the bot should be tweened to. If you exclude a dimension (like `x`, `y`, or `z`), then it will remain unchanged.
 
-The **fourth parameter** is optional and is the easing options that should be used.
+The **fourth parameter** is optional and is the options that should be used.
 It is an object with the following properties:
 
 ```typescript
-let easing: {
-    /**
-     * The type of easing.
-     */
-    type: 'linear'
-        | 'quadratic'
-        | 'cubic'
-        | 'quartic'
-        | 'quintic'
-        | 'sinusoidal'
-        | 'exponential'
-        | 'circular'
-        | 'elastic';
+let options: {
 
     /**
-     * Whether to apply the easing at the
-     * start (in), end (out), or start and end (inout) of the tween.
+     * The amount of time that the tween takes to complete in seconds.
+     * The maximum duration is 24 hours (86,400 seconds).
+     * The minimum duration is 0.
+     * Defaults to 1 if not specified.
      */
-    mode: 'in' | 'out' | 'inout';
+    duration?: number;
+
+    /**
+     * The options for easing.
+     * Defaults to "linear" "inout" if not specified.
+     */
+    easing?: {
+        /**
+         * The type of easing.
+        */
+        type: 'linear'
+            | 'quadratic'
+            | 'cubic'
+            | 'quartic'
+            | 'quintic'
+            | 'sinusoidal'
+            | 'exponential'
+            | 'circular'
+            | 'elastic';
+
+        /**
+         * Whether to apply the easing at the
+         * start (in), end (out), or start and end (inout) of the tween.
+         */
+        mode: 'in' | 'out' | 'inout';
+    }
 };
 ```
 
@@ -4252,7 +4267,7 @@ experiment.localPositionTween(
     });
 ```
 
-2. Tween the bot with quadratic easing.
+1. Tween the bot over 5 seconds.
 ```typescript
 experiment.localPositionTween(
     this,
@@ -4261,8 +4276,23 @@ experiment.localPositionTween(
         x: 10,
     },
     {
-        type: 'quadratic',
-        mode: 'inout'
+        duration: 5
+    });
+```
+
+2. Tween the bot with quadratic easing.
+```typescript
+experiment.localPositionTween(
+    this,
+    'home',
+    {
+        x: 10,
+    },
+    { 
+        easing: {
+            type: 'quadratic',
+            mode: 'inout'
+        }
     });
 ```
 
@@ -4281,29 +4311,44 @@ Note that the tween will only work if the given dimension is currently in the pa
 
 The **third parameter** is the rotation that the bot should be tweened to in radians. If you exclude a dimension (like `x`, `y`, or `z`), then it will remain unchanged.
 
-The **fourth parameter** is optional and is the easing options that should be used.
+The **fourth parameter** is optional and is the options that should be used.
 It is an object with the following properties:
 
 ```typescript
-let easing: {
-    /**
-     * The type of easing.
-     */
-    type: 'linear'
-        | 'quadratic'
-        | 'cubic'
-        | 'quartic'
-        | 'quintic'
-        | 'sinusoidal'
-        | 'exponential'
-        | 'circular'
-        | 'elastic';
+let options: {
 
     /**
-     * Whether to apply the easing at the
-     * start (in), end (out), or start and end (inout) of the tween.
+     * The amount of time that the tween takes to complete in seconds.
+     * The maximum duration is 24 hours (86,400 seconds).
+     * The minimum duration is 0.
+     * Defaults to 1.
      */
-    mode: 'in' | 'out' | 'inout';
+    duration?: number;
+
+    /**
+     * The options for easing.
+     * Defaults to "linear" "inout" if not specified.
+     */
+    easing?: {
+        /**
+         * The type of easing.
+        */
+        type: 'linear'
+            | 'quadratic'
+            | 'cubic'
+            | 'quartic'
+            | 'quintic'
+            | 'sinusoidal'
+            | 'exponential'
+            | 'circular'
+            | 'elastic';
+
+        /**
+         * Whether to apply the easing at the
+         * start (in), end (out), or start and end (inout) of the tween.
+         */
+        mode: 'in' | 'out' | 'inout';
+    }
 };
 ```
 
@@ -4319,6 +4364,19 @@ experiment.localRotationTween(
     });
 ```
 
+2. Tween the bot for 5 seconds.
+```typescript
+experiment.localRotationTween(
+    this,
+    'home',
+    {
+        z: Math.PI / 2,
+    },
+    {
+        duration: 5
+    });
+```
+
 2. Tween the bot with quadratic easing.
 ```typescript
 experiment.localRotationTween(
@@ -4328,8 +4386,10 @@ experiment.localRotationTween(
         z: Math.PI / 2,
     },
     {
-        type: 'quadratic',
-        mode: 'inout'
+        easing: {
+            type: 'quadratic',
+            mode: 'inout'
+        }
     });
 ```
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4204,6 +4204,8 @@ experiment.localFormAnimation(this, "jump");
 Locally plays a tween that moves the given bot in the given dimension to the given position.
 Optionally allows customizing the easing of the tween.
 
+Returns a promise that resolves when the tween is finished.
+
 While the tween is playing, any updates to the bot's position and rotation are ignored.
 Once the tween is done playing, any change to the bot will reset the position/rotation.
 
@@ -4300,6 +4302,8 @@ experiment.localPositionTween(
 
 Locally plays a tween that rotates the given bot in the given dimension to the given rotation.
 Optionally allows customizing the easing of the tween.
+
+Returns a promise that resolves when the tween is finished.
 
 While the tween is playing, any updates to the bot's position and rotation are ignored.
 Once the tween is done playing, any change to the bot will reset the position/rotation.

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -1996,6 +1996,11 @@ export interface LocalTweenAction extends Action {
      * The easing that should be used.
      */
     easing: Easing;
+
+    /**
+     * The duration of the tween in seconds.
+     */
+    duration: number;
 }
 
 /**
@@ -3849,12 +3854,14 @@ export function localFormAnimation(
  * @param dimension The dimension that the bot should be tweened in.
  * @param position The position of the bot.
  * @param easing The easing to use.
+ * @param duration The duration of the tween in seconds.
  */
 export function localPositionTween(
     botId: string,
     dimension: string,
     position: { x?: number; y?: number; z?: number },
-    easing: Easing = { type: 'linear', mode: 'inout' }
+    easing: Easing = { type: 'linear', mode: 'inout' },
+    duration: number = 1
 ): LocalPositionTweenAction {
     return {
         type: 'local_tween',
@@ -3863,6 +3870,7 @@ export function localPositionTween(
         dimension,
         easing,
         position,
+        duration,
     };
 }
 
@@ -3872,12 +3880,15 @@ export function localPositionTween(
  * @param dimension The dimension that the bot should be tweened in.
  * @param position The position of the bot.
  * @param easing The easing to use.
+ * @param duration The duration of the tween in seconds.
+ *
  */
 export function localRotationTween(
     botId: string,
     dimension: string,
     rotation: { x?: number; y?: number; z?: number },
-    easing: Easing = { type: 'linear', mode: 'inout' }
+    easing: Easing = { type: 'linear', mode: 'inout' },
+    duration: number = 1
 ): LocalRotationTweenAction {
     return {
         type: 'local_tween',
@@ -3886,6 +3897,7 @@ export function localRotationTween(
         dimension,
         easing,
         rotation,
+        duration,
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -1972,6 +1972,11 @@ export interface Easing {
 }
 
 /**
+ * The maximum allowed duration for tweens.
+ */
+export const MAX_TWEEN_DURATION = 60 * 60 * 24;
+
+/**
  * Defines an event that runs a tween locally.
  */
 export interface LocalTweenAction extends Action {
@@ -3870,7 +3875,7 @@ export function localPositionTween(
         dimension,
         easing,
         position,
-        duration,
+        duration: clamp(duration, 0, MAX_TWEEN_DURATION),
     };
 }
 
@@ -3897,7 +3902,7 @@ export function localRotationTween(
         dimension,
         easing,
         rotation,
-        duration,
+        duration: clamp(duration, 0, MAX_TWEEN_DURATION),
     };
 }
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -88,8 +88,6 @@ export type ExtraActions =
     | RequestFullscreenAction
     | ExitFullscreenAction
     | LocalFormAnimationAction
-    | LocalPositionTweenAction
-    | LocalRotationTweenAction
     | GetPlayerCountAction;
 
 /**
@@ -157,7 +155,9 @@ export type AsyncActions =
     | DeviceActionError
     | PlaySoundAction
     | BufferSoundAction
-    | CancelSoundAction;
+    | CancelSoundAction
+    | LocalPositionTweenAction
+    | LocalRotationTweenAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1979,7 +1979,7 @@ export const MAX_TWEEN_DURATION = 60 * 60 * 24;
 /**
  * Defines an event that runs a tween locally.
  */
-export interface LocalTweenAction extends Action {
+export interface LocalTweenAction extends AsyncAction {
     type: 'local_tween';
 
     /**
@@ -3866,7 +3866,8 @@ export function localPositionTween(
     dimension: string,
     position: { x?: number; y?: number; z?: number },
     easing: Easing = { type: 'linear', mode: 'inout' },
-    duration: number = 1
+    duration: number = 1,
+    taskId?: string | number
 ): LocalPositionTweenAction {
     return {
         type: 'local_tween',
@@ -3876,6 +3877,7 @@ export function localPositionTween(
         easing,
         position,
         duration: clamp(duration, 0, MAX_TWEEN_DURATION),
+        taskId,
     };
 }
 
@@ -3893,7 +3895,8 @@ export function localRotationTween(
     dimension: string,
     rotation: { x?: number; y?: number; z?: number },
     easing: Easing = { type: 'linear', mode: 'inout' },
-    duration: number = 1
+    duration: number = 1,
+    taskId?: string | number
 ): LocalRotationTweenAction {
     return {
         type: 'local_tween',
@@ -3903,6 +3906,7 @@ export function localRotationTween(
         easing,
         rotation,
         duration: clamp(duration, 0, MAX_TWEEN_DURATION),
+        taskId,
     };
 }
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4171,6 +4171,46 @@ describe('AuxLibrary', () => {
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+
+            it('should clamp the duration to 0 if it is negative', () => {
+                const action = library.api.experiment.localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: -1,
+                    }
+                );
+                const expected = localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    { type: 'linear', mode: 'inout' },
+                    0
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should clamp the duration to 24 hours if it is too large', () => {
+                const action = library.api.experiment.localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: Infinity,
+                    }
+                );
+                const expected = localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    { type: 'linear', mode: 'inout' },
+                    60 * 60 * 24 // 24 hours in seconds
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
         });
 
         describe('experiment.localRotationTween()', () => {
@@ -4243,6 +4283,46 @@ describe('AuxLibrary', () => {
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
                     99
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should clamp the duration to 0 if it is negative', () => {
+                const action = library.api.experiment.localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: -1,
+                    }
+                );
+                const expected = localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    { type: 'linear', mode: 'inout' },
+                    0
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should clamp the duration to 24 hours if it is too large', () => {
+                const action = library.api.experiment.localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: Infinity,
+                    }
+                );
+                const expected = localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    { type: 'linear', mode: 'inout' },
+                    60 * 60 * 24 // 24 hours in seconds
                 );
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4099,7 +4099,7 @@ describe('AuxLibrary', () => {
 
         describe('experiment.localPositionTween()', () => {
             it('should emit a LocalPositionTweenAction', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     bot1,
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4111,14 +4111,16 @@ describe('AuxLibrary', () => {
                     bot1.id,
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    { type: 'quadratic', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should support passing a bot ID directly', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4130,14 +4132,16 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    { type: 'quadratic', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should default the easing to linear inout', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 }
@@ -4146,14 +4150,16 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'linear', mode: 'inout' }
+                    { type: 'linear', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should support a custom duration', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4166,14 +4172,15 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     undefined,
-                    99
+                    99,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should clamp the duration to 0 if it is negative', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4186,14 +4193,15 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
-                    0
+                    0,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should clamp the duration to 24 hours if it is too large', () => {
-                const action = library.api.experiment.localPositionTween(
+                const action: any = library.api.experiment.localPositionTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4206,16 +4214,17 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
-                    60 * 60 * 24 // 24 hours in seconds
+                    60 * 60 * 24, // 24 hours in seconds
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });
 
         describe('experiment.localRotationTween()', () => {
             it('should emit a LocalRotationTweenAction', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     bot1,
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4227,14 +4236,16 @@ describe('AuxLibrary', () => {
                     bot1.id,
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    { type: 'quadratic', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should support passing a bot ID directly', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4246,14 +4257,16 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    { type: 'quadratic', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should default the easing to linear inout', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 }
@@ -4262,14 +4275,16 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'linear', mode: 'inout' }
+                    { type: 'linear', mode: 'inout' },
+                    undefined,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should support a custum duration', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4282,14 +4297,15 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
-                    99
+                    99,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should clamp the duration to 0 if it is negative', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4302,14 +4318,15 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
-                    0
+                    0,
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
 
             it('should clamp the duration to 24 hours if it is too large', () => {
-                const action = library.api.experiment.localRotationTween(
+                const action: any = library.api.experiment.localRotationTween(
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
@@ -4322,9 +4339,10 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' },
-                    60 * 60 * 24 // 24 hours in seconds
+                    60 * 60 * 24, // 24 hours in seconds
+                    context.tasks.size
                 );
-                expect(action).toEqual(expected);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4103,7 +4103,9 @@ describe('AuxLibrary', () => {
                     bot1,
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    {
+                        easing: { type: 'quadratic', mode: 'inout' },
+                    }
                 );
                 const expected = localPositionTween(
                     bot1.id,
@@ -4120,7 +4122,9 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    {
+                        easing: { type: 'quadratic', mode: 'inout' },
+                    }
                 );
                 const expected = localPositionTween(
                     'abc',
@@ -4143,6 +4147,26 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' }
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support a custom duration', () => {
+                const action = library.api.experiment.localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: 99,
+                    }
+                );
+                const expected = localPositionTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    undefined,
+                    99
                 );
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
@@ -4155,7 +4179,9 @@ describe('AuxLibrary', () => {
                     bot1,
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    {
+                        easing: { type: 'quadratic', mode: 'inout' },
+                    }
                 );
                 const expected = localRotationTween(
                     bot1.id,
@@ -4172,7 +4198,9 @@ describe('AuxLibrary', () => {
                     'abc',
                     'dim',
                     { x: 1, y: 2, z: 3 },
-                    { type: 'quadratic', mode: 'inout' }
+                    {
+                        easing: { type: 'quadratic', mode: 'inout' },
+                    }
                 );
                 const expected = localRotationTween(
                     'abc',
@@ -4195,6 +4223,26 @@ describe('AuxLibrary', () => {
                     'dim',
                     { x: 1, y: 2, z: 3 },
                     { type: 'linear', mode: 'inout' }
+                );
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support a custum duration', () => {
+                const action = library.api.experiment.localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    {
+                        duration: 99,
+                    }
+                );
+                const expected = localRotationTween(
+                    'abc',
+                    'dim',
+                    { x: 1, y: 2, z: 3 },
+                    { type: 'linear', mode: 'inout' },
+                    99
                 );
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -307,6 +307,21 @@ export interface BotFilterFunction {
 }
 
 /**
+ * Defines a set of options for a tween.
+ */
+export interface TweenOptions {
+    /**
+     * The easing for the tween.
+     */
+    easing?: Easing;
+
+    /**
+     * The duration of the tween in seconds.
+     */
+    duration?: number;
+}
+
+/**
  * Creates a library that includes the default functions and APIs.
  * @param context The global context that should be used.
  */
@@ -2652,16 +2667,22 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param bot The bot or bot ID to tween.
      * @param dimension The dimension that the bot should be tweened in.
      * @param position The position that the bot should be tweened to.
-     * @param easing The easing that should be used for the tween.
+     * @param options The options that should be used for the tween.
      */
     function localPositionTween(
         bot: Bot | string,
         dimension: string,
         position: { x: number; y: number; z?: number },
-        easing?: Easing
+        options?: TweenOptions
     ): LocalPositionTweenAction {
         return addAction(
-            calcLocalPositionTween(getID(bot), dimension, position, easing)
+            calcLocalPositionTween(
+                getID(bot),
+                dimension,
+                position,
+                options ? options.easing : undefined,
+                options ? options.duration : undefined
+            )
         );
     }
 
@@ -2670,16 +2691,22 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param bot The bot or bot ID to tween.
      * @param dimension The dimension that the bot should be tweened in.
      * @param rotation The rotation that the bot should be tweened to.
-     * @param easing The easing that should be used for the tween.
+     * @param options The options that should be used for the tween.
      */
     function localRotationTween(
         bot: Bot | string,
         dimension: string,
         rotation: { x: number; y: number; z?: number },
-        easing?: Easing
+        options?: TweenOptions
     ): LocalRotationTweenAction {
         return addAction(
-            calcLocalRotationTween(getID(bot), dimension, rotation, easing)
+            calcLocalRotationTween(
+                getID(bot),
+                dimension,
+                rotation,
+                options ? options.easing : undefined,
+                options ? options.duration : undefined
+            )
         );
     }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -2674,16 +2674,17 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         dimension: string,
         position: { x: number; y: number; z?: number },
         options?: TweenOptions
-    ): LocalPositionTweenAction {
-        return addAction(
-            calcLocalPositionTween(
-                getID(bot),
-                dimension,
-                position,
-                options ? options.easing : undefined,
-                options ? options.duration : undefined
-            )
+    ): Promise<void> {
+        const task = context.createTask();
+        const action = calcLocalPositionTween(
+            getID(bot),
+            dimension,
+            position,
+            options ? options.easing : undefined,
+            options ? options.duration : undefined,
+            task.taskId
         );
+        return addAsyncAction(task, action);
     }
 
     /**
@@ -2698,16 +2699,17 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         dimension: string,
         rotation: { x: number; y: number; z?: number },
         options?: TweenOptions
-    ): LocalRotationTweenAction {
-        return addAction(
-            calcLocalRotationTween(
-                getID(bot),
-                dimension,
-                rotation,
-                options ? options.easing : undefined,
-                options ? options.duration : undefined
-            )
+    ): Promise<void> {
+        const task = context.createTask();
+        const action = calcLocalRotationTween(
+            getID(bot),
+            dimension,
+            rotation,
+            options ? options.easing : undefined,
+            options ? options.duration : undefined,
+            task.taskId
         );
+        return addAsyncAction(task, action);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1488,6 +1488,21 @@ declare interface Easing {
 }
 
 /**
+ * Defines the set of possible options for tweens.
+ */
+declare interface TweenOptions {
+    /**
+     * The easing type and mode that the tween should use.
+     */
+    easing?: Easing;
+
+    /**
+     * The amount of time that the tween should take in seconds.
+     */
+    duration?: number;
+}
+
+/**
  * Defines an event that runs a tween locally.
  */
 declare interface LocalTweenAction extends Action {
@@ -3615,13 +3630,13 @@ declare global {
          * @param bot The bot or bot ID to tween.
          * @param dimension The dimension that the bot should be tweened in.
          * @param position The position that the bot should be tweened to.
-         * @param easing The easing that should be used for the tween.
+         * @param options The options that should be used for the tween.
          */
         localPositionTween(
             bot: Bot | string,
             dimension: string,
             position: { x?: number, y?: number, z?: number },
-            easing?: Easing
+            options?: TweenOptions
         ): LocalPositionTweenAction;
 
         /**
@@ -3629,13 +3644,13 @@ declare global {
          * @param bot The bot or bot ID to tween.
          * @param dimension The dimension that the bot should be tweened in.
          * @param rotation The rotation that the bot should be tweened to.
-         * @param easing The easing that should be used for the tween.
+         * @param options The options that should be used for the tween.
          */
         localRotationTween(
             bot: Bot | string,
             dimension: string,
             rotation: { x?: number, y?: number, z?: number },
-            easing?: Easing
+            options?: TweenOptions
         ): LocalRotationTweenAction;
     };
 }

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -313,6 +313,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 this._tween = new TWEEN.Tween<any>(this.bot3D.position)
                     .to(<any>targetPosition)
                     .easing(easing)
+                    .duration(event.duration * 1000)
                     .onUpdate(() => this.bot3D.updateMatrixWorld())
                     .onComplete(() => (this._tween = null))
                     .start(currentTime);
@@ -333,6 +334,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                 )
                     .to(<any>targetRotation)
                     .easing(easing)
+                    .duration(event.duration * 1000)
                     .onUpdate(() => this.bot3D.updateMatrixWorld())
                     .onComplete(() => (this._tween = null))
                     .start(currentTime);


### PR DESCRIPTION
### :boom: Breaking Changes

-   Changed `experiment.localPositionTween()` and `experiment.localRotationTween()` to take different arguments and return a promise.
    -   the 4th parameter is now an options object instead of the easing options.
    -   This options object is able to accept easing and duration values.
    -   Additionally the functions now return promises.
    -   See the docs for examples.

### :bug: Bug Fixes

-   Fixed an issue where `experiment.localPositionTween()` and `experiment.localRotationTween()` may not execute if triggered during `@onCreate()`.