### PR TITLE
Sheet Portal Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Date: TBD
 
+### :boom: Breaking Changes
+
+-   Renamed the `_editingBot` tag to `editingBot`.
+
 ### :rocket: Improvements
 
 -   sheetPortal Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # CasualOS Changelog
 
+## V1.2.13
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   sheetPortal Improvements
+    -   Added the `@onSheetTagClick` listener which is triggered when a tag name is clicked.
+    -   Added the `@onSheetBotIDClick` listener which is triggered when a Bot ID is clicked.
+    -   Added the `@onSheetBotClick` listener which is triggered when a bot visualization is clicked in the sheet.
+    -   Added the `sheetPortalShowButton` config bot tag to control whether the button in the bottom right corner of the sheet is shown.
+    -   Added the `sheetPortalButtonIcon` config bot tag to control the icon on the button in the bottom right corner of the sheet.
+    -   Added the `sheetPortalButtonHint` config bot tag to control the tooltip on the button in the bottom right corner of the sheet.
+    -   Added the `sheetPortalAllowedTags` config bot tag to control which tags are allowed to be shown and edited in the sheet portal.
+    -   Swapped the position of the new bot and new tag buttons in the sheet.
+    -   Added the `editingTag` tag which contains the tag that the player is currently editing.
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where `clearTagMasks()` would error if given a bot that had no tag masks.
+
 ## V1.2.12
 
 #### Date: 9/22/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### :bug: Bug Fixes
 
