### PR TITLE
Multi-User Text Editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CasualOS Changelog
 
+## V1.3.0
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Added multi-user text editing.
+    -   Work on shared bots when editing a tag value with the multi-line editor.
+-   Added the cursor bot form.
+    -   Used to add a cursor indicator to the multi-line editor.
+    -   Works by setting the `form` tag to "cursor" and placing the bot in the corresponding tag portal dimension.
+        -   For example, to put a cursor in the multi-line editor for the `test` tag on a bot you would set `{targetBot.id}.test` to true.
+    -   Supported tags are:
+        -   `color` - Specifies the color of the cursor.
+        -   `label` - Specifies a label that should appear on the cursor when the mouse is hovering over it.
+        -   `labelColor` - Specifies the color of the text in the cursor label.
+        -   `{dimension}Start` - Specifies the index at which the cursor selection starts (Mirrors `cursorStartIndex` from the player bot).
+        -   `{dimension}End` - Specifies the index at which the cursor selection ends (Mirrors `cursorEndIndex` from the player bot).
+-   Added the `pageTitle`, `cursorStartIndex`, and `cursorEndIndex` tags to the player bot.
+    -   `pageTitle` is used to set the title of the current browser tab.
+    -   `cursorStartIndex` contains the starting index of the player's text selection inside the multi-line editor.
+    -   `cursorEndIndex` contains the ending index of the player's text selection inside the multi-line editor.
+    -   Note that when `cursorStartIndex` is larger than `cursorEndIndex` it means that the player has selected text from the right to the left. This is important because text will always be inserted at `cursorEndIndex`.
+
 ## V1.2.21
 
 #### Date: 11/5/2020

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -539,6 +539,11 @@ The shape that the bot should be displayed as.
   <PossibleValueCode id="iframe-form" value='iframe'>
     A webpage loaded into a 3D iframe. See <TagLink tag="formSubtype"/> for additional options.
   </PossibleValueCode>
+  <PossibleValueCode value='cursor'>
+    The bot will appear as a cursor in the multi-line editor.
+    You also need to place the bot in the same dimension that the tag portal uses
+    for the cursor to appear.
+  </PossibleValueCode>
 </PossibleValuesTable>
 
 ### `formSubtype`
@@ -905,6 +910,28 @@ The Z (yaw) rotation in radians that the bot should be rotated by.
 <PossibleValuesTable>
   <PossibleValue value='Any Number'>
     Specifies the Z rotation of a bot in a dimension. (Default is 0)
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `[dimension]Start`
+
+The selection start index for cursor bots that are in the multi-line editor (tag portal/sheet portal).
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='Any Number'>
+    Specifies the index at which the cursor selection starts. (Default is 0)
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `[dimension]End`
+
+The selection end index for cursor bots that are in the multi-line editor (tag portal/sheet portal).
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValue value='Any Number'>
+    Specifies the index at which the cursor selection ends. (Default is 0)
   </PossibleValue>
 </PossibleValuesTable>
 
@@ -2211,6 +2238,18 @@ The URL that is currently specified in the tab.
   </PossibleValue>
 </PossibleValuesTable>
 
+### `pageTitle`
+
+The title that should be displayed on the web browser tab.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValue value='Any String'>
+    The title that should be displayed.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `editingBot`
 
 <Badges>
@@ -2227,6 +2266,34 @@ Only available on the player bot.
 </Badges>
 
 The tag that the user is currently editing.
+Only available on the player bot.
+
+### `cursorStartIndex`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The selection start index of the player's cursor in the current <TagLink tag='editingTag'/>.
+
+Note that when <TagLink tag='cursorStartIndex'/> is larger than <TagLink tag='cursorEndIndex'/> it means 
+that the player has selected text from the right to the left.
+This is important because text will always be inserted at <TagLink tag='cursorEndIndex'/>.
+
+Only available on the player bot.
+
+### `cursorEndIndex`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The selection end index of the player's cursor in the current <TagLink tag='editingTag'/>.
+
+Note that when <TagLink tag='cursorEndIndex'/> is smaller than <TagLink tag='cursorStartIndex'/> it means 
+that the player has selected text from the right to the left.
+This is important because text will always be inserted at <TagLink tag='cursorEndIndex'/>.
+
 Only available on the player bot.
 
 ## Hidden Tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -6991,6 +6991,12 @@
 				"@types/range-parser": "*"
 			}
 		},
+		"@types/faker": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.3.tgz",
+			"integrity": "sha512-7YTyCRoujZWYaCpDLslQJ8QzaFWFLZZ3mZ7Vfr/jJHascRmSd05pYteyt2FK4btF2vXyGq0obuoyLpcF99OvaA==",
+			"dev": true
+		},
 		"@types/fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -12608,6 +12614,12 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"faker": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+			"integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==",
+			"dev": true
 		},
 		"fancy-log": {
 			"version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,9 @@
         "webpack-node-externals": "^1.7.2",
         "worker-loader": "^2.0.0",
         "@types/mock-fs": "4.10.0",
-        "mock-fs": "4.10.2"
+        "mock-fs": "4.10.2",
+        "faker": "5.1.0",
+        "@types/faker": "5.1.3"
     },
     "dependencies": {}
 }

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1642,6 +1642,49 @@ describe('AuxCausalTree2', () => {
                 });
             });
 
