### PR TITLE
Menu improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     -   Added the ability to set arbitrary CSS styles on a menu bot by using the `menuItemStyle` tag.
         -   This lets you use margins and borders to indicate grouping.
     -   Added the ability to show a pie-chart progress bar on a menu item by using the `progressBar` tags.
+    -   Added the ability to use `@onPointerUp` and `@onPointerDown` for menu.
 
 ## V1.2.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CasualOS Changelog
 
+## V1.2.17
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Improved bots in the menu portal to support additional tags.
+    -   Added the ability to change the height of menu items by using `scale` and `scaleY`.
+    -   Added the ability to set an icon for a menu item by using the `formAddress` tag.
+    -   Added the ability to set arbitrary CSS styles on a menu bot by using the `menuItemStyle` tag.
+        -   This lets you use margins and borders to indicate grouping.
+    -   Added the ability to show a pie-chart progress bar on a menu item by using the `progressBar` tags.
+
 ## V1.2.16
 
 #### Date: 10/16/2020

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -789,6 +789,16 @@ When setting this tag via the sheet, it is useful to utilize formulas to ensure 
   </PossibleValue>
 </PossibleValuesTable>
 
+#### Examples:
+
+1. Round the top corners of the menu bot.
+```typescript
+=({
+    'border-radius': '8px 8px 0 0',
+    'margin-top': '8px'
+})
+```
+
 ## Dimension Tags
 
 ### `[dimension]`

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -568,6 +568,9 @@ When <TagLink tag='form'/> is set to `iframe` and <TagLink tag='formSubtype'/> i
 
 When <TagLink tag='form'/> is set to `iframe` and <TagLink tag='formSubtype'/> is set to `src`, the address should be the URL of the webpage that should be displayed.
 