+-   Fixed an issue where cells in the sheet portal would not cover the entire cell area.
 -   Fixed an issue where `clearTagMasks()` would error if given a bot that had no tag masks.
 
 ## V1.2.12

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -946,6 +946,39 @@ let that: {
 };
 ```
 
+### `@onSheetTagClick`
+
+A shout that is sent when a tag name is clicked in the sheet portal.
+
+#### Arguments:
+```typescript
+let that: {
+    tag: string;
+};
+```
+
+### `@onSheetBotClick`
+
+A shout that is sent when a Bot is clicked in the sheet portal.
+
+#### Arguments:
+```typescript
+let that: {
+    bot: Bot;
+};
+```
+
+### `@onSheetBotIDClick`
+
+A shout that is sent when a Bot ID is clicked in the sheet portal.
+
+#### Arguments:
+```typescript
+let that: {
+    bot: Bot;
+};
+```
+
 ### `@onRemoteWhisper`
 
 A shout that is sent whenever a message is received from another player.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1398,6 +1398,20 @@ The [tooltip](https://en.wikipedia.org/wiki/Tooltip) that should be shown on the
   </PossibleValue>
 </PossibleValuesTable>
 
+### `sheetPortalAllowedTags`
+
+The list of tags that should be allowed in the sheet portal.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    All tags are allowed. (Default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Array'>
+    Only the specified tags can be shown in the sheet portal.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ## History Tags
 
 History tags are tags that are automatically applied to bots in the `history` space.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1352,6 +1352,52 @@ The [tooltip](https://en.wikipedia.org/wiki/Tooltip) that should be shown on the
   </PossibleValue>
 </PossibleValuesTable>
 
+### `sheetPortalShowButton`
+
+Whether the sheet portal should show a button that allows a custom action.
+When set to true, the button will be displayed in the lower right hand corner of the sheet portal.
+
+Clicking the button will trigger a <TagLink tag='@onClick'/> on the sheet portal config bot.
+If there is no `@onClick`, then the sheet portal will be closed.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The button is shown. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+      No button is shown.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `sheetPortalButtonIcon`
+
+The [Material Icon](https://material.io/resources/icons/?style=baseline) that should be shown on the sheet portal button.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='web_asset'>
+    The Web Asset icon. (Default)
+  </PossibleValue>
+  <PossibleValue value='Any Material Icon'>
+    See <a href='https://material.io/resources/icons/?style=baseline'>https://material.io/resources/icons/?style=baseline</a>.
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `sheetPortalButtonHint`
+
+The [tooltip](https://en.wikipedia.org/wiki/Tooltip) that should be shown on the sheet portal button.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='Page Portal'>
+    "Page Portal" (Default)
+  </PossibleValueCode>
+  <PossibleValue value='Any String'>
+    The text that should be displayed as a hint when the user hovers their mouse over the button.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ## History Tags
 
 History tags are tags that are automatically applied to bots in the `history` space.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -2130,15 +2130,7 @@ The URL that is currently specified in the tab.
   </PossibleValue>
 </PossibleValuesTable>
 
-## Hidden Tags
-
-Hidden tags are tags that are hidden in the sheet by default.
-
-<Alert type='info'>
-  You can make your own hidden tags by adding a `_` (underscore) to the start of the tag.
-</Alert>
-
-### `_editingBot`
+### `editingBot`
 
 <Badges>
   <UserBotBadge/>
@@ -2146,3 +2138,20 @@ Hidden tags are tags that are hidden in the sheet by default.
 
 The ID of the bot that the user is currently editing.
 Only available on the player bot.
+
+### `editingTag`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The tag that the user is currently editing.
+Only available on the player bot.
+
+## Hidden Tags
+
+Hidden tags are tags that are hidden in the sheet by default.
+
+<Alert type='info'>
+  You can make your own hidden tags by adding a `_` (underscore) to the start of the tag.
+</Alert>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1225,6 +1225,7 @@ export const KNOWN_TAGS: string[] = [
     'sheetPortalShowButton',
     'sheetPortalButtonIcon',
     'sheetPortalButtonHint',
+    'sheetPortalAllowedTags',
 
     'color',
     'creator',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1371,6 +1371,7 @@ export const KNOWN_TAGS: string[] = [
 
     ON_SHEET_TAG_CLICK,
     ON_SHEET_BOT_ID_CLICK,
+    ON_SHEET_BOT_CLICK,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1370,6 +1370,7 @@ export const KNOWN_TAGS: string[] = [
     ON_ANY_BOTS_CHANGED_ACTION_NAME,
 
     ON_SHEET_TAG_CLICK,
+    ON_SHEET_BOT_ID_CLICK,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -200,7 +200,7 @@ export interface BotTags {
     ['menuPortalConfigBot']?: string;
     ['leftWristPortalConfigBot']?: string;
     ['rightWristPortalConfigBot']?: string;
-    ['_editingBot']?: string;
+    ['editingBot']?: string;
 
     // Admin channel task tags
     ['auxRunningTasks']?: boolean;
@@ -1187,7 +1187,8 @@ export const KNOWN_TAGS: string[] = [
     'rightPointer_squeeze',
     'forceSignedScripts',
 
-    '_editingBot',
+    'editingBot',
+    'editingTag',
 
     'portalColor',
     'portalLocked',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1075,11 +1075,16 @@ export const TAG_PORTAL: string = 'tagPortal';
 export const DATA_PORTAL: string = 'dataPortal';
 
 /**
+ * The name of the sheet portal.
+ */
+export const SHEET_PORTAL: string = 'sheetPortal';
+
+/**
  * The list of all portal tags.
  */
 export const KNOWN_PORTALS: string[] = [
     'pagePortal',
-    'sheetPortal',
+    SHEET_PORTAL,
     'inventoryPortal',
     'menuPortal',
     'leftWristPortal',
@@ -1216,6 +1221,9 @@ export const KNOWN_TAGS: string[] = [
     'tagPortalShowButton',
     'tagPortalButtonIcon',
     'tagPortalButtonHint',
+    'sheetPortalShowButton',
+    'sheetPortalButtonIcon',
+    'sheetPortalButtonHint',
 
     'color',
     'creator',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1037,6 +1037,21 @@ export const ON_BOT_CHANGED_ACTION_NAME = 'onBotChanged';
 export const ON_ANY_BOTS_CHANGED_ACTION_NAME = 'onAnyBotsChanged';
 
 /**
+ * The name of the event that is triggered when a tag is clicked in the sheet.
+ */
+export const ON_SHEET_TAG_CLICK = 'onSheetTagClick';
+
+/**
+ * The name of the event that is triggered when a Bot's ID is clicked in the sheet.
+ */
+export const ON_SHEET_BOT_ID_CLICK = 'onSheetBotIDClick';
+
+/**
+ * The name of the event that is triggered when a Bot is clicked in the sheet.
+ */
+export const ON_SHEET_BOT_CLICK = 'onSheetBotClick';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -1353,6 +1368,8 @@ export const KNOWN_TAGS: string[] = [
 
     ON_BOT_CHANGED_ACTION_NAME,
     ON_ANY_BOTS_CHANGED_ACTION_NAME,
+
+    ON_SHEET_TAG_CLICK,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -1614,6 +1614,92 @@ describe('BotCalculations', () => {
                 { tag: 'other', space: null },
             ]);
         });
+
+        it('should only exclude tags not in the allowed tags list', () => {
+            const bots: Bot[] = [
+                {
+                    id: 'test',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                    },
+                },
+                {
+                    id: 'test2',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        tag: 'hello',
+                    },
+                },
+                {
+                    id: 'test3',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        tag: 'again',
+                    },
+                },
+                {
+                    id: 'test4',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        other: 'tag',
+                    },
+                },
+            ];
+
+            const tags = botTags(bots, [], [], ['tag', 'other']);
+
+            expect(tags).toEqual([
+                { tag: 'tag', space: null },
+                { tag: 'other', space: null },
+            ]);
+        });
+
+        it('should not include extra tags if theyre not in the allowed tags list', () => {
+            const bots: Bot[] = [
+                {
+                    id: 'test',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                    },
+                },
+                {
+                    id: 'test2',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        tag: 'hello',
+                    },
+                },
+                {
+                    id: 'test3',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        tag: 'again',
+                    },
+                },
+                {
+                    id: 'test4',
+                    tags: {
+                        _position: { x: 0, y: 0, z: 0 },
+                        _workspace: 'abc',
+                        other: 'tag',
+                    },
+                },
+            ];
+
+            const tags = botTags(bots, [], ['_position'], ['tag', 'other']);
+
+            expect(tags).toEqual([
+                { tag: 'tag', space: null },
+                { tag: 'other', space: null },
+            ]);
+        });
     });
 
     describe('createContextId()', () => {

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4556,6 +4556,11 @@ describe('AuxLibrary', () => {
             });
         });
 
+        it('should do nothing if the bot does not have any tag masks', () => {
+            library.api.clearTagMasks(bot1);
+            expect(bot1.maskChanges).toEqual({});
+        });
+
         it('should remove the tag masks from the given bot and space', () => {
             bot1[SET_TAG_MASK_SYMBOL]('name', 'bob', 'local');
             bot1[SET_TAG_MASK_SYMBOL]('other', 'bob', 'local');

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -711,6 +711,13 @@ describe('RuntimeBot', () => {
             expect(script.masks.value).toEqual(null);
             expect(script.masks.other).toEqual(null);
         });
+
+        it('should work when the bot has no tag masks', () => {
+            script[CLEAR_TAG_MASKS_SYMBOL]('local');
+
+            expect(script.changes).toEqual({});
+            expect(script.maskChanges).toEqual({});
+        });
     });
 });
 

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -406,11 +406,15 @@ export function createRuntimeBot(
 
     Object.defineProperty(script, CLEAR_TAG_MASKS_SYMBOL, {
         value: (space: string) => {
-            let spaces = hasValue(space) ? [space] : TAG_MASK_SPACE_PRIORITIES;
-            for (let space of spaces) {
-                const tags = bot.masks[space];
-                for (let tag in tags) {
-                    script[SET_TAG_MASK_SYMBOL](tag, null, space);
+            if (bot.masks) {
+                let spaces = hasValue(space)
+                    ? [space]
+                    : TAG_MASK_SPACE_PRIORITIES;
+                for (let space of spaces) {
+                    const tags = bot.masks[space];
+                    for (let tag in tags) {
+                        script[SET_TAG_MASK_SYMBOL](tag, null, space);
+                    }
                 }
             }
         },

--- a/src/aux-server/README.md
+++ b/src/aux-server/README.md
@@ -94,6 +94,7 @@ The AUX Server Docker image can be configured using the following environment va
 -   `SANDBOX_TYPE`: The type of sandboxing that should be used to separate AUX Scripts from the host environment. Possible options are `none` and `deno`. `none` provides no sandboxing and therefore no security guarentees. `deno` uses the [Deno](https://deno.land/) runtime. Defaults to `none` while the sandbox is in testing.
 -   `STAGE_TYPE`: The type of stage store that should be used for atoms that have not yet been committed. Possible options are `mongodb` and `redis`. `mongodb` uses MongoDB to store atoms while `redis` uses Redis. Note that `redis` is not persistent which makes data loss more likely. Defaults to `redis`.
 -   `GPIO`: Whether to enable GPIO support. Enabled by default on ARM. Disabled by default otherwise.
+-   `DEBUG`: Whether to enable debug mode. Setting this to `true` will enable some more debug logs, particularly for Deno.
 
 ## Security Note
 

--- a/src/aux-server/aux-web/shared/vue-components/BotID/BotID.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotID/BotID.ts
@@ -27,11 +27,7 @@ export default class BotID extends Vue {
         super();
     }
 
-    copyID() {
-        copyToClipboard(this.bots.id);
-        const sim = appManager.simulationManager.primary;
-        if (sim) {
-            sim.helper.transaction(toast('Copied!'));
-        }
+    click() {
+        this.$emit('click', this.bots.id);
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotID/BotID.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotID/BotID.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="tag bot-id clonable" @click="copyID()">
+    <span class="tag bot-id clonable" @click="click()">
         {{ shortID }}
     </span>
 </template>

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
@@ -1,7 +1,12 @@
 import Vue, { ComponentOptions } from 'vue';
 import Component from 'vue-class-component';
 import { Provide, Prop, Inject, Watch } from 'vue-property-decorator';
-import { Bot, hasValue, BotTags } from '@casual-simulation/aux-common';
+import {
+    Bot,
+    hasValue,
+    BotTags,
+    ON_SHEET_TAG_CLICK,
+} from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { appManager } from '../../AppManager';
 import BotTable from '../BotTable/BotTable';
@@ -61,11 +66,20 @@ export default class BotSheet extends Vue {
         });
     }
 
-    goToTag(tag: string) {
-        this._simulation.helper.updateBot(this._simulation.helper.userBot, {
-            tags: {
-                sheetPortal: tag,
-            },
-        });
+    async goToTag(tag: string) {
+        const result = await this._simulation.helper.shout(
+            ON_SHEET_TAG_CLICK,
+            null,
+            {
+                tag: tag,
+            }
+        );
+        if (result.results.length <= 0) {
+            this._simulation.helper.updateBot(this._simulation.helper.userBot, {
+                tags: {
+                    sheetPortal: tag,
+                },
+            });
+        }
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
@@ -40,6 +40,7 @@ export default class BotSheet extends Vue {
     showButton: boolean = true;
     buttonIcon: string = null;
     buttonHint: string = null;
+    allowedTags: string[] = null;
 
     private _simulation: BrowserSimulation;
     private _currentConfig: SheetPortalConfig;
@@ -82,7 +83,7 @@ export default class BotSheet extends Vue {
     }
 
     tagFocusChanged(bot: Bot, tag: string, focused: boolean) {
-        this._simulation.helper.setEditingBot(bot);
+        this._simulation.helper.setEditingBot(bot, tag);
     }
 
     async exitSheet() {
@@ -166,10 +167,12 @@ export default class BotSheet extends Vue {
             this.showButton = this._currentConfig.showButton;
             this.buttonIcon = this._currentConfig.buttonIcon;
             this.buttonHint = this._currentConfig.buttonHint;
+            this.allowedTags = this._currentConfig.allowedTags;
         } else {
             this.showButton = true;
             this.buttonIcon = null;
             this.buttonHint = null;
+            this.allowedTags = null;
         }
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
@@ -7,7 +7,9 @@ import {
     BotTags,
     ON_SHEET_TAG_CLICK,
     ON_SHEET_BOT_ID_CLICK,
+    ON_SHEET_BOT_CLICK,
     toast,
+    tweenTo,
 } from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { appManager } from '../../AppManager';
@@ -67,6 +69,22 @@ export default class BotSheet extends Vue {
         this._simulation.helper.updateBot(this._simulation.helper.userBot, {
             tags: tags,
         });
+    }
+
+    async botClick(bot: Bot) {
+        const result = await this._simulation.helper.shout(
+            ON_SHEET_BOT_CLICK,
+            null,
+            {
+                bot: bot,
+            }
+        );
+        if (result.results.length <= 0) {
+            this.exitSheet();
+            this._simulation.helper.transaction(
+                tweenTo(bot.id, undefined, undefined, undefined, 0)
+            );
+        }
     }
 
     async botIDClick(id: string) {

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
@@ -6,11 +6,14 @@ import {
     hasValue,
     BotTags,
     ON_SHEET_TAG_CLICK,
+    ON_SHEET_BOT_ID_CLICK,
+    toast,
 } from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { appManager } from '../../AppManager';
 import BotTable from '../BotTable/BotTable';
 import { SubscriptionLike } from 'rxjs';
+import { copyToClipboard } from '../../SharedUtils';
 
 @Component({
     components: {
@@ -64,6 +67,20 @@ export default class BotSheet extends Vue {
         this._simulation.helper.updateBot(this._simulation.helper.userBot, {
             tags: tags,
         });
+    }
+
+    async botIDClick(id: string) {
+        const result = await this._simulation.helper.shout(
+            ON_SHEET_BOT_ID_CLICK,
+            null,
+            {
+                bot: this._simulation.helper.botsState[id],
+            }
+        );
+        if (result.results.length <= 0) {
+            copyToClipboard(id);
+            this._simulation.helper.transaction(toast('Copied!'));
+        }
     }
 
     async goToTag(tag: string) {

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
@@ -17,6 +17,7 @@
                     :showExitSheet="showButton"
                     :exitSheetIcon="buttonIcon"
                     :exitSheetHint="buttonHint"
+                    :allowedTags="allowedTags"
                 ></bot-table>
             </md-card-content>
         </md-card>

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
@@ -14,6 +14,9 @@
                     :diffSelected="isDiff"
                     :dimension="dimension"
                     :showNewBot="showNewBot"
+                    :showExitSheet="showButton"
+                    :exitSheetIcon="buttonIcon"
+                    :exitSheetHint="buttonHint"
                 ></bot-table>
             </md-card-content>
         </md-card>

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
@@ -8,6 +8,7 @@
                     @tagFocusChanged="tagFocusChanged"
                     @exitSheet="exitSheet()"
                     @goToTag="goToTag"
+                    @botIDClick="botIDClick"
                     :bots="bots"
                     :diffSelected="isDiff"
                     :dimension="dimension"

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.vue
@@ -9,6 +9,7 @@
                     @exitSheet="exitSheet()"
                     @goToTag="goToTag"
                     @botIDClick="botIDClick"
+                    @botClick="botClick"
                     :bots="bots"
                     :diffSelected="isDiff"
                     :dimension="dimension"

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/SheetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/SheetPortalConfig.ts
@@ -36,34 +36,21 @@ import { Simulation } from '@casual-simulation/aux-vm';
 /**
  * Defines a class that is able to watch dimension confic bots and update values.
  */
-export class TagPortalConfig implements SubscriptionLike {
+export class SheetPortalConfig implements SubscriptionLike {
     private _sub: Subscription;
     private _portalTag: string;
     private _updated: Subject<void>;
-    private _style: Object;
     private _showButton: boolean;
     private _buttonIcon: string;
     private _buttonHint: string;
     private _configBot: Bot;
     private _simulation: Simulation;
 
-    /**
-     * Gets the CSS style that should be applied.
-     */
-    get style(): Object {
-        if (hasValue(this._style)) {
-            return this._style;
-        }
-        return calculateMeetPortalAnchorPointOffset(
-            DEFAULT_TAG_PORTAL_ANCHOR_POINT
-        );
-    }
-
     get showButton(): boolean {
         if (hasValue(this._showButton)) {
             return this._showButton;
         }
-        return false;
+        return true;
     }
 
     get buttonIcon(): string {
@@ -96,20 +83,8 @@ export class TagPortalConfig implements SubscriptionLike {
         return this._updated;
     }
 
-    buttonClick() {
-        if (!this._simulation || !this._configBot) {
-            return;
-        }
-        const dimension = calculateBotValue(
-            null,
-            this._simulation.helper.userBot,
-            this._portalTag
-        );
-        this._simulation.helper.action(
-            CLICK_ACTION_NAME,
-            [this._configBot],
-            onClickArg(null, dimension)
-        );
+    get configBot() {
+        return this._configBot;
     }
 
     constructor(portalTag: string, simulation: BrowserSimulation) {
@@ -134,7 +109,6 @@ export class TagPortalConfig implements SubscriptionLike {
     }
 
     protected _clearPortalValues() {
-        this._style = null;
         this._showButton = null;
         this._buttonIcon = null;
         this._buttonHint = null;
@@ -146,49 +120,22 @@ export class TagPortalConfig implements SubscriptionLike {
         bot: PrecalculatedBot,
         portalTag: string
     ) {
-        this._style = calculateBotValue(calc, bot, 'tagPortalStyle');
-        if (typeof this._style !== 'object') {
-            this._style = null;
-        }
-        const anchorPoint = calculateBotValue(
-            calc,
-            bot,
-            'auxTagPortalAnchorPoint'
-        );
-
-        if (hasValue(anchorPoint)) {
-            if (!this._style) {
-                this._style = {
-                    top: null,
-                    bottom: null,
-                    height: null,
-                    width: null,
-                    'min-height': null,
-                    'min-width': null,
-                    left: null,
-                    right: null,
-                };
-            }
-            const offset = getBotTagPortalAnchorPointOffset(calc, bot);
-            merge(this._style, offset);
-        }
-
         this._showButton = calculateBooleanTagValue(
             calc,
             bot,
-            'auxTagPortalShowButton',
+            'auxSheetPortalShowButton',
             null
         );
         this._buttonIcon = calculateStringTagValue(
             calc,
             bot,
-            'auxTagPortalButtonIcon',
+            'auxSheetPortalButtonIcon',
             null
         );
         this._buttonHint = calculateStringTagValue(
             calc,
             bot,
-            'auxTagPortalButtonHint',
+            'auxSheetPortalButtonHint',
             null
         );
         this._updated.next();

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/SheetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/SheetPortalConfig.ts
@@ -22,6 +22,7 @@ import {
     Bot,
     CLICK_ACTION_NAME,
     onClickArg,
+    calculateStringListTagValue,
 } from '@casual-simulation/aux-common';
 import { Color } from 'three';
 import {
@@ -43,6 +44,7 @@ export class SheetPortalConfig implements SubscriptionLike {
     private _showButton: boolean;
     private _buttonIcon: string;
     private _buttonHint: string;
+    private _allowedTags: string[];
     private _configBot: Bot;
     private _simulation: Simulation;
 
@@ -63,6 +65,13 @@ export class SheetPortalConfig implements SubscriptionLike {
     get buttonHint(): string {
         if (hasValue(this._buttonHint)) {
             return this._buttonHint;
+        }
+        return null;
+    }
+
+    get allowedTags(): string[] {
+        if (hasValue(this._allowedTags)) {
+            return this._allowedTags;
         }
         return null;
     }
@@ -112,6 +121,7 @@ export class SheetPortalConfig implements SubscriptionLike {
         this._showButton = null;
         this._buttonIcon = null;
         this._buttonHint = null;
+        this._allowedTags = null;
         this._updated.next();
     }
 
@@ -136,6 +146,12 @@ export class SheetPortalConfig implements SubscriptionLike {
             calc,
             bot,
             'auxSheetPortalButtonHint',
+            null
+        );
+        this._allowedTags = calculateStringListTagValue(
+            calc,
+            bot,
+            'auxSheetPortalAllowedTags',
             null
         );
         this._updated.next();

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
@@ -549,6 +549,10 @@ export default class BotTable extends Vue {
         );
     }
 
+    botClicked(bot: Bot) {
+        this.$emit('botClick', bot);
+    }
+
     async downloadBots() {
         if (this.hasBots) {
             const stored = await this.getBotManager().exportBots(

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
@@ -97,6 +97,9 @@ export default class BotTable extends Vue {
     @Prop({ default: 'Page Portal' })
     exitSheetHint: string;
 
+    @Prop({})
+    allowedTags: string[];
+
     tags: { tag: string; space: string }[] = [];
     addedTags: string[] = [];
     lastEditedTag: string = null;
@@ -113,7 +116,6 @@ export default class BotTable extends Vue {
     viewMode: 'rows' | 'columns' = 'columns';
     showHidden: boolean = false;
 
-    tagWhitelist: (string | boolean)[][] = [];
     editableMap: Map<string, boolean>;
 
     private _simulation: BrowserSimulation;
@@ -169,22 +171,6 @@ export default class BotTable extends Vue {
 
     isMobile(): boolean {
         return this._isMobile;
-    }
-
-    isWhitelistTagActive(index: number | string): boolean {
-        if (typeof index === 'number') {
-            if (index < 0) {
-                return false;
-            }
-            return <boolean>this.tagWhitelist[index][1];
-        } else {
-            const idx = this.tagWhitelist.findIndex((bl) => bl[0] === index);
-            return this.isWhitelistTagActive(idx);
-        }
-    }
-
-    getWhitelistCount(index: number): number {
-        return this.tagWhitelist[index].length - 2;
     }
 
     isBotReadOnly(bot: Bot): boolean {
@@ -271,7 +257,6 @@ export default class BotTable extends Vue {
 
         this.lastSelectionCount = this.bots.length;
 
-        this.setTagWhitelist();
         this._updateTags();
         this.numBotsSelected = this.bots.length;
         if (this.focusedBot) {
@@ -645,7 +630,6 @@ export default class BotTable extends Vue {
 
     toggleHidden() {
         this.showHidden = !this.showHidden;
-        this.setTagWhitelist();
         this._updateTags();
     }
 
@@ -663,7 +647,6 @@ export default class BotTable extends Vue {
             this.addedTags.splice(index, 1);
         }
 
-        this.setTagWhitelist();
         this._updateTags();
     }
 
@@ -723,7 +706,6 @@ export default class BotTable extends Vue {
             return [];
         });
 
-        this.setTagWhitelist();
         this._updateTags();
         this.numBotsSelected = this.bots.length;
         this._updateEditable();
@@ -755,214 +737,10 @@ export default class BotTable extends Vue {
                 this.bots,
                 this.tags.map((t) => t.tag),
                 allExtraTags,
-                this.tagWhitelist
+                this.allowedTags
             ),
             (t) => t.tag
         );
-    }
-
-    toggleWhitelistIndex(index: number) {
-        this.tagWhitelist[index][1] = !this.tagWhitelist[index][1];
-        this._updateTags();
-    }
-
-    setTagWhitelist() {
-        let sortedArray: string[] = getAllBotTags(this.bots, true).sort();
-
-        // remove any duplicates from the array to fix multiple bots adding in duplicate tags
-        sortedArray = sortedArray.filter(function (elem, index, self) {
-            return index === self.indexOf(elem);
-        });
-
-        let whitelist: (string | boolean)[][] = [];
-
-        let hiddenList: (string | boolean)[] = [];
-        let generalList: (string | boolean)[] = [];
-        let listenerList: (string | boolean)[] = [];
-        let formulaList: (string | boolean)[] = [];
-
-        for (let i = sortedArray.length - 1; i >= 0; i--) {
-            const tag = sortedArray[i];
-            let removed = false;
-            if (isHiddenTag(tag)) {
-                hiddenList.push(tag);
-                if (!removed) {
-                    sortedArray.splice(i, 1);
-                    removed = true;
-                }
-            }
-            if (this.isTagOnlyScripts(tag, null)) {
-                listenerList.push(tag);
-                if (!removed) {
-                    sortedArray.splice(i, 1);
-                    removed = true;
-                }
-            }
-            if (this.isTagOnlyFormulas(tag, null)) {
-                formulaList.push(tag);
-                if (!removed) {
-                    sortedArray.splice(i, 1);
-                    removed = true;
-                }
-            }
-        }
-
-        let camelCaseRegex = /(?=[A-Z])/g;
-
-        let current = '';
-        let tempArray: (string | boolean)[] = [];
-        for (let i = sortedArray.length - 1; i >= 0; i--) {
-            if (
-                current.split(camelCaseRegex)[0] !=
-                sortedArray[i].split(camelCaseRegex)[0]
-            ) {
-                if (tempArray.length > 0) {
-                    if (whitelist.length === 0) {
-                        whitelist = [tempArray];
-                    } else {
-                        whitelist.push(tempArray);
-                    }
-                }
-
-                tempArray = [];
-            }
-            current = sortedArray[i];
-
-            // if new tag matces the current tag section
-            if (tempArray.length === 0) {
-                // if the temp array has been reset
-
-                // add the section name in slot 0
-                tempArray.push(current.split(camelCaseRegex)[0]);
-
-                let activeCheck = false;
-                // add the section visibility in slot 1
-                if (this.tagWhitelist.length > 0) {
-                    this.tagWhitelist.forEach((element) => {
-                        if (element[0] === tempArray[0]) {
-                            activeCheck = <boolean>element[1];
-                        }
-                    });
-                }
-                tempArray.push(activeCheck);
-
-                // add the tag that started the match in slot 2
-                tempArray.push(current);
-
-                sortedArray.splice(i, 2);
-            } else {
-                tempArray.push(sortedArray[i]);
-                sortedArray.splice(i, 1);
-            }
-        }
-
-        // makes sure if the loop ends on an array it will add in the temp array correctly to the whitelist
-        if (tempArray.length > 0) {
-            if (whitelist.length === 0) {
-                whitelist = [tempArray];
-            } else {
-                whitelist.push(tempArray);
-            }
-        }
-
-        if (hiddenList.length > 0) {
-            let activeCheck = false;
-
-            if (this.tagWhitelist.length > 0) {
-                this.tagWhitelist.forEach((element) => {
-                    if (element[0] === 'hidden') {
-                        activeCheck = <boolean>element[1];
-                    }
-                });
-            }
-
-            hiddenList.unshift(activeCheck);
-            hiddenList.unshift('hidden');
-            whitelist.unshift(hiddenList);
-        } else {
-            hiddenList.forEach((hiddenTags) => {
-                sortedArray.push(<string>hiddenTags);
-            });
-        }
-
-        if (listenerList.length > 0) {
-            let activeCheck = false;
-
-            if (this.tagWhitelist.length > 0) {
-                this.tagWhitelist.forEach((element) => {
-                    if (element[0] === '@') {
-                        activeCheck = <boolean>element[1];
-                    }
-                });
-            }
-
-            listenerList.unshift(activeCheck);
-            listenerList.unshift('@');
-            whitelist.unshift(listenerList);
-        }
-
-        if (formulaList.length > 0) {
-            let activeCheck = false;
-
-            if (this.tagWhitelist.length > 0) {
-                this.tagWhitelist.forEach((element) => {
-                    if (element[0] === '@') {
-                        activeCheck = <boolean>element[1];
-                    }
-                });
-            }
-
-            formulaList.unshift(activeCheck);
-            formulaList.unshift('=');
-            whitelist.unshift(formulaList);
-        }
-
-        if (sortedArray.length > 0) {
-            let activeCheck = true;
-
-            if (this.tagWhitelist.length > 0) {
-                this.tagWhitelist.forEach((element) => {
-                    if (element[0] === '#') {
-                        activeCheck = <boolean>element[1];
-                    }
-                });
-            }
-
-            generalList.unshift(activeCheck);
-            generalList.unshift('#');
-
-            sortedArray.forEach((generalTags) => {
-                generalList.push(<string>generalTags);
-            });
-
-            whitelist.unshift(generalList);
-        }
-
-        this.tagWhitelist = whitelist;
-    }
-
-    getTagWhitelist(): string[] {
-        let tagList: string[] = [];
-
-        this.tagWhitelist.forEach((element) => {
-            tagList.push(<string>element[0]);
-        });
-
-        return tagList;
-    }
-
-    getVisualTagWhitelist(index: number): string {
-        let newWhitelist: string;
-
-        if ((<string>this.tagWhitelist[index][0]).length > 15) {
-            newWhitelist =
-                (<string>this.tagWhitelist[index][0]).substring(0, 15) + '..';
-        } else {
-            newWhitelist =
-                (<string>this.tagWhitelist[index][0]).substring(0, 15) + '*';
-        }
-
-        return '#' + newWhitelist;
     }
 
     private _updateEditable() {

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
@@ -583,6 +583,10 @@ export default class BotTable extends Vue {
         return false;
     }
 
+    async botIDClick(id: string) {
+        this.$emit('botIDClick', id);
+    }
+
     onTagChanged(bot: Bot, tag: string, value: string, space: string) {
         this.lastEditedTag = this.focusedTag = tag;
         this.focusedBot = bot;

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
@@ -88,6 +88,15 @@ export default class BotTable extends Vue {
     @Prop({ required: true })
     showNewBot: boolean;
 
+    @Prop({ default: true })
+    showExitSheet: boolean;
+
+    @Prop({ default: 'web_asset' })
+    exitSheetIcon: string;
+
+    @Prop({ default: 'Page Portal' })
+    exitSheetHint: string;
+
     tags: { tag: string; space: string }[] = [];
     addedTags: string[] = [];
     lastEditedTag: string = null;
@@ -118,6 +127,20 @@ export default class BotTable extends Vue {
     deletedBotId: string = '';
     showBotDestroyed: boolean = false;
     lastSelectionCount: number = 0;
+
+    get finalExitSheetIcon() {
+        if (hasValue(this.exitSheetIcon)) {
+            return this.exitSheetIcon;
+        }
+        return 'web_asset';
+    }
+
+    get finalExitSheetHint() {
+        if (hasValue(this.exitSheetHint)) {
+            return this.exitSheetHint;
+        }
+        return 'Page Portal';
+    }
 
     uiHtmlElements(): HTMLElement[] {
         if (this.$refs.tags) {

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
@@ -13,6 +13,14 @@
                         <div v-show="!isMakingNewTag">
                             <!-- keep place here so it shows up as empty-->
                             <md-button
+                                v-if="!isSearch && showNewBot"
+                                class="md-icon-button create-bot"
+                                @click="createBot()"
+                            >
+                                <cube-icon></cube-icon>
+                                <md-tooltip>Create Empty Bot</md-tooltip>
+                            </md-button>
+                            <md-button
                                 v-show="hasBots"
                                 class="md-icon-button"
                                 @click="openNewTag()"
@@ -29,14 +37,6 @@
                                     <img alt="Add Tag" src="../../public/icons/tag-add.png" />
                                 </picture>
                                 <md-tooltip>Add Tag</md-tooltip>
-                            </md-button>
-                            <md-button
-                                v-if="!isSearch && showNewBot"
-                                class="md-icon-button create-bot"
-                                @click="createBot()"
-                            >
-                                <cube-icon></cube-icon>
-                                <md-tooltip>Create Empty Bot</md-tooltip>
                             </md-button>
                         </div>
                     </div>

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
@@ -167,9 +167,9 @@
                 </div>
             </div>
             <div class="bot-table-middle">
-                <md-button class="md-fab exit-sheet" @click="exitSheet()">
-                    <md-icon>web_asset</md-icon>
-                    <md-tooltip>Page Portal</md-tooltip>
+                <md-button v-if="showExitSheet" class="md-fab exit-sheet" @click="exitSheet()">
+                    <md-icon>{{ finalExitSheetIcon }}</md-icon>
+                    <md-tooltip>{{ finalExitSheetHint }}</md-tooltip>
                 </md-button>
             </div>
             <tag-value-editor-wrapper v-if="focusedBot && focusedTag && !isBotReadOnly(focusedBot)">

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
@@ -110,6 +110,7 @@
                             :allowCloning="true"
                             :shortID="getShortId(bot)"
                             class="bot-cell header"
+                            @click="botIDClick"
                         >
                         </bot-id>
 

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.vue
@@ -96,7 +96,7 @@
                                 ref="tags"
                                 :allowCloning="true"
                                 :createMod="true"
-                                @click="selectBot(bot)"
+                                @click="botClicked(bot)"
                             >
                             </mini-bot>
                         </div>

--- a/src/aux-server/aux-web/shared/vue-components/BotValue/BotValue.css
+++ b/src/aux-server/aux-web/shared/vue-components/BotValue/BotValue.css
@@ -1,6 +1,8 @@
 .value-input-container {
     display: inline-block;
     position: relative;
+    width: 100%;
+    height: 100%;
 }
 
 .value-input {

--- a/src/aux-server/server/config.dev.ts
+++ b/src/aux-server/server/config.dev.ts
@@ -57,6 +57,7 @@ const config: Config = {
     drives: path.resolve(__dirname, '..', '..', 'drives'),
     sandbox: 'deno',
     gpio: true,
+    debug: false,
 };
 
 export default config;

--- a/src/aux-server/server/config.prod.ts
+++ b/src/aux-server/server/config.prod.ts
@@ -79,8 +79,9 @@ if (
             },
         };
         console.log(
-            `[Config] Enabling CassandraDB for Causal Repos with:\n\tkeyspace: ${cassandraKeyspace}\n\tcreateKeyspace: ${cassandraKeyspace ===
-                'true'}`
+            `[Config] Enabling CassandraDB for Causal Repos with:\n\tkeyspace: ${cassandraKeyspace}\n\tcreateKeyspace: ${
+                cassandraKeyspace === 'true'
+            }`
         );
     }
 }
@@ -102,6 +103,8 @@ const botsTimeToLive =
     parseInt(process.env.BOTS_TIME_TO_LIVE) || 60 * 60 * 24 * 7;
 
 const gpio = process.env.GPIO === 'true' || false;
+
+const debug = process.env.DEBUG === 'true';
 
 const config: Config = {
     socket: {
@@ -168,6 +171,7 @@ const config: Config = {
     drives: path.resolve(__dirname, '..', '..', 'drives'),
     sandbox: sandboxType,
     gpio: gpio,
+    debug: debug,
 };
 
 export default config;

--- a/src/aux-server/server/config.ts
+++ b/src/aux-server/server/config.ts
@@ -42,6 +42,11 @@ export interface Config {
      * Whether to enable GPIO support.
      */
     gpio: boolean;
+
+    /**
+     * Whether to enable debug logging.
+     */
+    debug: boolean;
 }
 
 export type SandboxType = 'none' | 'deno';

--- a/src/aux-server/server/server.ts
+++ b/src/aux-server/server/server.ts
@@ -267,7 +267,7 @@ export class ClientServer {
                                     optimizedData: <any>optimizedData,
                                     optimizedContentType: optimizedContentType,
                                 },
-                                val => !!val
+                                (val) => !!val
                             )
                         );
 
@@ -449,19 +449,16 @@ export class Server {
 
         this._app.use(cors());
 
-        this._mongoClient = await connect(
-            this._config.mongodb.url,
-            {
-                useNewUrlParser: this._config.mongodb.useNewUrlParser,
-            } as MongoClientOptions
-        );
+        this._mongoClient = await connect(this._config.mongodb.url, {
+            useNewUrlParser: this._config.mongodb.useNewUrlParser,
+        } as MongoClientOptions);
         if (this._config.cassandradb) {
             console.log('[Server] Using CassandraDB');
             const requestTracker = new CassandraTracker.RequestLogger({
                 slowThreshold: this._config.cassandradb.slowRequestTime,
             });
             const requestEmitter = <EventEmitter>(<any>requestTracker).emitter;
-            requestEmitter.on('slow', message => {
+            requestEmitter.on('slow', (message) => {
                 console.log(`[Cassandra] ${message}`);
             });
 
@@ -469,7 +466,7 @@ export class Server {
             if ('awsRegion' in this._config.cassandradb) {
                 const config = this._config.cassandradb;
                 const region = AWS_KEYSPACES_REGIONS.find(
-                    r => r.region === config.awsRegion
+                    (r) => r.region === config.awsRegion
                 );
                 if (!region) {
                     throw new Error(
@@ -660,7 +657,7 @@ export class Server {
             .branchInfo(id)
             .pipe(
                 first(),
-                map(info => info.exists)
+                map((info) => info.exists)
             )
             .toPromise();
 
@@ -675,7 +672,11 @@ export class Server {
                 ? new DenoSimulationImpl(
                       user,
                       id,
-                      null,
+                      {
+                          version: null,
+                          versionHash: null,
+                          debug: this._config.debug,
+                      },
                       'http://localhost:3000'
                   )
                 : nodeSimulationForBranch(user, this._webhooksClient, id);
@@ -684,7 +685,7 @@ export class Server {
 
             // Wait for full sync
             await simulation.connection.syncStateChanged
-                .pipe(first(synced => synced))
+                .pipe(first((synced) => synced))
                 .toPromise();
 
             const bot = simulation.helper.botsState[portal];
@@ -695,9 +696,9 @@ export class Server {
 
             const bots = sortBy(
                 simulation.index.findBotsWithTag(portal),
-                b => b.id
+                (b) => b.id
             );
-            const values = bots.map(b => {
+            const values = bots.map((b) => {
                 if (isFormula(b.tags[portal])) {
                     return calculateBotValue(null, b, portal);
                 } else {
@@ -748,7 +749,7 @@ export class Server {
             .branchInfo(id)
             .pipe(
                 first(),
-                map(info => info.exists)
+                map((info) => info.exists)
             )
             .toPromise();
 
@@ -788,7 +789,7 @@ export class Server {
         );
 
         if (result.results.length > 0) {
-            let firstValue = result.results.find(r => hasValue(r));
+            let firstValue = result.results.find((r) => hasValue(r));
             if (firstValue) {
                 if (typeof firstValue === 'object') {
                     if (typeof firstValue.headers === 'object') {
@@ -833,7 +834,7 @@ export class Server {
                 const result = await this._directory.findEntries(ip);
                 if (result.type === 'query_results') {
                     return res.send(
-                        result.entries.map(e => ({
+                        result.entries.map((e) => ({
                             publicName: e.publicName,
                             url: url.format({
                                 protocol: req.protocol,
@@ -886,9 +887,7 @@ export class Server {
         }
 
         console.log(
-            `[Server] Configuring Directory Client for ${
-                this._config.directory.client.upstream
-            }`
+            `[Server] Configuring Directory Client for ${this._config.directory.client.upstream}`
         );
 
         const tunnelClient = this._config.directory.client.tunnel
@@ -984,7 +983,11 @@ export class Server {
                       new DenoSimulationImpl(
                           user,
                           branch,
-                          null,
+                          {
+                              version: null,
+                              versionHash: null,
+                              debug: this._config.debug,
+                          },
                           'http://localhost:3000'
                       )
                 : (user, client, branch) =>
@@ -1011,7 +1014,7 @@ export class Server {
         const bridge = new ConnectionBridge(checkoutDevice);
         const client = new CausalRepoClient(bridge.clientConnection);
         const module = new CheckoutModule2(
-            key => new Stripe(key),
+            (key) => new Stripe(key),
             checkoutUser,
             client
         );
@@ -1179,7 +1182,7 @@ function getWebhooksUser(): AuxUser {
  * @param func
  */
 function dataPortalMiddleware(func: express.Handler) {
-    return function(req: Request, res: Response, next: NextFunction) {
+    return function (req: Request, res: Response, next: NextFunction) {
         if (hasValue(req.query.story) && hasValue(req.query[DATA_PORTAL])) {
             return func(req, res, next);
         } else {

--- a/src/aux-vm-browser/managers/BotPanelManager.ts
+++ b/src/aux-vm-browser/managers/BotPanelManager.ts
@@ -16,6 +16,7 @@ import {
     createPrecalculatedBot,
     filterBotsBySelection,
     botsInDimension,
+    SHEET_PORTAL,
 } from '@casual-simulation/aux-common';
 
 /**
@@ -68,7 +69,7 @@ export class BotPanelManager implements SubscriptionLike {
     unsubscribe(): void {
         if (!this.closed) {
             this.closed = true;
-            this._subs.forEach(s => s.unsubscribe());
+            this._subs.forEach((s) => s.unsubscribe());
             this._subs = null;
         }
     }
@@ -85,7 +86,7 @@ export class BotPanelManager implements SubscriptionLike {
         return bufferedEvents.pipe(
             flatMap(async () => {
                 if (this._helper.userBot) {
-                    const dimension = this._helper.userBot.values.sheetPortal;
+                    const dimension = this._helper.userBot.values[SHEET_PORTAL];
                     if (!!dimension && dimension !== true) {
                         const bots = filterBotsBySelection(
                             this._helper.objects,

--- a/src/aux-vm/managers/BotHelper.spec.ts
+++ b/src/aux-vm/managers/BotHelper.spec.ts
@@ -53,17 +53,18 @@ describe('BotHelper', () => {
     });
 
     describe('setEditingBot()', () => {
-        it('should set the _editingBot tag on the user bot', async () => {
+        it('should set the editingBot and editingTag tags on the user bot', async () => {
             helper.botsState = {
                 user: createPrecalculatedBot('user'),
                 test: createPrecalculatedBot('test'),
             };
-            await helper.setEditingBot(helper.botsState['test']);
+            await helper.setEditingBot(helper.botsState['test'], 'abc');
 
             expect(vm.events).toEqual([
                 botUpdated('user', {
                     tags: {
-                        _editingBot: 'test',
+                        editingBot: 'test',
+                        editingTag: 'abc',
                     },
                 }),
             ]);

--- a/src/aux-vm/managers/BotHelper.ts
+++ b/src/aux-vm/managers/BotHelper.ts
@@ -22,6 +22,7 @@ import {
     CREATE_ACTION_NAME,
     CREATE_ANY_ACTION_NAME,
     BotSpace,
+    hasValue,
 } from '@casual-simulation/aux-common';
 import { BaseHelper } from './BaseHelper';
 import { AuxVM } from '../vm/AuxVM';
@@ -126,7 +127,7 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
         const calc = this.createContext();
         const events = calculateDestroyBotEvents(calc, bot);
         await this.transaction(...events);
-        return events.some(e => e.type === 'remove_bot' && e.id === bot.id);
+        return events.some((e) => e.type === 'remove_bot' && e.id === bot.id);
     }
 
     /**
@@ -148,8 +149,8 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
     actions(
         actions: { eventName: string; bots: Bot[]; arg?: any }[]
     ): ShoutAction[] {
-        return actions.map(b => {
-            const botIds = b.bots ? b.bots.map(f => f.id) : null;
+        return actions.map((b) => {
+            const botIds = b.bots ? b.bots.map((f) => f.id) : null;
             const actionData = action(b.eventName, botIds, this.userId, b.arg);
             return actionData;
         });
@@ -162,7 +163,7 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
      * @param arg The argument that should be passed to the event handlers.
      */
     async action(eventName: string, bots: Bot[], arg?: any): Promise<void> {
-        const botIds = bots ? bots.map(f => f.id) : null;
+        const botIds = bots ? bots.map((f) => f.id) : null;
         const actionData = action(eventName, botIds, this.userId, arg);
         await this._vm.sendEvents([actionData]);
     }
@@ -175,10 +176,14 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
      */
     async shout(
         eventName: string,
-        bots: Bot[],
+        bots: (Bot | string)[],
         arg?: any
     ): Promise<ChannelActionResult> {
-        const botIds = bots ? bots.map(f => f.id) : null;
+        const botIds = bots
+            ? bots
+                  .filter((b) => hasValue(b))
+                  .map((f) => (typeof f === 'object' ? f.id : f))
+            : null;
         return await this._vm.shout(eventName, botIds, arg);
     }
 

--- a/src/aux-vm/managers/BotHelper.ts
+++ b/src/aux-vm/managers/BotHelper.ts
@@ -239,10 +239,11 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
      * Sets the bot that the user is editing.
      * @param bot The bot.
      */
-    setEditingBot(bot: Bot) {
+    setEditingBot(bot: Bot, tag: string) {
         return this.updateBot(this.userBot, {
             tags: {
-                _editingBot: bot.id,
+                editingBot: bot.id,
+                editingTag: tag,
             },
         });
     }

--- a/src/aux-vm/vm/AuxConfig.ts
+++ b/src/aux-vm/vm/AuxConfig.ts
@@ -29,6 +29,12 @@ export interface AuxConfigParameters {
      * that have valid signatures.
      */
     forceSignedScripts?: boolean;
+
+    /**
+     * Whether to run in debug mode.
+     * This will likely cause more verbose console output.
+     */
+    debug?: boolean;
 }
 
 export function buildVersionNumber(config: AuxConfigParameters) {

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -156,7 +156,7 @@ export class TestAuxVM implements AuxVM {
 
     async getTags(): Promise<string[]> {
         let objects = getActiveObjects(this.state);
-        let allTags = union(...objects.map(o => tagsOnBot(o))).sort();
+        let allTags = union(...objects.map((o) => tagsOnBot(o))).sort();
         return allTags;
     }
 


### PR DESCRIPTION
### :boom: Breaking Changes

-   Renamed the `_editingBot` tag to `editingBot`.

### :rocket: Improvements

-   sheetPortal Improvements
    -   Added the `@onSheetTagClick` listener which is triggered when a tag name is clicked.
    -   Added the `@onSheetBotIDClick` listener which is triggered when a Bot ID is clicked.
    -   Added the `@onSheetBotClick` listener which is triggered when a bot visualization is clicked in the sheet.
    -   Added the `sheetPortalShowButton` config bot tag to control whether the button in the bottom right corner of the sheet is shown.
    -   Added the `sheetPortalButtonIcon` config bot tag to control the icon on the button in the bottom right corner of the sheet.
    -   Added the `sheetPortalButtonHint` config bot tag to control the tooltip on the button in the bottom right corner of the sheet.
    -   Added the `sheetPortalAllowedTags` config bot tag to control which tags are allowed to be shown and edited in the sheet portal.
    -   Swapped the position of the new bot and new tag buttons in the sheet.
    -   Added the `editingTag` tag which contains the tag that the player is currently editing.

### :bug: Bug Fixes

-   Fixed an issue where cells in the sheet portal would not cover the entire cell area.
-   Fixed an issue where `clearTagMasks()` would error if given a bot that had no tag masks.