### PR TITLE
Add the experiment.getAnchorPointPosition() and math.getAnchorPointOffset() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CasualOS Changelog
 
+## V1.2.15
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Added the `experiment.getAnchorPointPosition()` and `math.getAnchorPointOffset()` functions.
+    -   These are useful for determining where a bot would be placed if it had a particular anchor point.
+    -   See the [docs](https://docs.casualsimulation.com/docs/actions) for more info.
+
 ## V1.2.14
 
 #### Date: 10/7/2020

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3775,6 +3775,21 @@ const groundPoint = math.intersectPlane(pointerPosition, pointerDirection);
 player.toast(groundPoint);
 ```
 
+### `math.getAnchorPointOffset(anchorPoint)`
+
+Calculates the 3D position offset for the given anchor point and returns it.
+This is essentially <ActionLink action='experiment.getAnchorPointPosition(bot, dimension, anchorPoint)'/> but without the bot's position/scale applied.
+
+The **third parameter** is the anchor point that should be calculated. Can be any valid <TagLink tag="anchorPoint"/> value.
+
+#### Examples:
+
+1. Calculate the anchor point offset for "bottom".
+```typescript
+const offset = math.getAnchorPointOffset("bottom");
+player.toast(offset);
+```
+
 ## Crypto Actions
 
 ### `crypto.sha256(...data)`
@@ -4443,6 +4458,59 @@ experiment.localRotationTween(
             mode: 'inout'
         }
     });
+```
+
+### `experiment.getAnchorPointPosition(bot, dimension, anchorPoint)`
+
+Gets the absolute position in the given dimension that the center of the given bot would be placed at if the bot was using the given anchor point.
+
+The **first parameter** is the bot that the anchor point position should be calculated for.
+
+The **second parameter** is the dimension that the anchor point position should be calculated in.
+
+The **third parameter** is the anchor point that should be calculated. Can be any valid <TagLink tag="anchorPoint"/> value.
+
+#### Examples:
+
+1. Get the top anchor point of the current bot in the "home" dimension.
+```typescript
+const point = experiment.getAnchorPointPosition(bot, "home", "top");
+player.toast(point);
+```
+
+2. Get the back right anchor point of the current bot in the "home" dimension.
+```typescript
+const point = experiment.getAnchorPointPosition(bot, "home", [ 0.5, -0.5, 0 ]);
+player.toast(point);
+```
+
+3. Place bots at each of the anchor points.
+```typescript
+let points = [
+    'top',
+    'bottom',
+    'front',
+    'back',
+    'left',
+    'right',
+    'center',
+];
+
+for(let point of points) {
+    let pos = experiment.getAnchorPointPosition(bot, player.getCurrentDimension(), point);
+    create({
+        space: 'player',
+        color: 'green',
+        [player.getCurrentDimension()]: true,
+        [player.getCurrentDimension() + "X"]: pos.x,
+        [player.getCurrentDimension() + "Y"]: pos.y,
+        [player.getCurrentDimension() + "Z"]: pos.z,
+        positioningMode: 'absolute',
+        anchorPoint: 'center',
+        targetAnchorPoint: point,
+        scale: 0.1,
+    });
+}
 ```
 
 [listen-tag]: docs/listen-tags

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -6,6 +6,104 @@ export type Object = Bot;
 export type Workspace = Bot;
 
 /**
+ * Defines a symbol that is used to clear changes on a runtime bot.
+ */
+export const CLEAR_CHANGES_SYMBOL = Symbol('clear_changes');
+
+/**
+ * Defines a symbol that is used to set a tag mask on a runtime bot.
+ */
+export const SET_TAG_MASK_SYMBOL = Symbol('set_tag_mask');
+
+/**
+ * Defines a symbol that is used to get a tag mask on a runtime bot.
+ */
+export const GET_TAG_MASK_SYMBOL = Symbol('get_tag_mask');
+
+/**
+ * Defines a symbol that is used to get all the tag masks on a runtime bot.
+ */
+export const CLEAR_TAG_MASKS_SYMBOL = Symbol('clear_tag_masks');
+
+/**
+ * Defines an interface for a bot in a script/formula.
+ *
+ * The difference between this and Bot is that the tags
+ * are calculated values and raw is the original tag values.
+ *
+ * i.e. tags will evaluate formulas while raw will return the formula scripts themselves.
+ */
+export interface RuntimeBot {
+    id: string;
+    space?: BotSpace;
+
+    /**
+     * The calculated tag values.
+     * This lets you get the calculated values from formulas.
+     */
+    tags: ScriptTags;
+
+    /**
+     * The raw tag values. This lets you get the raw script text from formulas.
+     */
+    raw: BotTags;
+
+    /**
+     * The tag masks that have been applied to this bot.
+     */
+    masks: BotTags;
+
+    /**
+     * The changes that have been made to the bot.
+     */
+    changes: BotTags;
+
+    /**
+     * The tag mask changes that have been made to the bot.
+     */
+    maskChanges: BotTagMasks;
+
+    /**
+     * The signatures that are on the bot.
+     */
+    signatures: BotSignatures;
+
+    /**
+     * The calculated listener functions.
+     * This lets you get the compiled listener functions.
+     */
+    listeners: CompiledBotListeners;
+
+    /**
+     * A function that can clear all the changes from the runtime bot.
+     */
+    [CLEAR_CHANGES_SYMBOL]: () => void;
+
+    /**
+     * A function that can set a tag mask on the bot.
+     */
+    [SET_TAG_MASK_SYMBOL]: (tag: string, value: any, space?: string) => void;
+
+    /**
+     * A function that can clear the tag masks from the bot.
+     * @param space The space that the masks should be cleared from. If not specified then all tag masks in all spaces will be cleared.
+     */
+    [CLEAR_TAG_MASKS_SYMBOL]: (space?: string) => any;
+}
+
+/**
+ * An interface that maps tag names to compiled listener functions.
+ */
+export interface CompiledBotListeners {
+    [tag: string]: CompiledBotListener;
+}
+
+/**
+ * The type of a compiled bot listener.
+ */
+export type CompiledBotListener = (arg?: any) => any;
+
+/**
  * Defines an interface for a bot that is precalculated.
  */
 export interface PrecalculatedBot extends Bot {

--- a/src/aux-common/bots/BotCalculationContext.ts
+++ b/src/aux-common/bots/BotCalculationContext.ts
@@ -31,6 +31,9 @@ export function cacheFunction<T>(
     func: () => T,
     ...args: (string | number | boolean)[]
 ): T {
+    if (!calc) {
+        return func();
+    }
     let key = name;
     for (let arg of args) {
         key += `-${arg}`;

--- a/src/aux-common/runtime/AuxGlobalContext.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.ts
@@ -7,10 +7,10 @@ import {
     botAdded,
     botRemoved,
     DEFAULT_ENERGY,
+    RuntimeBot,
 } from '../bots';
 import sortedIndexBy from 'lodash/sortedIndexBy';
 import {
-    RuntimeBot,
     RuntimeBotFactory,
     RuntimeBotsState,
     RealtimeEditMode,
@@ -171,7 +171,7 @@ export interface AsyncTask {
  * @param bot The bot.
  */
 function indexInContext(context: AuxGlobalContext, bot: Bot): number {
-    const index = sortedIndexBy(context.bots, <RuntimeBot>bot, sb => sb.id);
+    const index = sortedIndexBy(context.bots, <RuntimeBot>bot, (sb) => sb.id);
     const expected = context.bots.length > index ? context.bots[index] : null;
     if (!!expected && expected.id === bot.id) {
         return index;
@@ -189,7 +189,7 @@ export function addToContext(context: AuxGlobalContext, ...bots: RuntimeBot[]) {
         if (!!context.state[bot.id]) {
             throw new Error('Bot already exists in the context!');
         }
-        const index = sortedIndexBy(context.bots, bot, sb => sb.id);
+        const index = sortedIndexBy(context.bots, bot, (sb) => sb.id);
         context.bots.splice(index, 0, bot);
         context.state[bot.id] = bot;
     }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4379,12 +4379,12 @@ describe('AuxLibrary', () => {
 
         describe('experiment.getAnchorPointPosition()', () => {
             const cases = [
-                ['top', 'top', { x: 1, y: 1, z: 1 }, { x: 1, y: 1, z: 1.5 }],
+                ['top', 'top', { x: 1, y: 1, z: 1 }, { x: 1, y: 1, z: 0.5 }],
                 [
                     'bottom',
                     'bottom',
                     { x: 1, y: 1, z: 1 },
-                    { x: 1, y: 1, z: 0.5 },
+                    { x: 1, y: 1, z: 1.5 },
                 ],
                 [
                     'center',
@@ -4399,12 +4399,18 @@ describe('AuxLibrary', () => {
                     { x: 1, y: 1.5, z: 1 },
                 ],
                 ['back', 'back', { x: 1, y: 1, z: 1 }, { x: 1, y: 0.5, z: 1 }],
-                ['left', 'left', { x: 1, y: 1, z: 1 }, { x: 0.5, y: 1, z: 1 }],
+                ['left', 'left', { x: 1, y: 1, z: 1 }, { x: 1.5, y: 1, z: 1 }],
                 [
                     'right',
                     'right',
                     { x: 1, y: 1, z: 1 },
-                    { x: 1.5, y: 1, z: 1 },
+                    { x: 0.5, y: 1, z: 1 },
+                ],
+                [
+                    '[1, 2, 3]',
+                    [1, 2, 3],
+                    { x: 1, y: 1, z: 1 },
+                    { x: 0, y: -1, z: -2 },
                 ],
             ];
 
@@ -6717,6 +6723,27 @@ describe('AuxLibrary', () => {
             expect(point.x).toBeCloseTo(0);
             expect(point.y).toBeCloseTo(0);
             expect(point.z).toBeCloseTo(0);
+        });
+    });
+
+    describe('math.getAnchorPointOffset()', () => {
+        const cases = [
+            ['center', { x: 0, y: 0, z: 0 }],
+            ['front', { x: 0, y: -0.5, z: 0 }],
+            ['back', { x: 0, y: 0.5, z: 0 }],
+            ['bottom', { x: 0, y: 0, z: 0.5 }],
+            ['top', { x: 0, y: 0, z: -0.5 }],
+            ['left', { x: 0.5, y: 0, z: 0 }],
+            ['right', { x: -0.5, y: 0, z: 0 }],
+
+            // Should mirror the coordinates when using literals
+            [[1, 2, 3], { x: -1, y: -2, z: -3 }],
+        ];
+
+        it.each(cases)('should support %s', (mode: any, expected: any) => {
+            expect(library.api.math.getAnchorPointOffset(mode)).toEqual(
+                expected
+            );
         });
     });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -113,6 +113,10 @@ import {
     cancelSound,
     localPositionTween,
     localRotationTween,
+    getAnchorPointOffset,
+    calculateAnchorPointOffset,
+    RuntimeBot,
+    SET_TAG_MASK_SYMBOL,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -125,7 +129,7 @@ import {
     TestScriptBotFactory,
     createDummyRuntimeBot,
 } from './test/TestScriptBotFactory';
-import { RuntimeBot, RuntimeBatcher, SET_TAG_MASK_SYMBOL } from './RuntimeBot';
+import { RuntimeBatcher } from './RuntimeBot';
 import { AuxVersion } from './AuxVersion';
 import { AuxDevice } from './AuxDevice';
 import { shuffle } from 'lodash';
@@ -4371,6 +4375,57 @@ describe('AuxLibrary', () => {
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+        });
+
+        describe('experiment.getAnchorPointPosition()', () => {
+            const cases = [
+                ['top', 'top', { x: 1, y: 1, z: 1 }, { x: 1, y: 1, z: 1.5 }],
+                [
+                    'bottom',
+                    'bottom',
+                    { x: 1, y: 1, z: 1 },
+                    { x: 1, y: 1, z: 0.5 },
+                ],
+                [
+                    'center',
+                    'center',
+                    { x: 1, y: 1, z: 1 },
+                    { x: 1, y: 1, z: 1 },
+                ],
+                [
+                    'front',
+                    'front',
+                    { x: 1, y: 1, z: 1 },
+                    { x: 1, y: 1.5, z: 1 },
+                ],
+                ['back', 'back', { x: 1, y: 1, z: 1 }, { x: 1, y: 0.5, z: 1 }],
+                ['left', 'left', { x: 1, y: 1, z: 1 }, { x: 0.5, y: 1, z: 1 }],
+                [
+                    'right',
+                    'right',
+                    { x: 1, y: 1, z: 1 },
+                    { x: 1.5, y: 1, z: 1 },
+                ],
+            ];
+
+            describe.each(cases)(
+                'should support %s',
+                (desc, anchorPoint, pos, expected) => {
+                    it('should return the position of the given anchor point in world space', () => {
+                        bot1.tags.homeX = pos.x;
+                        bot1.tags.homeY = pos.y;
+                        bot1.tags.homeZ = pos.z;
+
+                        const position = library.api.experiment.getAnchorPointPosition(
+                            bot1,
+                            'home',
+                            anchorPoint
+                        );
+
+                        expect(position).toEqual(expected);
+                    });
+                }
+            );
         });
     });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4410,7 +4410,7 @@ describe('AuxLibrary', () => {
                     '[1, 2, 3]',
                     [1, 2, 3],
                     { x: 1, y: 1, z: 1 },
-                    { x: 0, y: -1, z: -2 },
+                    { x: 0, y: 3, z: -2 },
                 ],
             ];
 
@@ -4429,6 +4429,50 @@ describe('AuxLibrary', () => {
                         );
 
                         expect(position).toEqual(expected);
+                    });
+
+                    it('should handle custom uniform scale', () => {
+                        bot1.tags.homeX = pos.x;
+                        bot1.tags.homeY = pos.y;
+                        bot1.tags.homeZ = pos.z;
+                        bot1.tags.scale = 2;
+
+                        const position = library.api.experiment.getAnchorPointPosition(
+                            bot1,
+                            'home',
+                            anchorPoint
+                        );
+
+                        const scaled = {
+                            x: (expected.x - pos.x) * 2 + pos.x,
+                            y: (expected.y - pos.y) * 2 + pos.y,
+                            z: (expected.z - pos.z) * 2 + pos.z,
+                        };
+
+                        expect(position).toEqual(scaled);
+                    });
+
+                    it('should handle custom non-uniform scale', () => {
+                        bot1.tags.homeX = pos.x;
+                        bot1.tags.homeY = pos.y;
+                        bot1.tags.homeZ = pos.z;
+                        bot1.tags.scaleX = 2;
+                        bot1.tags.scaleY = 3;
+                        bot1.tags.scaleZ = 4;
+
+                        const position = library.api.experiment.getAnchorPointPosition(
+                            bot1,
+                            'home',
+                            anchorPoint
+                        );
+
+                        const scaled = {
+                            x: (expected.x - pos.x) * 2 + pos.x,
+                            y: (expected.y - pos.y) * 3 + pos.y,
+                            z: (expected.z - pos.z) * 4 + pos.z,
+                        };
+
+                        expect(position).toEqual(scaled);
                     });
                 }
             );
@@ -6728,16 +6772,16 @@ describe('AuxLibrary', () => {
 
     describe('math.getAnchorPointOffset()', () => {
         const cases = [
-            ['center', { x: 0, y: 0, z: 0 }],
-            ['front', { x: 0, y: -0.5, z: 0 }],
-            ['back', { x: 0, y: 0.5, z: 0 }],
-            ['bottom', { x: 0, y: 0, z: 0.5 }],
-            ['top', { x: 0, y: 0, z: -0.5 }],
-            ['left', { x: 0.5, y: 0, z: 0 }],
-            ['right', { x: -0.5, y: 0, z: 0 }],
+            ['center', { x: 0, y: -0, z: 0 }],
+            ['front', { x: 0, y: 0.5, z: 0 }],
+            ['back', { x: 0, y: -0.5, z: 0 }],
+            ['bottom', { x: 0, y: -0, z: 0.5 }],
+            ['top', { x: 0, y: -0, z: -0.5 }],
+            ['left', { x: 0.5, y: -0, z: 0 }],
+            ['right', { x: -0.5, y: -0, z: 0 }],
 
             // Should mirror the coordinates when using literals
-            [[1, 2, 3], { x: -1, y: -2, z: -3 }],
+            [[1, 2, 3], { x: -1, y: 2, z: -3 }],
         ];
 
         it.each(cases)('should support %s', (mode: any, expected: any) => {

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -133,6 +133,14 @@ import {
     Easing,
     LocalPositionTweenAction,
     LocalRotationTweenAction,
+    BotAnchorPoint,
+    calculateAnchorPoint,
+    calculateAnchorPointOffset,
+    getBotPosition,
+    RuntimeBot,
+    isRuntimeBot,
+    SET_TAG_MASK_SYMBOL,
+    CLEAR_TAG_MASKS_SYMBOL,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -141,12 +149,6 @@ import {
     DeviceSelector,
 } from '@casual-simulation/causal-trees';
 import uuidv4 from 'uuid/v4';
-import {
-    RuntimeBot,
-    isRuntimeBot,
-    SET_TAG_MASK_SYMBOL,
-    CLEAR_TAG_MASKS_SYMBOL,
-} from './RuntimeBot';
 import { RanOutOfEnergyError } from './AuxResults';
 import '../polyfill/Array.first.polyfill';
 import '../polyfill/Array.last.polyfill';
@@ -527,6 +529,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 localFormAnimation,
                 localPositionTween,
                 localRotationTween,
+                getAnchorPointPosition,
             },
 
             math: {
@@ -2723,6 +2726,28 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             task.taskId
         );
         return addAsyncAction(task, action);
+    }
+
+    /**
+     * Gets the position of the given anchor point.
+     * @param bot The bot.
+     * @param dimension The dimension to get the position of.
+     * @param anchorPoint The anchor point.
+     */
+    function getAnchorPointPosition(
+        bot: Bot,
+        dimension: string,
+        anchorPoint: BotAnchorPoint
+    ) {
+        const value = calculateAnchorPoint(anchorPoint);
+        const offset = calculateAnchorPointOffset(value);
+        const position = getBotPosition(null, bot, dimension);
+
+        return {
+            x: position.x - offset.x,
+            y: position.y - offset.y,
+            z: position.z - offset.z,
+        };
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -141,6 +141,7 @@ import {
     isRuntimeBot,
     SET_TAG_MASK_SYMBOL,
     CLEAR_TAG_MASKS_SYMBOL,
+    getBotScale,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -2740,14 +2741,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         dimension: string,
         anchorPoint: BotAnchorPoint
     ) {
-        const value = calculateAnchorPoint(anchorPoint);
         const offset = getAnchorPointOffset(anchorPoint);
+        const scale = getBotScale(null, bot, 1);
         const position = getBotPosition(null, bot, dimension);
 
         return {
-            x: position.x + offset.x,
-            y: position.y + offset.y,
-            z: position.z + offset.z,
+            x: position.x + offset.x * scale.x,
+            y: position.y + offset.y * scale.y,
+            z: position.z + offset.z * scale.z,
         };
     }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -542,6 +542,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 random,
                 getForwardDirection,
                 intersectPlane,
+                getAnchorPointOffset,
             },
 
             crypto: {
@@ -2729,7 +2730,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     }
 
     /**
-     * Gets the position of the given anchor point.
+     * Gets the position that the center of the given bot would placed at if it had the given anchor point.
      * @param bot The bot.
      * @param dimension The dimension to get the position of.
      * @param anchorPoint The anchor point.
@@ -2740,13 +2741,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         anchorPoint: BotAnchorPoint
     ) {
         const value = calculateAnchorPoint(anchorPoint);
-        const offset = calculateAnchorPointOffset(value);
+        const offset = getAnchorPointOffset(anchorPoint);
         const position = getBotPosition(null, bot, dimension);
 
         return {
-            x: position.x - offset.x,
-            y: position.y - offset.y,
-            z: position.z - offset.z,
+            x: position.x + offset.x,
+            y: position.y + offset.y,
+            z: position.z + offset.z,
         };
     }
 
@@ -2904,6 +2905,20 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Gets the position offset for the given bot anchor point.
+     * @param anchorPoint The anchor point to get the offset for.
+     */
+    function getAnchorPointOffset(anchorPoint: BotAnchorPoint) {
+        const value = calculateAnchorPoint(anchorPoint);
+        const offset = calculateAnchorPointOffset(value);
+        return {
+            x: offset.x,
+            y: -offset.y,
+            z: offset.z,
+        };
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1811,6 +1811,19 @@ declare interface Bot {
 }
 
 /**
+ * Defines the possible bot anchor points.
+ */
+declare type BotAnchorPoint =
+    | 'top'
+    | 'front'
+    | 'back'
+    | 'left'
+    | 'right'
+    | 'bottom'
+    | 'center'
+    | [number, number, number];
+
+/**
  * Defines an interface for the state that an AUX bot can contain.
  */
 declare interface BotsState {
@@ -3484,6 +3497,13 @@ declare global {
          * @param direction The direction that the ray is pointing.
          */
         intersectPlane(origin: Point3D, direction: Point3D): Point3D;
+
+        /**
+         * Gets the position offset for the given bot anchor point.
+         * This is useful for doing custom math using anchor points.
+         * @param anchorPoint The anchor point to get the offset for.
+         */
+        getAnchorPointOffset(anchorPoint: BotAnchorPoint): Point3D;
     };
 
     // @ts-ignore: Ignore redeclaration
@@ -3684,5 +3704,17 @@ declare global {
             rotation: { x?: number, y?: number, z?: number },
             options?: TweenOptions
         ): LocalRotationTweenAction;
+
+        /**
+         * Gets the position that the center of the given bot would placed at if the bot was using the given anchor point.
+         * @param bot The bot.
+         * @param dimension The dimension to get the position of.
+         * @param anchorPoint The anchor point.
+         */
+        getAnchorPointPosition(
+            bot: Bot,
+            dimension: string,
+            anchorPoint: BotAnchorPoint
+        ): {x: number, y: number, z: number};
     };
 }

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -40,6 +40,9 @@ import {
     updatedBot,
     TAG_MASK_SPACE_PRIORITIES,
     BotTagMasks,
+    RuntimeBot,
+    CLEAR_CHANGES_SYMBOL,
+    CompiledBotListener,
 } from '../bots';
 import { Observable, Subject, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -60,16 +63,9 @@ import {
     RuntimeBotInterface,
     RuntimeBotFactory,
     createRuntimeBot,
-    RuntimeBot,
     RealtimeEditMode,
-    CLEAR_CHANGES_SYMBOL,
-    isRuntimeBot,
 } from './RuntimeBot';
-import {
-    CompiledBot,
-    CompiledBotsState,
-    CompiledBotListener,
-} from './CompiledBot';
+import { CompiledBot, CompiledBotsState } from './CompiledBot';
 import sortBy from 'lodash/sortBy';
 import transform from 'lodash/transform';
 import { BatchingZoneSpec } from './BatchingZoneSpec';

--- a/src/aux-common/runtime/CompiledBot.ts
+++ b/src/aux-common/runtime/CompiledBot.ts
@@ -5,9 +5,10 @@ import {
     BotSpace,
     hasValue,
     BotSignatures,
+    CompiledBotListeners,
+    RuntimeBot,
 } from '../bots';
 import uuid from 'uuid/v4';
-import { RuntimeBot } from './RuntimeBot';
 
 // Types of bots
 // 1. Raw bot - original data
@@ -45,18 +46,6 @@ export interface CompiledBot extends PrecalculatedBot {
      */
     script: RuntimeBot;
 }
-
-/**
- * An interface that maps tag names to compiled listener functions.
- */
-export interface CompiledBotListeners {
-    [tag: string]: CompiledBotListener;
-}
-
-/**
- * The type of a compiled bot listener.
- */
-export type CompiledBotListener = (arg?: any) => any;
 
 /**
  * An interface that maps tag names to the compiled values for a bot.

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -7,18 +7,18 @@ import {
     PLAYER_PARTITION_ID,
     OTHER_PLAYERS_PARTITION_ID,
     DEFAULT_TAG_MASK_SPACE,
+    RuntimeBot,
+    CLEAR_CHANGES_SYMBOL,
+    SET_TAG_MASK_SYMBOL,
+    CLEAR_TAG_MASKS_SYMBOL,
+    isRuntimeBot,
 } from '../bots';
 import { AuxGlobalContext, MemoryGlobalContext } from './AuxGlobalContext';
 import {
     createRuntimeBot,
     RuntimeBotInterface,
-    RuntimeBot,
     RealtimeEditMode,
-    CLEAR_CHANGES_SYMBOL,
-    isRuntimeBot,
     flattenTagMasks,
-    SET_TAG_MASK_SYMBOL,
-    CLEAR_TAG_MASKS_SYMBOL,
 } from './RuntimeBot';
 import { TestScriptBotFactory } from './test/TestScriptBotFactory';
 import { createCompiledBot, CompiledBot } from './CompiledBot';

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -15,98 +15,13 @@ import {
     DEFAULT_TAG_MASK_SPACE,
     TAG_MASK_SPACE_PRIORITIES_REVERSE,
     TAG_MASK_SPACE_PRIORITIES,
-} from '../bots';
-import {
-    CompiledBot,
-    CompiledBotListeners,
+    RuntimeBot,
+    CLEAR_CHANGES_SYMBOL,
+    SET_TAG_MASK_SYMBOL,
+    CLEAR_TAG_MASKS_SYMBOL,
     CompiledBotListener,
-} from './CompiledBot';
-
-/**
- * Defines a symbol that is used to clear changes on a runtime bot.
- */
-export const CLEAR_CHANGES_SYMBOL = Symbol('clear_changes');
-
-/**
- * Defines a symbol that is used to set a tag mask on a runtime bot.
- */
-export const SET_TAG_MASK_SYMBOL = Symbol('set_tag_mask');
-
-/**
- * Defines a symbol that is used to get a tag mask on a runtime bot.
- */
-export const GET_TAG_MASK_SYMBOL = Symbol('get_tag_mask');
-
-/**
- * Defines a symbol that is used to get all the tag masks on a runtime bot.
- */
-export const CLEAR_TAG_MASKS_SYMBOL = Symbol('clear_tag_masks');
-
-/**
- * Defines an interface for a bot in a script/formula.
- *
- * The difference between this and Bot is that the tags
- * are calculated values and raw is the original tag values.
- *
- * i.e. tags will evaluate formulas while raw will return the formula scripts themselves.
- */
-export interface RuntimeBot {
-    id: string;
-    space?: BotSpace;
-
-    /**
-     * The calculated tag values.
-     * This lets you get the calculated values from formulas.
-     */
-    tags: ScriptTags;
-
-    /**
-     * The raw tag values. This lets you get the raw script text from formulas.
-     */
-    raw: BotTags;
-
-    /**
-     * The tag masks that have been applied to this bot.
-     */
-    masks: BotTags;
-
-    /**
-     * The changes that have been made to the bot.
-     */
-    changes: BotTags;
-
-    /**
-     * The tag mask changes that have been made to the bot.
-     */
-    maskChanges: BotTagMasks;
-
-    /**
-     * The signatures that are on the bot.
-     */
-    signatures: BotSignatures;
-
-    /**
-     * The calculated listener functions.
-     * This lets you get the compiled listener functions.
-     */
-    listeners: CompiledBotListeners;
-
-    /**
-     * A function that can clear all the changes from the runtime bot.
-     */
-    [CLEAR_CHANGES_SYMBOL]: () => void;
-
-    /**
-     * A function that can set a tag mask on the bot.
-     */
-    [SET_TAG_MASK_SYMBOL]: (tag: string, value: any, space?: string) => void;
-
-    /**
-     * A function that can clear the tag masks from the bot.
-     * @param space The space that the masks should be cleared from. If not specified then all tag masks in all spaces will be cleared.
-     */
-    [CLEAR_TAG_MASKS_SYMBOL]: (space?: string) => any;
-}
+} from '../bots';
+import { CompiledBot } from './CompiledBot';
 
 /**
  * Defines an interface that contains runtime bots state.
@@ -114,26 +29,6 @@ export interface RuntimeBot {
  */
 export interface RuntimeBotsState {
     [id: string]: RuntimeBot;
-}
-
-/**
- * Determines if the given bot is a runtime bot.
- * @param bot The bot to check.
- */
-export function isRuntimeBot(bot: any): bot is RuntimeBot {
-    if (!!bot && typeof bot === 'object') {
-        return (
-            !!bot.id &&
-            typeof bot.tags === 'object' &&
-            typeof bot.raw === 'object' &&
-            typeof bot.masks === 'object' &&
-            typeof bot.tags.toJSON === 'function' &&
-            typeof bot.listeners === 'object' &&
-            typeof bot.changes === 'object' &&
-            typeof bot.maskChanges === 'object'
-        );
-    }
-    return false;
 }
 
 /**

--- a/src/aux-common/runtime/Utils.ts
+++ b/src/aux-common/runtime/Utils.ts
@@ -1,5 +1,5 @@
-import { isRuntimeBot, RealtimeEditMode } from './RuntimeBot';
-import { isBot } from '../bots/BotCalculations';
+import { RealtimeEditMode } from './RuntimeBot';
+import { isBot, isRuntimeBot } from '../bots/BotCalculations';
 import { AuxPartitionRealtimeStrategy } from '../partitions/AuxPartition';
 import forOwn from 'lodash/forOwn';
 
@@ -54,7 +54,7 @@ function _convertToCopiableValue(
             const result = [] as any[];
             map.set(value, result);
             result.push(
-                ...value.map(val =>
+                ...value.map((val) =>
                     _convertToCopiableValue(val, depth + 1, map)
                 )
             );

--- a/src/aux-common/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-common/runtime/test/TestScriptBotFactory.ts
@@ -6,19 +6,15 @@ import {
     BotSignatures,
     botsFromShortIds,
     TAG_MASK_SPACE_PRIORITIES,
+    RuntimeBot,
 } from '../../bots';
 import {
     createRuntimeBot,
     RuntimeBotInterface,
     RuntimeBotFactory,
-    RuntimeBot,
     RealtimeEditMode,
 } from '../RuntimeBot';
-import {
-    createCompiledBot,
-    CompiledBotListener,
-    CompiledBot,
-} from '../CompiledBot';
+import { createCompiledBot, CompiledBot } from '../CompiledBot';
 import pickBy from 'lodash/pickBy';
 
 export class TestScriptBotFactory implements RuntimeBotFactory {


### PR DESCRIPTION
### :rocket: Improvements

-   Added the `experiment.getAnchorPointPosition()` and `math.getAnchorPointOffset()` functions.
    -   These are useful for determining where a bot would be placed if it had a particular anchor point.
    -   See the [docs](https://docs.casualsimulation.com/docs/actions) for more info.