+            it('should apply multiple edit sequences in order', () => {
+                let tree = auxTree('a');
+                const script = `abcdefghijklmnopqrstuvwxyz`;
+
+                ({ tree } = applyEvents(tree, [
+                    botAdded(
+                        createBot('test', {
+                            abc: script,
+                        })
+                    ),
+                ]));
+
+                ({ tree, result } = applyEvents(tree, [
+                    botUpdated('test', {
+                        tags: {
+                            abc: edits(
+                                {},
+                                [preserve(3), del(3)],
+                                [preserve(6), del(3)]
+                            ),
+                        },
+                    }),
+                ]));
+
+                expect(result.update).toEqual({
+                    test: {
+                        tags: {
+                            abc: edits(
+                                { a: 5 },
+                                [preserve(3), del(3)],
+                                [preserve(6), del(3)]
+                            ),
+                        },
+                    },
+                });
+
+                expect(tree.state).toEqual({
+                    test: createBot('test', {
+                        abc: 'abcghimnopqrstuvwxyz',
+                    }),
+                });
+            });
+
             describe('fuzzing', () => {
                 faker.seed(95423);
 

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -881,6 +881,89 @@ describe('AuxCausalTree2', () => {
                 expect(atoms).toEqual([bot1, tag1, val1, insert1]);
             });
 
+            it('should support inserting into a new tag', () => {
+                tree = auxTree('a');
+
+                let bot1 = atom(atomId('a', 1), null, bot('test'));
+
+                ({ tree } = applyAtoms(tree, [bot1]));
+
+                let atoms = tree.weave.getAtoms();
+                expect(atoms).toEqual([bot1]);
+
+                ({ tree, updates, result } = applyEvents(tree, [
+                    botUpdated('test', {
+                        tags: {
+                            abc: edit({ a: 3 }, insert('ghi')),
+                        },
+                    }),
+                ]));
+
+                expect(tree.state).toEqual({
+                    test: createBot('test', {
+                        abc: 'ghi',
+                    }),
+                });
+                expect(result.update).toEqual({
+                    test: {
+                        tags: {
+                            abc: edit({ a: 4 }, insert('ghi')),
+                        },
+                    },
+                });
+
+                let tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                let val1 = atom(atomId('a', 3), tag1, value(''));
+                let insert1 = atom(atomId('a', 4), val1, insertOp(0, 'ghi'));
+
+                atoms = tree.weave.getAtoms();
+                expect(atoms).toEqual([bot1, tag1, val1, insert1]);
+            });
+
+            it('should support inserting into a new tag mask', () => {
+                tree = auxTree('a');
+
+                ({ tree, updates, result } = applyEvents(
+                    tree,
+                    [
+                        botUpdated('test', {
+                            masks: {
+                                space: {
+                                    abc: edit({ a: 3 }, insert('ghi')),
+                                },
+                            },
+                        }),
+                    ],
+                    'space'
+                ));
+
+                expect(tree.state).toEqual({
+                    test: {
+                        masks: {
+                            space: {
+                                abc: 'ghi',
+                            },
+                        },
+                    },
+                });
+                expect(result.update).toEqual({
+                    test: {
+                        masks: {
+                            space: {
+                                abc: edit({ a: 3 }, insert('ghi')),
+                            },
+                        },
+                    },
+                });
+
+                let tag1 = atom(atomId('a', 1), null, tagMask('test', 'abc'));
+                let val1 = atom(atomId('a', 2), tag1, value(''));
+                let insert1 = atom(atomId('a', 3), val1, insertOp(0, 'ghi'));
+
+                const atoms = tree.weave.getAtoms();
+                expect(atoms).toEqual([tag1, val1, insert1]);
+            });
+
             it('should support inserting text with a specific timestamp', () => {
                 const bot1A = atom(atomId('b', 100), null, bot('test2'));
                 const tag1A = atom(atomId('b', 101), bot1A, tag('tag1'));

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1559,14 +1559,16 @@ describe('AuxCausalTree2', () => {
                 });
             });
 
-            describe.only('fuzzing', () => {
+            describe('fuzzing', () => {
                 faker.seed(95423);
 
-                const cases = generateRandomEditCases(10);
+                const cases = generateRandomEditCases(25);
 
-                describe.each(cases.slice(1 + 3))(
+                describe.each(cases)(
                     '%s -> %s',
                     (startText, endText, intermediateTexts, edits) => {
+                        const space = 'space';
+
                         it('should be able to apply the given edits to produce the final text', () => {
                             let tree = auxTree('a');
 
@@ -1581,7 +1583,6 @@ describe('AuxCausalTree2', () => {
                             for (let i = 0; i < edits.length; i++) {
                                 let edit = edits[i];
                                 let str = intermediateTexts[i];
-                                let original = tree.state.test.tags.abc;
 
                                 ({ tree, updates, result } = applyEvents(tree, [
                                     botUpdated('test', {
@@ -1590,10 +1591,6 @@ describe('AuxCausalTree2', () => {
                                         },
                                     }),
                                 ]));
-
-                                if (tree.state.test.tags.abc !== str) {
-                                    debugger;
-                                }
 
                                 expect(tree.state).toEqual({
                                     test: createBot('test', {

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -18,6 +18,7 @@ import {
     CertificateOp,
     signedCert,
     insertOp,
+    tagMask,
 } from './AuxOpTypes';
 import { createBot } from '../bots/BotCalculations';
 import {
@@ -858,7 +859,7 @@ describe('AuxCausalTree2', () => {
                 expect(result.update).toEqual({
                     test: {
                         tags: {
-                            abc: edit({ a: 4 }, preserve(0), insert('ghi')),
+                            abc: edit({ a: 4 }, insert('ghi')),
                         },
                     },
                 });
@@ -953,6 +954,81 @@ describe('AuxCausalTree2', () => {
                     insert2,
                     insert4,
                 ]);
+            });
+
+            it('should support inserting into a tag mask', () => {
+                let tag1 = atom(
+                    atomId('a', 4),
+                    null,
+                    tagMask('test1', 'other')
+                );
+                let val1 = atom(atomId('a', 5), tag1, value('xyz'));
+                let insert1 = atom(atomId('a', 6), val1, insertOp(0, 'ghi'));
+
+                ({ tree, updates, result } = applyEvents(
+                    tree,
+                    [
+                        botUpdated('test1', {
+                            masks: {
+                                space: {
+                                    other: 'xyz',
+                                },
+                            },
+                        }),
+                    ],
+                    'space'
+                ));
+
+                ({ tree, updates, result } = applyEvents(
+                    tree,
+                    [
+                        botUpdated('test1', {
+                            masks: {
+                                space: {
+                                    other: edit({ a: 5 }, insert('ghi')),
+                                },
+                            },
+                        }),
+                    ],
+                    'space'
+                ));
+
+                expect(tree.state).toEqual({
+                    test: {
+                        id: 'test',
+                        tags: {
+                            abc: 'def',
+                        },
+                    },
+                    test1: {
+                        masks: {
+                            space: {
+                                other: 'ghixyz',
+                            },
+                        },
+                    },
+                });
+                expect(updates).toEqual({
+                    addedBots: [],
+                    removedBots: [],
+                    updatedBots: [],
+                });
+                expect(result.update).toEqual({
+                    test1: {
+                        masks: {
+                            space: {
+                                other: edit({ a: 6 }, insert('ghi')),
+                            },
+                        },
+                    },
+                });
+
+                const tagNode = tree.weave.getNode(tag1.id);
+                const atoms = [tagNode, ...iterateCausalGroup(tagNode)].map(
+                    (n) => n.atom
+                );
+
+                expect(atoms).toEqual([tag1, val1, insert1]);
             });
         });
 
@@ -1318,17 +1394,17 @@ describe('AuxCausalTree2', () => {
                 value1,
             ]));
 
-            expect(tree).toEqual({
-                site: {
-                    id: 'a',
-                    time: 3,
-                },
-                weave: expect.anything(),
-                state: {
-                    bot1: createBot('bot1', {
-                        tag1: 'abc',
-                    }),
-                },
+            expect(tree.site).toEqual({
+                id: 'a',
+                time: 3,
+            });
+            expect(tree.version).toEqual({
+                a: 3,
+            });
+            expect(tree.state).toEqual({
+                bot1: createBot('bot1', {
+                    tag1: 'abc',
+                }),
             });
             expect(updates).toEqual({
                 addedBots: [
@@ -1462,21 +1538,21 @@ describe('AuxCausalTree2', () => {
                 'test'
             ));
 
-            expect(tree).toEqual({
-                site: {
-                    id: 'a',
-                    time: 3,
-                },
-                weave: expect.anything(),
-                state: {
-                    bot1: createBot(
-                        'bot1',
-                        {
-                            tag1: 'abc',
-                        },
-                        <any>'test'
-                    ),
-                },
+            expect(tree.site).toEqual({
+                id: 'a',
+                time: 3,
+            });
+            expect(tree.version).toEqual({
+                a: 3,
+            });
+            expect(tree.state).toEqual({
+                bot1: createBot(
+                    'bot1',
+                    {
+                        tag1: 'abc',
+                    },
+                    <any>'test'
+                ),
             });
             expect(updates).toEqual({
                 addedBots: [
@@ -1528,21 +1604,21 @@ describe('AuxCausalTree2', () => {
                 'test'
             ));
 
-            expect(tree).toEqual({
-                site: {
-                    id: 'a',
-                    time: 4,
-                },
-                weave: expect.anything(),
-                state: {
-                    bot1: createBot(
-                        'bot1',
-                        {
-                            tag1: 'def',
-                        },
-                        <any>'test'
-                    ),
-                },
+            expect(tree.site).toEqual({
+                id: 'a',
+                time: 4,
+            });
+            expect(tree.version).toEqual({
+                a: 4,
+            });
+            expect(tree.state).toEqual({
+                bot1: createBot(
+                    'bot1',
+                    {
+                        tag1: 'def',
+                    },
+                    <any>'test'
+                ),
             });
             expect(updates).toEqual({
                 addedBots: [],

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -2619,5 +2619,65 @@ describe('AuxCausalTree2', () => {
                 },
             ]);
         });
+
+        it('should correctly load tag edits on the initial load', () => {
+            const bot1 = atom(atomId('a', 1), null, bot('bot1'));
+            const tag1 = atom(atomId('a', 2), bot1, tag('tag1'));
+            const value1 = atom(atomId('a', 3), tag1, value('abc'));
+            const insert1 = atom(atomId('a', 4), value1, insertOp(0, 'ghi'));
+            const delete1 = atom(atomId('a', 5), value1, deleteOp(0, 1));
+
+            ({ tree, updates, results } = applyAtoms(
+                tree,
+                [bot1, tag1, value1, insert1, delete1],
+                [],
+                undefined,
+                true
+            ));
+
+            expect(tree.site).toEqual({
+                id: 'a',
+                time: 5,
+            });
+            expect(tree.version).toEqual({
+                a: 5,
+            });
+            expect(tree.state).toEqual({
+                bot1: createBot('bot1', {
+                    tag1: 'ghibc',
+                }),
+            });
+            expect(updates).toEqual({
+                addedBots: [
+                    createBot('bot1', {
+                        tag1: 'ghibc',
+                    }),
+                ],
+                updatedBots: [],
+                removedBots: [],
+            });
+            expect(results).toEqual([
+                {
+                    type: 'atom_added',
+                    atom: bot1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: tag1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: value1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: insert1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: delete1,
+                },
+            ]);
+        });
     });
 });

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -730,32 +730,13 @@ describe('AuxCausalTree2', () => {
                     bot1B,
                     tag1B,
                     val1B,
-                    del1B,
                 ]));
+
+                ({ tree } = applyAtoms(tree, [del1B]));
 
                 expect(tree.state).toEqual({
                     test: createBot('test', {
                         abc: 'def',
-                    }),
-                    test2: createBot('test2', {
-                        tag1: 'val1A',
-                    }),
-                });
-
-                ({ tree, updates } = applyEvents(tree, [
-                    botUpdated('test2', {
-                        tags: {
-                            tag1: 'new',
-                        },
-                    }),
-                ]));
-
-                expect(tree.state).toEqual({
-                    test: createBot('test', {
-                        abc: 'def',
-                    }),
-                    test2: createBot('test2', {
-                        tag1: 'new',
                     }),
                 });
             });
@@ -864,7 +845,7 @@ describe('AuxCausalTree2', () => {
                 ({ tree, updates, result } = applyEvents(tree, [
                     botUpdated('test', {
                         tags: {
-                            abc: edit(1, insert('ghi')),
+                            abc: edit({ a: 3 }, insert('ghi')),
                         },
                     }),
                 ]));
@@ -877,7 +858,7 @@ describe('AuxCausalTree2', () => {
                 expect(result.update).toEqual({
                     test: {
                         tags: {
-                            abc: edit(4, preserve(0), insert('ghi')),
+                            abc: edit({ a: 4 }, preserve(0), insert('ghi')),
                         },
                     },
                 });
@@ -934,7 +915,7 @@ describe('AuxCausalTree2', () => {
                 ({ tree, updates, result } = applyEvents(tree, [
                     botUpdated('test2', {
                         tags: {
-                            tag1: edit(104, preserve(3), insert('ghi')),
+                            tag1: edit({ b: 104 }, preserve(3), insert('ghi')),
                         },
                     }),
                 ]));
@@ -950,27 +931,27 @@ describe('AuxCausalTree2', () => {
                 expect(result.update).toEqual({
                     test2: {
                         tags: {
-                            tag1: edit(106, preserve(6), insert('ghi')),
+                            tag1: edit({ a: 107 }, preserve(6), insert('ghi')),
                         },
                     },
                 });
 
                 const insert4 = atom(
-                    atomId('a', 106),
+                    atomId('a', 107),
                     insert2,
                     insertOp(1, 'ghi')
                 );
                 const botAtoms = [
                     ...iterateCausalGroup(tree.weave.getNode(bot1A.id)),
-                ];
+                ].map((n) => n.atom);
 
                 expect(botAtoms).toEqual([
                     tag1A,
                     val1A,
-                    insert4,
                     insert3,
-                    insert2,
                     insert1,
+                    insert2,
+                    insert4,
                 ]);
             });
         });

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1605,6 +1605,63 @@ describe('AuxCausalTree2', () => {
                                 }),
                             });
                         });
+
+                        it('should be able to apply the given edit to tag masks', () => {
+                            let tree = auxTree('a');
+
+                            ({ tree } = applyEvents(
+                                tree,
+                                [
+                                    botUpdated('test', {
+                                        masks: {
+                                            [space]: {
+                                                abc: startText,
+                                            },
+                                        },
+                                    }),
+                                ],
+                                space
+                            ));
+
+                            for (let i = 0; i < edits.length; i++) {
+                                let edit = edits[i];
+                                let str = intermediateTexts[i];
+
+                                ({ tree, updates, result } = applyEvents(
+                                    tree,
+                                    [
+                                        botUpdated('test', {
+                                            masks: {
+                                                [space]: {
+                                                    abc: edit,
+                                                },
+                                            },
+                                        }),
+                                    ],
+                                    space
+                                ));
+
+                                expect(tree.state).toEqual({
+                                    test: {
+                                        masks: {
+                                            [space]: {
+                                                abc: str,
+                                            },
+                                        },
+                                    },
+                                });
+                            }
+
+                            expect(tree.state).toEqual({
+                                test: {
+                                    masks: {
+                                        [space]: {
+                                            abc: endText,
+                                        },
+                                    },
+                                },
+                            });
+                        });
                     }
                 );
             });

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1470,6 +1470,56 @@ describe('AuxCausalTree2', () => {
 
                 expect(botAtoms).toEqual([tag1, val1, insert1]);
             });
+
+            it('should be able to reset a tag to its original value by setting it', () => {
+                let bot1 = atom(atomId('a', 1), null, bot('test'));
+                let tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                let val1 = atom(atomId('a', 3), tag1, value('def'));
+
+                // Insert "ghi" at index 3 when the text looks like "v!@@@!!al1A".
+                // Should result with an edit that makes "###v!@ghi@@!!al1A"
+                ({ tree, updates, result } = applyEvents(tree, [
+                    botUpdated('test', {
+                        tags: {
+                            abc: edit({}, preserve(3), insert('ghi')),
+                        },
+                    }),
+                ]));
+
+                expect(tree.state).toEqual({
+                    test: createBot('test', {
+                        abc: 'defghi',
+                    }),
+                });
+                expect(result.update).toEqual({
+                    test: {
+                        tags: {
+                            abc: edit({ a: 4 }, preserve(3), insert('ghi')),
+                        },
+                    },
+                });
+
+                ({ tree, updates, result } = applyEvents(tree, [
+                    botUpdated('test', {
+                        tags: {
+                            abc: 'def',
+                        },
+                    }),
+                ]));
+
+                expect(tree.state).toEqual({
+                    test: createBot('test', {
+                        abc: 'def',
+                    }),
+                });
+                expect(result.update).toEqual({
+                    test: {
+                        tags: {
+                            abc: 'def',
+                        },
+                    },
+                });
+            });
         });
 
         describe('certificates', () => {

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1563,8 +1563,9 @@ describe('AuxCausalTree2', () => {
                 faker.seed(95423);
 
                 const cases = generateRandomEditCases(25);
+                const paragraphCases = generateRandomEditParagraphCases(5);
 
-                describe.each(cases)(
+                describe.each([...cases, ...paragraphCases])(
                     '%s -> %s',
                     (startText, endText, intermediateTexts, edits) => {
                         const space = 'space';
@@ -1690,6 +1691,61 @@ describe('AuxCausalTree2', () => {
                                 max: currentText.length,
                             });
                             const newText = faker.lorem.word();
+                            tagEdit = edit(
+                                {},
+                                preserve(preserveCount),
+                                insert(newText)
+                            );
+                        } else {
+                            const preserveCount = faker.random.number({
+                                min: 0,
+                                max: currentText.length - 1,
+                            });
+                            const deleteCount = faker.random.number({
+                                min: 1,
+                                max: currentText.length - preserveCount,
+                            });
+                            tagEdit = edit(
+                                {},
+                                preserve(preserveCount),
+                                del(deleteCount)
+                            );
+                        }
+                        edits.push(tagEdit);
+                        currentText = applyEdit(currentText, tagEdit);
+                        strings.push(currentText);
+                    }
+
+                    cases.push([startText, currentText, strings, edits]);
+                }
+
+                return cases;
+            }
+
+            function generateRandomEditParagraphCases(
+                count: number
+            ): [string, string, string[], TagEdit[]][] {
+                // Generate a bunch of
+                let cases = [] as [string, string, string[], TagEdit[]][];
+                for (let i = 0; i < count; i++) {
+                    const startText = faker.lorem.paragraph(4);
+                    const editCount = faker.random.number({
+                        min: 1,
+                        max: startText.length,
+                    });
+                    let edits = [] as TagEdit[];
+                    let strings = [] as string[];
+                    let currentText = startText;
+
+                    for (let b = 0; b < editCount; b++) {
+                        const shouldInsert = faker.random.boolean();
+                        let tagEdit: TagEdit;
+                        if (shouldInsert || currentText.length <= 0) {
+                            const preserveCount = faker.random.number({
+                                min: 0,
+                                max: currentText.length,
+                            });
+                            const newText = faker.lorem.sentence();
                             tagEdit = edit(
                                 {},
                                 preserve(preserveCount),

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -27,6 +27,7 @@ import {
     WeaveResult,
     addAtom,
     Atom,
+    iterateCausalGroup,
 } from '@casual-simulation/causal-trees/core2';
 import {
     botAdded,
@@ -39,7 +40,7 @@ import {
     revokeCertificate,
     stateUpdatedEvent,
 } from '../bots';
-import { BotStateUpdates, edit, insert } from './AuxStateHelpers';
+import { BotStateUpdates, edit, insert, preserve } from './AuxStateHelpers';
 import reducer, { CERTIFIED_SPACE, certificateId } from './AuxWeaveReducer';
 import { Action } from '@casual-simulation/causal-trees';
 
@@ -853,6 +854,13 @@ describe('AuxCausalTree2', () => {
             });
 
             it('should support inserting text via a tag edit', () => {
+                let bot1 = atom(atomId('a', 1), null, bot('test'));
+                let tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                let val1 = atom(atomId('a', 3), tag1, value('def'));
+
+                let atoms = tree.weave.getAtoms();
+                expect(atoms).toEqual([bot1, tag1, val1]);
+
                 ({ tree, updates, result } = applyEvents(tree, [
                     botUpdated('test', {
                         tags: {
@@ -869,17 +877,14 @@ describe('AuxCausalTree2', () => {
                 expect(result.update).toEqual({
                     test: {
                         tags: {
-                            abc: edit(1, insert('ghi')),
+                            abc: edit(4, preserve(0), insert('ghi')),
                         },
                     },
                 });
 
-                let bot1 = atom(atomId('a', 1), null, bot('test'));
-                let tag1 = atom(atomId('a', 2), bot1, tag('abc'));
-                let val1 = atom(atomId('a', 3), tag1, value('def'));
                 let insert1 = atom(atomId('a', 4), val1, insertOp(0, 'ghi'));
 
-                const atoms = tree.weave.getAtoms();
+                atoms = tree.weave.getAtoms();
                 expect(atoms).toEqual([bot1, tag1, val1, insert1]);
             });
         });

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1685,6 +1685,56 @@ describe('AuxCausalTree2', () => {
                 });
             });
 
+            const valueCases = [
+                [
+                    'numbers',
+                    123,
+                    edit({}, preserve(1), insert('abc')),
+                    '1abc23',
+                ],
+                [
+                    'booleans',
+                    true,
+                    edit({}, preserve(1), insert('abc')),
+                    'tabcrue',
+                ],
+                [
+                    'objects',
+                    { prop: 'yes' },
+                    edit({}, preserve(1), insert('abc')),
+                    '{abc"prop":"yes"}',
+                ],
+            ];
+
+            it.each(valueCases)(
+                'should support %s',
+                (desc, initialValue, edit, expected) => {
+                    let tree = auxTree('a');
+
+                    ({ tree } = applyEvents(tree, [
+                        botAdded(
+                            createBot('test', {
+                                abc: initialValue,
+                            })
+                        ),
+                    ]));
+
+                    ({ tree } = applyEvents(tree, [
+                        botUpdated('test', {
+                            tags: {
+                                abc: edit,
+                            },
+                        }),
+                    ]));
+
+                    expect(tree.state).toEqual({
+                        test: createBot('test', {
+                            abc: expected,
+                        }),
+                    });
+                }
+            );
+
             describe('fuzzing', () => {
                 faker.seed(95423);
 

--- a/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.spec.ts
@@ -1738,5 +1738,59 @@ describe('AuxCausalTree2', () => {
                 },
             ]);
         });
+
+        it('should support insert atoms on newly added bots', () => {
+            const bot1 = atom(atomId('a', 1), null, bot('bot1'));
+            const tag1 = atom(atomId('a', 2), bot1, tag('tag1'));
+            const value1 = atom(atomId('a', 3), tag1, value('abc'));
+            const insert1 = atom(atomId('a', 4), value1, insertOp(0, 'ghi'));
+
+            ({ tree, updates, results } = applyAtoms(tree, [
+                bot1,
+                tag1,
+                value1,
+                insert1,
+            ]));
+
+            expect(tree.site).toEqual({
+                id: 'a',
+                time: 4,
+            });
+            expect(tree.version).toEqual({
+                a: 4,
+            });
+            expect(tree.state).toEqual({
+                bot1: createBot('bot1', {
+                    tag1: 'ghiabc',
+                }),
+            });
+            expect(updates).toEqual({
+                addedBots: [
+                    createBot('bot1', {
+                        tag1: 'ghiabc',
+                    }),
+                ],
+                updatedBots: [],
+                removedBots: [],
+            });
+            expect(results).toEqual([
+                {
+                    type: 'atom_added',
+                    atom: bot1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: tag1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: value1,
+                },
+                {
+                    type: 'atom_added',
+                    atom: insert1,
+                },
+            ]);
+        });
     });
 });

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -256,6 +256,9 @@ export function applyEvents(
                     if (op.type === 'preserve') {
                         index += op.count;
                     } else if (op.type === 'insert') {
+                        if (op.text.length <= 0) {
+                            continue;
+                        }
                         const editPos = findEditPosition(
                             currentVal,
                             version,
@@ -277,6 +280,9 @@ export function applyEvents(
                         );
                         index += op.text.length;
                     } else if (op.type === 'delete') {
+                        if (op.count <= 0) {
+                            continue;
+                        }
                         const editPos = findEditPosition(
                             currentVal,
                             version,

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -261,6 +261,7 @@ export function applyEvents(
             if (!currentVal || val !== currentVal.atom.value.value) {
                 let valueResult: AuxResult;
                 if (isTagEdit(val)) {
+                    let editTime = val.timestamp;
                     valueResult = auxResultIdentity();
                     for (let ops of val.operations) {
                         let index = 0;
@@ -294,8 +295,8 @@ export function applyEvents(
                     }
                 } else {
                     valueResult = addAtom(node.atom, value(val));
-                    result = mergeAuxResults(result, valueResult);
                 }
+                result = mergeAuxResults(result, valueResult);
                 const newAtom = addedAtom(valueResult.results[0]);
                 if (newAtom) {
                     const weaveResult = tree.weave.removeSiblingsBefore(

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -19,6 +19,7 @@ import {
     AtomCardinality,
     first,
     calculateTimeFromId,
+    iterateChildren,
 } from '@casual-simulation/causal-trees/core2';
 import {
     AuxOp,
@@ -368,7 +369,11 @@ export function applyEvents(
             }
 
             const currentVal = findValueNode(node);
-            if (!currentVal || val !== currentVal.atom.value.value) {
+            if (
+                !currentVal ||
+                val !== currentVal.atom.value.value ||
+                first(iterateChildren(currentVal)) !== undefined
+            ) {
                 const valueResult = updateTag(node, currentVal, val);
                 result = mergeAuxResults(result, valueResult);
                 const newAtom = addedAtom(valueResult.results[0]) as Atom<

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -36,6 +36,7 @@ import {
     TagMaskOp,
     insertOp,
     ValueOp,
+    AuxOpType,
 } from './AuxOpTypes';
 import { BotsState, PartialBotsState, BotTags } from '../bots/Bot';
 import reducer, { certificateId } from './AuxWeaveReducer';
@@ -337,8 +338,10 @@ export function applyEvents(
             if (!currentVal || val !== currentVal.atom.value.value) {
                 const valueResult = updateTag(node, currentVal, val);
                 result = mergeAuxResults(result, valueResult);
-                const newAtom = addedAtom(valueResult.results[0]);
-                if (newAtom) {
+                const newAtom = addedAtom(valueResult.results[0]) as Atom<
+                    AuxOp
+                >;
+                if (newAtom && newAtom.value.type === AuxOpType.Value) {
                     const weaveResult = tree.weave.removeSiblingsBefore(
                         newAtom
                     );
@@ -379,7 +382,7 @@ export function applyEvents(
                 result = mergeAuxResults(result, valueResult);
 
                 const newAtom = addedAtom(valueResult.results[0]);
-                if (newAtom) {
+                if (newAtom && newAtom.value.type === AuxOpType.Value) {
                     const weaveResult = tree.weave.removeSiblingsBefore(
                         newAtom
                     );

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -258,6 +258,18 @@ export function applyEvents(
                 ...val.version,
                 [tree.site.id]: tree.site.time,
             };
+
+            if (!currentVal) {
+                const valueResult = addAtom(updatedTree, node.atom, value(''));
+                updatedTree = applyTreeResult(updatedTree, valueResult);
+                const newAtom = addedAtom(valueResult.results[0]);
+                currentVal = updatedTree.weave.getNode(newAtom.id);
+                for (let result of valueResult.results) {
+                    update = reducer(updatedTree.weave, result, update, space);
+                }
+                results.push(...valueResult.results);
+            }
+
             for (let ops of val.operations) {
                 let index = 0;
                 // let atoms = [] as Atom<AuxOp>[];
@@ -289,7 +301,12 @@ export function applyEvents(
                             insertResult
                         );
                         for (let result of insertResult.results) {
-                            update = reducer(tree.weave, result, update, space);
+                            update = reducer(
+                                updatedTree.weave,
+                                result,
+                                update,
+                                space
+                            );
                         }
                         results.push(...insertResult.results);
                         index += op.text.length;
@@ -323,7 +340,7 @@ export function applyEvents(
                             );
                             for (let result of deleteResult.results) {
                                 update = reducer(
-                                    tree.weave,
+                                    updatedTree.weave,
                                     result,
                                     update,
                                     space
@@ -415,7 +432,11 @@ export function applyEvents(
             }
 
             const currentVal = findValueNode(node);
-            if (!currentVal || val !== currentVal.atom.value.value) {
+            if (
+                !currentVal ||
+                val !== currentVal.atom.value.value ||
+                first(iterateChildren(currentVal)) !== undefined
+            ) {
                 const valueResult = updateTag(node, currentVal, val);
                 result = mergeAuxResults(result, valueResult);
 

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -253,7 +253,10 @@ export function applyEvents(
             let update = {};
             let updatedTree = tree as CausalTree<any>;
             let results = [] as WeaveResult[];
-            const version = val.version;
+            const version = {
+                ...val.version,
+                [tree.site.id]: tree.site.time,
+            };
             for (let ops of val.operations) {
                 let index = 0;
                 // let atoms = [] as Atom<AuxOp>[];

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -272,7 +272,6 @@ export function applyEvents(
 
             for (let ops of val.operations) {
                 let index = 0;
-                // let atoms = [] as Atom<AuxOp>[];
                 for (let op of ops) {
                     if (op.type === 'preserve') {
                         index += op.count;
@@ -768,15 +767,6 @@ export function applyAtoms(
 ) {
     let update: PartialBotsState = {};
     let results = [] as WeaveResult[];
-    // if (atoms) {
-    //     insertAtoms(tree, atoms, results);
-    // }
-    // if (removedAtoms) {
-    //     removeAtoms(tree, removedAtoms, results);
-    // }
-    // for (let result of results) {
-    //     reducer(tree.weave, result, update, space);
-    // }
 
     if (atoms) {
         for (let atom of atoms) {
@@ -816,22 +806,3 @@ export function applyAtoms(
 
     return { tree, updates, results, update };
 }
-
-// /**
-//  * Removes the given atoms from the given tree.
-//  * Returns the new tree and a list of updates that occurred.
-//  * @param tree The tree.
-//  * @param hashes The atom hashes to remove.
-//  */
-// export function removeAtoms(tree: AuxCausalTree, hashes: string[]) {
-//     const prevState = tree.state;
-//     let result = auxResultIdentity();
-//     for (let hash of hashes) {
-//         const removeResult = removeAuxAtom(tree, hash);
-//         tree = applyAuxResult(tree, removeResult);
-//         result = mergeAuxResults(result, removeResult);
-//     }
-//     const updates = stateUpdates(prevState, result.update);
-
-//     return { tree, updates, result };
-// }

--- a/src/aux-common/aux-format-2/AuxCausalTree2.ts
+++ b/src/aux-common/aux-format-2/AuxCausalTree2.ts
@@ -352,6 +352,8 @@ export function applyEvents(
                         index += op.count;
                     }
                 }
+
+                version[updatedTree.site.id] = updatedTree.site.time;
             }
 
             let auxResult: AuxResult = {

--- a/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
@@ -22,6 +22,50 @@ describe('AuxStateHelpers', () => {
                 const final = apply(current, update);
                 expect(final).toEqual(update);
             });
+
+            it('should support tag edits on new bots', () => {
+                const current = {};
+                const update = {
+                    test: {
+                        tags: {
+                            abc: edit({}, insert('def')),
+                        },
+                    },
+                };
+
+                const final = apply(current, update);
+                expect(final).toEqual({
+                    test: {
+                        tags: {
+                            abc: 'def',
+                        },
+                    },
+                });
+            });
+
+            it('should support tag mask edits on new bots', () => {
+                const current = {};
+                const update = {
+                    test: {
+                        masks: {
+                            space: {
+                                abc: edit({}, insert('def')),
+                            },
+                        },
+                    },
+                };
+
+                const final = apply(current, update);
+                expect(final).toEqual({
+                    test: {
+                        masks: {
+                            space: {
+                                abc: 'def',
+                            },
+                        },
+                    },
+                });
+            });
         });
 
         describe('updated bots', () => {

--- a/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
@@ -992,6 +992,24 @@ describe('AuxStateHelpers', () => {
                 edit({ a: 1 }, preserve(1), del(1)),
                 'ac',
             ],
+            [
+                'should be able insert into a number',
+                123,
+                edit({ a: 1 }, preserve(1), insert('abc')),
+                '1abc23',
+            ],
+            [
+                'should be able insert into a boolean',
+                false,
+                edit({ a: 1 }, preserve(1), insert('abc')),
+                'fabcalse',
+            ],
+            [
+                'should be able insert into an object',
+                { prop: 'yes' },
+                edit({ a: 1 }, preserve(1), insert('abc')),
+                '{abc"prop":"yes"}',
+            ],
         ];
 
         it.each(editCases)('%s', (desc, start, edits, expected) => {

--- a/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.spec.ts
@@ -162,7 +162,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, preserve(3), insert('ghi')),
+                                abc: edit({ a: 1 }, preserve(3), insert('ghi')),
                             },
                         },
                     };
@@ -184,7 +184,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, insert('ghi')),
+                                abc: edit({ a: 1 }, insert('ghi')),
                             },
                         },
                     };
@@ -206,7 +206,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, preserve(1), insert('ghi')),
+                                abc: edit({ a: 1 }, preserve(1), insert('ghi')),
                             },
                         },
                     };
@@ -228,7 +228,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, preserve(1), del(2)),
+                                abc: edit({ a: 1 }, preserve(1), del(2)),
                             },
                         },
                     };
@@ -250,7 +250,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, del(2)),
+                                abc: edit({ a: 1 }, del(2)),
                             },
                         },
                     };
@@ -272,7 +272,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, preserve(1), del(1)),
+                                abc: edit({ a: 1 }, preserve(1), del(1)),
                             },
                         },
                     };
@@ -295,7 +295,7 @@ describe('AuxStateHelpers', () => {
                         test: {
                             tags: {
                                 abc: edit(
-                                    1,
+                                    { a: 1 },
                                     preserve(1),
                                     del(1),
                                     insert('a'),
@@ -347,7 +347,7 @@ describe('AuxStateHelpers', () => {
                     const update = {
                         test: {
                             tags: {
-                                abc: edit(1, insert('ghi')),
+                                abc: edit({ a: 1 }, insert('ghi')),
                             },
                         },
                     };
@@ -531,7 +531,7 @@ describe('AuxStateHelpers', () => {
                                 masks: {
                                     shared: {
                                         abc: edit(
-                                            1,
+                                            { a: 1 },
                                             preserve(3),
                                             insert('ghi')
                                         ),
@@ -570,7 +570,7 @@ describe('AuxStateHelpers', () => {
                             test: {
                                 masks: {
                                     shared: {
-                                        abc: edit(1, insert('ghi')),
+                                        abc: edit({ a: 1 }, insert('ghi')),
                                     },
                                 },
                             },
@@ -607,7 +607,7 @@ describe('AuxStateHelpers', () => {
                                 masks: {
                                     shared: {
                                         abc: edit(
-                                            1,
+                                            { a: 1 },
                                             preserve(1),
                                             insert('ghi')
                                         ),
@@ -646,7 +646,11 @@ describe('AuxStateHelpers', () => {
                             test: {
                                 masks: {
                                     shared: {
-                                        abc: edit(1, preserve(1), del(2)),
+                                        abc: edit(
+                                            { a: 1 },
+                                            preserve(1),
+                                            del(2)
+                                        ),
                                     },
                                 },
                             },
@@ -682,7 +686,7 @@ describe('AuxStateHelpers', () => {
                             test: {
                                 masks: {
                                     shared: {
-                                        abc: edit(1, del(2)),
+                                        abc: edit({ a: 1 }, del(2)),
                                     },
                                 },
                             },
@@ -718,7 +722,11 @@ describe('AuxStateHelpers', () => {
                             test: {
                                 masks: {
                                     shared: {
-                                        abc: edit(1, preserve(1), del(1)),
+                                        abc: edit(
+                                            { a: 1 },
+                                            preserve(1),
+                                            del(1)
+                                        ),
                                     },
                                 },
                             },
@@ -755,7 +763,7 @@ describe('AuxStateHelpers', () => {
                                 masks: {
                                     shared: {
                                         abc: edit(
-                                            1,
+                                            { a: 1 },
                                             preserve(1),
                                             del(1),
                                             insert('a'),
@@ -881,63 +889,63 @@ describe('AuxStateHelpers', () => {
             [
                 'should be able to insert at the end',
                 'abc',
-                edit(1, preserve(3), insert('def')),
+                edit({ a: 1 }, preserve(3), insert('def')),
                 'abcdef',
             ],
             [
                 'should be able to insert at the beginning',
                 'abc',
-                edit(1, insert('def')),
+                edit({ a: 1 }, insert('def')),
                 'defabc',
             ],
             [
                 'should be able to insert in the middle',
                 'abc',
-                edit(1, preserve(1), insert('def')),
+                edit({ a: 1 }, preserve(1), insert('def')),
                 'adefbc',
             ],
 
             [
                 'should replace an undefined value with the inserted value',
                 undefined,
-                edit(1, insert('def')),
+                edit({ a: 1 }, insert('def')),
                 'def',
             ],
             [
                 'should be able to insert multiple times into undefined',
                 undefined,
-                edit(1, insert('abc'), insert('def')),
+                edit({ a: 1 }, insert('abc'), insert('def')),
                 'abcdef',
             ],
             [
                 'should replace an null value with the inserted value',
                 null,
-                edit(1, insert('def')),
+                edit({ a: 1 }, insert('def')),
                 'def',
             ],
             [
                 'should be able to insert multiple times into null',
                 null,
-                edit(1, insert('abc'), insert('def')),
+                edit({ a: 1 }, insert('abc'), insert('def')),
                 'abcdef',
             ],
 
             [
                 'should be able to delete at the end',
                 'abc',
-                edit(1, preserve(2), del(1)),
+                edit({ a: 1 }, preserve(2), del(1)),
                 'ab',
             ],
             [
                 'should be able to delete at the beginning',
                 'abc',
-                edit(1, del(1)),
+                edit({ a: 1 }, del(1)),
                 'bc',
             ],
             [
                 'should be able to delete in the middle',
                 'abc',
-                edit(1, preserve(1), del(1)),
+                edit({ a: 1 }, preserve(1), del(1)),
                 'ac',
             ],
         ];

--- a/src/aux-common/aux-format-2/AuxStateHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.ts
@@ -10,6 +10,7 @@ import { merge, splice } from '../utils';
 import { hasValue, isBot } from '../bots/BotCalculations';
 import { sortBy } from 'lodash';
 import { VersionVector } from '@casual-simulation/causal-trees';
+import { convertToString } from './AuxWeaveHelpers';
 
 /**
  * The name of the property that indicates an object represents a tag edit.
@@ -432,21 +433,17 @@ export function updates(
  * @param edit The edit that should be applied.
  */
 export function applyEdit(value: any, edit: TagEdit): any {
-    if (!hasValue(value)) {
-        value = '';
-    }
-    if (typeof value === 'string') {
-        for (let ops of edit.operations) {
-            let index = 0;
-            for (let op of ops) {
-                if (op.type === 'preserve') {
-                    index += op.count;
-                } else if (op.type === 'insert') {
-                    value = splice(value, index, 0, op.text);
-                    index += op.text.length;
-                } else {
-                    value = splice(value, index, op.count, '');
-                }
+    value = convertToString(value);
+    for (let ops of edit.operations) {
+        let index = 0;
+        for (let op of ops) {
+            if (op.type === 'preserve') {
+                index += op.count;
+            } else if (op.type === 'insert') {
+                value = splice(value, index, 0, op.text);
+                index += op.text.length;
+            } else {
+                value = splice(value, index, op.count, '');
             }
         }
     }

--- a/src/aux-common/aux-format-2/AuxStateHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.ts
@@ -193,6 +193,7 @@ export function apply<T extends BotsState, U extends PartialBotsState>(
         }
 
         let bot = updatedState[id] as Bot | PrecalculatedBot;
+        let isNewBot = !(id in state);
         if (!bot) {
             bot = Object.assign({}, update[id]) as any;
             updatedState[id] = bot as any;
@@ -208,7 +209,10 @@ export function apply<T extends BotsState, U extends PartialBotsState>(
             for (let tag in botUpdate.tags) {
                 let val = botUpdate.tags[tag];
                 if (isTagEdit(val)) {
-                    bot.tags[tag] = applyEdit(bot.tags[tag], val);
+                    bot.tags[tag] = applyEdit(
+                        isNewBot ? '' : bot.tags[tag],
+                        val
+                    );
                 } else {
                     bot.tags[tag] = val;
                 }
@@ -238,7 +242,7 @@ export function apply<T extends BotsState, U extends PartialBotsState>(
                     let val = tags[tag];
                     if (isTagEdit(val)) {
                         bot.masks[space][tag] = applyEdit(
-                            bot.masks[space][tag],
+                            isNewBot ? '' : bot.masks[space][tag],
                             val
                         );
                     } else {

--- a/src/aux-common/aux-format-2/AuxStateHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.ts
@@ -9,6 +9,7 @@ import {
 import { merge, splice } from '../utils';
 import { hasValue, isBot } from '../bots/BotCalculations';
 import { sortBy } from 'lodash';
+import { VersionVector } from '@casual-simulation/causal-trees';
 
 /**
  * The name of the property that indicates an object represents a tag edit.
@@ -133,13 +134,6 @@ export interface TagEdit {
      * The operations that are part of the edit.
      */
     operations: TagEditOp[][];
-}
-
-/**
- * Defines an interface that represents a map of site IDs to timestamps.
- */
-export interface VersionVector {
-    [site: string]: number;
 }
 
 export type TagEditOp = TagPreserveOp | TagInsertOp | TagDeleteOp;

--- a/src/aux-common/aux-format-2/AuxStateHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxStateHelpers.ts
@@ -113,7 +113,7 @@ export function mergeVersions(
         ...first,
     };
     for (let site in second) {
-        final[site] = Math.max(final[site], second[site]);
+        final[site] = Math.max(final[site] || 0, second[site] || 0);
     }
 
     return final;

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -307,6 +307,23 @@ describe('AuxWeaveHelpers', () => {
             expect(result.index).toBe(3);
         });
 
+        it('should be able to insert into an empty value', () => {
+            const v1 = atom(atomId('a', 3), t1, value(''));
+            insertAtoms(b1, t1, v1);
+
+            const valueNode = weave.getNode(v1.id);
+
+            const result = findEditPosition(
+                valueNode,
+                {
+                    a: 5,
+                },
+                0
+            );
+            expect(result.node.atom).toBe(v1);
+            expect(result.index).toBe(0);
+        });
+
         it('should be able to insert a value into another site insert', () => {
             insertAtoms(b1, t1, v1, i3);
 
@@ -1000,6 +1017,40 @@ describe('AuxWeaveHelpers', () => {
                     index: 0,
                     count: 1,
                     node: 'a5',
+                },
+            ]);
+        });
+
+        it('should handle deleting from multiple segments when the start position happens to in the middle of a segment', () => {
+            const a1 = textSegment('a1', 'abcd');
+            const a2 = textSegment('a2', 'efgh');
+            const a3 = textSegment('a3', 'ijklmnop');
+            const a4 = textSegment('a4', 'qrstuv');
+
+            const positions = [
+                ...findMultipleEditPositions(2, 20, [a1, a2, a3, a4], 'right'),
+            ];
+
+            expect(positions).toEqual([
+                {
+                    index: 2,
+                    count: 2,
+                    node: 'a1',
+                },
+                {
+                    index: 0,
+                    count: 4,
+                    node: 'a2',
+                },
+                {
+                    index: 0,
+                    count: 8,
+                    node: 'a3',
+                },
+                {
+                    index: 0,
+                    count: 6,
+                    node: 'a4',
                 },
             ]);
         });

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -177,7 +177,7 @@ describe('AuxWeaveHelpers', () => {
 
             for (let [timestamp, index, expectedAtom, expectedIndex] of cases) {
                 const result = findEditPosition(valueNode, timestamp, index);
-                expect(result.atom).toBe(expectedAtom);
+                expect(result.node.atom).toBe(expectedAtom);
                 expect(result.index).toBe(expectedIndex);
             }
         });
@@ -193,7 +193,7 @@ describe('AuxWeaveHelpers', () => {
         it('should treat value nodes as a segment', () => {
             const b1 = atom(atomId('a', 1), null, bot('test'));
             const t1 = atom(atomId('a', 2), b1, tag('abc'));
-            
+
             const v1 = atom(atomId('a', 3), t1, value('111'));
 
             insert(b1, t1, v1);

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -5,6 +5,8 @@ import {
     SiteStatus,
     newSite,
     createAtom,
+    iterateCausalGroup,
+    Atom,
 } from '@casual-simulation/causal-trees/core2';
 import { AuxOp, bot, tag, value, deleteOp, insertOp } from './AuxOpTypes';
 import {
@@ -12,8 +14,11 @@ import {
     findValueNode,
     findBotNode,
     findEditPosition,
+    calculateOrderedEdits,
 } from './AuxWeaveHelpers';
 import { createBot } from '../bots';
+import reducer from './AuxWeaveReducer';
+import { apply } from './AuxStateHelpers';
 
 describe('AuxWeaveHelpers', () => {
     describe('findBotNode()', () => {
@@ -176,5 +181,414 @@ describe('AuxWeaveHelpers', () => {
                 expect(result.index).toBe(expectedIndex);
             }
         });
+    });
+
+    describe.only('calculateOrderedEdits()', () => {
+        let weave: Weave<AuxOp>;
+
+        beforeEach(() => {
+            weave = new Weave();
+        });
+
+        it('should treat value nodes as a segment', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+            
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+
+            insert(b1, t1, v1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([{ text: '111', atom: v1 }]);
+        });
+
+        it('should remove deleted sections from value nodes', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(1, 2));
+
+            insert(b1, t1, v1, d0);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([{ text: '11', atom: v1 }]);
+        });
+
+        it('should not report empty text segments', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(0, 3));
+
+            insert(b1, t1, v1, d0);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([]);
+        });
+
+        it('should support multiple delete atoms on a single value node', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(1, 2));
+            const d1 = atom(atomId('a', 5, 1), v1, deleteOp(2, 3));
+
+            insert(b1, t1, v1, d0, d1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([{ text: '1', atom: v1 }]);
+        });
+
+        it('should support overlapping delete atoms on a single value node', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(1, 2));
+            const d1 = atom(atomId('a', 5, 1), v1, deleteOp(1, 3));
+
+            insert(b1, t1, v1, d0, d1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([{ text: '1', atom: v1 }]);
+        });
+
+        it('should remove deleted sections from insert nodes', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(1, '222'));
+            const d0 = atom(atomId('a', 5, 1), i1, deleteOp(1, 2));
+
+            insert(b1, t1, v1, i1, d0);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '1', atom: v1 },
+                { text: '22', atom: i1 },
+                { text: '11', atom: v1 },
+            ]);
+        });
+
+        it('should support multiple delete atoms on a single insert node', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(1, '222'));
+            const d0 = atom(atomId('a', 5, 1), i1, deleteOp(1, 2));
+            const d1 = atom(atomId('a', 6, 1), i1, deleteOp(2, 3));
+
+            insert(b1, t1, v1, i1, d0, d1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '1', atom: v1 },
+                { text: '2', atom: i1 },
+                { text: '11', atom: v1 },
+            ]);
+        });
+
+        it('should support overlapping delete atoms on a single insert node', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(1, '222'));
+            const d0 = atom(atomId('a', 5, 1), i1, deleteOp(1, 2));
+            const d1 = atom(atomId('a', 6, 1), i1, deleteOp(1, 3));
+
+            insert(b1, t1, v1, i1, d0, d1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '1', atom: v1 },
+                { text: '2', atom: i1 },
+                { text: '11', atom: v1 },
+            ]);
+        });
+
+        it('should treat insert nodes as a segment', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(3, '222'));
+
+            insert(b1, t1, v1, i1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '111', atom: v1 },
+                { text: '222', atom: i1 },
+            ]);
+        });
+
+        it('should place insert operations with a zero index before the value operation', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(0, '222'));
+
+            insert(b1, t1, v1, i1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '222', atom: i1 },
+                { text: '111', atom: v1 },
+            ]);
+        });
+
+        it('should split a text segment if an insert is in the middle', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(1, '222'));
+
+            insert(b1, t1, v1, i1);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '1', atom: v1 },
+                { text: '222', atom: i1 },
+                { text: '11', atom: v1 },
+            ]);
+        });
+
+        it('should support sibling inserts on a value', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            const i1 = atom(atomId('a', 4), v1, insertOp(1, '222'));
+            const i2 = atom(atomId('a', 5), v1, insertOp(2, '333'));
+
+            insert(b1, t1, v1, i1, i2);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '1', atom: v1 },
+                { text: '222', atom: i1 },
+                { text: '1', atom: v1 },
+                { text: '333', atom: i2 },
+                { text: '1', atom: v1 },
+            ]);
+        });
+
+        it('should split inserts and deletes into a sequence of edits', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            // 111
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(1, 2));
+            // 11
+            const i1 = atom(atomId('a', 5), v1, insertOp(0, '222'));
+            // 22211
+            const d1 = atom(atomId('a', 6, 1), i1, deleteOp(2, 3));
+            // 2211
+            const i2 = atom(atomId('a', 7), v1, insertOp(2, '333'));
+            // 2213331 - insert is in the middle of v1 because it should apply to "111" and not "11"
+            const i3 = atom(atomId('a', 9), i1, insertOp(2, '444'));
+            // 2244413331
+            const d3 = atom(atomId('a', 10, 1), i3, deleteOp(2, 3));
+            // 224413331
+
+            insert(b1, t1, v1, d0, i1, d1, i2, i3, d3);
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '22', atom: i1 },
+                { text: '44', atom: i3 },
+                { text: '1', atom: v1 },
+                { text: '333', atom: i2 },
+                { text: '1', atom: v1 },
+            ]);
+        });
+
+        it('should report the same value as the reducer', () => {
+            const b1 = atom(atomId('a', 1), null, bot('test'));
+            const t1 = atom(atomId('a', 2), b1, tag('abc'));
+
+            const v1 = atom(atomId('a', 3), t1, value('111'));
+            // 111
+            const d0 = atom(atomId('a', 4, 1), v1, deleteOp(1, 2));
+            // 11
+            const i1 = atom(atomId('a', 5), v1, insertOp(0, '222'));
+            // 22211
+            const d1 = atom(atomId('a', 6, 1), i1, deleteOp(2, 3));
+            // 2211
+            const i2 = atom(atomId('a', 7), v1, insertOp(2, '333'));
+            // 2213331 - insert is in the middle of v1 because it should apply to "111" and not "11"
+            const i3 = atom(atomId('a', 9), i1, insertOp(2, '444'));
+            // 2244413331
+            const d3 = atom(atomId('a', 10, 1), i3, deleteOp(2, 3));
+            // 224413331
+
+            let atoms = [b1, t1, v1, d0, i1, d1, i2, i3, d3];
+            let state = {};
+            for (let atom of atoms) {
+                const weaveResult = weave.insert(atom);
+                const update = reducer(weave, weaveResult);
+                state = apply(state, update);
+            }
+
+            const valueNode = weave.getNode(v1.id);
+            const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
+
+            const segments = calculateOrderedEdits(nodes);
+
+            const result = segments.map((s) => ({
+                text: s.text,
+                atom: s.node.atom,
+            }));
+
+            expect(result).toEqual([
+                { text: '22', atom: i1 },
+                { text: '44', atom: i3 },
+                { text: '1', atom: v1 },
+                { text: '333', atom: i2 },
+                { text: '1', atom: v1 },
+            ]);
+            expect(state).toEqual({
+                test: createBot('test', {
+                    abc: '224413331',
+                }),
+            });
+        });
+
+        function insert(...atoms: Atom<AuxOp>[]) {
+            for (let atom of atoms) {
+                const result = weave.insert(atom);
+                if (result.type !== 'atom_added') {
+                    throw new Error(
+                        'Unable to add atom to weave: ' + result.type
+                    );
+                }
+            }
+        }
     });
 });

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -183,7 +183,7 @@ describe('AuxWeaveHelpers', () => {
         });
     });
 
-    describe.only('calculateOrderedEdits()', () => {
+    describe('calculateOrderedEdits()', () => {
         let weave: Weave<AuxOp>;
 
         beforeEach(() => {
@@ -205,10 +205,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
-            expect(result).toEqual([{ text: '111', atom: v1 }]);
+            expect(result).toEqual([
+                { text: '111', marked: '111', offset: 0, atom: v1 },
+            ]);
         });
 
         it('should remove deleted sections from value nodes', () => {
@@ -227,10 +231,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
-            expect(result).toEqual([{ text: '11', atom: v1 }]);
+            expect(result).toEqual([
+                { text: '11', marked: '1•1', offset: 0, atom: v1 },
+            ]);
         });
 
         it('should not report empty text segments', () => {
@@ -249,6 +257,8 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
@@ -272,10 +282,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
-            expect(result).toEqual([{ text: '1', atom: v1 }]);
+            expect(result).toEqual([
+                { text: '1', marked: '1••', offset: 0, atom: v1 },
+            ]);
         });
 
         it('should support overlapping delete atoms on a single value node', () => {
@@ -295,10 +309,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
-            expect(result).toEqual([{ text: '1', atom: v1 }]);
+            expect(result).toEqual([
+                { text: '1', marked: '1••', offset: 0, atom: v1 },
+            ]);
         });
 
         it('should remove deleted sections from insert nodes', () => {
@@ -318,13 +336,15 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '1', atom: v1 },
-                { text: '22', atom: i1 },
-                { text: '11', atom: v1 },
+                { text: '1', marked: '1', offset: 0, atom: v1 },
+                { text: '22', marked: '2•2', offset: 0, atom: i1 },
+                { text: '11', marked: '11', offset: 1, atom: v1 },
             ]);
         });
 
@@ -346,13 +366,15 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '1', atom: v1 },
-                { text: '2', atom: i1 },
-                { text: '11', atom: v1 },
+                { text: '1', marked: '1', offset: 0, atom: v1 },
+                { text: '2', marked: '2••', offset: 0, atom: i1 },
+                { text: '11', marked: '11', offset: 1, atom: v1 },
             ]);
         });
 
@@ -374,13 +396,15 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '1', atom: v1 },
-                { text: '2', atom: i1 },
-                { text: '11', atom: v1 },
+                { text: '1', marked: '1', offset: 0, atom: v1 },
+                { text: '2', marked: '2••', offset: 0, atom: i1 },
+                { text: '11', marked: '11', offset: 1, atom: v1 },
             ]);
         });
 
@@ -400,12 +424,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '111', atom: v1 },
-                { text: '222', atom: i1 },
+                { text: '111', marked: '111', offset: 0, atom: v1 },
+                { text: '222', marked: '222', offset: 0, atom: i1 },
             ]);
         });
 
@@ -425,12 +451,14 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '222', atom: i1 },
-                { text: '111', atom: v1 },
+                { text: '222', marked: '222', offset: 0, atom: i1 },
+                { text: '111', marked: '111', offset: 0, atom: v1 },
             ]);
         });
 
@@ -450,13 +478,15 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '1', atom: v1 },
-                { text: '222', atom: i1 },
-                { text: '11', atom: v1 },
+                { text: '1', marked: '1', offset: 0, atom: v1 },
+                { text: '222', marked: '222', offset: 0, atom: i1 },
+                { text: '11', marked: '11', offset: 1, atom: v1 },
             ]);
         });
 
@@ -477,15 +507,17 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '1', atom: v1 },
-                { text: '222', atom: i1 },
-                { text: '1', atom: v1 },
-                { text: '333', atom: i2 },
-                { text: '1', atom: v1 },
+                { text: '1', marked: '1', offset: 0, atom: v1 },
+                { text: '222', marked: '222', offset: 0, atom: i1 },
+                { text: '1', marked: '1', offset: 1, atom: v1 },
+                { text: '333', marked: '333', offset: 0, atom: i2 },
+                { text: '1', marked: '1', offset: 2, atom: v1 },
             ]);
         });
 
@@ -517,15 +549,17 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '22', atom: i1 },
-                { text: '44', atom: i3 },
-                { text: '1', atom: v1 },
-                { text: '333', atom: i2 },
-                { text: '1', atom: v1 },
+                { text: '22', marked: '22', offset: 0, atom: i1 },
+                { text: '44', marked: '44•', offset: 0, atom: i3 },
+                { text: '1', marked: '1•', offset: 0, atom: v1 },
+                { text: '333', marked: '333', offset: 0, atom: i2 },
+                { text: '1', marked: '1', offset: 2, atom: v1 },
             ]);
         });
 