+When the bot is in the menu portal, this is the URL of the image that should be shown on the menu item.
+If the given value is not a URL, then the specified [Material Icon](https://material.io/resources/icons/?style=baseline) will be shown.
+
 ### `formAnimation`
 
 The name of the animation that the mesh should play.
@@ -783,27 +786,6 @@ When setting this tag via the sheet, it is useful to utilize formulas to ensure 
   </PossibleValueCode>
   <PossibleValue value='Any Object'>
     The properties of the object will be applied as special styling to the menu item.
-  </PossibleValue>
-</PossibleValuesTable>
-
-### `menuIcon`
-
-The [Material Icon](https://material.io/resources/icons/?style=baseline) or image that should be shown on the menu item.
-Only applies to bots that are being shown in the menu portal.
-
-If the value is a URL, then the image at the given URL will be used for the icon.
-If the value is not a URL, then the given [Material Icon](https://material.io/resources/icons/?style=baseline) will be used.
-
-#### Possible values are:
-<PossibleValuesTable>
-  <PossibleValue value='Empty String'>
-    No icon. (Default)
-  </PossibleValue>
-  <PossibleValue value='Any URL'>
-    The image at the URL is used.
-  </PossibleValue>
-  <PossibleValue value='Any Material Icon'>
-    See <a href='https://material.io/resources/icons/?style=baseline'>https://material.io/resources/icons/?style=baseline</a>.
   </PossibleValue>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -766,6 +766,47 @@ When the transformer bot and this bot are in the same dimension, this bot will i
   </PossibleValue>
 </PossibleValuesTable>
 
+### `menuItemStyle`
+
+The custom [CSS styles](https://developer.mozilla.org/en-US/docs/Web/CSS) that should be applied to the menu item.
+Only applies to bots that are being shown in the menu portal.
+
+This is useful for positioning and styling the item in ways that are not possible using normal tags.
+Overridden by conflicting properties like <TagLink tag='color'/> or <TagLink tag='labelColor'/>.
+
+When setting this tag via the sheet, it is useful to utilize formulas to ensure that the resulting value is considered an object.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    No special styling. (Default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Object'>
+    The properties of the object will be applied as special styling to the menu item.
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `menuIcon`
+
+The [Material Icon](https://material.io/resources/icons/?style=baseline) or image that should be shown on the menu item.
+Only applies to bots that are being shown in the menu portal.
+
+If the value is a URL, then the image at the given URL will be used for the icon.
+If the value is not a URL, then the given [Material Icon](https://material.io/resources/icons/?style=baseline) will be used.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='Empty String'>
+    No icon. (Default)
+  </PossibleValue>
+  <PossibleValue value='Any URL'>
+    The image at the URL is used.
+  </PossibleValue>
+  <PossibleValue value='Any Material Icon'>
+    See <a href='https://material.io/resources/icons/?style=baseline'>https://material.io/resources/icons/?style=baseline</a>.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ## Dimension Tags
 
 ### `[dimension]`

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1369,7 +1369,6 @@ export const KNOWN_TAGS: string[] = [
     'focusable',
     'transformer',
     'menuItemStyle',
-    'menuIcon',
 
     'taskOutput',
     'taskError',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1368,6 +1368,7 @@ export const KNOWN_TAGS: string[] = [
     'pointable',
     'focusable',
     'transformer',
+    'menuItemStyle',
 
     'taskOutput',
     'taskError',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1581,6 +1581,13 @@ export function onPointerEnterExitArg(bot: Bot, dimension: string) {
     };
 }
 
+export function onPointerUpDownArg(bot: Bot, dimension: string) {
+    return {
+        bot,
+        dimension,
+    };
+}
+
 export interface BotDropDestination {
     x: number;
     y: number;

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1369,6 +1369,7 @@ export const KNOWN_TAGS: string[] = [
     'focusable',
     'transformer',
     'menuItemStyle',
+    'menuIcon',
 
     'taskOutput',
     'taskError',

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -24,3 +24,7 @@
     height: 24px;
     margin-right: 8px;
 }
+
+.menu-bot-progress {
+    float: right;
+}

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -4,3 +4,7 @@
     font-size: 16px;
     flex: 1 1 auto;
 }
+
+.menu-bot.md-list-item > .md-list-item-button {
+    height: 100%;
+}

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -3,8 +3,24 @@
     white-space: normal;
     font-size: 16px;
     flex: 1 1 auto;
+    line-height: 24px;
 }
 
 .menu-bot.md-list-item > .md-list-item-button {
     height: 100%;
+}
+
+.menu-bot .md-icon.md-theme-default {
+    color: inherit;
+}
+
+.menu-bot-icon {
+    display: inline;
+}
+
+.menu-bot-icon {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
 }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -46,9 +46,9 @@ export default class MenuBot extends Vue {
 
     get style(): any {
         return {
+            ...this.extraStyle,
             'background-color': this.backgroundColor,
             height: this.scaleY * 40 + 'px',
-            ...this.extraStyle,
         };
     }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -15,10 +15,12 @@ import {
     onAnyClickArg,
     hasValue,
     getBotScale,
+    calculateStringTagValue,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../shared/AppManager';
 import { DimensionItem } from '../DimensionItem';
 import { first } from '@casual-simulation/causal-trees';
+import { safeParseURL } from '../PlayerUtils';
 
 @Component({
     components: {},
@@ -35,6 +37,12 @@ export default class MenuBot extends Vue {
     backgroundColor: string = '#FFF';
     scaleY: number = 1;
     extraStyle: Object = {};
+    icon: string = null;
+    iconIsURL: boolean = false;
+
+    get hasIcon() {
+        return hasValue(this.icon);
+    }
 
     get style(): any {
         return {
@@ -54,12 +62,15 @@ export default class MenuBot extends Vue {
             this._updateAlignment(calc, item.bot);
             this._updateScale(calc, item.bot);
             this._updateStyle(calc, item.bot);
+            this._updateIcon(calc, item.bot);
         } else {
             this.label = '';
             this.labelColor = '#000';
             this.backgroundColor = '#FFF';
             this.scaleY = 1;
             this.extraStyle = {};
+            this.icon = null;
+            this.iconIsURL = false;
         }
     }
 
@@ -124,6 +135,12 @@ export default class MenuBot extends Vue {
             style = null;
         }
         this.extraStyle = style || {};
+    }
+
+    private _updateIcon(calc: BotCalculationContext, bot: Bot) {
+        const icon = calculateStringTagValue(calc, bot, 'menuIcon', null);
+        this.icon = icon;
+        this.iconIsURL = !!safeParseURL(icon);
     }
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -34,6 +34,15 @@ export default class MenuBot extends Vue {
     labelAlign: BotLabelAlignment = 'center';
     backgroundColor: string = '#FFF';
     scaleY: number = 1;
+    extraStyle: Object = {};
+
+    get style(): any {
+        return {
+            'background-color': this.backgroundColor,
+            height: this.scaleY * 40 + 'px',
+            ...this.extraStyle,
+        };
+    }
 
     @Watch('item')
     private async _botChanged(item: DimensionItem) {
@@ -44,11 +53,13 @@ export default class MenuBot extends Vue {
             this._updateColor(calc, item.bot);
             this._updateAlignment(calc, item.bot);
             this._updateScale(calc, item.bot);
+            this._updateStyle(calc, item.bot);
         } else {
             this.label = '';
             this.labelColor = '#000';
             this.backgroundColor = '#FFF';
             this.scaleY = 1;
+            this.extraStyle = {};
         }
     }
 
@@ -105,6 +116,14 @@ export default class MenuBot extends Vue {
     private _updateScale(calc: BotCalculationContext, bot: Bot) {
         const scale = getBotScale(calc, bot, 1);
         this.scaleY = scale.y;
+    }
+
+    private _updateStyle(calc: BotCalculationContext, bot: Bot) {
+        let style = calculateBotValue(calc, bot, 'menuItemStyle');
+        if (typeof style !== 'object') {
+            style = null;
+        }
+        this.extraStyle = style || {};
     }
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -152,7 +152,7 @@ export default class MenuBot extends Vue {
     }
 
     private _updateIcon(calc: BotCalculationContext, bot: Bot) {
-        const icon = calculateStringTagValue(calc, bot, 'menuIcon', null);
+        const icon = calculateStringTagValue(calc, bot, 'auxFormAddress', null);
         this.icon = icon;
         this.iconIsURL = !!safeParseURL(icon);
     }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -14,6 +14,7 @@ import {
     ANY_CLICK_ACTION_NAME,
     onAnyClickArg,
     hasValue,
+    getBotScale,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../shared/AppManager';
 import { DimensionItem } from '../DimensionItem';
@@ -32,6 +33,7 @@ export default class MenuBot extends Vue {
     labelColor: string = '#000';
     labelAlign: BotLabelAlignment = 'center';
     backgroundColor: string = '#FFF';
+    scaleY: number = 1;
 
     @Watch('item')
     private async _botChanged(item: DimensionItem) {
@@ -41,10 +43,12 @@ export default class MenuBot extends Vue {
             this._updateLabel(calc, item.bot);
             this._updateColor(calc, item.bot);
             this._updateAlignment(calc, item.bot);
+            this._updateScale(calc, item.bot);
         } else {
             this.label = '';
             this.labelColor = '#000';
             this.backgroundColor = '#FFF';
+            this.scaleY = 1;
         }
     }
 
@@ -96,6 +100,11 @@ export default class MenuBot extends Vue {
 
     private _updateAlignment(calc: BotCalculationContext, bot: Bot) {
         this.labelAlign = getBotLabelAlignment(calc, bot);
+    }
+
+    private _updateScale(calc: BotCalculationContext, bot: Bot) {
+        const scale = getBotScale(calc, bot, 1);
+        this.scaleY = scale.y;
     }
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -16,14 +16,19 @@ import {
     hasValue,
     getBotScale,
     calculateStringTagValue,
+    calculateNumericalTagValue,
+    clamp,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../shared/AppManager';
 import { DimensionItem } from '../DimensionItem';
 import { first } from '@casual-simulation/causal-trees';
 import { safeParseURL } from '../PlayerUtils';
+import PieProgress from '../../shared/vue-components/PieProgress/PieProgress';
 
 @Component({
-    components: {},
+    components: {
+        'pie-progress': PieProgress,
+    },
 })
 export default class MenuBot extends Vue {
     @Prop() item: DimensionItem;
@@ -39,6 +44,13 @@ export default class MenuBot extends Vue {
     extraStyle: Object = {};
     icon: string = null;
     iconIsURL: boolean = false;
+    progress: number = null;
+    progressBarForeground: string = null;
+    progressBarBackground: string = null;
+
+    get hasProgress() {
+        return hasValue(this.progress);
+    }
 
     get hasIcon() {
         return hasValue(this.icon);
@@ -63,6 +75,7 @@ export default class MenuBot extends Vue {
             this._updateScale(calc, item.bot);
             this._updateStyle(calc, item.bot);
             this._updateIcon(calc, item.bot);
+            this._updateProgress(calc, item.bot);
         } else {
             this.label = '';
             this.labelColor = '#000';
@@ -71,6 +84,7 @@ export default class MenuBot extends Vue {
             this.extraStyle = {};
             this.icon = null;
             this.iconIsURL = false;
+            this.progress = null;
         }
     }
 
@@ -141,6 +155,35 @@ export default class MenuBot extends Vue {
         const icon = calculateStringTagValue(calc, bot, 'menuIcon', null);
         this.icon = icon;
         this.iconIsURL = !!safeParseURL(icon);
+    }
+
+    private _updateProgress(calc: BotCalculationContext, bot: Bot) {
+        let progress = calculateNumericalTagValue(
+            calc,
+            bot,
+            'auxProgressBar',
+            null
+        );
+
+        this.progress = hasValue(progress) ? clamp(progress, 0, 1) : null;
+
+        let colorTagValue: any = calculateBotValue(
+            calc,
+            bot,
+            'auxProgressBarColor'
+        );
+        let bgColorTagValue: any = calculateBotValue(
+            calc,
+            bot,
+            'auxProgressBarBackgroundColor'
+        );
+
+        this.progressBarForeground = hasValue(colorTagValue)
+            ? colorTagValue
+            : '#000';
+        this.progressBarBackground = hasValue(bgColorTagValue)
+            ? bgColorTagValue
+            : '#fff';
     }
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -12,6 +12,13 @@
             <span>
                 {{ label }}
             </span>
+            <span class="menu-bot-progress" v-if="hasProgress">
+                <pie-progress
+                    :progress="progress"
+                    :color="progressBarForeground"
+                    :backgroundColor="progressBarBackground"
+                ></pie-progress>
+            </span>
         </div>
     </md-list-item>
 </template>

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -1,10 +1,5 @@
 <template>
-    <md-list-item
-        class="menu-bot"
-        :class="{ active: selected }"
-        :style="{ 'background-color': backgroundColor, height: scaleY * 40 + 'px' }"
-        @click="click()"
-    >
+    <md-list-item class="menu-bot" :class="{ active: selected }" :style="style" @click="click()">
         <div
             class="menu-bot-text"
             v-show="label"

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -2,7 +2,7 @@
     <md-list-item
         class="menu-bot"
         :class="{ active: selected }"
-        :style="{ 'background-color': backgroundColor }"
+        :style="{ 'background-color': backgroundColor, height: scaleY * 40 + 'px' }"
         @click="click()"
     >
         <div

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -1,5 +1,11 @@
 <template>
-    <md-list-item class="menu-bot" :class="{ active: selected }" :style="style" @click="click()">
+    <md-list-item
+        class="menu-bot"
+        :class="{ active: selected }"
+        :style="style"
+        @click="click()"
+        @mousedown="mouseDown()"
+    >
         <div
             class="menu-bot-text"
             v-show="label"

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -3,9 +3,15 @@
         <div
             class="menu-bot-text"
             v-show="label"
-            :style="{ color: labelColor, 'text-align': labelAlign }"
+            :style="{ 'text-align': labelAlign, color: labelColor }"
         >
-            {{ label }}
+            <span class="menu-bot-icon" v-if="hasIcon">
+                <img v-if="iconIsURL" :src="icon" />
+                <md-icon v-else>{{ icon }}</md-icon>
+            </span>
+            <span>
+                {{ label }}
+            </span>
         </div>
     </md-list-item>
 </template>

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
@@ -131,3 +131,7 @@ html.ar-app .webxr-sessions canvas {
     background-color: #c5c5c5;
     color: rgba(0, 0, 0.54);
 }
+
+.menu .md-list.md-theme-default {
+    background-color: transparent;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.vue
@@ -5,17 +5,15 @@
         <div class="ui-container">
             <div class="toolbar menu">
                 <div>
-                    <md-card v-if="menu.length > 0" class="menu-layout md-dense">
-                        <md-list class="md-dense">
-                            <menu-bot
-                                v-for="(item, index) in menu"
-                                :key="item.bot.id"
-                                :item="item"
-                                :index="index"
-                            >
-                            </menu-bot>
-                        </md-list>
-                    </md-card>
+                    <md-list class="md-dense">
+                        <menu-bot
+                            v-for="(item, index) in menu"
+                            :key="item.bot.id"
+                            :item="item"
+                            :index="index"
+                        >
+                        </menu-bot>
+                    </md-list>
                 </div>
             </div>
 

--- a/src/aux-server/aux-web/aux-player/PlayerUtils.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerUtils.ts
@@ -28,3 +28,16 @@ export function doesBotDefinePlayerDimension(
         matchFound: dimensions.indexOf(dimension) >= 0,
     };
 }
+
+/**
+ * Safely parses the given URL.
+ * If the given URL is invalid, null will be returned. Otherwise, the parsed URL object will be returned.
+ * @param url The URL to parse.
+ */
+export function safeParseURL(url: string): URL {
+    try {
+        return new URL(url);
+    } catch (err) {
+        return null;
+    }
+}

--- a/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
@@ -29,6 +29,7 @@ import {
     getBotPosition,
     isBot,
     addDebugApi,
+    onPointerUpDownArg,
 } from '@casual-simulation/aux-common';
 import { IOperation } from '../../shared/interaction/IOperation';
 import { BaseInteractionManager } from '../../shared/interaction/BaseInteractionManager';
@@ -286,17 +287,25 @@ export class PlayerInteractionManager extends BaseInteractionManager {
     }
 
     handlePointerDown(bot3D: AuxBot3D, bot: Bot, simulation: Simulation): void {
-        simulation.helper.action('onPointerDown', [bot], {
-            dimension: [...bot3D.dimensionGroup.dimensions.values()][0],
-            bot: bot,
-        });
+        simulation.helper.action(
+            'onPointerDown',
+            [bot],
+            onPointerUpDownArg(
+                bot,
+                [...bot3D.dimensionGroup.dimensions.values()][0]
+            )
+        );
     }
 
     handlePointerUp(bot3D: AuxBot3D, bot: Bot, simulation: Simulation): void {
-        simulation.helper.action('onPointerUp', [bot], {
-            dimension: [...bot3D.dimensionGroup.dimensions.values()][0],
-            bot: bot,
-        });
+        simulation.helper.action(
+            'onPointerUp',
+            [bot],
+            onPointerUpDownArg(
+                bot,
+                [...bot3D.dimensionGroup.dimensions.values()][0]
+            )
+        );
     }
 
     handleFocusEnter(bot3D: AuxBot3D, bot: Bot, simulation: Simulation): void {

--- a/src/aux-server/aux-web/shared/scene/Input.ts
+++ b/src/aux-server/aux-web/shared/scene/Input.ts
@@ -198,7 +198,7 @@ export class Input {
         if (otherViewports && isOnViewport) {
             // Make sure that there are no other view ports that are overlapping this one.
             const viewportsToTest = otherViewports.filter(
-                v => v.layer >= viewport.layer && v !== viewport
+                (v) => v.layer >= viewport.layer && v !== viewport
             );
 
             for (let i = 0; i < viewportsToTest.length; i++) {
@@ -245,7 +245,7 @@ export class Input {
         element: HTMLElement
     ): boolean {
         let elements = document.elementsFromPoint(clientPos.x, clientPos.y);
-        return some(elements, e => e === element);
+        return some(elements, (e) => e === element);
     }
 
     constructor(game: Game) {
@@ -379,7 +379,7 @@ export class Input {
      */
     public isMouseButtonDownOnAnyElements(elements: HTMLElement[]): boolean {
         const downElement = this._targetData.inputDown;
-        const matchingElement = elements.find(e =>
+        const matchingElement = elements.find((e) =>
             Input.isElementContainedByOrEqual(downElement, e)
         );
         return !!matchingElement;
@@ -410,7 +410,7 @@ export class Input {
      */
     public isMouseFocusingOnAnyElements(elements: HTMLElement[]): boolean {
         const overElement = this._targetData.inputOver;
-        const matchingElement = elements.find(e =>
+        const matchingElement = elements.find((e) =>
             Input.isElementContainedByOrEqual(overElement, e)
         );
         return !!matchingElement;
@@ -441,7 +441,7 @@ export class Input {
      * @param event The event.
      * @param elements The elements.
      */
-    public isEventForAnyElement(
+    public static isEventForAnyElement(
         event: MouseEvent | TouchEvent,
         elements: HTMLElement[]
     ): boolean {
@@ -455,7 +455,7 @@ export class Input {
             );
         }
 
-        const matchingElement = elements.find(e =>
+        const matchingElement = elements.find((e) =>
             Input.isElementContainedByOrEqual(el, e)
         );
         return !!matchingElement;
@@ -1035,7 +1035,7 @@ export class Input {
             this._inputType = InputType.Mouse;
         if (this._inputType != InputType.Mouse) return;
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1070,7 +1070,7 @@ export class Input {
             this._inputType = InputType.Mouse;
         if (this._inputType != InputType.Mouse) return;
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1102,7 +1102,7 @@ export class Input {
             this._inputType = InputType.Mouse;
         if (this._inputType != InputType.Mouse) return;
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1138,7 +1138,7 @@ export class Input {
             this._inputType = InputType.Mouse;
         if (this._inputType != InputType.Mouse) return;
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1253,17 +1253,11 @@ export class Input {
         if (this.debugLevel >= 2) {
             if (wheelFrame.ctrl) {
                 console.log(
-                    `wheel w/ ctrl fireOnFrame: ${
-                        wheelFrame.moveFrame
-                    }, delta: (${wheelFrame.delta.x}, ${wheelFrame.delta.y}, ${
-                        wheelFrame.delta.z
-                    })`
+                    `wheel w/ ctrl fireOnFrame: ${wheelFrame.moveFrame}, delta: (${wheelFrame.delta.x}, ${wheelFrame.delta.y}, ${wheelFrame.delta.z})`
                 );
             } else {
                 console.log(
-                    `wheel fireOnFrame: ${wheelFrame.moveFrame}, delta: (${
-                        wheelFrame.delta.x
-                    }, ${wheelFrame.delta.y}, ${wheelFrame.delta.z})`
+                    `wheel fireOnFrame: ${wheelFrame.moveFrame}, delta: (${wheelFrame.delta.x}, ${wheelFrame.delta.y}, ${wheelFrame.delta.z})`
                 );
             }
         }
@@ -1273,6 +1267,11 @@ export class Input {
         if (this._inputType == InputType.Undefined)
             this._inputType = InputType.Touch;
         if (this._inputType != InputType.Touch) return;
+
+        // Ignore all touches on elements that are not in the HTML elements list
+        if (!Input.isEventForAnyElement(event, this.htmlElements)) {
+            return;
+        }
 
         const count = this._touchListenerCounts.get(event.target) || 0;
         if (count === 0) {
@@ -1300,9 +1299,7 @@ export class Input {
             }
         }
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
-            event.preventDefault();
-        }
+        event.preventDefault();
 
         // For the touchstart event, it is a list of the touch points that became active with the current event.
         let changed = event.changedTouches;
@@ -1351,7 +1348,7 @@ export class Input {
         if (this._inputType != InputType.Touch) return;
 
         event.stopImmediatePropagation();
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1361,7 +1358,7 @@ export class Input {
         for (let i = 0; i < changed.length; i++) {
             let touch = changed.item(i);
 
-            let existingTouch = find(this._touchData, d => {
+            let existingTouch = find(this._touchData, (d) => {
                 return d.identifier === touch.identifier;
             });
             existingTouch.clientPos = new Vector2(touch.clientX, touch.clientY);
@@ -1418,9 +1415,7 @@ export class Input {
 
             if (this.debugLevel >= 1) {
                 console.log(
-                    `removing ${count} (${
-                        event.changedTouches.length
-                    }) touch listeners for `,
+                    `removing ${count} (${event.changedTouches.length}) touch listeners for `,
                     event.target
                 );
             }
@@ -1438,7 +1433,7 @@ export class Input {
             }
         }
 
-        if (this.isEventForAnyElement(event, this.htmlElements)) {
+        if (Input.isEventForAnyElement(event, this.htmlElements)) {
             event.preventDefault();
         }
 
@@ -1453,7 +1448,7 @@ export class Input {
                 HTMLElement
             >document.elementFromPoint(touch.clientX, touch.clientY);
 
-            let existingTouch = find(this._touchData, d => {
+            let existingTouch = find(this._touchData, (d) => {
                 return d.identifier === touch.identifier;
             });
             existingTouch.state.setUpFrame(this.time.frameCount);
@@ -1520,7 +1515,7 @@ export class Input {
             // Handle a canceled touche the same as a touch end.
             let touch = changed.item(i);
 
-            let existingTouch = find(this._touchData, d => {
+            let existingTouch = find(this._touchData, (d) => {
                 return d.identifier === touch.identifier;
             });
             existingTouch.state.setUpFrame(this.time.frameCount);
@@ -1549,7 +1544,7 @@ export class Input {
     private _handleInputSourcesUpdated(event: XRInputSourcesChangeEvent) {
         for (let source of event.added) {
             let controller = this._controllerData.find(
-                c => c.inputSource === source
+                (c) => c.inputSource === source
             );
             if (!controller) {
                 controller = {
@@ -1567,7 +1562,7 @@ export class Input {
         }
         for (let source of event.removed) {
             const index = this._controllerData.findIndex(
-                c => c.inputSource === source
+                (c) => c.inputSource === source
             );
             if (index >= 0) {
                 const removed = this._controllerData.splice(index, 1);
@@ -1595,7 +1590,7 @@ export class Input {
             this._inputType = InputType.Controller;
         if (this._inputType != InputType.Controller) return;
         const controller = this._controllerData.find(
-            c => c.inputSource === event.inputSource
+            (c) => c.inputSource === event.inputSource
         );
         if (!controller) {
             return;
@@ -1622,7 +1617,7 @@ export class Input {
             this._inputType = InputType.Controller;
         if (this._inputType != InputType.Controller) return;
         const controller = this._controllerData.find(
-            c => c.inputSource === event.inputSource
+            (c) => c.inputSource === event.inputSource
         );
         if (!controller) {
             return;
@@ -1652,7 +1647,7 @@ export class Input {
             this._inputType = InputType.Controller;
         if (this._inputType != InputType.Controller) return;
         const controller = this._controllerData.find(
-            c => c.inputSource === event.inputSource
+            (c) => c.inputSource === event.inputSource
         );
         if (!controller) {
             return;
@@ -1679,7 +1674,7 @@ export class Input {
             this._inputType = InputType.Controller;
         if (this._inputType != InputType.Controller) return;
         const controller = this._controllerData.find(
-            c => c.inputSource === event.inputSource
+            (c) => c.inputSource === event.inputSource
         );
         if (!controller) {
             return;

--- a/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.css
+++ b/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.css
@@ -1,0 +1,10 @@
+svg {
+    width: 24px;
+    height: 24px;
+    transform: rotate(-90deg);
+    border-radius: 50%;
+}
+
+circle {
+    stroke-width: 32;
+}

--- a/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.ts
+++ b/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.ts
@@ -1,0 +1,27 @@
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { Prop, Watch } from 'vue-property-decorator';
+
+@Component({})
+export default class PieProgress extends Vue {
+    @Prop({ required: true }) progress: number;
+    @Prop({ required: true }) color: string;
+    @Prop({ required: true }) backgroundColor: string;
+
+    // get fillStyle() {
+    //     if (this.progress > 0.5) {
+    //         return {
+    //             transform: 'rotate(' + (this.progress - 0.5) +'turn)',
+    //             'background-color': this.color
+    //         };
+    //     } else {
+    //         return {
+    //             transform: 'rotate(' + this.progress  +'turn)'
+    //         };
+    //     }
+    // }
+
+    constructor() {
+        super();
+    }
+}

--- a/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.ts
+++ b/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.ts
@@ -8,19 +8,6 @@ export default class PieProgress extends Vue {
     @Prop({ required: true }) color: string;
     @Prop({ required: true }) backgroundColor: string;
 
-    // get fillStyle() {
-    //     if (this.progress > 0.5) {
-    //         return {
-    //             transform: 'rotate(' + (this.progress - 0.5) +'turn)',
-    //             'background-color': this.color
-    //         };
-    //     } else {
-    //         return {
-    //             transform: 'rotate(' + this.progress  +'turn)'
-    //         };
-    //     }
-    // }
-
     constructor() {
         super();
     }

--- a/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.vue
+++ b/src/aux-server/aux-web/shared/vue-components/PieProgress/PieProgress.vue
@@ -1,0 +1,16 @@
+<template>
+    <svg viewBox="0 0 32 32" :style="{ background: backgroundColor }">
+        <circle
+            :style="{
+                fill: color,
+                stroke: backgroundColor,
+                'stroke-dasharray': progress * 100 + ' 100',
+            }"
+            r="16"
+            cx="16"
+            cy="16"
+        />
+    </svg>
+</template>
+<script src="./PieProgress.ts"></script>
+<style src="./PieProgress.css" scoped></style>


### PR DESCRIPTION
### :rocket: Improvements

-   Improved bots in the menu portal to support additional tags.
    -   Added the ability to change the height of menu items by using `scale` and `scaleY`.
    -   Added the ability to set an icon for a menu item by using the `formAddress` tag.
    -   Added the ability to set arbitrary CSS styles on a menu bot by using the `menuItemStyle` tag.
        -   This lets you use margins and borders to indicate grouping.
    -   Added the ability to show a pie-chart progress bar on a menu item by using the `progressBar` tags.
    -   Added the ability to use `@onPointerUp` and `@onPointerDown` for menu.