@@ -563,15 +597,17 @@ describe('AuxWeaveHelpers', () => {
 
             const result = segments.map((s) => ({
                 text: s.text,
+                marked: s.marked.replace(/\0/g, '•'),
+                offset: s.offset,
                 atom: s.node.atom,
             }));
 
             expect(result).toEqual([
-                { text: '22', atom: i1 },
-                { text: '44', atom: i3 },
-                { text: '1', atom: v1 },
-                { text: '333', atom: i2 },
-                { text: '1', atom: v1 },
+                { text: '22', marked: '22', offset: 0, atom: i1 },
+                { text: '44', marked: '44•', offset: 0, atom: i3 },
+                { text: '1', marked: '1•', offset: 0, atom: v1 },
+                { text: '333', marked: '333', offset: 0, atom: i2 },
+                { text: '1', marked: '1', offset: 2, atom: v1 },
             ]);
             expect(state).toEqual({
                 test: createBot('test', {

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -375,11 +375,13 @@ describe('AuxWeaveHelpers', () => {
             const mapped = result.map((r) => ({
                 atom: r.node.atom,
                 index: r.index,
+                count: r.count,
             }));
             expect(mapped).toEqual([
-                { index: 0, count: 3, atom: v1 },
                 { index: 0, count: 3, atom: i1 },
+                { index: 0, count: 2, atom: v1 },
                 { index: 0, count: 3, atom: i2 },
+                { index: 2, count: 1, atom: v1 },
             ]);
         });
 
@@ -880,7 +882,7 @@ describe('AuxWeaveHelpers', () => {
         it('should return the node and index that the deletes start at', () => {
             const a1 = textSegment('a1', 'abcdef');
 
-            const positions = findMultipleEditPositions(0, 1, [a1]);
+            const positions = [...findMultipleEditPositions(0, 1, [a1])];
 
             expect(positions).toEqual([
                 {
@@ -896,7 +898,9 @@ describe('AuxWeaveHelpers', () => {
             const a2 = textSegment('a2', 'cd');
             const a3 = textSegment('a3', 'ef');
 
-            const positions = findMultipleEditPositions(0, 6, [a1, a2, a3]);
+            const positions = [
+                ...findMultipleEditPositions(0, 6, [a1, a2, a3]),
+            ];
 
             expect(positions).toEqual([
                 {
@@ -918,29 +922,31 @@ describe('AuxWeaveHelpers', () => {
         });
 
         it('should return the correct count for segments that have deleted characters between the start and end', () => {
-            const a1 = textSegment('a1', 'a•b');
+            const a1 = textSegment('a1', 'a••b');
 
-            const positions = findMultipleEditPositions(0, 2, [a1]);
+            const positions = [...findMultipleEditPositions(0, 2, [a1])];
 
             expect(positions).toEqual([
                 {
                     index: 0,
-                    count: 3,
+                    count: 4,
                     node: 'a1',
                 },
             ]);
         });
 
-        it('should handle deleting from segments that have some deleted characters', () => {
+        it('should handle deleting from multiple segments that have some deleted characters', () => {
             const a1 = textSegment('a1', '•ab');
             const a2 = textSegment('a2', 'c•d');
             const a3 = textSegment('a3', 'ef•');
 
-            const positions = findMultipleEditPositions(0, 6, [a1, a2, a3]);
+            const positions = [
+                ...findMultipleEditPositions(0, 6, [a1, a2, a3]),
+            ];
 
             expect(positions).toEqual([
                 {
-                    index: 0,
+                    index: 1,
                     count: 2,
                     node: 'a1',
                 },
@@ -957,8 +963,6 @@ describe('AuxWeaveHelpers', () => {
             ]);
         });
     });
-
-    describe('findSingleEditPosition()', () => {});
 });
 
 function textSegment(id: string, text: string): TextSegment {

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.spec.ts
@@ -882,7 +882,9 @@ describe('AuxWeaveHelpers', () => {
         it('should return the node and index that the deletes start at', () => {
             const a1 = textSegment('a1', 'abcdef');
 
-            const positions = [...findMultipleEditPositions(0, 1, [a1])];
+            const positions = [
+                ...findMultipleEditPositions(0, 1, [a1], 'right'),
+            ];
 
             expect(positions).toEqual([
                 {
@@ -899,7 +901,7 @@ describe('AuxWeaveHelpers', () => {
             const a3 = textSegment('a3', 'ef');
 
             const positions = [
-                ...findMultipleEditPositions(0, 6, [a1, a2, a3]),
+                ...findMultipleEditPositions(0, 6, [a1, a2, a3], 'right'),
             ];
 
             expect(positions).toEqual([
@@ -924,7 +926,9 @@ describe('AuxWeaveHelpers', () => {
         it('should return the correct count for segments that have deleted characters between the start and end', () => {
             const a1 = textSegment('a1', 'a••b');
 
-            const positions = [...findMultipleEditPositions(0, 2, [a1])];
+            const positions = [
+                ...findMultipleEditPositions(0, 2, [a1], 'right'),
+            ];
 
             expect(positions).toEqual([
                 {
@@ -941,7 +945,7 @@ describe('AuxWeaveHelpers', () => {
             const a3 = textSegment('a3', 'ef•');
 
             const positions = [
-                ...findMultipleEditPositions(0, 6, [a1, a2, a3]),
+                ...findMultipleEditPositions(0, 6, [a1, a2, a3], 'right'),
             ];
 
             expect(positions).toEqual([
@@ -959,6 +963,43 @@ describe('AuxWeaveHelpers', () => {
                     index: 0,
                     count: 2,
                     node: 'a3',
+                },
+            ]);
+        });
+
+        it('should handle deleting from multiple segments when the start position happens to match the end of a segment', () => {
+            const a1 = textSegment('a1', 'a');
+            const a2 = textSegment('a2', 'b');
+            const a3 = textSegment('a3', 'c');
+            const a4 = textSegment('a4', 'd');
+            const a5 = textSegment('a5', 'e');
+            const a6 = textSegment('a6', 'f');
+            const a7 = textSegment('a7', 'g');
+
+            const positions = [
+                ...findMultipleEditPositions(
+                    2,
+                    3,
+                    [a1, a2, a3, a4, a5, a6, a7],
+                    'right'
+                ),
+            ];
+
+            expect(positions).toEqual([
+                {
+                    index: 0,
+                    count: 1,
+                    node: 'a3',
+                },
+                {
+                    index: 0,
+                    count: 1,
+                    node: 'a4',
+                },
+                {
+                    index: 0,
+                    count: 1,
+                    node: 'a5',
                 },
             ]);
         });

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -194,6 +194,7 @@ export function calculateOrderedEdits(
             let segment: TextSegmentInfo = {
                 text: atomValue.value,
                 node: node as WeaveNode<ValueOp>,
+                offset: 0,
                 totalLength: atomValue.value.length,
             };
             segments.push(segment);
@@ -201,6 +202,7 @@ export function calculateOrderedEdits(
             const segment: TextSegmentInfo = {
                 text: atomValue.text,
                 node: node as WeaveNode<InsertOp>,
+                offset: 0,
                 totalLength: atomValue.text.length,
             };
             let count = 0;
@@ -223,10 +225,12 @@ export function calculateOrderedEdits(
                             atomValue.index - count
                         ),
                         node: lastSegment.node,
+                        offset: lastSegment.offset + 0,
                         totalLength: lastSegment.totalLength,
                     };
                     const second: TextSegmentInfo = {
                         text: lastSegment.text.slice(atomValue.index - count),
+                        offset: lastSegment.offset + (atomValue.index - count),
                         node: lastSegment.node,
                         totalLength: lastSegment.totalLength,
                     };
@@ -256,6 +260,8 @@ export function calculateOrderedEdits(
     return segments
         .map((s) => ({
             text: s.text.replace(/\0/g, ''),
+            marked: s.text,
+            offset: s.offset,
             node: s.node,
         }))
         .filter((s) => s.text.length > 0);
@@ -269,6 +275,18 @@ export interface TextSegment {
      * The text of the edit.
      */
     text: string;
+
+    /**
+     * The index offset that this segment starts at.
+     * Useful when the node was split into two segments.
+     */
+    offset: number;
+
+    /**
+     * The text that includes null characters to indicate characters that were deleted.
+     */
+    marked: string;
+
     /**
      * The node that the edit text was produced from.
      */
@@ -278,11 +296,27 @@ export interface TextSegment {
 /**
  * Defines an interface that contains extra information about a text segment.
  */
-export interface TextSegmentInfo extends TextSegment {
+export interface TextSegmentInfo {
+    /**
+     * The text of the edit.
+     */
+    text: string;
+
     /**
      * The total length of text sequences.
      */
     totalLength: number;
+
+    /**
+     * The index offset that this segment starts at.
+     * Useful when the node was split into two segments.
+     */
+    offset: number;
+
+    /**
+     * The node that the edit text was produced from.
+     */
+    node: WeaveNode<ValueOp | InsertOp>;
 }
 
 export interface EditPosition {

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -234,20 +234,42 @@ export function* findMultipleEditPositions(
             const relativeIndex = Math.abs(count - index);
             const countUntilEnd = edit.text.length - relativeIndex;
 
+            // TODO: Reconcile the relative index of the edit text and
+            // the index that is needed inside the marked text.
+            let relativeIndexOffset = 0;
+            for (
+                let i = 0, b = 0;
+                i < relativeIndex && b < edit.marked.length;
+
+            ) {
+                let normalChar = edit.text[i];
+                let markedChar = edit.marked[b];
+
+                if (normalChar === markedChar) {
+                    i += 1;
+                } else {
+                    relativeIndexOffset += 1;
+                }
+
+                b += 1;
+            }
+
+            const finalOffset = relativeIndex + relativeIndexOffset;
+
             const nodeDeleteCount = Math.min(countUntilEnd, remaining);
-            const textBefore = edit.marked.slice(0, relativeIndex);
+            // const textBefore = edit.marked.slice(0, finalOffset);
             const textAfter = edit.marked.slice(
-                relativeIndex,
+                finalOffset,
                 edit.marked.length
             );
 
             let removedCharacterCount = 0;
             let deleteCountOffset = 0;
-            for (let char of textBefore) {
-                if (char === '\0') {
-                    removedCharacterCount += 1;
-                }
-            }
+            // for (let char of textBefore) {
+            //     if (char === '\0') {
+            //         removedCharacterCount += 1;
+            //     }
+            // }
 
             let afterIndex = 0;
 
@@ -275,7 +297,7 @@ export function* findMultipleEditPositions(
             }
 
             yield {
-                index: relativeIndex + removedCharacterCount + edit.offset,
+                index: finalOffset + removedCharacterCount + edit.offset,
                 count: nodeDeleteCount + deleteCountOffset,
                 node: edit.node,
             };

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -142,12 +142,12 @@ export function findValueNodeByValue(
  * Finds the node and index at which the given edit should happen at.
  * Useful for applying edits to a causal tree.
  * @param value The value node.
- * @param timestamp The last timestamp that was available when the edit was made.
+ * @param version The last timestamps that were available when the edit was made.
  * @param index The index at which the edit should happen.
  */
 export function findEditPosition(
     value: WeaveNode<AuxOp>,
-    timestamp: number,
+    version: VersionVector,
     index: number
 ): EditPosition {
     if (value.atom.value.type !== AuxOpType.Value) {
@@ -155,27 +155,36 @@ export function findEditPosition(
             'Invalid Argument. The weave node must be a value node.'
         );
     }
+
+    const children = [value, ...iterateChildren(value)];
+    const filtered = children.filter((c) => {
+        const timestamp = version[c.atom.id.site] || -1;
+        return c.atom.id.timestamp <= timestamp;
+    });
+    const edits = calculateOrderedEdits(filtered);
+
+    let count = 0;
+    for (let edit of edits) {
+        if (count + edit.text.length >= index) {
+            const relativeIndex = Math.abs(count - index);
+            const textBefore = edit.marked.slice(0, relativeIndex);
+
+            let removedCharacterCount = 0;
+            for (let char of textBefore) {
+                if (char === '\0') {
+                    removedCharacterCount += 1;
+                }
+            }
+
+            return {
+                index: relativeIndex + removedCharacterCount + edit.offset,
+                node: edit.node,
+            };
+        }
+        count += edit.text.length;
+    }
+
     return null;
-
-    // let val = value.atom.value.value as any;
-    // const children = sortBy([...iterateChildren(value)], n => {
-    //     if (n.atom.value.type === AuxOpType.Insert) {
-    //         return n.atom.value.index;
-    //     } else if(n.atom.value.type === AuxOpType.Delete) {
-    //         return n.atom.value.start;
-    //     }
-    // });
-    // for (let node of iterateCausalGroup(value)) {
-    //     if (node.atom.id.timestamp > timestamp) {
-    //         continue;
-    //     }
-
-    //     if (node.atom.value.type === AuxOpType.Insert) {
-    //         val = splice(val, node.atom.value.index, 0, node.atom.value.text);
-    //     } else if(node.atom.value.type === AuxOpType.Delete) {
-    //         val = splice(val, node.atom.value.start, node.atom.value.)
-    //     }
-    // }
 }
 
 /**
@@ -265,6 +274,13 @@ export function calculateOrderedEdits(
             node: s.node,
         }))
         .filter((s) => s.text.length > 0);
+}
+
+/**
+ * Defines an interface that represents a map of site IDs to timestamps.
+ */
+export interface VersionVector {
+    [site: string]: number;
 }
 
 /**

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -429,6 +429,17 @@ export function calculateOrderedEdits(
         .filter((s) => preserveEmptyEdits || s.text.length > 0);
 }
 
+/**
+ * Calculates the final text value for the given value node.
+ * @param weave The weave.
+ * @param value The value node.
+ */
+export function calculateFinalEditValue(value: WeaveNode<ValueOp>): string {
+    const children = [value, ...iterateCausalGroup(value)];
+    const edits = calculateOrderedEdits(children);
+    return edits.map((e) => e.text).join('');
+}
+
 export function convertToString(value: any): string {
     if (!hasValue(value)) {
         return '';

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -229,8 +229,6 @@ export function* findMultipleEditPositions(
                 ? count + edit.text.length >= index
                 : count + edit.text.length > index;
         if (reachedStart) {
-            // const numAlreadyDeleted = deleteCount - remaining;
-            // const finalIndex = Math.max(index - numAlreadyDeleted, 0);
             const relativeIndex = Math.abs(count - index);
             const countUntilEnd = edit.text.length - relativeIndex;
 
@@ -257,7 +255,6 @@ export function* findMultipleEditPositions(
             const finalOffset = relativeIndex + relativeIndexOffset;
 
             const nodeDeleteCount = Math.min(countUntilEnd, remaining);
-            // const textBefore = edit.marked.slice(0, finalOffset);
             const textAfter = edit.marked.slice(
                 finalOffset,
                 edit.marked.length
@@ -265,11 +262,6 @@ export function* findMultipleEditPositions(
 
             let removedCharacterCount = 0;
             let deleteCountOffset = 0;
-            // for (let char of textBefore) {
-            //     if (char === '\0') {
-            //         removedCharacterCount += 1;
-            //     }
-            // }
 
             let afterIndex = 0;
 

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -24,6 +24,7 @@ import {
 } from '@casual-simulation/causal-trees/core2';
 import isEqual from 'lodash/isEqual';
 import { splice } from '../utils';
+import { hasValue } from '../bots/BotCalculations';
 
 /**
  * Finds the first weave node that defines a bot with the given ID.
@@ -329,8 +330,9 @@ export function calculateOrderedEdits(
     for (let node of nodes) {
         const atomValue = node.atom.value;
         if (atomValue.type === AuxOpType.Value) {
+            let text = convertToString(atomValue.value);
             let segment: TextSegmentInfo = {
-                text: atomValue.value,
+                text: text,
                 node: node as WeaveNode<ValueOp>,
                 offset: 0,
                 totalLength: atomValue.value.length,
@@ -425,6 +427,19 @@ export function calculateOrderedEdits(
             node: s.node,
         }))
         .filter((s) => preserveEmptyEdits || s.text.length > 0);
+}
+
+export function convertToString(value: any): string {
+    if (!hasValue(value)) {
+        return '';
+    }
+    if (typeof value === 'string') {
+        return value;
+    } else if (typeof value !== 'object' && value !== undefined) {
+        return value.toString();
+    } else {
+        return JSON.stringify(value);
+    }
 }
 
 /**

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -20,12 +20,12 @@ import {
     idEquals,
     AtomId,
     atom,
+    VersionVector,
 } from '@casual-simulation/causal-trees/core2';
 import reducer from './AuxWeaveReducer';
 import isEqual from 'lodash/isEqual';
 import { splice } from '../utils';
 import { sortBy } from 'lodash';
-import { VersionVector } from './AuxStateHelpers';
 
 /**
  * Finds the first weave node that defines a bot with the given ID.

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -192,6 +192,13 @@ export function findEditPosition(
     });
     const edits = calculateOrderedEdits(filtered);
 
+    if (edits.length <= 0 && typeof deleteCount === 'undefined') {
+        return {
+            index: 0,
+            node: value,
+        };
+    }
+
     if (typeof deleteCount === 'number') {
         return [
             ...findMultipleEditPositions(index, deleteCount, edits, 'right'),
@@ -222,6 +229,8 @@ export function* findMultipleEditPositions(
                 ? count + edit.text.length >= index
                 : count + edit.text.length > index;
         if (reachedStart) {
+            // const numAlreadyDeleted = deleteCount - remaining;
+            // const finalIndex = Math.max(index - numAlreadyDeleted, 0);
             const relativeIndex = Math.abs(count - index);
             const countUntilEnd = edit.text.length - relativeIndex;
 
@@ -272,6 +281,7 @@ export function* findMultipleEditPositions(
             };
 
             remaining -= nodeDeleteCount;
+            count += relativeIndex;
         } else {
             count += edit.text.length;
         }

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -138,11 +138,46 @@ export function findValueNodeByValue(
     return null;
 }
 
+/**
+ * Finds the node and index at which the given edit should happen at.
+ * Useful for applying edits to a causal tree.
+ * @param value The value node.
+ * @param timestamp The last timestamp that was available when the edit was made.
+ * @param index The index at which the edit should happen.
+ */
 export function findEditPosition(
     value: WeaveNode<AuxOp>,
     timestamp: number,
     index: number
-): any {}
+): EditPosition {
+    if (value.atom.value.type !== AuxOpType.Value) {
+        throw new Error(
+            'Invalid Argument. The weave node must be a value node.'
+        );
+    }
+    return null;
+
+    // let val = value.atom.value.value as any;
+    // const children = sortBy([...iterateChildren(value)], n => {
+    //     if (n.atom.value.type === AuxOpType.Insert) {
+    //         return n.atom.value.index;
+    //     } else if(n.atom.value.type === AuxOpType.Delete) {
+    //         return n.atom.value.start;
+    //     }
+    // });
+    // for (let node of iterateCausalGroup(value)) {
+    //     if (node.atom.id.timestamp > timestamp) {
+    //         continue;
+    //     }
+
+    //     if (node.atom.value.type === AuxOpType.Insert) {
+    //         val = splice(val, node.atom.value.index, 0, node.atom.value.text);
+    //     } else if(node.atom.value.type === AuxOpType.Delete) {
+    //         val = splice(val, node.atom.value.start, node.atom.value.)
+    //     }
+    // }
+}
+
 /**
  * Calculates the list of ordered edits for the given value node.
  * This iterates each insert op and delete op and returns a list of text segments that have been derived from the value.

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -25,6 +25,7 @@ import reducer from './AuxWeaveReducer';
 import isEqual from 'lodash/isEqual';
 import { splice } from '../utils';
 import { sortBy } from 'lodash';
+import { VersionVector } from './AuxStateHelpers';
 
 /**
  * Finds the first weave node that defines a bot with the given ID.
@@ -156,7 +157,7 @@ export function findEditPosition(
         );
     }
 
-    const children = [value, ...iterateChildren(value)];
+    const children = [value, ...iterateCausalGroup(value)];
     const filtered = children.filter((c) => {
         const timestamp = version[c.atom.id.site] || -1;
         return c.atom.id.timestamp <= timestamp;
@@ -274,13 +275,6 @@ export function calculateOrderedEdits(
             node: s.node,
         }))
         .filter((s) => s.text.length > 0);
-}
-
-/**
- * Defines an interface that represents a map of site IDs to timestamps.
- */
-export interface VersionVector {
-    [site: string]: number;
 }
 
 /**

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -304,9 +304,11 @@ export function findSingleEditPosition(index: number, edits: TextSegment[]) {
  * Calculates the list of ordered edits for the given value node.
  * This iterates each insert op and delete op and returns a list of text segments that have been derived from the value.
  * @param nodes The list of nodes that the edits should be calculated from.
+ * @param preserveEmptyEdits Whether to preserve empty edits in the output list.
  */
 export function calculateOrderedEdits(
-    nodes: WeaveNode<AuxOp>[]
+    nodes: WeaveNode<AuxOp>[],
+    preserveEmptyEdits: boolean = false
 ): TextSegment[] {
     let segments = [] as TextSegmentInfo[];
 
@@ -386,7 +388,7 @@ export function calculateOrderedEdits(
             offset: s.offset,
             node: s.node,
         }))
-        .filter((s) => s.text.length > 0);
+        .filter((s) => preserveEmptyEdits || s.text.length > 0);
 }
 
 /**

--- a/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveHelpers.ts
@@ -131,6 +131,12 @@ export function findValueNodeByValue(
     return null;
 }
 
+export function findEditPosition(
+    value: WeaveNode<AuxOp>,
+    timestamp: number,
+    index: number
+): any {}
+
 // /**
 //  * Adds the given atom to the weave.
 //  * Returns the new site status, weave result, atom that was added, and status update.

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -2355,6 +2355,133 @@ describe('AuxWeaveReducer', () => {
                         },
                     });
                 });
+
+                it('should handle deletes for a value that was split by multiple inserts', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '111')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(2, '222')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(0, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [bot1, tag1, value1, insert1, insert2]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    let u = reduce(weave, weave.insert(delete1), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '111222',
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '111222',
+                            },
+                        },
+                    });
+                });
+
+                it('should handle deletes for a value that is partially deleted and was split by an insert', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('111111'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(5, '222')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(0, '3')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(2, 3)
+                    );
+                    const delete2 = atom(
+                        atomId('a', 7, 1),
+                        value1,
+                        deleteOp(5, 6)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [
+                        bot1,
+                        tag1,
+                        value1,
+                        insert1,
+                        insert2,
+                        delete1,
+                    ]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '311112221',
+                            },
+                        },
+                    });
+
+                    let u = reduce(weave, weave.insert(delete2), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '31111222',
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '31111222',
+                            },
+                        },
+                    });
+                });
             });
 
             describe('TagMask', () => {
@@ -3684,6 +3811,143 @@ describe('AuxWeaveReducer', () => {
                             masks: {
                                 [space]: {
                                     abc: '111',
+                                },
+                            },
+                        },
+                    });
+                });
+
+                it('should handle deletes for a value that was split by multiple inserts', () => {
+                    const tag1 = atom(
+                        atomId('a', 2),
+                        null,
+                        tagMask('test', 'abc')
+                    );
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '111')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(2, '222')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(0, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [tag1, value1, insert1, insert2]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    let u = reduce(weave, weave.insert(delete1), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '111222',
+                                },
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '111222',
+                                },
+                            },
+                        },
+                    });
+                });
+
+                it('should handle deletes for a value that is partially deleted and was split by an insert', () => {
+                    const tag1 = atom(
+                        atomId('a', 2),
+                        null,
+                        tagMask('test', 'abc')
+                    );
+                    const value1 = atom(atomId('a', 3), tag1, value('111111'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(5, '222')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(0, '3')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(2, 3)
+                    );
+                    const delete2 = atom(
+                        atomId('a', 7, 1),
+                        value1,
+                        deleteOp(5, 6)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [
+                        tag1,
+                        value1,
+                        insert1,
+                        insert2,
+                        delete1,
+                    ]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '311112221',
+                                },
+                            },
+                        },
+                    });
+
+                    let u = reduce(weave, weave.insert(delete2), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '31111222',
+                                },
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '31111222',
                                 },
                             },
                         },

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -1228,7 +1228,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(4, preserve(1), insert('ghi')),
+                                abc: edit({ a: 4 }, preserve(1), insert('ghi')),
                             },
                         },
                     });
@@ -1272,7 +1272,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(2), insert('222')),
+                                abc: edit({ a: 5 }, preserve(2), insert('222')),
                             },
                         },
                     });
@@ -1325,7 +1325,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(1), insert('222')),
+                                abc: edit({ a: 5 }, preserve(1), insert('222')),
                             },
                         },
                     });
@@ -1369,7 +1369,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(4, preserve(4), insert('111')),
+                                abc: edit({ a: 4 }, preserve(4), insert('111')),
                             },
                         },
                     });
@@ -1404,7 +1404,11 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(1), insert('111111')),
+                                abc: edit(
+                                    { a: 5 },
+                                    preserve(1),
+                                    insert('111111')
+                                ),
                             },
                         },
                     });
@@ -1461,7 +1465,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(7, preserve(5), insert('333')),
+                                abc: edit({ a: 7 }, preserve(5), insert('333')),
                             },
                         },
                     });
@@ -1496,7 +1500,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(2), del(2)),
+                                abc: edit({ a: 5 }, preserve(2), del(2)),
                             },
                         },
                     });
@@ -1540,7 +1544,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(4), del(2)),
+                                abc: edit({ a: 5 }, preserve(4), del(2)),
                             },
                         },
                     });
@@ -1584,7 +1588,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(5, preserve(1), del(1)),
+                                abc: edit({ a: 5 }, preserve(1), del(1)),
                             },
                         },
                     });
@@ -1628,7 +1632,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(4, preserve(1), del(1)),
+                                abc: edit({ a: 4 }, preserve(1), del(1)),
                             },
                         },
                     });
@@ -1720,7 +1724,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(6, preserve(1), del(1)),
+                                abc: edit({ a: 6 }, preserve(1), del(1)),
                             },
                         },
                     });
@@ -1769,7 +1773,11 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(6, preserve(2), insert('22222')),
+                                abc: edit(
+                                    { a: 6 },
+                                    preserve(2),
+                                    insert('22222')
+                                ),
                             },
                         },
                     });
@@ -1827,7 +1835,11 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(6, preserve(2), insert('22222')),
+                                abc: edit(
+                                    { a: 6 },
+                                    preserve(2),
+                                    insert('22222')
+                                ),
                             },
                         },
                     });
@@ -1867,7 +1879,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(6, preserve(1), insert('222')),
+                                abc: edit({ a: 6 }, preserve(1), insert('222')),
                             },
                         },
                     });
@@ -1925,7 +1937,7 @@ describe('AuxWeaveReducer', () => {
                     expect(update).toEqual({
                         ['test']: {
                             tags: {
-                                abc: edit(6, preserve(2), insert('222')),
+                                abc: edit({ a: 6 }, preserve(2), insert('222')),
                             },
                         },
                     });
@@ -1977,7 +1989,7 @@ describe('AuxWeaveReducer', () => {
                         ['test']: {
                             tags: {
                                 abc: edits(
-                                    5,
+                                    { a: 5 },
                                     [preserve(1), insert('111')],
                                     [preserve(1), insert('222')]
                                 ),
@@ -2023,7 +2035,7 @@ describe('AuxWeaveReducer', () => {
                         ['test']: {
                             tags: {
                                 abc: edits(
-                                    5,
+                                    { a: 5 },
                                     [preserve(1), del(1)],
                                     [preserve(1), del(1)]
                                 ),
@@ -2078,7 +2090,7 @@ describe('AuxWeaveReducer', () => {
                         ['test']: {
                             tags: {
                                 abc: edits(
-                                    5,
+                                    { a: 5 },
                                     [preserve(1), del(1)],
                                     [preserve(1), insert('111')]
                                 ),
@@ -2091,6 +2103,80 @@ describe('AuxWeaveReducer', () => {
                             id: 'test',
                             tags: {
                                 abc: 'd111f',
+                            },
+                        },
+                    });
+                });
+
+                it('should handle multiple overlapping inserts in the same update', () => {
+                    const bot1 = atom(atomId('b', 100), null, bot('test'));
+                    const tag1 = atom(atomId('b', 101), bot1, tag('tag1'));
+                    const val1 = atom(atomId('b', 102), tag1, value('val1A'));
+
+                    const insert1 = atom(
+                        atomId('b', 103),
+                        val1,
+                        insertOp(1, '!!!')
+                    );
+                    // After: v!!!al1A
+
+                    const insert2 = atom(
+                        atomId('b', 104),
+                        insert1,
+                        insertOp(1, '@@@')
+                    );
+                    // After: v!@@@!!al1A
+
+                    const insert3 = atom(
+                        atomId('b', 105),
+                        val1,
+                        insertOp(0, '###')
+                    );
+                    // After: ###v!@@@!!al1A
+
+                    state = add(bot1, tag1, val1);
+
+                    let update = reduce(
+                        weave,
+                        weave.insert(insert1),
+                        undefined,
+                        space
+                    );
+
+                    let update2 = reduce(
+                        weave,
+                        weave.insert(insert2),
+                        update,
+                        space
+                    );
+
+                    let update3 = reduce(
+                        weave,
+                        weave.insert(insert3),
+                        update,
+                        space
+                    );
+
+                    state = apply(state, update3);
+
+                    expect(update3).toEqual({
+                        ['test']: {
+                            tags: {
+                                tag1: edits(
+                                    { b: 105 },
+                                    [preserve(1), insert('!!!')],
+                                    [preserve(2), insert('@@@')],
+                                    [preserve(0), insert('###')]
+                                ),
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                tag1: '###v!@@@!!al1A',
                             },
                         },
                     });

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -2556,6 +2556,74 @@ describe('AuxWeaveReducer', () => {
                         },
                     });
                 });
+
+                it('should skip inserts if it is the initial update', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, 'ghi')
+                    );
+
+                    state = add(bot1, tag1, value1);
+
+                    let update = reduce(
+                        weave,
+                        weave.insert(insert1),
+                        undefined,
+                        space,
+                        true
+                    );
+
+                    state = apply(state, update);
+
+                    expect(update).toEqual({});
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: 'def',
+                            },
+                        },
+                    });
+                });
+
+                it('should skip deletes if it is the initial update', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const delete1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        deleteOp(1, 2)
+                    );
+
+                    state = add(bot1, tag1, value1);
+
+                    let update = reduce(
+                        weave,
+                        weave.insert(delete1),
+                        undefined,
+                        space,
+                        true
+                    );
+
+                    state = apply(state, update);
+
+                    expect(update).toEqual({});
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: 'def',
+                            },
+                        },
+                    });
+                });
             });
 
             describe('TagMask', () => {

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -4027,6 +4027,85 @@ describe('AuxWeaveReducer', () => {
                         },
                     });
                 });
+
+                it('should handle deletes for a value that had a slice completely deleted', () => {
+                    const tag1 = atom(
+                        atomId('a', 2),
+                        null,
+                        tagMask('test', 'abc')
+                    );
+                    const value1 = atom(atomId('a', 3), tag1, value('111'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '2')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(2, '3')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(1, 2)
+                    );
+                    const delete2 = atom(
+                        atomId('a', 7, 1),
+                        value1,
+                        deleteOp(2, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [
+                        tag1,
+                        value1,
+                        insert1,
+                        insert2,
+                        delete1,
+                    ]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '1231',
+                                },
+                            },
+                        },
+                    });
+
+                    let u = reduce(weave, weave.insert(delete2), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '123',
+                                },
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '123',
+                                },
+                            },
+                        },
+                    });
+                });
             });
         });
     });

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -2482,6 +2482,80 @@ describe('AuxWeaveReducer', () => {
                         },
                     });
                 });
+
+                it('should handle deletes for a value that had a slice completely deleted', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('111'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '2')
+                    );
+                    const insert2 = atom(
+                        atomId('a', 5),
+                        value1,
+                        insertOp(2, '3')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 6, 1),
+                        value1,
+                        deleteOp(1, 2)
+                    );
+                    const delete2 = atom(
+                        atomId('a', 7, 1),
+                        value1,
+                        deleteOp(2, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [
+                        bot1,
+                        tag1,
+                        value1,
+                        insert1,
+                        insert2,
+                        delete1,
+                    ]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '1231',
+                            },
+                        },
+                    });
+
+                    let u = reduce(weave, weave.insert(delete2), update, space);
+                    state = apply(state, u);
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '123',
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '123',
+                            },
+                        },
+                    });
+                });
             });
 
             describe('TagMask', () => {

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.spec.ts
@@ -2310,6 +2310,51 @@ describe('AuxWeaveReducer', () => {
                         },
                     });
                 });
+
+                it('should handle deletes for a value that was split by an insert', () => {
+                    const bot1 = atom(atomId('a', 1), null, bot('test'));
+                    const tag1 = atom(atomId('a', 2), bot1, tag('abc'));
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '111')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 5, 1),
+                        value1,
+                        deleteOp(0, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [bot1, tag1, value1, insert1, delete1]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '111',
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            id: 'test',
+                            tags: {
+                                abc: '111',
+                            },
+                        },
+                    });
+                });
             });
 
             describe('TagMask', () => {
@@ -3589,6 +3634,56 @@ describe('AuxWeaveReducer', () => {
                             masks: {
                                 [space]: {
                                     abc: 'df',
+                                },
+                            },
+                        },
+                    });
+                });
+
+                it('should handle deletes for a value that was split by an insert', () => {
+                    const tag1 = atom(
+                        atomId('a', 2),
+                        null,
+                        tagMask('test', 'abc')
+                    );
+                    const value1 = atom(atomId('a', 3), tag1, value('def'));
+                    const insert1 = atom(
+                        atomId('a', 4),
+                        value1,
+                        insertOp(1, '111')
+                    );
+                    const delete1 = atom(
+                        atomId('a', 5, 1),
+                        value1,
+                        deleteOp(0, 3)
+                    );
+
+                    let update = {} as PartialBotsState;
+                    for (let atom of [tag1, value1, insert1, delete1]) {
+                        let u = reduce(
+                            weave,
+                            weave.insert(atom),
+                            update,
+                            space
+                        );
+                        state = apply(state, u);
+                    }
+
+                    expect(update).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '111',
+                                },
+                            },
+                        },
+                    });
+
+                    expect(state).toEqual({
+                        ['test']: {
+                            masks: {
+                                [space]: {
+                                    abc: '111',
                                 },
                             },
                         },

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -51,7 +51,6 @@ import {
     preserve,
     TagEditOp,
 } from './AuxStateHelpers';
-import { exist } from '@hapi/joi';
 
 export const CERT_ID_NAMESPACE = 'a1307e2b-8d80-4945-9792-2cd483c45e24';
 export const CERTIFIED_SPACE = 'certified';

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -303,7 +303,7 @@ function insertAtomAddedReducer(
                     [tagName]: mergeEdits(
                         possibleEdit,
                         edit(
-                            atom.id.timestamp,
+                            { [atom.id.site]: atom.id.timestamp },
                             preserve(count),
                             insert(op.text)
                         )
@@ -316,7 +316,7 @@ function insertAtomAddedReducer(
             [id]: {
                 tags: {
                     [tagName]: edit(
-                        atom.id.timestamp,
+                        { [atom.id.site]: atom.id.timestamp },
                         preserve(count),
                         insert(op.text)
                     ),
@@ -391,7 +391,7 @@ function deleteTextReducer(
                         [tagName]: mergeEdits(
                             possibleEdit,
                             edit(
-                                atom.id.timestamp,
+                                { [atom.id.site]: atom.id.timestamp },
                                 preserve(count),
                                 del(length)
                             )
@@ -404,7 +404,7 @@ function deleteTextReducer(
                 [id]: {
                     tags: {
                         [tagName]: edit(
-                            atom.id.timestamp,
+                            { [atom.id.site]: atom.id.timestamp },
                             preserve(count),
                             del(length)
                         ),
@@ -946,11 +946,6 @@ function deleteBot(
     id: string,
     state: PartialBotsState
 ): PartialBotsState {
-    let nodes = [...findBotNodes(weave, id)];
-    if (nodes.length > 0) {
-        return state;
-    }
-
     lodashMerge(state, {
         [id]: null,
     });

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -41,6 +41,8 @@ import {
 } from './AuxWeaveHelpers';
 import reverse from 'lodash/reverse';
 import {
+    apply,
+    applyEdit,
     del,
     edit,
     insert,
@@ -49,6 +51,7 @@ import {
     preserve,
     TagEditOp,
 } from './AuxStateHelpers';
+import { exist } from '@hapi/joi';
 
 export const CERT_ID_NAMESPACE = 'a1307e2b-8d80-4945-9792-2cd483c45e24';
 export const CERTIFIED_SPACE = 'certified';
@@ -304,26 +307,31 @@ function insertAtomAddedReducer(
     }
     ops.push(insert(op.text));
 
-    const possibleEdit = state?.[id]?.tags?.[tagName];
-    if (isTagEdit(possibleEdit)) {
+    const existingValue = state?.[id]?.tags?.[tagName];
+    if (isTagEdit(existingValue)) {
         lodashMerge(state, {
             [id]: {
                 tags: {
                     [tagName]: mergeEdits(
-                        possibleEdit,
+                        existingValue,
                         edit({ [atom.id.site]: atom.id.timestamp }, ...ops)
                     ),
                 },
             },
         });
     } else {
+        let tagEdit = edit({ [atom.id.site]: atom.id.timestamp }, ...ops);
+
+        let finalValue: any;
+        if (hasValue(existingValue)) {
+            finalValue = applyEdit(existingValue, tagEdit);
+        } else {
+            finalValue = tagEdit;
+        }
         lodashMerge(state, {
             [id]: {
                 tags: {
-                    [tagName]: edit(
-                        { [atom.id.site]: atom.id.timestamp },
-                        ...ops
-                    ),
+                    [tagName]: finalValue,
                 },
             },
         });
@@ -377,14 +385,14 @@ function insertTagMaskAtomAddedReducer(
     }
     ops.push(insert(op.text));
 
-    const possibleEdit = state?.[id]?.masks?.[space]?.[tagName];
-    if (isTagEdit(possibleEdit)) {
+    const existingValue = state?.[id]?.masks?.[space]?.[tagName];
+    if (isTagEdit(existingValue)) {
         lodashMerge(state, {
             [id]: {
                 masks: {
                     [space]: {
                         [tagName]: mergeEdits(
-                            possibleEdit,
+                            existingValue,
                             edit({ [atom.id.site]: atom.id.timestamp }, ...ops)
                         ),
                     },
@@ -392,14 +400,19 @@ function insertTagMaskAtomAddedReducer(
             },
         });
     } else {
+        let tagEdit = edit({ [atom.id.site]: atom.id.timestamp }, ...ops);
+
+        let finalValue: any;
+        if (hasValue(existingValue)) {
+            finalValue = applyEdit(existingValue, tagEdit);
+        } else {
+            finalValue = tagEdit;
+        }
         lodashMerge(state, {
             [id]: {
                 masks: {
                     [space]: {
-                        [tagName]: edit(
-                            { [atom.id.site]: atom.id.timestamp },
-                            ...ops
-                        ),
+                        [tagName]: finalValue,
                     },
                 },
             },
@@ -489,26 +502,32 @@ function deleteTextReducer(
         }
         ops.push(del(length));
 
-        const possibleEdit = state?.[id]?.tags?.[tagName];
-        if (isTagEdit(possibleEdit)) {
+        const existingValue = state?.[id]?.tags?.[tagName];
+        if (isTagEdit(existingValue)) {
             lodashMerge(state, {
                 [id]: {
                     tags: {
                         [tagName]: mergeEdits(
-                            possibleEdit,
+                            existingValue,
                             edit({ [atom.id.site]: atom.id.timestamp }, ...ops)
                         ),
                     },
                 },
             });
         } else {
+            const tagEdit = edit({ [atom.id.site]: atom.id.timestamp }, ...ops);
+
+            let finalValue: any;
+            if (hasValue(existingValue)) {
+                finalValue = applyEdit(existingValue, tagEdit);
+            } else {
+                finalValue = tagEdit;
+            }
+
             lodashMerge(state, {
                 [id]: {
                     tags: {
-                        [tagName]: edit(
-                            { [atom.id.site]: atom.id.timestamp },
-                            ...ops
-                        ),
+                        [tagName]: finalValue,
                     },
                 },
             });
@@ -573,14 +592,14 @@ function deleteTagMaskTextReducer(
         }
         ops.push(del(length));
 
-        const possibleEdit = state?.[id]?.masks?.[space]?.[tagName];
-        if (isTagEdit(possibleEdit)) {
+        const existingValue = state?.[id]?.masks?.[space]?.[tagName];
+        if (isTagEdit(existingValue)) {
             lodashMerge(state, {
                 [id]: {
                     masks: {
                         [space]: {
                             [tagName]: mergeEdits(
-                                possibleEdit,
+                                existingValue,
                                 edit(
                                     { [atom.id.site]: atom.id.timestamp },
                                     ...ops
@@ -591,14 +610,20 @@ function deleteTagMaskTextReducer(
                 },
             });
         } else {
+            const tagEdit = edit({ [atom.id.site]: atom.id.timestamp }, ...ops);
+
+            let finalValue: any;
+            if (hasValue(existingValue)) {
+                finalValue = applyEdit(existingValue, tagEdit);
+            } else {
+                finalValue = tagEdit;
+            }
+
             lodashMerge(state, {
                 [id]: {
                     masks: {
                         [space]: {
-                            [tagName]: edit(
-                                { [atom.id.site]: atom.id.timestamp },
-                                ...ops
-                            ),
+                            [tagName]: finalValue,
                         },
                     },
                 },

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -477,7 +477,7 @@ function deleteTextReducer(
 
     const nodes = [valueNode, ...iterateCausalGroup(valueNode)];
     const filtered = nodes.filter((n) => !idEquals(n.atom.id, atom.id));
-    const edits = calculateOrderedEdits(filtered);
+    const edits = calculateOrderedEdits(filtered, true);
 
     let ops = [] as TagEditOp[];
     for (let { count, length } of findDeletePoints(
@@ -647,7 +647,7 @@ export function* findDeletePoints(
         if (idEquals(e.node.atom.id, atom.cause)) {
             // We also only care about edits that this atom affects.
             // Basically we want to filter out all edits that the delete doesn't contain.
-            if (nodeCount + e.marked.length > value.start - e.offset) {
+            if (nodeCount + e.marked.length > value.start) {
                 // Go through each character in the edit and determine
                 // if it should be deleted or if it has already been deleted.
                 for (
@@ -698,7 +698,7 @@ export function* findDeletePoints(
                 }
             }
 
-            nodeCount += e.text.length;
+            nodeCount += e.marked.length;
         }
 
         // If we created a delete point in this round then

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -287,11 +287,15 @@ function insertAtomAddedReducer(
     const edits = calculateOrderedEdits(nodes);
 
     let count = 0;
-    for (let edit of edits) {
-        if (edit.node.atom === atom) {
+
+    // NOTE: the variable cannot be named "edit" because
+    // then webpack will not compile the reference to th edit() function
+    // correctly.
+    for (let e of edits) {
+        if (e.node.atom === atom) {
             break;
         }
-        count += edit.text.length;
+        count += e.text.length;
     }
 
     let ops = [] as TagEditOp[];
@@ -356,11 +360,15 @@ function insertTagMaskAtomAddedReducer(
     const edits = calculateOrderedEdits(nodes);
 
     let count = 0;
-    for (let edit of edits) {
-        if (edit.node.atom === atom) {
+
+    // NOTE: the variable cannot be named "edit" because
+    // then webpack will not compile the reference to th edit() function
+    // correctly.
+    for (let e of edits) {
+        if (e.node.atom === atom) {
             break;
         }
-        count += edit.text.length;
+        count += e.text.length;
     }
 
     let ops = [] as TagEditOp[];

--- a/src/aux-common/aux-format-2/AuxWeaveReducer.ts
+++ b/src/aux-common/aux-format-2/AuxWeaveReducer.ts
@@ -554,7 +554,7 @@ function deleteTagMaskTextReducer(
 
     const nodes = [value, ...iterateCausalGroup(value)];
     const filtered = nodes.filter((n) => !idEquals(n.atom.id, atom.id));
-    const edits = calculateOrderedEdits(filtered);
+    const edits = calculateOrderedEdits(filtered, true);
 
     let ops = [] as TagEditOp[];
     for (let { count, length } of findDeletePoints(

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -299,6 +299,8 @@ export interface BotTags {
     ['leftWristPortalConfigBot']?: string;
     ['rightWristPortalConfigBot']?: string;
     ['editingBot']?: string;
+    cursorStartIndex?: number;
+    cursorEndIndex?: number;
     ['pagePixelWidth']?: number;
     ['pagePixelHeight']?: number;
 
@@ -1292,6 +1294,8 @@ export const KNOWN_TAGS: string[] = [
 
     'editingBot',
     'editingTag',
+    'cursorStartIndex',
+    'cursorEndIndex',
 
     'portalColor',
     'portalLocked',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -409,6 +409,8 @@ export type BotShape =
     | 'frustum'
     | 'helix'
     | 'egg'
+    | 'hex'
+    | 'cursor'
     | 'nothing';
 
 /**

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1260,6 +1260,7 @@ export const KNOWN_TAGS: string[] = [
     'inventoryCameraRotationOffsetZ',
     'pagePixelWidth',
     'pagePixelHeight',
+    'pageTitle',
 
     'mousePointerPositionX',
     'mousePointerPositionY',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1191,7 +1191,8 @@ export function getBotShape(calc: BotCalculationContext, bot: Bot): BotShape {
         shape === 'frustum' ||
         shape === 'helix' ||
         shape === 'egg' ||
-        shape === 'hex'
+        shape === 'hex' ||
+        shape === 'cursor'
     ) {
         return shape;
     }

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -910,6 +910,7 @@ export function botCalculationContextTests(
             ['egg'],
             ['helix'],
             ['hex'],
+            ['cursor'],
         ];
         const tagCases = ['auxForm', 'form'];
 

--- a/src/aux-common/partitions/AuxPartition.ts
+++ b/src/aux-common/partitions/AuxPartition.ts
@@ -12,7 +12,7 @@ import {
     User,
     Action,
     RemoteActions,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { Observable, SubscriptionLike } from 'rxjs';
 
@@ -129,7 +129,7 @@ export interface AuxPartitionBase extends SubscriptionLike {
     /**
      * Gets an observable list that resolves whenever the partition state version is updated.
      */
-    onVersionUpdated: Observable<VersionVector>;
+    onVersionUpdated: Observable<CurrentVersion>;
 
     /**
      * Gets an observable list of errors from the partition.
@@ -159,7 +159,7 @@ export interface ProxyBridgePartition extends AuxPartitionBase {
         onError?: (error: any) => void,
         onEvents?: (actions: Action[]) => void,
         onStatusUpdated?: (status: StatusUpdate) => void,
-        onVersionUpdated?: (version: VersionVector) => void
+        onVersionUpdated?: (version: CurrentVersion) => void
     ): Promise<void>;
 
     setSpace(space: string): Promise<void>;

--- a/src/aux-common/partitions/AuxPartition.ts
+++ b/src/aux-common/partitions/AuxPartition.ts
@@ -12,6 +12,7 @@ import {
     User,
     Action,
     RemoteActions,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { Observable, SubscriptionLike } from 'rxjs';
 
@@ -126,6 +127,11 @@ export interface AuxPartitionBase extends SubscriptionLike {
     onStateUpdated: Observable<StateUpdatedEvent>;
 
     /**
+     * Gets an observable list that resolves whenever the partition state version is updated.
+     */
+    onVersionUpdated: Observable<VersionVector>;
+
+    /**
      * Gets an observable list of errors from the partition.
      */
     onError: Observable<any>;
@@ -152,7 +158,8 @@ export interface ProxyBridgePartition extends AuxPartitionBase {
         onStateUpdated?: (state: StateUpdatedEvent) => void,
         onError?: (error: any) => void,
         onEvents?: (actions: Action[]) => void,
-        onStatusUpdated?: (status: StatusUpdate) => void
+        onStatusUpdated?: (status: StatusUpdate) => void,
+        onVersionUpdated?: (version: VersionVector) => void
     ): Promise<void>;
 
     setSpace(space: string): Promise<void>;

--- a/src/aux-common/partitions/BotPartition.ts
+++ b/src/aux-common/partitions/BotPartition.ts
@@ -11,7 +11,7 @@ import {
     BotPartitionConfig,
     SearchPartitionClientConfig,
 } from './AuxPartitionConfig';
-import { Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import {
     DeviceAction,
     StatusUpdate,
@@ -20,6 +20,7 @@ import {
     SESSION_ID_CLAIM,
     USER_ROLE,
     Action,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { startWith } from 'rxjs/operators';
 import flatMap from 'lodash/flatMap';
@@ -63,6 +64,7 @@ export class BotPartitionImpl implements BotPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onStateUpdated = new Subject<StateUpdatedEvent>();
+    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
     private _onError = new Subject<any>();
     private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
@@ -95,6 +97,10 @@ export class BotPartitionImpl implements BotPartition {
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {

--- a/src/aux-common/partitions/BotPartition.ts
+++ b/src/aux-common/partitions/BotPartition.ts
@@ -20,7 +20,7 @@ import {
     SESSION_ID_CLAIM,
     USER_ROLE,
     Action,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { startWith } from 'rxjs/operators';
 import flatMap from 'lodash/flatMap';
@@ -64,7 +64,10 @@ export class BotPartitionImpl implements BotPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onStateUpdated = new Subject<StateUpdatedEvent>();
-    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    private _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+        currentSite: null,
+        vector: {},
+    });
     private _onError = new Subject<any>();
     private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
@@ -99,7 +102,7 @@ export class BotPartitionImpl implements BotPartition {
         );
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 

--- a/src/aux-common/partitions/CausalRepoPartition.ts
+++ b/src/aux-common/partitions/CausalRepoPartition.ts
@@ -3,9 +3,10 @@ import {
     StatusUpdate,
     Action,
     RemoteActions,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { AuxCausalTree, auxTree, applyEvents } from '../aux-format-2';
-import { Observable, Subscription, Subject } from 'rxjs';
+import { Observable, Subscription, Subject, BehaviorSubject } from 'rxjs';
 import {
     CausalRepoPartition,
     AuxPartitionRealtimeStrategy,
@@ -51,6 +52,7 @@ export class CausalRepoPartitionImpl implements CausalRepoPartition {
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
+    protected _onVersionUpdated = new BehaviorSubject<VersionVector>({});
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -81,6 +83,10 @@ export class CausalRepoPartitionImpl implements CausalRepoPartition {
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this._tree.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {
@@ -204,6 +210,7 @@ export class CausalRepoPartitionImpl implements CausalRepoPartition {
             update.updatedBots.length > 0
         ) {
             this._onStateUpdated.next(update);
+            this._onVersionUpdated.next(this._tree.version);
         }
 
         if (actions && actions.length > 0) {

--- a/src/aux-common/partitions/MemoryPartition.ts
+++ b/src/aux-common/partitions/MemoryPartition.ts
@@ -20,8 +20,12 @@ import {
     PartialBotsState,
     BotSpace,
 } from '../bots';
-import { Observable, Subject } from 'rxjs';
-import { StatusUpdate, Action } from '@casual-simulation/causal-trees';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import {
+    StatusUpdate,
+    Action,
+    VersionVector,
+} from '@casual-simulation/causal-trees';
 import { startWith } from 'rxjs/operators';
 import flatMap from 'lodash/flatMap';
 import union from 'lodash/union';
@@ -50,6 +54,7 @@ class MemoryPartitionImpl implements MemoryPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onStateUpdated = new Subject<StateUpdatedEvent>();
+    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
     private _onError = new Subject<any>();
     private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
@@ -79,6 +84,10 @@ class MemoryPartitionImpl implements MemoryPartition {
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {

--- a/src/aux-common/partitions/MemoryPartition.ts
+++ b/src/aux-common/partitions/MemoryPartition.ts
@@ -49,7 +49,7 @@ export function createMemoryPartition(
     return undefined;
 }
 
-class MemoryPartitionImpl implements MemoryPartition {
+export class MemoryPartitionImpl implements MemoryPartition {
     private _onBotsAdded = new Subject<Bot[]>();
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();

--- a/src/aux-common/partitions/MemoryPartition.ts
+++ b/src/aux-common/partitions/MemoryPartition.ts
@@ -24,7 +24,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import {
     StatusUpdate,
     Action,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { startWith } from 'rxjs/operators';
 import flatMap from 'lodash/flatMap';
@@ -54,7 +54,10 @@ export class MemoryPartitionImpl implements MemoryPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onStateUpdated = new Subject<StateUpdatedEvent>();
-    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    private _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+        currentSite: null,
+        vector: {},
+    });
     private _onError = new Subject<any>();
     private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
@@ -86,7 +89,7 @@ export class MemoryPartitionImpl implements MemoryPartition {
         );
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 

--- a/src/aux-common/partitions/OtherPlayersPartition.ts
+++ b/src/aux-common/partitions/OtherPlayersPartition.ts
@@ -17,7 +17,7 @@ import {
 } from '@casual-simulation/causal-trees';
 import {
     CausalRepoClient,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees/core2';
 import {
     OtherPlayersPartition,
@@ -75,7 +75,10 @@ export class OtherPlayersPartitionImpl implements OtherPlayersPartition {
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
-    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    private _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+        currentSite: null,
+        vector: {},
+    });
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -144,7 +147,7 @@ export class OtherPlayersPartitionImpl implements OtherPlayersPartition {
         );
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 

--- a/src/aux-common/partitions/OtherPlayersPartition.ts
+++ b/src/aux-common/partitions/OtherPlayersPartition.ts
@@ -15,7 +15,10 @@ import {
     SESSION_ID_CLAIM,
     RemoteActions,
 } from '@casual-simulation/causal-trees';
-import { CausalRepoClient } from '@casual-simulation/causal-trees/core2';
+import {
+    CausalRepoClient,
+    VersionVector,
+} from '@casual-simulation/causal-trees/core2';
 import {
     OtherPlayersPartition,
     AuxPartitionRealtimeStrategy,
@@ -44,7 +47,7 @@ import {
     isBot,
     PartialBotsState,
 } from '../bots';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { skip, startWith } from 'rxjs/operators';
 import { createCausalRepoClientPartition } from './RemoteCausalRepoPartition';
 import sortBy from 'lodash/sortBy';
@@ -72,6 +75,7 @@ export class OtherPlayersPartitionImpl implements OtherPlayersPartition {
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
+    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -138,6 +142,10 @@ export class OtherPlayersPartitionImpl implements OtherPlayersPartition {
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {

--- a/src/aux-common/partitions/ProxyBridgePartition.ts
+++ b/src/aux-common/partitions/ProxyBridgePartition.ts
@@ -6,6 +6,7 @@ import {
     StatusUpdate,
     Action,
     RemoteActions,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { Bot, UpdatedBot, BotAction, StateUpdatedEvent } from '../bots';
 import { Observable, Subscription } from 'rxjs';
@@ -39,6 +40,10 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
     }
     get onStatusUpdated(): Observable<StatusUpdate> {
         return this._partition.onStatusUpdated;
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._partition.onVersionUpdated;
     }
 
     get space(): string {
@@ -90,7 +95,8 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
         onStateUpdated?: (update: StateUpdatedEvent) => void,
         onError?: (error: any) => void,
         onEvents?: (actions: Action[]) => void,
-        onStatusUpdated?: (status: StatusUpdate) => void
+        onStatusUpdated?: (status: StatusUpdate) => void,
+        onVersionUpdated?: (version: VersionVector) => void
     ): Promise<void> {
         if (onBotsAdded) {
             this._sub.add(
@@ -126,6 +132,13 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
             this._sub.add(
                 this.onStatusUpdated.subscribe((status) =>
                     onStatusUpdated(status)
+                )
+            );
+        }
+        if (onVersionUpdated) {
+            this._sub.add(
+                this.onVersionUpdated.subscribe((version) =>
+                    onVersionUpdated(version)
                 )
             );
         }

--- a/src/aux-common/partitions/ProxyBridgePartition.ts
+++ b/src/aux-common/partitions/ProxyBridgePartition.ts
@@ -6,7 +6,7 @@ import {
     StatusUpdate,
     Action,
     RemoteActions,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { Bot, UpdatedBot, BotAction, StateUpdatedEvent } from '../bots';
 import { Observable, Subscription } from 'rxjs';
@@ -42,7 +42,7 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
         return this._partition.onStatusUpdated;
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._partition.onVersionUpdated;
     }
 
@@ -96,7 +96,7 @@ export class ProxyBridgePartitionImpl implements ProxyBridgePartition {
         onError?: (error: any) => void,
         onEvents?: (actions: Action[]) => void,
         onStatusUpdated?: (status: StatusUpdate) => void,
-        onVersionUpdated?: (version: VersionVector) => void
+        onVersionUpdated?: (version: CurrentVersion) => void
     ): Promise<void> {
         if (onBotsAdded) {
             this._sub.add(

--- a/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -8,8 +8,9 @@ import {
 import {
     CausalRepoClient,
     CausalRepoCommit,
+    VersionVector,
 } from '@casual-simulation/causal-trees/core2';
-import { Observable, Subscription, Subject } from 'rxjs';
+import { Observable, Subscription, Subject, BehaviorSubject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 import {
     BotAction,
@@ -61,6 +62,7 @@ export class RemoteCausalRepoHistoryPartitionImpl
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
+    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -99,6 +101,10 @@ export class RemoteCausalRepoHistoryPartitionImpl
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {

--- a/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoHistoryPartition.ts
@@ -8,7 +8,7 @@ import {
 import {
     CausalRepoClient,
     CausalRepoCommit,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees/core2';
 import { Observable, Subscription, Subject, BehaviorSubject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
@@ -62,7 +62,10 @@ export class RemoteCausalRepoHistoryPartitionImpl
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
-    private _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    private _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+        currentSite: null,
+        vector: {},
+    });
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -103,7 +106,7 @@ export class RemoteCausalRepoHistoryPartitionImpl
         );
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -20,6 +20,7 @@ import {
     CommitData,
     atomMap,
     calculateCommitDiff,
+    VersionVector,
 } from '@casual-simulation/causal-trees/core2';
 import {
     AuxCausalTree,
@@ -28,7 +29,7 @@ import {
     BotStateUpdates,
     applyAtoms,
 } from '../aux-format-2';
-import { Observable, Subscription, Subject } from 'rxjs';
+import { Observable, Subscription, Subject, BehaviorSubject } from 'rxjs';
 import { startWith, first } from 'rxjs/operators';
 import {
     BotAction,
@@ -91,6 +92,7 @@ export class RemoteCausalRepoPartitionImpl
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
+    protected _onVersionUpdated = new BehaviorSubject<VersionVector>({});
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -141,6 +143,10 @@ export class RemoteCausalRepoPartitionImpl
         return this._onStateUpdated.pipe(
             startWith(stateUpdatedEvent(this._tree.state))
         );
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     get onError(): Observable<any> {
@@ -652,6 +658,7 @@ export class RemoteCausalRepoPartitionImpl
             update.updatedBots.length > 0
         ) {
             this._onStateUpdated.next(update);
+            this._onVersionUpdated.next(this._tree.version);
         }
     }
 }

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -115,6 +115,7 @@ export class RemoteCausalRepoPartitionImpl
     private _tree: AuxCausalTree = auxTree();
     private _client: CausalRepoClient;
     private _synced: boolean;
+    private _gotInitialAtoms: boolean = false;
 
     private: boolean;
 
@@ -573,6 +574,7 @@ export class RemoteCausalRepoPartitionImpl
 
                             // Re-create the tree (and therefore weave) to reset the cardinality rules.
                             this._tree = auxTree();
+                            this._gotInitialAtoms = false;
                             this._applyAtoms(event.atoms, []);
                         }
                     },
@@ -599,8 +601,10 @@ export class RemoteCausalRepoPartitionImpl
             this._tree,
             atoms,
             removedAtoms,
-            this.space
+            this.space,
+            !this._gotInitialAtoms
         );
+        this._gotInitialAtoms = true;
         this._tree = tree;
         this._sendUpdates(updates, stateUpdatedEvent(update));
     }

--- a/src/aux-common/partitions/RemoteCausalRepoPartition.ts
+++ b/src/aux-common/partitions/RemoteCausalRepoPartition.ts
@@ -20,7 +20,8 @@ import {
     CommitData,
     atomMap,
     calculateCommitDiff,
-    VersionVector,
+    CurrentVersion,
+    treeVersion,
 } from '@casual-simulation/causal-trees/core2';
 import {
     AuxCausalTree,
@@ -92,7 +93,7 @@ export class RemoteCausalRepoPartitionImpl
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
-    protected _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    protected _onVersionUpdated: BehaviorSubject<CurrentVersion>;
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -145,7 +146,7 @@ export class RemoteCausalRepoPartitionImpl
         );
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 
@@ -199,6 +200,10 @@ export class RemoteCausalRepoPartitionImpl
         this._temporary = config.temporary;
         this._remoteEvents =
             'remoteEvents' in config ? config.remoteEvents : true;
+        this._onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+            currentSite: this._tree.site.id,
+            vector: {},
+        });
 
         // static implies read only
         this._readOnly = config.readOnly || this._static || false;
@@ -658,7 +663,7 @@ export class RemoteCausalRepoPartitionImpl
             update.updatedBots.length > 0
         ) {
             this._onStateUpdated.next(update);
-            this._onVersionUpdated.next(this._tree.version);
+            this._onVersionUpdated.next(treeVersion(this._tree));
         }
     }
 }

--- a/src/aux-common/partitions/test/PartitionTests.ts
+++ b/src/aux-common/partitions/test/PartitionTests.ts
@@ -10,7 +10,7 @@ import {
     stateUpdatedEvent,
 } from '../../bots';
 import { Subscription, never } from 'rxjs';
-import { StatusUpdate, VersionVector } from '@casual-simulation/causal-trees';
+import { CurrentVersion, StatusUpdate } from '@casual-simulation/causal-trees';
 import { waitAsync } from '../../test/TestHelpers';
 import {
     first,
@@ -31,7 +31,7 @@ export function testPartitionImplementation(
     let updated: UpdatedBot[];
     let statuses: StatusUpdate[];
     let updates: StateUpdatedEvent[];
-    let version: VersionVector;
+    let version: CurrentVersion;
     let sub: Subscription;
     beforeEach(async () => {
         sub = new Subscription();
@@ -635,7 +635,7 @@ export function testPartitionImplementation(
 
                 await waitAsync();
 
-                const editVersion = { ...version };
+                const editVersion = { ...version.vector };
                 await partition.applyEvents([
                     botUpdated('test', {
                         tags: {
@@ -653,7 +653,7 @@ export function testPartitionImplementation(
                     stateUpdatedEvent({
                         test: {
                             tags: {
-                                abc: edit(version, insert('ghi')),
+                                abc: edit(version.vector, insert('ghi')),
                             },
                         },
                     }),
@@ -671,7 +671,7 @@ export function testPartitionImplementation(
 
                 await waitAsync();
 
-                const editVersion = { ...version };
+                const editVersion = { ...version.vector };
                 await partition.applyEvents([
                     botUpdated('test', {
                         tags: {
@@ -689,7 +689,7 @@ export function testPartitionImplementation(
                     stateUpdatedEvent({
                         test: {
                             tags: {
-                                abc: edit(version, del(2)),
+                                abc: edit(version.vector, del(2)),
                             },
                         },
                     }),
@@ -882,7 +882,7 @@ export function testPartitionImplementation(
                         botUpdated('test', {
                             masks: {
                                 testSpace: {
-                                    abc: edit(version, insert('ghi')),
+                                    abc: edit(version.vector, insert('ghi')),
                                 },
                             },
                         }),
@@ -905,7 +905,10 @@ export function testPartitionImplementation(
                             test: {
                                 masks: {
                                     testSpace: {
-                                        abc: edit(version, insert('ghi')),
+                                        abc: edit(
+                                            version.vector,
+                                            insert('ghi')
+                                        ),
                                     },
                                 },
                             },
@@ -930,7 +933,7 @@ export function testPartitionImplementation(
                         botUpdated('test', {
                             masks: {
                                 testSpace: {
-                                    abc: edit(version, del(2)),
+                                    abc: edit(version.vector, del(2)),
                                 },
                             },
                         }),
@@ -953,7 +956,7 @@ export function testPartitionImplementation(
                             test: {
                                 masks: {
                                     testSpace: {
-                                        abc: edit(version, del(2)),
+                                        abc: edit(version.vector, del(2)),
                                     },
                                 },
                             },

--- a/src/aux-common/partitions/test/PartitionTests.ts
+++ b/src/aux-common/partitions/test/PartitionTests.ts
@@ -783,6 +783,56 @@ export function testPartitionImplementation(
                     }),
                 ]);
             });
+
+            const valueCases = [
+                [
+                    'numbers',
+                    123,
+                    edit({}, preserve(1), insert('abc')),
+                    '1abc23',
+                ],
+                [
+                    'booleans',
+                    true,
+                    edit({}, preserve(1), insert('abc')),
+                    'tabcrue',
+                ],
+                [
+                    'objects',
+                    { prop: 'yes' },
+                    edit({}, preserve(1), insert('abc')),
+                    '{abc"prop":"yes"}',
+                ],
+            ];
+
+            it.each(valueCases)(
+                'should support %s',
+                async (desc, initial, edit, expected) => {
+                    await partition.applyEvents([
+                        botAdded(
+                            createBot('test', {
+                                abc: initial,
+                            })
+                        ),
+                    ]);
+
+                    await waitAsync();
+
+                    await partition.applyEvents([
+                        botUpdated('test', {
+                            tags: {
+                                abc: edit,
+                            },
+                        }),
+                    ]);
+
+                    expect(partition.state).toEqual({
+                        test: createBot('test', {
+                            abc: expected,
+                        }),
+                    });
+                }
+            );
         });
 
         describe('TagMasks', () => {

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -5064,7 +5064,7 @@ describe('AuxRuntime', () => {
                             test: {
                                 tags: {
                                     abc: edit(
-                                        1,
+                                        {},
                                         preserve(1),
                                         insert('1'),
                                         del(1)
@@ -5079,7 +5079,7 @@ describe('AuxRuntime', () => {
                             test: {
                                 tags: {
                                     abc: edit(
-                                        1,
+                                        {},
                                         preserve(1),
                                         insert('1'),
                                         del(1)
@@ -5109,7 +5109,7 @@ describe('AuxRuntime', () => {
                         stateUpdatedEvent({
                             test: {
                                 tags: {
-                                    abc: edit(1, preserve(4), insert('+3')),
+                                    abc: edit({}, preserve(4), insert('+3')),
                                 },
                             },
                         })
@@ -5119,7 +5119,7 @@ describe('AuxRuntime', () => {
                         state: {
                             test: {
                                 tags: {
-                                    abc: edit(1, preserve(4), insert('+3')),
+                                    abc: edit({}, preserve(4), insert('+3')),
                                 },
                                 values: {
                                     abc: 6,
@@ -5785,7 +5785,7 @@ describe('AuxRuntime', () => {
                                     masks: {
                                         tempLocal: {
                                             abc: edit(
-                                                1,
+                                                {},
                                                 preserve(1),
                                                 insert('1'),
                                                 del(1)
@@ -5803,7 +5803,7 @@ describe('AuxRuntime', () => {
                                     masks: {
                                         tempLocal: {
                                             abc: edit(
-                                                1,
+                                                {},
                                                 preserve(1),
                                                 insert('1'),
                                                 del(1)
@@ -5843,7 +5843,7 @@ describe('AuxRuntime', () => {
                                     masks: {
                                         tempLocal: {
                                             abc: edit(
-                                                1,
+                                                {},
                                                 preserve(4),
                                                 insert('+3')
                                             ),
@@ -5860,7 +5860,7 @@ describe('AuxRuntime', () => {
                                     masks: {
                                         tempLocal: {
                                             abc: edit(
-                                                1,
+                                                {},
                                                 preserve(4),
                                                 insert('+3')
                                             ),

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -63,14 +63,14 @@ export default class PlayerHome extends Vue {
 
     @Watch('query')
     async onQueryChanged() {
-        const story = this.query['story'] as (string | string[]);
+        const story = this.query['story'] as string | string[];
         await this._setStory(story);
         for (let [sim, sub] of this._simulations) {
             getUserBotAsync(sim).subscribe(
-                bot => {
+                (bot) => {
                     this._updatePlayerTags(sim, bot);
                 },
-                err => console.error(err)
+                (err) => console.error(err)
             );
         }
     }
@@ -79,10 +79,10 @@ export default class PlayerHome extends Vue {
     async onUrlChanged() {
         for (let [sim, sub] of this._simulations) {
             getUserBotAsync(sim).subscribe(
-                bot => {
+                (bot) => {
                     this._updateUrlTag(sim, bot);
                 },
-                err => console.error(err)
+                (err) => console.error(err)
             );
         }
     }
@@ -95,12 +95,12 @@ export default class PlayerHome extends Vue {
         this.isLoading = true;
         this._simulations = new Map();
 
-        appManager.simulationManager.simulationAdded.subscribe(sim => {
+        appManager.simulationManager.simulationAdded.subscribe((sim) => {
             const sub = this._setupSimulation(sim);
             this._simulations.set(sim, sub);
         });
 
-        appManager.simulationManager.simulationRemoved.subscribe(sim => {
+        appManager.simulationManager.simulationRemoved.subscribe((sim) => {
             let sub = this._simulations.get(sim);
             if (sub) {
                 sub.unsubscribe();
@@ -109,7 +109,7 @@ export default class PlayerHome extends Vue {
 
         if (this.query) {
             // On first load check the story and load a default
-            let story = this.query['story'] as (string | string[]);
+            let story = this.query['story'] as string | string[];
             if (!hasValue(story)) {
                 // Generate a random story name
                 const randomName: string = uniqueNamesGenerator(namesConfig);
@@ -129,7 +129,7 @@ export default class PlayerHome extends Vue {
     private _setupSimulation(sim: BrowserSimulation): Subscription {
         let setInitialValues = false;
         return userBotTagsChanged(sim).subscribe(
-            update => {
+            (update) => {
                 if (!setInitialValues) {
                     setInitialValues = true;
                     this._updatePlayerTags(sim, update.bot);
@@ -149,12 +149,23 @@ export default class PlayerHome extends Vue {
                                 this._setStory(story);
                             }
                         }
+
+                        if (update.tags.has('pageTitle')) {
+                            // Title changed - update it
+                            const title = calculateStringTagValue(
+                                null,
+                                update.bot,
+                                'pageTitle',
+                                'auxPlayer'
+                            );
+                            document.title = title;
+                        }
                     }
                 }
 
                 this._sendPortalChangedEvents(sim, update);
             },
-            err => console.log(err)
+            (err) => console.log(err)
         );
     }
 
@@ -201,7 +212,7 @@ export default class PlayerHome extends Vue {
     private async _loadPrimarySimulation(newStory: string) {
         const sim = await appManager.setPrimarySimulation(newStory);
         sim.connection.syncStateChanged
-            .pipe(first(synced => synced))
+            .pipe(first((synced) => synced))
             .subscribe(() => {
                 this.isLoading = false;
             });

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -916,6 +916,7 @@ function watchModel(
                         insert(change.text),
                     ]);
                     index += change.rangeLength;
+                    offset += change.text.length;
                 }
                 await simulation.editBot(
                     bot,

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -102,8 +102,6 @@ function createHoverClass(
         content: '${label}';
         background-color: rgb(${bRed}, ${bGreen}, ${bBlue});
         color: rgb(${fRed}, ${fGreen}, ${fBlue});
-        background-color: #000;
-        color: #fff;
         border-width: 0;
         border-radius: 0;
         font-size: 12px;

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -48,6 +48,7 @@ import {
     bot,
     del,
     edit,
+    edits,
     insert,
     mergeVersions,
     preserve,
@@ -889,21 +890,22 @@ function watchModel(
                 if (applyingEdits) {
                     return;
                 }
-                let operations = [] as TagEditOp[];
+                let operations = [] as TagEditOp[][];
                 let index = 0;
                 let offset = info.isFormula || info.isScript ? 1 : 0;
-                for (let change of e.changes) {
-                    operations.push(
+                const changes = sortBy(e.changes, (c) => c.rangeOffset);
+                for (let change of changes) {
+                    operations.push([
                         preserve(change.rangeOffset - index + offset),
                         del(change.rangeLength),
-                        insert(change.text)
-                    );
+                        insert(change.text),
+                    ]);
                     index += change.rangeLength;
                 }
                 await simulation.editBot(
                     bot,
                     tag,
-                    edit(lastVersion.vector, ...operations),
+                    edits(lastVersion.vector, ...operations),
                     space
                 );
             })

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -925,26 +925,6 @@ function watchModel(
         )
     );
 
-    // sub.add(
-    //     toSubscription(
-    //         model.onDidChangeContent(async (e) => {
-    //             if (e.isFlush) {
-    //                 return;
-    //             }
-    //             let val = model.getValue();
-    //             if (info.isFormula) {
-    //                 val = '=' + val;
-    //             } else if (info.isScript) {
-    //                 if (val.indexOf('@') !== 0) {
-    //                     val = '@' + val;
-    //                 }
-    //             }
-    //             updateLanguage(model, tag, val);
-    //             await simulation.editBot(bot, tag, val, space);
-    //         })
-    //     )
-    // );
-
     sub.add(
         simulation.watcher.botsRemoved
             .pipe(

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -601,6 +601,7 @@ export function watchEditor(
             editor.onDidChangeCursorSelection((e) => {
                 const model = editor.getModel();
                 const info = models.get(model.uri.toString());
+                const dir = e.selection.getDirection();
                 const startIndex = model.getOffsetAt(
                     e.selection.getStartPosition()
                 );
@@ -608,11 +609,20 @@ export function watchEditor(
                     e.selection.getEndPosition()
                 );
 
-                let offset = info?.isScript || info?.isFormula ? 1 : 0;
+                const offset = info?.isScript || info?.isFormula ? 1 : 0;
+                let finalStartIndex = offset + startIndex;
+                let finalEndIndex = offset + endIndex;
+
+                if (dir === monaco.SelectionDirection.RTL) {
+                    const temp = finalStartIndex;
+                    finalStartIndex = finalEndIndex;
+                    finalEndIndex = temp;
+                }
+
                 simulation.helper.updateBot(simulation.helper.userBot, {
                     tags: {
-                        cursorStartIndex: offset + startIndex,
-                        cursorEndIndex: offset + endIndex,
+                        cursorStartIndex: finalStartIndex,
+                        cursorEndIndex: finalEndIndex,
                     },
                 });
             })

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -574,6 +574,9 @@ export function watchEditor(
                                 className: `bot-cursor ${colorClass}`,
                                 beforeContentClassName,
                                 afterContentClassName,
+                                stickiness:
+                                    monaco.editor.TrackedRangeStickiness
+                                        .GrowsOnlyWhenTypingAfter,
                             },
                         });
                     }

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -467,6 +467,8 @@ export function watchEditor(
                                 getBotShape(null, bot) === 'cursor'
                             ) {
                                 state[bot.id] = bot;
+                            } else {
+                                delete state[bot.id];
                             }
                         }
                     } else {

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -70,20 +70,18 @@ function createColorClass(
     backgroundColor: Color,
     alpha: number
 ): [string, string] {
+    const bRed = backgroundColor.r * 255;
+    const bGreen = backgroundColor.g * 255;
+    const bBlue = backgroundColor.b * 255;
     return [
         name,
         `.${name} {
-        background-color: rgba(${backgroundColor.r * 255}, ${
-            backgroundColor.g * 255
-        }, ${backgroundColor.b * 255}, ${alpha});
+        background-color: rgba(${bRed}, ${bGreen}, ${bBlue}, ${alpha});
     }
     
     .${name}::after {
-        border-color: rgba(${backgroundColor.r * 255}, ${
-            backgroundColor.g * 255
-        }, ${backgroundColor.b * 255}, ${alpha});
-    }
-    `,
+        border-color: rgba(${bRed}, ${bGreen}, ${bBlue}, ${alpha});
+    }`,
     ];
 }
 
@@ -93,14 +91,28 @@ function createHoverClass(
     foregroundColor: Color,
     label: string
 ): string {
+    const bRed = backgroundColor.r * 255;
+    const bGreen = backgroundColor.g * 255;
+    const bBlue = backgroundColor.b * 255;
+    const fRed = foregroundColor.r * 255;
+    const fGreen = foregroundColor.g * 255;
+    const fBlue = foregroundColor.b * 255;
     return `.${name}:hover::after {
         content: '${label}';
-        background-color: rgb(${backgroundColor.r * 255}, ${
-        backgroundColor.g * 255
-    }, ${backgroundColor.b * 255});
-        color: rgb(${foregroundColor.r * 255}, ${foregroundColor.g * 255}, ${
-        foregroundColor.b * 255
-    });
+        background-color: rgb(${bRed}, ${bGreen}, ${bBlue});
+        color: rgb(${fRed}, ${fGreen}, ${fBlue});
+        background-color: #000;
+        color: #fff;
+        border-width: 0;
+        border-radius: 0;
+        font-size: 12px;
+        line-height: 12px;
+        padding: 1px;
+        left: -2px;
+        top: -13px;
+        overflow: hidden;
+        width: auto;
+        height: auto;
     }`;
 }
 

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -424,8 +424,6 @@ export function watchSimulation(
     return sub;
 }
 
-const DECORATOR_OWNER_ID: number = 9731;
-
 export function watchEditor(
     simulation: Simulation,
     editor: monaco.editor.ICodeEditor
@@ -888,7 +886,6 @@ function watchModel(
             })
     );
 
-    // TODO:
     sub.add(
         toSubscription(
             model.onDidChangeContent(async (e) => {

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -744,6 +744,7 @@ function watchModel(
         simulation.watcher
             .botTagChanged(bot.id, tag, space)
             .pipe(
+                takeWhile((update) => update !== null),
                 tap((update) => {
                     lastVersion.vector = mergeVersions(
                         lastVersion.vector,
@@ -762,8 +763,7 @@ function watchModel(
                         )
                     );
                 }),
-                skip(1),
-                takeWhile((update) => update !== null)
+                skip(1)
             )
             .subscribe((update) => {
                 bot = update.bot;

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -470,14 +470,19 @@ function watchModel(
                     }
                     let script = getScript(bot, tag, space);
                     let value = model.getValue();
-                    if (script !== value) {
-                        model.setValue(script);
+                    try {
+                        applyingEdits = true;
+                        if (script !== value) {
+                            model.setValue(script);
+                        }
+                        updateLanguage(
+                            model,
+                            tag,
+                            getTagValueForSpace(bot, tag, space)
+                        );
+                    } finally {
+                        applyingEdits = false;
                     }
-                    updateLanguage(
-                        model,
-                        tag,
-                        getTagValueForSpace(bot, tag, space)
-                    );
                 }
             })
     );

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
@@ -65,6 +65,7 @@ export default class MonacoEditor extends Vue {
         });
         this._applyViewZones();
         this._watchSizeChanges();
+        this.$emit('editorMounted', this._editor);
     }
 
     private async _watchSizeChanges() {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
@@ -11,6 +11,10 @@ export default class MonacoEditor extends Vue {
     private _model: monaco.editor.ITextModel;
     private _resizeObserver: import('@juggle/resize-observer').ResizeObserver;
 
+    get editor() {
+        return this._editor;
+    }
+
     constructor() {
         super();
     }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditorUnscoped.css
@@ -1,3 +1,7 @@
 .monaco-editor .rename-box {
     top: 0;
 }
+
+.monaco-editor .monaco-hover {
+    top: 0;
+}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -138,7 +138,10 @@ export default class MonacoTagEditor extends Vue {
         this._sub.add(
             appManager.whileLoggedIn((user, sim) => {
                 this._simulation = sim;
-                const sub = watchSimulation(sim);
+                const sub = watchSimulation(
+                    sim,
+                    () => (<MonacoEditor>this.$refs?.editor).editor
+                );
 
                 const sub2 = sim.watcher.botsDiscovered
                     .pipe(
@@ -260,7 +263,13 @@ export default class MonacoTagEditor extends Vue {
         const space = this.space;
 
         const oldModel = this._model;
-        this._model = loadModel(this._simulation, bot, tag, space);
+        this._model = loadModel(
+            this._simulation,
+            bot,
+            tag,
+            space,
+            () => (<MonacoEditor>this.$refs?.editor).editor
+        );
         if (
             oldModel &&
             oldModel !== this._model &&

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -24,6 +24,8 @@ import {
     unloadModel,
     watchSimulation,
     setActiveModel,
+    toSubscription,
+    watchEditor,
 } from '../../MonacoHelpers';
 import * as monaco from '../../MonacoLibs';
 import { filter, tap } from 'rxjs/operators';
@@ -121,6 +123,10 @@ export default class MonacoTagEditor extends Vue {
         return false;
     }
 
+    get editor() {
+        return (<MonacoEditor>this.$refs?.editor).editor;
+    }
+
     constructor() {
         super();
         this.scriptErrors = [];
@@ -138,10 +144,7 @@ export default class MonacoTagEditor extends Vue {
         this._sub.add(
             appManager.whileLoggedIn((user, sim) => {
                 this._simulation = sim;
-                const sub = watchSimulation(
-                    sim,
-                    () => (<MonacoEditor>this.$refs?.editor).editor
-                );
+                const sub = watchSimulation(sim, () => this.editor);
 
                 const sub2 = sim.watcher.botsDiscovered
                     .pipe(
@@ -194,6 +197,10 @@ export default class MonacoTagEditor extends Vue {
 
     mounted() {
         this._updateModel();
+    }
+
+    onEditorMounted(editor: monaco.editor.IStandaloneCodeEditor) {
+        this._sub.add(watchEditor(this._simulation, editor));
     }
 
     destroyed() {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -59,7 +59,12 @@
                     </li>
                 </ul>
             </div>
-            <monaco-editor ref="editor" @focus="editorFocused" @blur="editorBlured"></monaco-editor>
+            <monaco-editor
+                ref="editor"
+                @focus="editorFocused"
+                @blur="editorBlured"
+                @editorMounted="onEditorMounted"
+            ></monaco-editor>
         </div>
     </div>
 </template>

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -70,3 +70,4 @@
 </template>
 <script src="./MonacoTagEditor.ts"></script>
 <style src="./MonacoTagEditor.css" scoped></style>
+<style src="./MonacoTagEditorUnscoped.css"></style>

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -20,18 +20,3 @@
     left: -4px;
     top: -5px;
 }
-
-.bot-cursor-notch:hover::after {
-    background-color: #000;
-    color: #fff;
-    border-width: 0;
-    border-radius: 0;
-    font-size: 12px;
-    line-height: 12px;
-    padding: 1px;
-    left: -2px;
-    top: -13px;
-    overflow: hidden;
-    width: auto;
-    height: auto;
-}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -10,12 +10,28 @@
     height: 100%;
 }
 
-/* .bot-cursor-notch::after {
+.bot-cursor-notch::after {
     position: absolute;
     content: ' ';
-    border-color: orange;
-    border: 3px solid;
+    border-color: #000;
+    border-style: solid;
+    border-width: 3px;
     border-radius: 4px;
     left: -4px;
     top: -5px;
-} */
+}
+
+.bot-cursor-notch:hover::after {
+    background-color: #000;
+    color: #fff;
+    border-width: 0;
+    border-radius: 0;
+    font-size: 12px;
+    line-height: 12px;
+    padding: 1px;
+    left: -2px;
+    top: -13px;
+    overflow: hidden;
+    width: auto;
+    height: auto;
+}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -1,5 +1,5 @@
 .bot-cursor {
-    background-color: rgba(255, 0, 0, 0.5);
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 .bot-cursor-notch {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -1,0 +1,3 @@
+.bot-cursor {
+    background-color: rgba(255, 0, 0, 0.5);
+}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -1,3 +1,21 @@
 .bot-cursor {
     background-color: rgba(255, 0, 0, 0.5);
 }
+
+.bot-cursor-notch {
+    position: absolute;
+    border-style: solid;
+    border-color: rgba(0, 0, 0, 0.1);
+    border-width: 2px 0 2px 2px;
+    height: 100%;
+}
+
+/* .bot-cursor-notch::after {
+    position: absolute;
+    content: ' ';
+    border-color: orange;
+    border: 3px solid;
+    border-radius: 4px;
+    left: -4px;
+    top: -5px;
+} */

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -1,6 +1,5 @@
 .bot-cursor {
     background-color: rgba(255, 0, 0, 0.5);
-    min-width: 8px;
 }
 
 .bot-cursor-notch {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditorUnscoped.css
@@ -1,5 +1,6 @@
 .bot-cursor {
     background-color: rgba(255, 0, 0, 0.5);
+    min-width: 8px;
 }
 
 .bot-cursor-notch {

--- a/src/aux-vm-browser/managers/BotPanelManager.spec.ts
+++ b/src/aux-vm-browser/managers/BotPanelManager.spec.ts
@@ -26,7 +26,12 @@ describe('BotPanelManager', () => {
         helper.userId = userId;
         index = new BotIndex();
 
-        watcher = new BotWatcher(helper, index, vm.stateUpdated);
+        watcher = new BotWatcher(
+            helper,
+            index,
+            vm.stateUpdated,
+            vm.versionUpdated
+        );
 
         await vm.sendEvents([
             botAdded(
@@ -42,7 +47,7 @@ describe('BotPanelManager', () => {
     describe('botsUpdated', () => {
         it('should resolve whenever a bot in the given dimension updates', async () => {
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 bots = e.bots;
             });
 
@@ -77,7 +82,7 @@ describe('BotPanelManager', () => {
 
         it('should resolve with no bots when there is no user', async () => {
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 bots = e.bots;
             });
 
@@ -101,7 +106,7 @@ describe('BotPanelManager', () => {
         it('should include all bots when the dimension is set to true', async () => {
             manager = new BotPanelManager(watcher, helper, false);
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 bots = e.bots;
             });
 
@@ -129,7 +134,7 @@ describe('BotPanelManager', () => {
         it('should include all bots when the dimension is set to id', async () => {
             manager = new BotPanelManager(watcher, helper, false);
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 bots = e.bots;
             });
 
@@ -156,7 +161,7 @@ describe('BotPanelManager', () => {
 
         it('should update when the user bot changes the viewed dimension', async () => {
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 bots = e.bots;
             });
 
@@ -184,7 +189,7 @@ describe('BotPanelManager', () => {
 
         it('should indicate whether the portal has a value', async () => {
             let hasPortal: boolean;
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 hasPortal = e.hasPortal;
             });
 
@@ -222,7 +227,7 @@ describe('BotPanelManager', () => {
 
         it('should indicate the dimension that the portal is using', async () => {
             let dimension: string;
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 dimension = e.dimension;
             });
 
@@ -261,7 +266,7 @@ describe('BotPanelManager', () => {
         it('should indicate that a single bot is selected', async () => {
             let isSingleBot = false;
             let bots: PrecalculatedBot[];
-            manager.botsUpdated.subscribe(e => {
+            manager.botsUpdated.subscribe((e) => {
                 isSingleBot = e.isSingleBot;
                 bots = e.bots;
             });

--- a/src/aux-vm-browser/managers/BrowserSimulationCalculations.spec.ts
+++ b/src/aux-vm-browser/managers/BrowserSimulationCalculations.spec.ts
@@ -42,7 +42,12 @@ describe('BrowserSimulationCalculations', () => {
         helper = new BotHelper(vm);
         helper.userId = userId;
         index = new BotIndex();
-        watcher = new BotWatcher(helper, index, vm.stateUpdated);
+        watcher = new BotWatcher(
+            helper,
+            index,
+            vm.stateUpdated,
+            vm.versionUpdated
+        );
     });
 
     describe('userBotChangedCore()', () => {
@@ -77,7 +82,7 @@ describe('BrowserSimulationCalculations', () => {
             let update: UpdatedBotInfo = null;
             userBotChangedCore(login, watcher)
                 .pipe(first())
-                .subscribe(u => (update = u));
+                .subscribe((u) => (update = u));
 
             await helper.createBot(userId, {
                 test: 'abc',
@@ -107,7 +112,7 @@ describe('BrowserSimulationCalculations', () => {
             let update: UpdatedBotInfo = null;
             userBotChangedCore(login, watcher)
                 .pipe(first())
-                .subscribe(u => (update = u));
+                .subscribe((u) => (update = u));
 
             vm.connectionStateChanged.next({
                 type: 'authentication',
@@ -181,7 +186,7 @@ describe('BrowserSimulationCalculations', () => {
                 watcher,
                 helper,
                 'auxPortal'
-            ).subscribe(bot => (update = bot));
+            ).subscribe((bot) => (update = bot));
 
             await helper.createBot(userId, {
                 auxPortalConfigBot: 'test',
@@ -221,7 +226,7 @@ describe('BrowserSimulationCalculations', () => {
                 watcher,
                 helper,
                 'auxPortal'
-            ).subscribe(bot => (update = bot));
+            ).subscribe((bot) => (update = bot));
 
             await helper.createBot(userId, {
                 auxPortalConfigBot: 'test',

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.ts
@@ -27,7 +27,7 @@ import {
 import {
     StatusUpdate,
     Action,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import flatMap from 'lodash/flatMap';
 import {
@@ -50,7 +50,10 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
-    protected _onVersionUpdated = new BehaviorSubject<VersionVector>({});
+    protected _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+        currentSite: null,
+        vector: {},
+    });
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -93,7 +96,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
         return this._onStatusUpdated;
     }
 
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
 

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.ts
@@ -24,9 +24,19 @@ import {
     BotTagMasks,
     BotTags,
 } from '@casual-simulation/aux-common';
-import { StatusUpdate, Action } from '@casual-simulation/causal-trees';
+import {
+    StatusUpdate,
+    Action,
+    VersionVector,
+} from '@casual-simulation/causal-trees';
 import flatMap from 'lodash/flatMap';
-import { Subject, Subscription, Observable, fromEventPattern } from 'rxjs';
+import {
+    Subject,
+    Subscription,
+    Observable,
+    fromEventPattern,
+    BehaviorSubject,
+} from 'rxjs';
 import { startWith, filter, map } from 'rxjs/operators';
 import pickBy from 'lodash/pickBy';
 import union from 'lodash/union';
@@ -40,6 +50,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
+    protected _onVersionUpdated = new BehaviorSubject<VersionVector>({});
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -80,6 +91,10 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
 
     get onStatusUpdated(): Observable<StatusUpdate> {
         return this._onStatusUpdated;
+    }
+
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
     }
 
     unsubscribe() {

--- a/src/aux-vm-browser/partitions/ProxyClientPartition.ts
+++ b/src/aux-vm-browser/partitions/ProxyClientPartition.ts
@@ -16,8 +16,9 @@ import {
     DeviceAction,
     StatusUpdate,
     Action,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { wrap, proxy, releaseProxy, Remote } from 'comlink';
 import { startWith } from 'rxjs/operators';
 import values from 'lodash/values';
@@ -44,6 +45,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
     private _onBotsRemoved: Subject<string[]>;
     private _onBotsUpdated: Subject<UpdatedBot[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
+    private _onVersionUpdated: BehaviorSubject<VersionVector>;
     private _onError: Subject<any>;
     private _onEvents: Subject<Action[]>;
     private _onStatusUpdated: Subject<StatusUpdate>;
@@ -78,6 +80,9 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
             startWith(stateUpdatedEvent(this.state))
         );
     }
+    get onVersionUpdated(): Observable<VersionVector> {
+        return this._onVersionUpdated;
+    }
     get onError(): Observable<any> {
         return this._onError;
     }
@@ -99,6 +104,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
         this._onBotsRemoved = new Subject<string[]>();
         this._onBotsUpdated = new Subject<UpdatedBot[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
+        this._onVersionUpdated = new BehaviorSubject<VersionVector>({});
         this._onError = new Subject<any>();
         this._onEvents = new Subject<Action[]>();
         this._onStatusUpdated = new Subject<StatusUpdate>();
@@ -115,6 +121,9 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
             proxy((error: any) => this._onError.next(error)),
             proxy((events: Action[]) => this._onEvents.next(events)),
             proxy((status: StatusUpdate) => this._onStatusUpdated.next(status)),
+            proxy((version: VersionVector) =>
+                this._onVersionUpdated.next(version)
+            ),
         ] as const;
 
         this._proxies = proxies;

--- a/src/aux-vm-browser/partitions/ProxyClientPartition.ts
+++ b/src/aux-vm-browser/partitions/ProxyClientPartition.ts
@@ -16,7 +16,7 @@ import {
     DeviceAction,
     StatusUpdate,
     Action,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { wrap, proxy, releaseProxy, Remote } from 'comlink';
@@ -45,7 +45,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
     private _onBotsRemoved: Subject<string[]>;
     private _onBotsUpdated: Subject<UpdatedBot[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
-    private _onVersionUpdated: BehaviorSubject<VersionVector>;
+    private _onVersionUpdated: BehaviorSubject<CurrentVersion>;
     private _onError: Subject<any>;
     private _onEvents: Subject<Action[]>;
     private _onStatusUpdated: Subject<StatusUpdate>;
@@ -80,7 +80,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
             startWith(stateUpdatedEvent(this.state))
         );
     }
-    get onVersionUpdated(): Observable<VersionVector> {
+    get onVersionUpdated(): Observable<CurrentVersion> {
         return this._onVersionUpdated;
     }
     get onError(): Observable<any> {
@@ -104,7 +104,10 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
         this._onBotsRemoved = new Subject<string[]>();
         this._onBotsUpdated = new Subject<UpdatedBot[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
-        this._onVersionUpdated = new BehaviorSubject<VersionVector>({});
+        this._onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+            currentSite: null,
+            vector: {},
+        });
         this._onError = new Subject<any>();
         this._onEvents = new Subject<Action[]>();
         this._onStatusUpdated = new Subject<StatusUpdate>();
@@ -121,7 +124,7 @@ export class ProxyClientPartitionImpl implements ProxyClientPartition {
             proxy((error: any) => this._onError.next(error)),
             proxy((events: Action[]) => this._onEvents.next(events)),
             proxy((status: StatusUpdate) => this._onStatusUpdated.next(status)),
-            proxy((version: VersionVector) =>
+            proxy((version: CurrentVersion) =>
                 this._onVersionUpdated.next(version)
             ),
         ] as const;

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -24,7 +24,7 @@ import {
     StatusUpdate,
     remapProgressPercent,
     DeviceAction,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import Bowser from 'bowser';
 
@@ -37,7 +37,7 @@ export class AuxVMImpl implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<VersionVector>;
+    private _versionUpdated: Subject<CurrentVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _iframe: HTMLIFrameElement;
@@ -60,7 +60,7 @@ export class AuxVMImpl implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<VersionVector>();
+        this._versionUpdated = new Subject<CurrentVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -157,7 +157,7 @@ export class AuxVMImpl implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<VersionVector> {
+    get versionUpdated(): Observable<CurrentVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -24,6 +24,7 @@ import {
     StatusUpdate,
     remapProgressPercent,
     DeviceAction,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import Bowser from 'bowser';
 
@@ -36,6 +37,7 @@ export class AuxVMImpl implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
+    private _versionUpdated: Subject<VersionVector>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _iframe: HTMLIFrameElement;
@@ -58,6 +60,7 @@ export class AuxVMImpl implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
+        this._versionUpdated = new Subject<VersionVector>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -125,13 +128,14 @@ export class AuxVMImpl implements AuxVM {
 
         let statusMapper = remapProgressPercent(0.2, 1);
         return await this._proxy.init(
-            proxy(events => this._localEvents.next(events)),
-            proxy(events => this._deviceEvents.next(events)),
-            proxy(state => this._stateUpdated.next(state)),
-            proxy(state =>
+            proxy((events) => this._localEvents.next(events)),
+            proxy((events) => this._deviceEvents.next(events)),
+            proxy((state) => this._stateUpdated.next(state)),
+            proxy((version) => this._versionUpdated.next(version)),
+            proxy((state) =>
                 this._connectionStateChanged.next(statusMapper(state))
             ),
-            proxy(err => this._onError.next(err))
+            proxy((err) => this._onError.next(err))
         );
     }
 
@@ -151,6 +155,10 @@ export class AuxVMImpl implements AuxVM {
      */
     get stateUpdated(): Observable<StateUpdatedEvent> {
         return this._stateUpdated;
+    }
+
+    get versionUpdated(): Observable<VersionVector> {
+        return this._versionUpdated;
     }
 
     async setUser(user: AuxUser): Promise<void> {

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -12,6 +12,7 @@ import {
     AuxVM,
     AuxUser,
     ChannelActionResult,
+    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import {
     AuxChannel,
@@ -37,7 +38,7 @@ export class AuxVMImpl implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<CurrentVersion>;
+    private _versionUpdated: Subject<ChannelStateVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _iframe: HTMLIFrameElement;
@@ -60,7 +61,7 @@ export class AuxVMImpl implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<CurrentVersion>();
+        this._versionUpdated = new Subject<ChannelStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -157,7 +158,7 @@ export class AuxVMImpl implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<CurrentVersion> {
+    get versionUpdated(): Observable<ChannelStateVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-deno/vm/DenoVM.ts
+++ b/src/aux-vm-deno/vm/DenoVM.ts
@@ -12,6 +12,7 @@ import {
     AuxVM,
     AuxUser,
     ChannelActionResult,
+    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import {
     AuxChannel,
@@ -23,7 +24,6 @@ import {
     StatusUpdate,
     remapProgressPercent,
     DeviceAction,
-    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { DenoWorker, polyfillMessageChannel } from 'deno-vm';
 import { URL } from 'url';
@@ -41,7 +41,7 @@ export class DenoVM implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<CurrentVersion>;
+    private _versionUpdated: Subject<ChannelStateVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _worker: DenoWorker;
@@ -63,7 +63,7 @@ export class DenoVM implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<CurrentVersion>();
+        this._versionUpdated = new Subject<ChannelStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -177,7 +177,7 @@ export class DenoVM implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<CurrentVersion> {
+    get versionUpdated(): Observable<ChannelStateVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-deno/vm/DenoVM.ts
+++ b/src/aux-vm-deno/vm/DenoVM.ts
@@ -23,6 +23,7 @@ import {
     StatusUpdate,
     remapProgressPercent,
     DeviceAction,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { DenoWorker, polyfillMessageChannel } from 'deno-vm';
 import { URL } from 'url';
@@ -40,6 +41,7 @@ export class DenoVM implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
+    private _versionUpdated: Subject<VersionVector>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _worker: DenoWorker;
@@ -61,6 +63,7 @@ export class DenoVM implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
+        this._versionUpdated = new Subject<VersionVector>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -148,6 +151,7 @@ export class DenoVM implements AuxVM {
             proxy((events) => this._localEvents.next(events)),
             proxy((events) => this._deviceEvents.next(events)),
             proxy((state) => this._stateUpdated.next(state)),
+            proxy((version) => this._versionUpdated.next(version)),
             proxy((state) =>
                 this._connectionStateChanged.next(statusMapper(state))
             ),
@@ -171,6 +175,10 @@ export class DenoVM implements AuxVM {
      */
     get stateUpdated(): Observable<StateUpdatedEvent> {
         return this._stateUpdated;
+    }
+
+    get versionUpdated(): Observable<VersionVector> {
+        return this._versionUpdated;
     }
 
     async setUser(user: AuxUser): Promise<void> {

--- a/src/aux-vm-deno/vm/DenoVM.ts
+++ b/src/aux-vm-deno/vm/DenoVM.ts
@@ -23,7 +23,7 @@ import {
     StatusUpdate,
     remapProgressPercent,
     DeviceAction,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { DenoWorker, polyfillMessageChannel } from 'deno-vm';
 import { URL } from 'url';
@@ -41,7 +41,7 @@ export class DenoVM implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<VersionVector>;
+    private _versionUpdated: Subject<CurrentVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _worker: DenoWorker;
@@ -63,7 +63,7 @@ export class DenoVM implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<VersionVector>();
+        this._versionUpdated = new Subject<CurrentVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -177,7 +177,7 @@ export class DenoVM implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<VersionVector> {
+    get versionUpdated(): Observable<CurrentVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-node/vm/AuxVMNode.ts
+++ b/src/aux-vm-node/vm/AuxVMNode.ts
@@ -3,6 +3,7 @@ import {
     AuxChannelErrorType,
     StoredAux,
     ChannelActionResult,
+    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import { Observable, Subject } from 'rxjs';
 import {
@@ -15,7 +16,6 @@ import {
     LoadingProgressCallback,
     StatusUpdate,
     DeviceAction,
-    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { AuxUser, BaseAuxChannel } from '@casual-simulation/aux-vm';
 
@@ -24,7 +24,7 @@ export class AuxVMNode implements AuxVM {
     private _localEvents: Subject<LocalActions[]>;
     private _deviceEvents: Subject<DeviceAction[]>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<CurrentVersion>;
+    private _versionUpdated: Subject<ChannelStateVersion>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -42,7 +42,7 @@ export class AuxVMNode implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<CurrentVersion> {
+    get versionUpdated(): Observable<ChannelStateVersion> {
         return this._versionUpdated;
     }
 
@@ -63,7 +63,7 @@ export class AuxVMNode implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<CurrentVersion>();
+        this._versionUpdated = new Subject<ChannelStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }

--- a/src/aux-vm-node/vm/AuxVMNode.ts
+++ b/src/aux-vm-node/vm/AuxVMNode.ts
@@ -15,7 +15,7 @@ import {
     LoadingProgressCallback,
     StatusUpdate,
     DeviceAction,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { AuxUser, BaseAuxChannel } from '@casual-simulation/aux-vm';
 
@@ -24,7 +24,7 @@ export class AuxVMNode implements AuxVM {
     private _localEvents: Subject<LocalActions[]>;
     private _deviceEvents: Subject<DeviceAction[]>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<VersionVector>;
+    private _versionUpdated: Subject<CurrentVersion>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -42,7 +42,7 @@ export class AuxVMNode implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<VersionVector> {
+    get versionUpdated(): Observable<CurrentVersion> {
         return this._versionUpdated;
     }
 
@@ -63,7 +63,7 @@ export class AuxVMNode implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<VersionVector>();
+        this._versionUpdated = new Subject<CurrentVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }

--- a/src/aux-vm-node/vm/AuxVMNode.ts
+++ b/src/aux-vm-node/vm/AuxVMNode.ts
@@ -15,6 +15,7 @@ import {
     LoadingProgressCallback,
     StatusUpdate,
     DeviceAction,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { AuxUser, BaseAuxChannel } from '@casual-simulation/aux-vm';
 
@@ -23,6 +24,7 @@ export class AuxVMNode implements AuxVM {
     private _localEvents: Subject<LocalActions[]>;
     private _deviceEvents: Subject<DeviceAction[]>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
+    private _versionUpdated: Subject<VersionVector>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -38,6 +40,10 @@ export class AuxVMNode implements AuxVM {
 
     get stateUpdated(): Observable<StateUpdatedEvent> {
         return this._stateUpdated;
+    }
+
+    get versionUpdated(): Observable<VersionVector> {
+        return this._versionUpdated;
     }
 
     get connectionStateChanged(): Observable<StatusUpdate> {
@@ -57,6 +63,7 @@ export class AuxVMNode implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
+        this._versionUpdated = new Subject<VersionVector>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -107,11 +114,12 @@ export class AuxVMNode implements AuxVM {
 
     async init(loadingCallback?: LoadingProgressCallback): Promise<void> {
         return await this._channel.initAndWait(
-            e => this._localEvents.next(e),
-            e => this._deviceEvents.next(e),
-            state => this._stateUpdated.next(state),
-            connection => this._connectionStateChanged.next(connection),
-            err => this._onError.next(err)
+            (e) => this._localEvents.next(e),
+            (e) => this._deviceEvents.next(e),
+            (state) => this._stateUpdated.next(state),
+            (version) => this._versionUpdated.next(version),
+            (connection) => this._connectionStateChanged.next(connection),
+            (err) => this._onError.next(err)
         );
     }
 

--- a/src/aux-vm/managers/BaseSimulation.ts
+++ b/src/aux-vm/managers/BaseSimulation.ts
@@ -110,7 +110,7 @@ export class BaseSimulation implements Simulation {
     }
 
     get localEvents() {
-        return this._vm.localEvents.pipe(flatMap(e => e));
+        return this._vm.localEvents.pipe(flatMap((e) => e));
     }
 
     get onError(): Observable<AuxChannelErrorType> {
@@ -118,7 +118,7 @@ export class BaseSimulation implements Simulation {
     }
 
     get deviceEvents() {
-        return this._vm.deviceEvents.pipe(flatMap(e => e));
+        return this._vm.deviceEvents.pipe(flatMap((e) => e));
     }
 
     /**
@@ -205,7 +205,7 @@ export class BaseSimulation implements Simulation {
         // during initialization.
         this._initBotWatcher();
         this._subscriptions.push(
-            this._vm.connectionStateChanged.subscribe(s => {
+            this._vm.connectionStateChanged.subscribe((s) => {
                 if (s.type === 'message') {
                     console.log(`[${s.source}] ${s.message}`);
                 }
@@ -223,7 +223,8 @@ export class BaseSimulation implements Simulation {
         this._watcher = new BotWatcher(
             this._helper,
             this._index,
-            this._vm.stateUpdated
+            this._vm.stateUpdated,
+            this._vm.versionUpdated
         );
     }
 
@@ -237,7 +238,7 @@ export class BaseSimulation implements Simulation {
     public unsubscribe() {
         this._setStatus('Dispose');
         this.closed = true;
-        this._subscriptions.forEach(s => s.unsubscribe());
+        this._subscriptions.forEach((s) => s.unsubscribe());
         this._subscriptions = [];
     }
 }

--- a/src/aux-vm/managers/BotHelper.spec.ts
+++ b/src/aux-vm/managers/BotHelper.spec.ts
@@ -65,6 +65,8 @@ describe('BotHelper', () => {
                     tags: {
                         editingBot: 'test',
                         editingTag: 'abc',
+                        cursorStartIndex: null,
+                        cursorEndIndex: null,
                     },
                 }),
             ]);

--- a/src/aux-vm/managers/BotHelper.ts
+++ b/src/aux-vm/managers/BotHelper.ts
@@ -244,6 +244,8 @@ export class BotHelper extends BaseHelper<PrecalculatedBot> {
             tags: {
                 editingBot: bot.id,
                 editingTag: tag,
+                cursorStartIndex: null,
+                cursorEndIndex: null,
             },
         });
     }

--- a/src/aux-vm/managers/BotWatcher.spec.ts
+++ b/src/aux-vm/managers/BotWatcher.spec.ts
@@ -34,7 +34,12 @@ describe('BotWatcher', () => {
 
         index = new BotIndex();
 
-        watcher = new BotWatcher(helper, index, vm.stateUpdated);
+        watcher = new BotWatcher(
+            helper,
+            index,
+            vm.stateUpdated,
+            vm.versionUpdated
+        );
     });
 
     it('should update the bot helper state', () => {
@@ -763,12 +768,14 @@ describe('BotWatcher', () => {
                     bot: createPrecalculatedBot('test', { test: 123 }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
                 {
                     type: 'update',
                     bot: createPrecalculatedBot('test', { abc: 'def' }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
             ]);
         });
@@ -800,12 +807,14 @@ describe('BotWatcher', () => {
                     bot: null,
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
                 {
                     type: 'update',
                     bot: createPrecalculatedBot('test', { abc: 'def' }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
             ]);
         });
@@ -831,6 +840,7 @@ describe('BotWatcher', () => {
                     bot: createPrecalculatedBot('test', { abc: 'def' }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
             ]);
         });
@@ -860,6 +870,7 @@ describe('BotWatcher', () => {
                     bot: createPrecalculatedBot('test', { abc: 'def' }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
                 null,
             ]);
@@ -897,6 +908,7 @@ describe('BotWatcher', () => {
                     bot: createPrecalculatedBot('test', { abc: 'def' }),
                     tag: 'abc',
                     space: null,
+                    version: {},
                 },
                 {
                     type: 'edit',
@@ -906,6 +918,7 @@ describe('BotWatcher', () => {
                     tag: 'abc',
                     space: null,
                     operations: [[preserve(1), insert('1'), del(1)]],
+                    version: {},
                 },
             ]);
         });
@@ -938,7 +951,12 @@ describe('BotWatcher', () => {
                 test: {
                     masks: {
                         shared: {
-                            abc: edit({}, preserve(1), insert('1'), del(1)),
+                            abc: edit(
+                                { a: 1 },
+                                preserve(1),
+                                insert('1'),
+                                del(1)
+                            ),
                         },
                     },
                     values: {
@@ -966,6 +984,7 @@ describe('BotWatcher', () => {
                     },
                     tag: 'abc',
                     space: 'shared',
+                    version: {},
                 },
                 {
                     type: 'edit',
@@ -985,6 +1004,7 @@ describe('BotWatcher', () => {
                     tag: 'abc',
                     space: 'shared',
                     operations: [[preserve(1), insert('1'), del(1)]],
+                    version: { a: 1 },
                 },
             ]);
         });

--- a/src/aux-vm/managers/BotWatcher.spec.ts
+++ b/src/aux-vm/managers/BotWatcher.spec.ts
@@ -262,7 +262,7 @@ describe('BotWatcher', () => {
             stateUpdatedEvent({
                 test: {
                     tags: {
-                        abc: edit(1, preserve(1), insert('p')),
+                        abc: edit({}, preserve(1), insert('p')),
                     },
                     values: {
                         abc: 'dpef',
@@ -882,7 +882,7 @@ describe('BotWatcher', () => {
             let secondUpdate = stateUpdatedEvent({
                 test: {
                     tags: {
-                        abc: edit(1, preserve(1), insert('1'), del(1)),
+                        abc: edit({}, preserve(1), insert('1'), del(1)),
                     },
                     values: {
                         abc: 'd1f',
@@ -938,7 +938,7 @@ describe('BotWatcher', () => {
                 test: {
                     masks: {
                         shared: {
-                            abc: edit(1, preserve(1), insert('1'), del(1)),
+                            abc: edit({}, preserve(1), insert('1'), del(1)),
                         },
                     },
                     values: {

--- a/src/aux-vm/managers/BotWatcher.ts
+++ b/src/aux-vm/managers/BotWatcher.ts
@@ -32,6 +32,7 @@ import {
     TagEditOp,
 } from '@casual-simulation/aux-common/aux-format-2';
 import { CurrentVersion, VersionVector } from '@casual-simulation/causal-trees';
+import { ChannelStateVersion } from '../vm/AuxChannel';
 
 /**
  * Defines an interface that contains information about an updated bot.
@@ -63,7 +64,7 @@ export class BotWatcher implements SubscriptionLike {
         string,
         { tag: string; space: string; subject: Subject<BotTagChange> }[]
     >;
-    private _lastVersion: CurrentVersion;
+    private _lastVersion: ChannelStateVersion;
 
     closed: boolean = false;
 
@@ -114,7 +115,7 @@ export class BotWatcher implements SubscriptionLike {
         helper: BotHelper,
         index: BotIndex,
         stateUpdated: Observable<StateUpdatedEvent>,
-        versionUpdated: Observable<CurrentVersion>
+        versionUpdated: Observable<ChannelStateVersion>
     ) {
         this._helper = helper;
         this._index = index;
@@ -124,7 +125,7 @@ export class BotWatcher implements SubscriptionLike {
         this._botTagsUpdatedObservable = new Subject<UpdatedBotInfo[]>();
         this._botTagUpdatedObservables = new Map();
         this._lastVersion = {
-            currentSite: null,
+            localSites: {},
             vector: {},
         };
 

--- a/src/aux-vm/managers/BotWatcher.ts
+++ b/src/aux-vm/managers/BotWatcher.ts
@@ -31,7 +31,7 @@ import {
     isTagEdit,
     TagEditOp,
 } from '@casual-simulation/aux-common/aux-format-2';
-import { VersionVector } from '@casual-simulation/causal-trees';
+import { CurrentVersion, VersionVector } from '@casual-simulation/causal-trees';
 
 /**
  * Defines an interface that contains information about an updated bot.
@@ -63,7 +63,7 @@ export class BotWatcher implements SubscriptionLike {
         string,
         { tag: string; space: string; subject: Subject<BotTagChange> }[]
     >;
-    private _lastVersion: VersionVector;
+    private _lastVersion: CurrentVersion;
 
     closed: boolean = false;
 
@@ -114,7 +114,7 @@ export class BotWatcher implements SubscriptionLike {
         helper: BotHelper,
         index: BotIndex,
         stateUpdated: Observable<StateUpdatedEvent>,
-        versionUpdated: Observable<VersionVector>
+        versionUpdated: Observable<CurrentVersion>
     ) {
         this._helper = helper;
         this._index = index;
@@ -123,7 +123,10 @@ export class BotWatcher implements SubscriptionLike {
         this._botsUpdatedObservable = new Subject<PrecalculatedBot[]>();
         this._botTagsUpdatedObservable = new Subject<UpdatedBotInfo[]>();
         this._botTagUpdatedObservables = new Map();
-        this._lastVersion = {};
+        this._lastVersion = {
+            currentSite: null,
+            vector: {},
+        };
 
         this._subs.push(
             stateUpdated
@@ -183,7 +186,7 @@ export class BotWatcher implements SubscriptionLike {
                                     bot,
                                     u.tags,
                                     null,
-                                    this._lastVersion
+                                    this._lastVersion.vector
                                 );
                             }
 
@@ -200,7 +203,7 @@ export class BotWatcher implements SubscriptionLike {
                                         bot,
                                         u.masks[space],
                                         space,
-                                        this._lastVersion
+                                        this._lastVersion.vector
                                     );
                                 }
                             }
@@ -336,7 +339,7 @@ export class BotWatcher implements SubscriptionLike {
                     bot,
                     tag,
                     space,
-                    version: _this._lastVersion,
+                    version: _this._lastVersion.vector,
                 } as BotTagChange),
                 endWith(null as BotTagChange)
             );

--- a/src/aux-vm/vm/AuxChannel.ts
+++ b/src/aux-vm/vm/AuxChannel.ts
@@ -9,6 +9,7 @@ import {
     StatusUpdate,
     DeviceAction,
     CurrentVersion,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { AuxConfig } from './AuxConfig';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
@@ -24,6 +25,23 @@ export interface AuxStatic {
      * Creates a new AUX using the given config.
      */
     new (defaultHost: string, user: AuxUser, config: AuxConfig): AuxChannel;
+}
+
+/**
+ * Defines an interface that represents the state version of a aux channel.
+ */
+export interface ChannelStateVersion {
+    /**
+     * A map of local site IDs.
+     */
+    localSites: {
+        [id: string]: boolean;
+    };
+
+    /**
+     * The current version vector.
+     */
+    vector: VersionVector;
 }
 
 /**
@@ -49,7 +67,7 @@ export interface AuxChannel extends SubscriptionLike {
     /**
      * The observable that should be triggered whenever the state version updated.
      */
-    onVersionUpdated: Observable<CurrentVersion>;
+    onVersionUpdated: Observable<ChannelStateVersion>;
 
     /**
      * The observable that should be triggered whenever the connection state changes.
@@ -73,7 +91,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: CurrentVersion) => void,
+        onVersionUpdated?: (version: ChannelStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;
@@ -90,7 +108,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: CurrentVersion) => void,
+        onVersionUpdated?: (version: ChannelStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;

--- a/src/aux-vm/vm/AuxChannel.ts
+++ b/src/aux-vm/vm/AuxChannel.ts
@@ -5,7 +5,11 @@ import {
     BotDependentInfo,
     ActionResult,
 } from '@casual-simulation/aux-common';
-import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
+import {
+    StatusUpdate,
+    DeviceAction,
+    VersionVector,
+} from '@casual-simulation/causal-trees';
 import { AuxConfig } from './AuxConfig';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { AuxUser } from '../AuxUser';
@@ -43,6 +47,11 @@ export interface AuxChannel extends SubscriptionLike {
     onStateUpdated: Observable<StateUpdatedEvent>;
 
     /**
+     * The observable that should be triggered whenever the state version updated.
+     */
+    onVersionUpdated: Observable<VersionVector>;
+
+    /**
      * The observable that should be triggered whenever the connection state changes.
      */
     onConnectionStateChanged: Observable<StatusUpdate>;
@@ -64,6 +73,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
+        onVersionUpdated?: (version: VersionVector) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;
@@ -80,6 +90,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
+        onVersionUpdated?: (version: VersionVector) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;

--- a/src/aux-vm/vm/AuxChannel.ts
+++ b/src/aux-vm/vm/AuxChannel.ts
@@ -8,7 +8,7 @@ import {
 import {
     StatusUpdate,
     DeviceAction,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { AuxConfig } from './AuxConfig';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
@@ -49,7 +49,7 @@ export interface AuxChannel extends SubscriptionLike {
     /**
      * The observable that should be triggered whenever the state version updated.
      */
-    onVersionUpdated: Observable<VersionVector>;
+    onVersionUpdated: Observable<CurrentVersion>;
 
     /**
      * The observable that should be triggered whenever the connection state changes.
@@ -73,7 +73,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: VersionVector) => void,
+        onVersionUpdated?: (version: CurrentVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;
@@ -90,7 +90,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: VersionVector) => void,
+        onVersionUpdated?: (version: CurrentVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;

--- a/src/aux-vm/vm/AuxVM.ts
+++ b/src/aux-vm/vm/AuxVM.ts
@@ -10,7 +10,7 @@ import { Initable } from '../managers/Initable';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { AuxUser } from '../AuxUser';
 import { StoredAux } from '../StoredAux';
-import { ChannelActionResult } from './AuxChannel';
+import { ChannelActionResult, ChannelStateVersion } from './AuxChannel';
 
 /**
  * Defines an interface for an AUX that is run inside a virtual machine.
@@ -39,7 +39,7 @@ export interface AuxVM extends Initable {
     /**
      * Gets the observable list of version updates from the simulation.
      */
-    versionUpdated: Observable<CurrentVersion>;
+    versionUpdated: Observable<ChannelStateVersion>;
 
     /**
      * Gets an observable that resolves whenever the connection state changes.

--- a/src/aux-vm/vm/AuxVM.ts
+++ b/src/aux-vm/vm/AuxVM.ts
@@ -4,7 +4,11 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
 } from '@casual-simulation/aux-common';
-import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
+import {
+    StatusUpdate,
+    DeviceAction,
+    VersionVector,
+} from '@casual-simulation/causal-trees';
 import { Observable } from 'rxjs';
 import { Initable } from '../managers/Initable';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
@@ -35,6 +39,11 @@ export interface AuxVM extends Initable {
      * Gets the observable list of state updates from the simulation.
      */
     stateUpdated: Observable<StateUpdatedEvent>;
+
+    /**
+     * Gets the observable list of version updates from the simulation.
+     */
+    versionUpdated: Observable<VersionVector>;
 
     /**
      * Gets an observable that resolves whenever the connection state changes.

--- a/src/aux-vm/vm/AuxVM.ts
+++ b/src/aux-vm/vm/AuxVM.ts
@@ -4,11 +4,7 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
 } from '@casual-simulation/aux-common';
-import {
-    StatusUpdate,
-    DeviceAction,
-    VersionVector,
-} from '@casual-simulation/causal-trees';
+import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
 import { Observable } from 'rxjs';
 import { Initable } from '../managers/Initable';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
@@ -43,7 +39,7 @@ export interface AuxVM extends Initable {
     /**
      * Gets the observable list of version updates from the simulation.
      */
-    versionUpdated: Observable<VersionVector>;
+    versionUpdated: Observable<CurrentVersion>;
 
     /**
      * Gets an observable that resolves whenever the connection state changes.

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -43,6 +43,7 @@ import merge from 'lodash/merge';
 import { waitAsync } from '@casual-simulation/aux-common/test/TestHelpers';
 import { Subject } from 'rxjs';
 import { cloneDeep } from 'lodash';
+import { ChannelStateVersion } from './AuxChannel';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid/v4');
@@ -400,7 +401,7 @@ describe('BaseAuxChannel', () => {
             };
             channel = new AuxChannelImpl(user, device, config);
 
-            let versions = [] as CurrentVersion[];
+            let versions = [] as ChannelStateVersion[];
 
             await channel.initAndWait();
 
@@ -416,7 +417,7 @@ describe('BaseAuxChannel', () => {
             });
 
             other.onVersionUpdated.next({
-                currentSite: null,
+                currentSite: 'b',
                 vector: {
                     b: 11,
                 },
@@ -434,15 +435,23 @@ describe('BaseAuxChannel', () => {
 
             expect(versions).toEqual([
                 {
-                    currentSite: 'a',
+                    localSites: {
+                        a: true,
+                    },
                     vector: { a: 10 },
                 },
                 {
-                    currentSite: 'a',
+                    localSites: {
+                        a: true,
+                        b: true,
+                    },
                     vector: { a: 10, b: 11 },
                 },
                 {
-                    currentSite: 'a',
+                    localSites: {
+                        a: true,
+                        b: true,
+                    },
                     vector: { a: 10, b: 11, c: 20 },
                 },
             ]);

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -32,7 +32,7 @@ import {
     DeviceInfo,
     Action,
     RemoteActions,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { StatusHelper } from './StatusHelper';
@@ -57,13 +57,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     private _hasRegisteredSubs: boolean;
     private _eventBuffer: BotAction[];
     private _hasInitialState: boolean;
-    private _version: VersionVector;
+    private _version: CurrentVersion;
 
     private _user: AuxUser;
     private _onLocalEvents: Subject<LocalActions[]>;
     private _onDeviceEvents: Subject<DeviceAction[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
-    private _onVersionUpdated: Subject<VersionVector>;
+    private _onVersionUpdated: Subject<CurrentVersion>;
     private _onConnectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -108,12 +108,15 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._onLocalEvents = new Subject<LocalActions[]>();
         this._onDeviceEvents = new Subject<DeviceAction[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
-        this._onVersionUpdated = new Subject<VersionVector>();
+        this._onVersionUpdated = new Subject<CurrentVersion>();
         this._onConnectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
         this._eventBuffer = [];
         this._hasInitialState = false;
-        this._version = {};
+        this._version = {
+            currentSite: null,
+            vector: {},
+        };
 
         this._onConnectionStateChanged.subscribe(null, (err) => {
             this._onError.next({
@@ -147,7 +150,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: VersionVector) => void,
+        onVersionUpdated?: (version: CurrentVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void> {
@@ -179,7 +182,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: VersionVector) => void,
+        onVersionUpdated?: (version: CurrentVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ) {
@@ -420,7 +423,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
             partition.onVersionUpdated
                 .pipe(
                     tap((v) => {
-                        this._version = mergeVersions(this._version, v);
+                        if (v.currentSite) {
+                            this._version.currentSite = v.currentSite;
+                        }
+                        this._version.vector = mergeVersions(
+                            this._version.vector,
+                            v.vector
+                        );
                         this._onVersionUpdated.next(this._version);
                     })
                 )

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -1,6 +1,10 @@
 import { Subject, SubscriptionLike } from 'rxjs';
 import { tap, first } from 'rxjs/operators';
-import { AuxChannel, ChannelActionResult } from './AuxChannel';
+import {
+    AuxChannel,
+    ChannelActionResult,
+    ChannelStateVersion,
+} from './AuxChannel';
 import { AuxUser } from '../AuxUser';
 import {
     LocalActions,
@@ -57,13 +61,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     private _hasRegisteredSubs: boolean;
     private _eventBuffer: BotAction[];
     private _hasInitialState: boolean;
-    private _version: CurrentVersion;
+    private _version: ChannelStateVersion;
 
     private _user: AuxUser;
     private _onLocalEvents: Subject<LocalActions[]>;
     private _onDeviceEvents: Subject<DeviceAction[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
-    private _onVersionUpdated: Subject<CurrentVersion>;
+    private _onVersionUpdated: Subject<ChannelStateVersion>;
     private _onConnectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -108,13 +112,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._onLocalEvents = new Subject<LocalActions[]>();
         this._onDeviceEvents = new Subject<DeviceAction[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
-        this._onVersionUpdated = new Subject<CurrentVersion>();
+        this._onVersionUpdated = new Subject<ChannelStateVersion>();
         this._onConnectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
         this._eventBuffer = [];
         this._hasInitialState = false;
         this._version = {
-            currentSite: null,
+            localSites: {},
             vector: {},
         };
 
@@ -150,7 +154,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: CurrentVersion) => void,
+        onVersionUpdated?: (version: ChannelStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void> {
@@ -182,7 +186,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: CurrentVersion) => void,
+        onVersionUpdated?: (version: ChannelStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ) {
@@ -424,7 +428,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
                 .pipe(
                     tap((v) => {
                         if (v.currentSite) {
-                            this._version.currentSite = v.currentSite;
+                            this._version.localSites[v.currentSite] = true;
                         }
                         this._version.vector = mergeVersions(
                             this._version.vector,

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -32,6 +32,7 @@ import {
     DeviceInfo,
     Action,
     RemoteActions,
+    VersionVector,
 } from '@casual-simulation/causal-trees';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { StatusHelper } from './StatusHelper';
@@ -39,6 +40,7 @@ import { StoredAux } from '../StoredAux';
 import pick from 'lodash/pick';
 import flatMap from 'lodash/flatMap';
 import { RealtimeEditMode } from '@casual-simulation/aux-common/runtime/RuntimeBot';
+import { mergeVersions } from '@casual-simulation/aux-common/aux-format-2';
 
 export interface AuxChannelOptions {}
 
@@ -55,11 +57,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     private _hasRegisteredSubs: boolean;
     private _eventBuffer: BotAction[];
     private _hasInitialState: boolean;
+    private _version: VersionVector;
 
     private _user: AuxUser;
     private _onLocalEvents: Subject<LocalActions[]>;
     private _onDeviceEvents: Subject<DeviceAction[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
+    private _onVersionUpdated: Subject<VersionVector>;
     private _onConnectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -73,6 +77,10 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
 
     get onStateUpdated() {
         return this._onStateUpdated;
+    }
+
+    get onVersionUpdated() {
+        return this._onVersionUpdated;
     }
 
     get onConnectionStateChanged() {
@@ -100,10 +108,12 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._onLocalEvents = new Subject<LocalActions[]>();
         this._onDeviceEvents = new Subject<DeviceAction[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
+        this._onVersionUpdated = new Subject<VersionVector>();
         this._onConnectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
         this._eventBuffer = [];
         this._hasInitialState = false;
+        this._version = {};
 
         this._onConnectionStateChanged.subscribe(null, (err) => {
             this._onError.next({
@@ -137,6 +147,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
+        onVersionUpdated?: (version: VersionVector) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void> {
@@ -145,6 +156,9 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         }
         if (onStateUpdated) {
             this.onStateUpdated.subscribe((s) => onStateUpdated(s));
+        }
+        if (onVersionUpdated) {
+            this.onVersionUpdated.subscribe((v) => onVersionUpdated(v));
         }
         if (onConnectionStateChanged) {
             this.onConnectionStateChanged.subscribe((s) =>
@@ -165,6 +179,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
+        onVersionUpdated?: (version: VersionVector) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ) {
@@ -175,6 +190,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
             onLocalEvents,
             onDeviceEvents,
             onStateUpdated,
+            onVersionUpdated,
             onConnectionStateChanged,
             onError
         );
@@ -398,6 +414,14 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
                             return;
                         }
                         this._handleStateUpdated(this._runtime.stateUpdated(e));
+                    })
+                )
+                .subscribe(null, (e: any) => console.error(e)),
+            partition.onVersionUpdated
+                .pipe(
+                    tap((v) => {
+                        this._version = mergeVersions(this._version, v);
+                        this._onVersionUpdated.next(this._version);
                     })
                 )
                 .subscribe(null, (e: any) => console.error(e))

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -24,7 +24,7 @@ import values from 'lodash/values';
 import union from 'lodash/union';
 import { AuxUser } from '../../AuxUser';
 import { StoredAux } from '../../StoredAux';
-import { ChannelActionResult } from '../../vm';
+import { ChannelActionResult, ChannelStateVersion } from '../../vm';
 
 export class TestAuxVM implements AuxVM {
     private _stateUpdated: Subject<StateUpdatedEvent>;
@@ -40,7 +40,7 @@ export class TestAuxVM implements AuxVM {
     localEvents: Observable<LocalActions[]>;
     deviceEvents: Observable<DeviceAction[]>;
     connectionStateChanged: Subject<StatusUpdate>;
-    versionUpdated: Subject<CurrentVersion>;
+    versionUpdated: Subject<ChannelStateVersion>;
     onError: Subject<AuxChannelErrorType>;
     grant: string;
     user: AuxUser;
@@ -72,7 +72,7 @@ export class TestAuxVM implements AuxVM {
         this._stateUpdated = new Subject<StateUpdatedEvent>();
         this.connectionStateChanged = new Subject<StatusUpdate>();
         this.onError = new Subject<AuxChannelErrorType>();
-        this.versionUpdated = new Subject<CurrentVersion>();
+        this.versionUpdated = new Subject<ChannelStateVersion>();
     }
 
     async shout(

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -18,7 +18,7 @@ import {
 import {
     StatusUpdate,
     DeviceAction,
-    VersionVector,
+    CurrentVersion,
 } from '@casual-simulation/causal-trees';
 import values from 'lodash/values';
 import union from 'lodash/union';
@@ -40,7 +40,7 @@ export class TestAuxVM implements AuxVM {
     localEvents: Observable<LocalActions[]>;
     deviceEvents: Observable<DeviceAction[]>;
     connectionStateChanged: Subject<StatusUpdate>;
-    versionUpdated: Subject<VersionVector>;
+    versionUpdated: Subject<CurrentVersion>;
     onError: Subject<AuxChannelErrorType>;
     grant: string;
     user: AuxUser;
@@ -72,7 +72,7 @@ export class TestAuxVM implements AuxVM {
         this._stateUpdated = new Subject<StateUpdatedEvent>();
         this.connectionStateChanged = new Subject<StatusUpdate>();
         this.onError = new Subject<AuxChannelErrorType>();
-        this.versionUpdated = new Subject<VersionVector>();
+        this.versionUpdated = new Subject<CurrentVersion>();
     }
 
     async shout(

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -15,7 +15,11 @@ import {
     BotDependentInfo,
     AuxRuntime,
 } from '@casual-simulation/aux-common';
-import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
+import {
+    StatusUpdate,
+    DeviceAction,
+    VersionVector,
+} from '@casual-simulation/causal-trees';
 import values from 'lodash/values';
 import union from 'lodash/union';
 import { AuxUser } from '../../AuxUser';
@@ -36,6 +40,7 @@ export class TestAuxVM implements AuxVM {
     localEvents: Observable<LocalActions[]>;
     deviceEvents: Observable<DeviceAction[]>;
     connectionStateChanged: Subject<StatusUpdate>;
+    versionUpdated: Subject<VersionVector>;
     onError: Subject<AuxChannelErrorType>;
     grant: string;
     user: AuxUser;
@@ -67,6 +72,7 @@ export class TestAuxVM implements AuxVM {
         this._stateUpdated = new Subject<StateUpdatedEvent>();
         this.connectionStateChanged = new Subject<StatusUpdate>();
         this.onError = new Subject<AuxChannelErrorType>();
+        this.versionUpdated = new Subject<VersionVector>();
     }
 
     async shout(

--- a/src/causal-trees/core2/CausalTree2.ts
+++ b/src/causal-trees/core2/CausalTree2.ts
@@ -10,6 +10,22 @@ import {
 import { Atom, AtomCardinality } from './Atom2';
 
 /**
+ * Defines an interface that represents the current version of a causal tree.
+ */
+export interface CurrentVersion {
+    /**
+     * The ID of the local site.
+     * Null if the local site does not have an ID.
+     */
+    currentSite: string | null;
+
+    /**
+     * The current version vector.
+     */
+    vector: VersionVector;
+}
+
+/**
  * Defines an interface that represents a map of site IDs to timestamps.
  */
 export interface VersionVector {
@@ -44,6 +60,17 @@ export function tree<T>(id?: string, time?: number): CausalTree<T> {
         version: {
             [id]: time,
         },
+    };
+}
+
+/**
+ * Gets the current version for the given tree.
+ * @param tree The tree.
+ */
+export function treeVersion<T>(tree: CausalTree<T>): CurrentVersion {
+    return {
+        currentSite: tree.site.id,
+        vector: tree.version,
     };
 }
 

--- a/src/causal-trees/core2/Weave2.ts
+++ b/src/causal-trees/core2/Weave2.ts
@@ -736,6 +736,9 @@ export function* iterateReverse<T>(start: WeaveNode<T>) {
  * @param result The weave result.
  */
 export function addedAtom(result: WeaveResult): Atom<any> {
+    if (!result) {
+        return null;
+    }
     if (result.type === 'atom_added') {
         return result.atom;
     } else if (result.type === 'conflict') {


### PR DESCRIPTION
### :rocket: Improvements

-   Added multi-user text editing.
    -   Work on shared bots when editing a tag value with the multi-line editor.
-   Added the cursor bot form.
    -   Used to add a cursor indicator to the multi-line editor.
    -   Works by setting the `form` tag to "cursor" and placing the bot in the corresponding tag portal dimension.
        -   For example, to put a cursor in the multi-line editor for the `test` tag on a bot you would set `{targetBot.id}.test` to true.
    -   Supported tags are:
        -   `color` - Specifies the color of the cursor.
        -   `label` - Specifies a label that should appear on the cursor when the mouse is hovering over it.
        -   `labelColor` - Specifies the color of the text in the cursor label.
        -   `{dimension}Start` - Specifies the index at which the cursor selection starts (Mirrors `cursorStartIndex` from the player bot).
        -   `{dimension}End` - Specifies the index at which the cursor selection ends (Mirrors `cursorEndIndex` from the player bot).
-   Added the `pageTitle`, `cursorStartIndex`, and `cursorEndIndex` tags to the player bot.
    -   `pageTitle` is used to set the title of the current browser tab.
    -   `cursorStartIndex` contains the starting index of the player's text selection inside the multi-line editor.
    -   `cursorEndIndex` contains the ending index of the player's text selection inside the multi-line editor.
    -   Note that when `cursorStartIndex` is larger than `cursorEndIndex` it means that the player has selected text from the right to the left. This is important because text will always be inserted at `cursorEndIndex`.