### PR TITLE
Add the insertTagText(), deleteTagText(), insertTagMaskText(), and deleteTagMaskText() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
     -   `cursorStartIndex` contains the starting index of the player's text selection inside the multi-line editor.
     -   `cursorEndIndex` contains the ending index of the player's text selection inside the multi-line editor.
     -   Note that when `cursorStartIndex` is larger than `cursorEndIndex` it means that the player has selected text from the right to the left. This is important because text will always be inserted at `cursorEndIndex`.
+-   Added the `insertTagText()`, `deleteTagText()`, `insertTagMaskText()`, and `deleteTagMaskText()` functions to allow scripts to work with multi-user text editing.
+    -   `insertTagText(bot, tag, index, text)` inserts the given text at the index into the given tag on the given bot.
+    -   `insertTagMaskText(bot, tag, index, text, space?)` inserts the given text at the index into the tag and bot. Optionally accepts the space of the tag mask.
+    -   `deleteTagText(bot, tag, index, deleteCount)` deletes the given number of characters at the index from the tag and bot.
+    -   `deleteTagMaskText(bot, tag, index, deleteCount, space?)` deletes the given number of characters at the index from the tag and bot. Optionally accepts the space of the tag mask.
 
 ## V1.2.21
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3803,6 +3803,118 @@ clearTagMasks(this);
 clearTagMasks(this, "local");
 ```
 
+### `insertTagText(bot, tag, index, text)`
+
+Inserts the given text into the tag at the given index.
+Useful for editing the text in a tag without interrupting other players that are editing the same tag.
+Returns the resulting raw tag value.
+
+The **first parameter** is the bot that should be edited.
+
+The **second parameter** is the tag that should be edited.
+
+The **third parameter** is the zero-based index that the text should be inserted at.
+
+The **fourth parameter** is the string of text that should be inserted.
+
+#### Examples:
+
+1. Add some text to the end of a tag.
+```
+insertTagText(bot, "myTag", tags.myTag.length, "xyz");
+```
+
+2. Add some text to the beginning of a tag.
+```
+insertTagText(bot, "myTag", 0, "abc");
+```
+
+### `insertTagMaskText(bot, tag, index, text, space?)`
+
+Inserts the given text into the tag mask at the given index.
+Useful for editing the text in a tag without interrupting other players that are editing the same tag.
+If a space is specified, then only the tag mask in that space will be changed.
+
+Returns the resulting raw tag value.
+
+The **first parameter** is the bot that should be edited.
+
+The **second parameter** is the tag that should be edited.
+
+The **third parameter** is the zero-based index that the text should be inserted at.
+
+The **fourth parameter** is the string of text that should be inserted.
+
+The **fifth parameter** is the space that the tag mask is in. If omitted, then the `tempLocal` space will be used.
+
+#### Examples:
+
+1. Add some text to the end of a tag mask.
+```
+insertTagMaskText(bot, "myTag", tags.myTag.length, "xyz");
+```
+
+2. Add some text to the beginning of a tag mask that is in the `local` space.
+```
+insertTagMaskText(bot, "myTag", 0, "abc", "local");
+```
+
+### `deleteTagText(bot, tag, index, count)`
+
+Deletes the specified number of characters from the given tag at the given index.
+Useful for editing the text in a tag without interrupting other players that are editing the same tag.
+Returns the resulting raw tag value.
+
+The **first parameter** is the bot that should be edited.
+
+The **second parameter** is the tag that should be edited.
+
+The **third parameter** is the zero-based index that the text should be deleted at.
+
+The **fourth parameter** is the number of characters that should be deleted.
+
+#### Examples:
+
+1. Delete the last two characters from a tag.
+```
+deleteTagText(bot, "myTag", tags.myTag.length - 2, 2);
+```
+
+2. Delete the first 3 characters from a tag.
+```
+deleteTagText(bot, "myTag", 0, 3);
+```
+
+### `deleteTagMaskText(bot, tag, index, count, space?)`
+
+Deletes the specified number of characters from the given tag mask at the given index.
+Useful for editing the text in a tag without interrupting other players that are editing the same tag.
+If a space is specified, then only the tag mask in that space will be changed.
+
+Returns the resulting raw tag value.
+
+The **first parameter** is the bot that should be edited.
+
+The **second parameter** is the tag that should be edited.
+
+The **third parameter** is the zero-based index that the text should be deleted at.
+
+The **fourth parameter** is the number of characters that should be deleted.
+
+The **fifth parameter** is the space that the tag mask is in. If omitted, then the `tempLocal` space will be used.
+
+#### Examples:
+
+1. Delete the last two characters from a tag mask.
+```
+deleteTagText(bot, "myTag", tags.myTag.length - 2, 2);
+```
+
+2. Delete the first 3 characters from a tag mask in the `local` space.
+```
+deleteTagText(bot, "myTag", 0, 3, "local");
+```
+
 ## Math Actions
 
 ### `math.sum(list)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3820,12 +3820,12 @@ The **fourth parameter** is the string of text that should be inserted.
 #### Examples:
 
 1. Add some text to the end of a tag.
-```
+```typescript
 insertTagText(bot, "myTag", tags.myTag.length, "xyz");
 ```
 
 2. Add some text to the beginning of a tag.
-```
+```typescript
 insertTagText(bot, "myTag", 0, "abc");
 ```
 
@@ -3850,12 +3850,12 @@ The **fifth parameter** is the space that the tag mask is in. If omitted, then t
 #### Examples:
 
 1. Add some text to the end of a tag mask.
-```
+```typescript
 insertTagMaskText(bot, "myTag", tags.myTag.length, "xyz");
 ```
 
 2. Add some text to the beginning of a tag mask that is in the `local` space.
-```
+```typescript
 insertTagMaskText(bot, "myTag", 0, "abc", "local");
 ```
 
@@ -3876,12 +3876,12 @@ The **fourth parameter** is the number of characters that should be deleted.
 #### Examples:
 
 1. Delete the last two characters from a tag.
-```
+```typescript
 deleteTagText(bot, "myTag", tags.myTag.length - 2, 2);
 ```
 
 2. Delete the first 3 characters from a tag.
-```
+```typescript
 deleteTagText(bot, "myTag", 0, 3);
 ```
 
@@ -3906,12 +3906,12 @@ The **fifth parameter** is the space that the tag mask is in. If omitted, then t
 #### Examples:
 
 1. Delete the last two characters from a tag mask.
-```
+```typescript
 deleteTagText(bot, "myTag", tags.myTag.length - 2, 2);
 ```
 
 2. Delete the first 3 characters from a tag mask in the `local` space.
-```
+```typescript
 deleteTagText(bot, "myTag", 0, 3, "local");
 ```
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1,3 +1,5 @@
+import { TagEditOp } from '../aux-format-2';
+
 export type PartialBot = Partial<Bot>;
 
 export type AuxDomain = 'builder' | 'player';
@@ -24,6 +26,11 @@ export const GET_TAG_MASK_SYMBOL = Symbol('get_tag_mask');
  * Defines a symbol that is used to get all the tag masks on a runtime bot.
  */
 export const CLEAR_TAG_MASKS_SYMBOL = Symbol('clear_tag_masks');
+
+/**
+ * Defines a symbol that is used to edit a tag or tag mask.
+ */
+export const EDIT_TAG_SYMBOL = Symbol('edit_tag');
 
 /**
  * Defines an interface for a bot in a script/formula.
@@ -89,6 +96,11 @@ export interface RuntimeBot {
      * @param space The space that the masks should be cleared from. If not specified then all tag masks in all spaces will be cleared.
      */
     [CLEAR_TAG_MASKS_SYMBOL]: (space?: string) => any;
+
+    /**
+     * A functino that can manipulate a tag or tag mask using the given edit operations.
+     */
+    [EDIT_TAG_SYMBOL]: (tag: string, space: string, ops: TagEditOp[]) => any;
 }
 
 /**

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -28,9 +28,14 @@ export const GET_TAG_MASK_SYMBOL = Symbol('get_tag_mask');
 export const CLEAR_TAG_MASKS_SYMBOL = Symbol('clear_tag_masks');
 
 /**
- * Defines a symbol that is used to edit a tag or tag mask.
+ * Defines a symbol that is used to edit a tag.
  */
 export const EDIT_TAG_SYMBOL = Symbol('edit_tag');
+
+/**
+ * Defines a symbol that is used to edit a  tag mask.
+ */
+export const EDIT_TAG_MASK_SYMBOL = Symbol('edit_tag_mask');
 
 /**
  * Defines an interface for a bot in a script/formula.
@@ -98,9 +103,18 @@ export interface RuntimeBot {
     [CLEAR_TAG_MASKS_SYMBOL]: (space?: string) => any;
 
     /**
-     * A functino that can manipulate a tag or tag mask using the given edit operations.
+     * A function that can manipulate a tag using the given edit operations.
      */
-    [EDIT_TAG_SYMBOL]: (tag: string, space: string, ops: TagEditOp[]) => any;
+    [EDIT_TAG_SYMBOL]: (tag: string, ops: TagEditOp[]) => any;
+
+    /**
+     * A function that can manipulate a tag mask using the given edit operations.
+     */
+    [EDIT_TAG_MASK_SYMBOL]: (
+        tag: string,
+        ops: TagEditOp[],
+        space: string
+    ) => any;
 }
 
 /**

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5213,9 +5213,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot1,
                 'abc',
-                'local',
                 0,
-                'hello'
+                'hello',
+                'local'
             );
 
             expect(result).toEqual('hello');
@@ -5235,9 +5235,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot2,
                 'abc',
-                'local',
                 0,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('123hello');
@@ -5257,9 +5257,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot2,
                 'abc',
-                'local',
                 2,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('he123llo');
@@ -5279,9 +5279,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot2,
                 'abc',
-                'local',
                 5,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('hello123');
@@ -5301,9 +5301,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot2,
                 'abc',
-                'local',
                 -1,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('hell123o');
@@ -5323,9 +5323,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot1,
                 'abc',
-                'local',
                 -1,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('123');
@@ -5345,9 +5345,9 @@ describe('AuxLibrary', () => {
             const result = library.api.insertTagMaskText(
                 bot2,
                 'abc',
-                'local',
                 7,
-                '123'
+                '123',
+                'local'
             );
 
             expect(result).toEqual('hello123');

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5364,6 +5364,108 @@ describe('AuxLibrary', () => {
         });
     });
 
+    describe('deleteTagText()', () => {
+        let bot1: RuntimeBot;
+        let bot2: RuntimeBot;
+
+        beforeEach(() => {
+            bot1 = createDummyRuntimeBot('test1');
+            bot2 = createDummyRuntimeBot('test2');
+
+            addToContext(context, bot1, bot2);
+
+            bot2.tags.abc = 'hello';
+            bot2[CLEAR_CHANGES_SYMBOL]();
+        });
+
+        it('should do nothing if the tag doesnt exist', () => {
+            const result = library.api.deleteTagText(bot1, 'abc', 0, 2);
+
+            expect(result).toEqual('');
+            expect(bot1.tags.abc).toBeUndefined();
+            expect(bot1.raw.abc).toBeUndefined();
+            expect(bot1.changes).toEqual({});
+        });
+
+        it('should delete the text from the start of the given tag', () => {
+            const result = library.api.deleteTagText(bot2, 'abc', 0, 2);
+
+            expect(result).toEqual('llo');
+            expect(bot2.tags.abc).toEqual('llo');
+            expect(bot2.raw.abc).toEqual('llo');
+            expect(bot2.changes).toEqual({
+                abc: edit(
+                    testScriptBotInterface.currentVersion.vector,
+                    preserve(0),
+                    del(2)
+                ),
+            });
+        });
+
+        it('should insert the text into the middle of the given tag', () => {
+            const result = library.api.deleteTagText(bot2, 'abc', 2, 2);
+
+            expect(result).toEqual('heo');
+            expect(bot2.tags.abc).toEqual('heo');
+            expect(bot2.raw.abc).toEqual('heo');
+            expect(bot2.changes).toEqual({
+                abc: edit(
+                    testScriptBotInterface.currentVersion.vector,
+                    preserve(2),
+                    del(2)
+                ),
+            });
+        });
+
+        it('should delete the text from the end of the given tag', () => {
+            const result = library.api.deleteTagText(bot2, 'abc', 3, 2);
+
+            expect(result).toEqual('hel');
+            expect(bot2.tags.abc).toEqual('hel');
+            expect(bot2.raw.abc).toEqual('hel');
+            expect(bot2.changes).toEqual({
+                abc: edit(
+                    testScriptBotInterface.currentVersion.vector,
+                    preserve(3),
+                    del(2)
+                ),
+            });
+        });
+
+        it('should allow negative numbers to delete from the end of the string', () => {
+            const result = library.api.deleteTagText(bot2, 'abc', -2, 2);
+
+            expect(result).toEqual('hel');
+            expect(bot2.tags.abc).toEqual('hel');
+            expect(bot2.raw.abc).toEqual('hel');
+            expect(bot2.changes).toEqual({
+                abc: edit(
+                    testScriptBotInterface.currentVersion.vector,
+                    preserve(3),
+                    del(2)
+                ),
+            });
+        });
+
+        it('should do nothing when using negative numbers to delete from the end of the string when the current tag value is empty', () => {
+            const result = library.api.deleteTagText(bot1, 'abc', -1, 1);
+
+            expect(result).toEqual('');
+            expect(bot1.tags.abc).toBeUndefined();
+            expect(bot1.raw.abc).toBeUndefined();
+            expect(bot1.changes).toEqual({});
+        });
+
+        it('should clamp to the end of the string', () => {
+            const result = library.api.deleteTagText(bot2, 'abc', 7, 1);
+
+            expect(result).toEqual('hello');
+            expect(bot2.tags.abc).toEqual('hello');
+            expect(bot2.raw.abc).toEqual('hello');
+            expect(bot2.changes).toEqual({});
+        });
+    });
+
     describe('removeTags()', () => {
         let bot1: RuntimeBot;
         let bot2: RuntimeBot;

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5073,6 +5073,76 @@ describe('AuxLibrary', () => {
         });
     });
 
+    describe('insertTagText()', () => {
+        let bot1: RuntimeBot;
+        let bot2: RuntimeBot;
+
+        beforeEach(() => {
+            bot1 = createDummyRuntimeBot('test1');
+            bot2 = createDummyRuntimeBot('test2');
+
+            addToContext(context, bot1, bot2);
+        });
+
+        it('should create the tag with the given text if it does not exist', () => {
+            const result = library.api.insertTagText(bot1, 'abc', 0, 'hello');
+
+            expect(result).toEqual('hello');
+            expect(bot1.tags.abc).toEqual('hello');
+            expect(bot1.raw.abc).toEqual('hello');
+        });
+
+        it('should insert the text into the start of the given tag', () => {
+            bot1.tags.abc = 'hello';
+
+            const result = library.api.insertTagText(bot1, 'abc', 0, '123');
+
+            expect(result).toEqual('123hello');
+            expect(bot1.tags.abc).toEqual('123hello');
+            expect(bot1.raw.abc).toEqual('123hello');
+        });
+
+        it('should insert the text into the middle of the given tag', () => {
+            bot1.tags.abc = 'hello';
+
+            const result = library.api.insertTagText(bot1, 'abc', 2, '123');
+
+            expect(result).toEqual('he123llo');
+            expect(bot1.tags.abc).toEqual('he123llo');
+            expect(bot1.raw.abc).toEqual('he123llo');
+        });
+
+        it('should insert the text into the end of the given tag', () => {
+            bot1.tags.abc = 'hello';
+
+            const result = library.api.insertTagText(bot1, 'abc', 5, '123');
+
+            expect(result).toEqual('hello123');
+            expect(bot1.tags.abc).toEqual('hello123');
+            expect(bot1.raw.abc).toEqual('hello123');
+        });
+
+        it('should allow negative numbers to insert from the end of the string', () => {
+            bot1.tags.abc = 'hello';
+
+            const result = library.api.insertTagText(bot1, 'abc', -1, '123');
+
+            expect(result).toEqual('hell123o');
+            expect(bot1.tags.abc).toEqual('hell123o');
+            expect(bot1.raw.abc).toEqual('hell123o');
+        });
+
+        it('should clamp to the end of the string', () => {
+            bot1.tags.abc = 'hello';
+
+            const result = library.api.insertTagText(bot1, 'abc', 7, '123');
+
+            expect(result).toEqual('hello123');
+            expect(bot1.tags.abc).toEqual('hello123');
+            expect(bot1.raw.abc).toEqual('hello123');
+        });
+    });
+
     describe('removeTags()', () => {
         let bot1: RuntimeBot;
         let bot2: RuntimeBot;

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3508,6 +3508,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
     /**
      * Inserts the given text into the given tag and space at the given index.
+     * Returns the resulting raw tag mask value.
      * @param bot The bot that should be edited.
      * @param tag The tag that should be edited.
      * @param space The space that the tag exists in.

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -175,7 +175,7 @@ import {
     verify as realVerify,
 } from '@casual-simulation/crypto';
 import { tagValueHash } from '../aux-format-2/AuxOpTypes';
-import { convertToString, insert, preserve } from '../aux-format-2';
+import { convertToString, del, insert, preserve } from '../aux-format-2';
 import { Euler, Vector3, Plane, Ray } from 'three';
 import { Runtime } from 'inspector';
 
@@ -375,6 +375,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             clearTagMasks,
             insertTagText,
             insertTagMaskText,
+            deleteTagText,
             removeTags,
             renameTag,
             applyMod,
@@ -3529,6 +3530,32 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         index = Math.max(0, Math.min(index, currentValue.length));
         bot[EDIT_TAG_SYMBOL](tag, space, [preserve(index), insert(text)]);
         return bot.masks[tag];
+    }
+
+    /**
+     * Deletes the specified number of characters from the given tag.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     */
+    function deleteTagText(
+        bot: RuntimeBot,
+        tag: string,
+        index: number,
+        count: number
+    ): string {
+        const currentValue = convertToString(bot.raw[tag]);
+        if (index < 0) {
+            index += currentValue.length;
+        }
+        index = Math.max(0, Math.min(index, currentValue.length));
+        count = Math.min(count, currentValue.length - index);
+        if (count > 0) {
+            bot[EDIT_TAG_SYMBOL](tag, null, [preserve(index), del(count)]);
+        }
+        return bot.raw[tag] || '';
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -377,6 +377,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             insertTagText,
             insertTagMaskText,
             deleteTagText,
+            deleteTagMaskText,
             removeTags,
             renameTag,
             applyMod,
@@ -3557,6 +3558,38 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             bot[EDIT_TAG_SYMBOL](tag, [preserve(index), del(count)]);
         }
         return bot.raw[tag] || '';
+    }
+
+    /**
+     * Deletes the specified number of characters from the given tag mask.
+     * Returns the resulting raw tag mask value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     * @param space The space that the tag mask exists in. If not specified then the tempLocal space will be used.
+     */
+    function deleteTagMaskText(
+        bot: RuntimeBot,
+        tag: string,
+        index: number,
+        count: number,
+        space?: string
+    ): string {
+        const currentValue = convertToString(bot.masks[tag]);
+        if (index < 0) {
+            index += currentValue.length;
+        }
+        index = Math.max(0, Math.min(index, currentValue.length));
+        count = Math.min(count, currentValue.length - index);
+        if (count > 0) {
+            bot[EDIT_TAG_MASK_SYMBOL](
+                tag,
+                [preserve(index), del(count)],
+                space
+            );
+        }
+        return bot.masks[tag] || '';
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -152,6 +152,7 @@ import {
     CLEAR_TAG_MASKS_SYMBOL,
     getBotScale,
     EDIT_TAG_SYMBOL,
+    BotSpace,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -176,6 +177,7 @@ import {
 import { tagValueHash } from '../aux-format-2/AuxOpTypes';
 import { convertToString, insert, preserve } from '../aux-format-2';
 import { Euler, Vector3, Plane, Ray } from 'three';
+import { Runtime } from 'inspector';
 
 /**
  * Defines an interface for a library of functions and values that can be used by formulas and listeners.
@@ -372,6 +374,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             setTagMask,
             clearTagMasks,
             insertTagText,
+            insertTagMaskText,
             removeTags,
             renameTag,
             applyMod,
@@ -3494,12 +3497,37 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         index: number,
         text: string
     ): string {
-        while (index < 0) {
-            const currentValue = bot.raw[tag];
-            index += convertToString(currentValue).length;
+        const currentValue = convertToString(bot.raw[tag]);
+        if (index < 0) {
+            index += currentValue.length;
         }
+        index = Math.max(0, Math.min(index, currentValue.length));
         bot[EDIT_TAG_SYMBOL](tag, null, [preserve(index), insert(text)]);
         return bot.raw[tag];
+    }
+
+    /**
+     * Inserts the given text into the given tag and space at the given index.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param space The space that the tag exists in.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     */
+    function insertTagMaskText(
+        bot: RuntimeBot,
+        tag: string,
+        space: BotSpace,
+        index: number,
+        text: string
+    ): string {
+        const currentValue = convertToString(bot.masks[tag]);
+        if (index < 0) {
+            index += currentValue.length;
+        }
+        index = Math.max(0, Math.min(index, currentValue.length));
+        bot[EDIT_TAG_SYMBOL](tag, space, [preserve(index), insert(text)]);
+        return bot.masks[tag];
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -151,6 +151,7 @@ import {
     SET_TAG_MASK_SYMBOL,
     CLEAR_TAG_MASKS_SYMBOL,
     getBotScale,
+    EDIT_TAG_SYMBOL,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -173,6 +174,7 @@ import {
     verify as realVerify,
 } from '@casual-simulation/crypto';
 import { tagValueHash } from '../aux-format-2/AuxOpTypes';
+import { convertToString, insert, preserve } from '../aux-format-2';
 import { Euler, Vector3, Plane, Ray } from 'three';
 
 /**
@@ -369,6 +371,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             setTag,
             setTagMask,
             clearTagMasks,
+            insertTagText,
             removeTags,
             renameTag,
             applyMod,
@@ -3475,6 +3478,28 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         } else if (bot && isRuntimeBot(bot)) {
             bot[CLEAR_TAG_MASKS_SYMBOL](space);
         }
+    }
+
+    /**
+     * Inserts the given text into the given tag at the given index.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     */
+    function insertTagText(
+        bot: RuntimeBot,
+        tag: string,
+        index: number,
+        text: string
+    ): string {
+        while (index < 0) {
+            const currentValue = bot.raw[tag];
+            index += convertToString(currentValue).length;
+        }
+        bot[EDIT_TAG_SYMBOL](tag, null, [preserve(index), insert(text)]);
+        return bot.raw[tag];
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -153,6 +153,7 @@ import {
     getBotScale,
     EDIT_TAG_SYMBOL,
     BotSpace,
+    EDIT_TAG_MASK_SYMBOL,
 } from '../bots';
 import sortBy from 'lodash/sortBy';
 import every from 'lodash/every';
@@ -3503,7 +3504,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             index += currentValue.length;
         }
         index = Math.max(0, Math.min(index, currentValue.length));
-        bot[EDIT_TAG_SYMBOL](tag, null, [preserve(index), insert(text)]);
+        bot[EDIT_TAG_SYMBOL](tag, [preserve(index), insert(text)]);
         return bot.raw[tag];
     }
 
@@ -3512,23 +3513,23 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Returns the resulting raw tag mask value.
      * @param bot The bot that should be edited.
      * @param tag The tag that should be edited.
-     * @param space The space that the tag exists in.
      * @param index The index that the text should be inserted at.
      * @param text The text that should be inserted.
+     * @param space The space that the tag exists in. If not specified then the tempLocal space will be used.
      */
     function insertTagMaskText(
         bot: RuntimeBot,
         tag: string,
-        space: BotSpace,
         index: number,
-        text: string
+        text: string,
+        space?: BotSpace
     ): string {
         const currentValue = convertToString(bot.masks[tag]);
         if (index < 0) {
             index += currentValue.length;
         }
         index = Math.max(0, Math.min(index, currentValue.length));
-        bot[EDIT_TAG_SYMBOL](tag, space, [preserve(index), insert(text)]);
+        bot[EDIT_TAG_MASK_SYMBOL](tag, [preserve(index), insert(text)], space);
         return bot.masks[tag];
     }
 
@@ -3553,7 +3554,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         index = Math.max(0, Math.min(index, currentValue.length));
         count = Math.min(count, currentValue.length - index);
         if (count > 0) {
-            bot[EDIT_TAG_SYMBOL](tag, null, [preserve(index), del(count)]);
+            bot[EDIT_TAG_SYMBOL](tag, [preserve(index), del(count)]);
         }
         return bot.raw[tag] || '';
     }

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2456,6 +2456,70 @@ declare global {
     function clearTagMasks(bot: Bot | Bot[], space?: BotSpace): void;
 
     /**
+     * Inserts the given text into the given tag at the given index.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     */
+    function insertTagText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        text: string
+    ): string;
+
+    /**
+     * Inserts the given text into the given tag and space at the given index.
+     * Returns the resulting raw tag mask value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     * @param space The space that the tag exists in. If not specified then the tempLocal space will be used.
+     */
+    function insertTagMaskText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        text: string,
+        space?: BotSpace
+    ): string;
+
+    /**
+     * Deletes the specified number of characters from the given tag.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     */
+    function deleteTagText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        count: number
+    ): string;
+
+    /**
+     * Deletes the specified number of characters from the given tag mask.
+     * Returns the resulting raw tag mask value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     * @param space The space that the tag mask exists in. If not specified then the tempLocal space will be used.
+     */
+    function deleteTagMaskText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        count: number,
+        space?: string
+    ): string;
+
+    /**
      * Creates a mod from declareed mod data.
      * @param bot The mod data that should be loaded.
      * @param tags The tags that should be included in the output mod.

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -8466,6 +8466,63 @@ describe('AuxRuntime', () => {
         });
     });
 
+    describe('updateTag()', () => {
+        it('should set the tag value on the bot', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        abc: 'def',
+                    }),
+                })
+            );
+
+            const bot = runtime.currentState['test'];
+            runtime.updateTag(bot, 'abc', 99);
+
+            expect(bot.tags.abc).toEqual(99);
+            expect(bot.values.abc).toEqual(99);
+            expect(runtime.getValue(bot, 'abc')).toEqual(99);
+        });
+
+        it('should be able to remove the tag by setting it to null', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        abc: 'def',
+                    }),
+                })
+            );
+
+            const bot = runtime.currentState['test'];
+            runtime.updateTag(bot, 'abc', null);
+
+            expect(bot.tags.abc).toBe(null);
+            expect(bot.values.abc).toBe(null);
+            expect(runtime.getValue(bot, 'abc')).toBe(null);
+        });
+
+        it('should support tag edits', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        abc: 'def',
+                    }),
+                })
+            );
+
+            const bot = runtime.currentState['test'];
+            runtime.updateTag(
+                bot,
+                'abc',
+                edit({}, preserve(1), insert('1'), del(1))
+            );
+
+            expect(bot.tags.abc).toEqual('d1f');
+            expect(bot.values.abc).toEqual('d1f');
+            expect(runtime.getValue(bot, 'abc')).toEqual('d1f');
+        });
+    });
+
     describe('unsubscribe()', () => {
         it('should cancel any scheduled tasks', () => {
             const test = jest.fn();

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -8521,6 +8521,30 @@ describe('AuxRuntime', () => {
             expect(bot.values.abc).toEqual('d1f');
             expect(runtime.getValue(bot, 'abc')).toEqual('d1f');
         });
+
+        it('should support multiple tag edits in a row', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        abc: 'def',
+                    }),
+                })
+            );
+
+            let bot = runtime.currentState['test'];
+            runtime.updateTag(
+                bot,
+                'abc',
+                edit({}, preserve(1), insert('1'), del(1))
+            );
+
+            bot = runtime.currentState['test'];
+            runtime.updateTag(bot, 'abc', edit({}, preserve(0), del(1)));
+
+            expect(bot.tags.abc).toEqual('1f');
+            expect(bot.values.abc).toEqual('1f');
+            expect(runtime.getValue(bot, 'abc')).toEqual('1f');
+        });
     });
 
     describe('unsubscribe()', () => {

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -29,6 +29,7 @@ import {
     applyEdit,
     del,
     edit,
+    edits,
     insert,
     isTagEdit,
     preserve,
@@ -791,6 +792,59 @@ describe('RuntimeBot', () => {
                         preserve(1),
                         insert('111'),
                         del(1)
+                    ),
+                },
+            });
+        });
+
+        it('should support multiple tag edits in a row', () => {
+            script[EDIT_TAG_SYMBOL]('abc', null, [
+                preserve(1),
+                insert('111'),
+                del(1),
+            ]);
+
+            script[EDIT_TAG_SYMBOL]('abc', null, [
+                preserve(2),
+                insert('2'),
+                del(1),
+            ]);
+
+            expect(script.tags.abc).toEqual('d121f');
+            expect(script.raw.abc).toEqual('d121f');
+            expect(script.changes.abc).toEqual(
+                edits(
+                    manager.currentVersion.vector,
+                    [preserve(1), insert('111'), del(1)],
+                    [preserve(2), insert('2'), del(1)]
+                )
+            );
+        });
+
+        it('should support multiple tag mask edits in a row', () => {
+            script[SET_TAG_MASK_SYMBOL]('abc', 'def', 'local');
+            script[CLEAR_CHANGES_SYMBOL]();
+
+            script[EDIT_TAG_SYMBOL]('abc', 'local', [
+                preserve(1),
+                insert('111'),
+                del(1),
+            ]);
+
+            script[EDIT_TAG_SYMBOL]('abc', 'local', [
+                preserve(2),
+                insert('2'),
+                del(1),
+            ]);
+
+            expect(script.masks.abc).toEqual('d121f');
+            expect(script.raw.abc).toEqual('def');
+            expect(script.maskChanges).toEqual({
+                local: {
+                    abc: edits(
+                        manager.currentVersion.vector,
+                        [preserve(1), insert('111'), del(1)],
+                        [preserve(2), insert('2'), del(1)]
                     ),
                 },
             });

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -772,6 +772,19 @@ describe('RuntimeBot', () => {
             );
         });
 
+        it('should not overwrite tag changes with edits', () => {
+            script.tags.abc = 'fun';
+            script[EDIT_TAG_SYMBOL]('abc', null, [
+                preserve(1),
+                insert('111'),
+                del(1),
+            ]);
+
+            expect(script.tags.abc).toEqual('f111n');
+            expect(script.raw.abc).toEqual('f111n');
+            expect(script.changes.abc).toEqual('f111n');
+        });
+
         it('should support editing tag masks', () => {
             script[SET_TAG_MASK_SYMBOL]('abc', 'def', 'local');
             script[CLEAR_CHANGES_SYMBOL]();
@@ -793,6 +806,25 @@ describe('RuntimeBot', () => {
                         insert('111'),
                         del(1)
                     ),
+                },
+            });
+        });
+
+        it('should not overwrite tag mask changes', () => {
+            script[SET_TAG_MASK_SYMBOL]('abc', 'def', 'local');
+
+            script[EDIT_TAG_SYMBOL]('abc', 'local', [
+                preserve(1),
+                insert('111'),
+                del(1),
+            ]);
+
+            expect(script.masks.abc).toEqual('d111f');
+            expect(script.raw.abc).toEqual('def');
+            expect(script.changes).toEqual({});
+            expect(script.maskChanges).toEqual({
+                local: {
+                    abc: 'd111f',
                 },
             });
         });

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -1,4 +1,11 @@
-import { edit, isTagEdit, mergeEdits, TagEditOp } from '../aux-format-2';
+import { upperFirst } from 'lodash';
+import {
+    applyEdit,
+    edit,
+    isTagEdit,
+    mergeEdits,
+    TagEditOp,
+} from '../aux-format-2';
 import {
     BotSpace,
     BotTags,
@@ -372,8 +379,9 @@ export function createRuntimeBot(
         if (isTagEdit(value)) {
             const currentValue = changedRawTags[tag];
             if (isTagEdit(currentValue)) {
-                changedRawTags[tag] = mergeEdits(currentValue, value);
-                return;
+                value = mergeEdits(currentValue, value);
+            } else if (hasValue(currentValue)) {
+                value = applyEdit(currentValue, value);
             }
         }
         changedRawTags[tag] = value;
@@ -388,6 +396,8 @@ export function createRuntimeBot(
                 const currentValue = changedMasks[space][tag];
                 if (isTagEdit(currentValue)) {
                     value = mergeEdits(currentValue, value);
+                } else if (hasValue(currentValue)) {
+                    value = applyEdit(currentValue, value);
                 }
             }
             changedMasks[space][tag] = value;

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -1,4 +1,4 @@
-import { edit, TagEditOp } from '../aux-format-2';
+import { edit, isTagEdit, mergeEdits, TagEditOp } from '../aux-format-2';
 import {
     BotSpace,
     BotTags,
@@ -95,9 +95,9 @@ export function createRuntimeBot(
             const mode = manager.updateTag(bot, key, value);
             if (mode === RealtimeEditMode.Immediate) {
                 rawTags[key] = value;
-                changedRawTags[key] = value;
+                changeTag(key, value);
             } else if (mode === RealtimeEditMode.Delayed) {
-                changedRawTags[key] = value;
+                changeTag(key, value);
             }
             return true;
         },
@@ -109,9 +109,9 @@ export function createRuntimeBot(
             const mode = manager.updateTag(bot, key, value);
             if (mode === RealtimeEditMode.Immediate) {
                 rawTags[key] = value;
-                changedRawTags[key] = value;
+                changeTag(key, value);
             } else if (mode === RealtimeEditMode.Delayed) {
-                changedRawTags[key] = value;
+                changeTag(key, value);
             }
             return true;
         },
@@ -141,9 +141,9 @@ export function createRuntimeBot(
             const mode = manager.updateTag(bot, key, value);
             if (mode === RealtimeEditMode.Immediate) {
                 rawTags[key] = value;
-                changedRawTags[key] = value;
+                changeTag(key, value);
             } else if (mode === RealtimeEditMode.Delayed) {
-                changedRawTags[key] = value;
+                changeTag(key, value);
             }
             return true;
         },
@@ -155,9 +155,9 @@ export function createRuntimeBot(
             const mode = manager.updateTag(bot, key, value);
             if (mode === RealtimeEditMode.Immediate) {
                 rawTags[key] = value;
-                changedRawTags[key] = value;
+                changeTag(key, value);
             } else if (mode === RealtimeEditMode.Delayed) {
-                changedRawTags[key] = value;
+                changeTag(key, value);
             }
             return true;
         },
@@ -368,10 +368,27 @@ export function createRuntimeBot(
 
     return script;
 
-    function changeTagMask(tag: string, value: string, spaces: string[]) {
+    function changeTag(tag: string, value: any) {
+        if (isTagEdit(value)) {
+            const currentValue = changedRawTags[tag];
+            if (isTagEdit(currentValue)) {
+                changedRawTags[tag] = mergeEdits(currentValue, value);
+                return;
+            }
+        }
+        changedRawTags[tag] = value;
+    }
+
+    function changeTagMask(tag: string, value: any, spaces: string[]) {
         for (let space of spaces) {
             if (!changedMasks[space]) {
                 changedMasks[space] = {};
+            }
+            if (isTagEdit(value)) {
+                const currentValue = changedMasks[space][tag];
+                if (isTagEdit(currentValue)) {
+                    value = mergeEdits(currentValue, value);
+                }
             }
             changedMasks[space][tag] = value;
         }

--- a/src/aux-common/runtime/RuntimeStateVersion.ts
+++ b/src/aux-common/runtime/RuntimeStateVersion.ts
@@ -1,0 +1,18 @@
+import { VersionVector } from '@casual-simulation/causal-trees';
+
+/**
+ * Defines an interface that represents the state version of a aux runtime.
+ */
+export interface RuntimeStateVersion {
+    /**
+     * A map of local site IDs.
+     */
+    localSites: {
+        [id: string]: boolean;
+    };
+
+    /**
+     * The current version vector.
+     */
+    vector: VersionVector;
+}

--- a/src/aux-common/runtime/index.ts
+++ b/src/aux-common/runtime/index.ts
@@ -5,5 +5,6 @@ export * from './Dependencies';
 export * from './Transpiler';
 export * from './AuxDevice';
 export * from './AuxVersion';
+export * from './RuntimeStateVersion';
 export * from './AuxRealtimeEditModeProvider';
 export * from './Utils';

--- a/src/aux-common/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-common/runtime/test/TestScriptBotFactory.ts
@@ -16,6 +16,7 @@ import {
 } from '../RuntimeBot';
 import { createCompiledBot, CompiledBot } from '../CompiledBot';
 import pickBy from 'lodash/pickBy';
+import { applyEdit, isTagEdit } from '../../aux-format-2';
 
 export class TestScriptBotFactory implements RuntimeBotFactory {
     createRuntimeBot(bot: Bot): RuntimeBot {
@@ -55,8 +56,15 @@ export function createDummyRuntimeBot(
 
 export const testScriptBotInterface: RuntimeBotInterface = {
     updateTag(bot: PrecalculatedBot, tag: string, newValue: any) {
-        bot.tags[tag] = newValue;
-        bot.values[tag] = newValue;
+        if (isTagEdit(newValue)) {
+            bot.values[tag] = bot.tags[tag] = applyEdit(
+                bot.tags[tag],
+                newValue
+            );
+        } else {
+            bot.tags[tag] = newValue;
+            bot.values[tag] = newValue;
+        }
         return RealtimeEditMode.Immediate;
     },
     getValue(bot: PrecalculatedBot, tag: string) {
@@ -98,7 +106,11 @@ export const testScriptBotInterface: RuntimeBotInterface = {
             if (!bot.masks[space]) {
                 bot.masks[space] = {};
             }
-            bot.masks[space][tag] = value;
+            if (isTagEdit(value)) {
+                bot.masks[space][tag] = applyEdit(bot.masks[space][tag], value);
+            } else {
+                bot.masks[space][tag] = value;
+            }
         }
         return RealtimeEditMode.Immediate;
     },

--- a/src/aux-common/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-common/runtime/test/TestScriptBotFactory.ts
@@ -102,4 +102,9 @@ export const testScriptBotInterface: RuntimeBotInterface = {
         }
         return RealtimeEditMode.Immediate;
     },
+
+    currentVersion: {
+        localSites: {},
+        vector: {},
+    },
 };

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -4,6 +4,7 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
     ProxyBridgePartitionImpl,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { Observable, Subject } from 'rxjs';
 import { wrap, proxy, Remote, expose, transfer } from 'comlink';
@@ -12,7 +13,6 @@ import {
     AuxVM,
     AuxUser,
     ChannelActionResult,
-    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import {
     AuxChannel,
@@ -38,7 +38,7 @@ export class AuxVMImpl implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<ChannelStateVersion>;
+    private _versionUpdated: Subject<RuntimeStateVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _iframe: HTMLIFrameElement;
@@ -61,7 +61,7 @@ export class AuxVMImpl implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<ChannelStateVersion>();
+        this._versionUpdated = new Subject<RuntimeStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -158,7 +158,7 @@ export class AuxVMImpl implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<ChannelStateVersion> {
+    get versionUpdated(): Observable<RuntimeStateVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-deno/vm/DenoVM.ts
+++ b/src/aux-vm-deno/vm/DenoVM.ts
@@ -4,6 +4,7 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
     ProxyBridgePartitionImpl,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { Observable, Subject } from 'rxjs';
 import { wrap, proxy, Remote, expose, transfer, Endpoint } from 'comlink';
@@ -12,7 +13,6 @@ import {
     AuxVM,
     AuxUser,
     ChannelActionResult,
-    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import {
     AuxChannel,
@@ -41,7 +41,7 @@ export class DenoVM implements AuxVM {
     private _deviceEvents: Subject<DeviceAction[]>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<ChannelStateVersion>;
+    private _versionUpdated: Subject<RuntimeStateVersion>;
     private _onError: Subject<AuxChannelErrorType>;
     private _config: AuxConfig;
     private _worker: DenoWorker;
@@ -63,7 +63,7 @@ export class DenoVM implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<ChannelStateVersion>();
+        this._versionUpdated = new Subject<RuntimeStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }
@@ -177,7 +177,7 @@ export class DenoVM implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<ChannelStateVersion> {
+    get versionUpdated(): Observable<RuntimeStateVersion> {
         return this._versionUpdated;
     }
 

--- a/src/aux-vm-node/vm/AuxVMNode.ts
+++ b/src/aux-vm-node/vm/AuxVMNode.ts
@@ -3,7 +3,6 @@ import {
     AuxChannelErrorType,
     StoredAux,
     ChannelActionResult,
-    ChannelStateVersion,
 } from '@casual-simulation/aux-vm';
 import { Observable, Subject } from 'rxjs';
 import {
@@ -11,6 +10,7 @@ import {
     BotAction,
     StateUpdatedEvent,
     BotDependentInfo,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import {
     LoadingProgressCallback,
@@ -24,7 +24,7 @@ export class AuxVMNode implements AuxVM {
     private _localEvents: Subject<LocalActions[]>;
     private _deviceEvents: Subject<DeviceAction[]>;
     private _stateUpdated: Subject<StateUpdatedEvent>;
-    private _versionUpdated: Subject<ChannelStateVersion>;
+    private _versionUpdated: Subject<RuntimeStateVersion>;
     private _connectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -42,7 +42,7 @@ export class AuxVMNode implements AuxVM {
         return this._stateUpdated;
     }
 
-    get versionUpdated(): Observable<ChannelStateVersion> {
+    get versionUpdated(): Observable<RuntimeStateVersion> {
         return this._versionUpdated;
     }
 
@@ -63,7 +63,7 @@ export class AuxVMNode implements AuxVM {
         this._localEvents = new Subject<LocalActions[]>();
         this._deviceEvents = new Subject<DeviceAction[]>();
         this._stateUpdated = new Subject<StateUpdatedEvent>();
-        this._versionUpdated = new Subject<ChannelStateVersion>();
+        this._versionUpdated = new Subject<RuntimeStateVersion>();
         this._connectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
     }

--- a/src/aux-vm/managers/BotWatcher.ts
+++ b/src/aux-vm/managers/BotWatcher.ts
@@ -11,6 +11,7 @@ import {
     hasTagOrMask,
     getTagValueForSpace,
     hasValue,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { Subject, Observable, SubscriptionLike, never } from 'rxjs';
 import {
@@ -31,8 +32,7 @@ import {
     isTagEdit,
     TagEditOp,
 } from '@casual-simulation/aux-common/aux-format-2';
-import { CurrentVersion, VersionVector } from '@casual-simulation/causal-trees';
-import { ChannelStateVersion } from '../vm/AuxChannel';
+import { VersionVector } from '@casual-simulation/causal-trees';
 
 /**
  * Defines an interface that contains information about an updated bot.
@@ -64,7 +64,7 @@ export class BotWatcher implements SubscriptionLike {
         string,
         { tag: string; space: string; subject: Subject<BotTagChange> }[]
     >;
-    private _lastVersion: ChannelStateVersion;
+    private _lastVersion: RuntimeStateVersion;
 
     closed: boolean = false;
 
@@ -115,7 +115,7 @@ export class BotWatcher implements SubscriptionLike {
         helper: BotHelper,
         index: BotIndex,
         stateUpdated: Observable<StateUpdatedEvent>,
-        versionUpdated: Observable<ChannelStateVersion>
+        versionUpdated: Observable<RuntimeStateVersion>
     ) {
         this._helper = helper;
         this._index = index;

--- a/src/aux-vm/vm/AuxChannel.ts
+++ b/src/aux-vm/vm/AuxChannel.ts
@@ -4,6 +4,7 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
     ActionResult,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import {
     StatusUpdate,
@@ -25,23 +26,6 @@ export interface AuxStatic {
      * Creates a new AUX using the given config.
      */
     new (defaultHost: string, user: AuxUser, config: AuxConfig): AuxChannel;
-}
-
-/**
- * Defines an interface that represents the state version of a aux channel.
- */
-export interface ChannelStateVersion {
-    /**
-     * A map of local site IDs.
-     */
-    localSites: {
-        [id: string]: boolean;
-    };
-
-    /**
-     * The current version vector.
-     */
-    vector: VersionVector;
 }
 
 /**
@@ -67,7 +51,7 @@ export interface AuxChannel extends SubscriptionLike {
     /**
      * The observable that should be triggered whenever the state version updated.
      */
-    onVersionUpdated: Observable<ChannelStateVersion>;
+    onVersionUpdated: Observable<RuntimeStateVersion>;
 
     /**
      * The observable that should be triggered whenever the connection state changes.
@@ -91,7 +75,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: ChannelStateVersion) => void,
+        onVersionUpdated?: (version: RuntimeStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;
@@ -108,7 +92,7 @@ export interface AuxChannel extends SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: ChannelStateVersion) => void,
+        onVersionUpdated?: (version: RuntimeStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void>;

--- a/src/aux-vm/vm/AuxVM.ts
+++ b/src/aux-vm/vm/AuxVM.ts
@@ -3,6 +3,7 @@ import {
     BotAction,
     StateUpdatedEvent,
     BotDependentInfo,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { StatusUpdate, DeviceAction } from '@casual-simulation/causal-trees';
 import { Observable } from 'rxjs';
@@ -10,7 +11,7 @@ import { Initable } from '../managers/Initable';
 import { AuxChannelErrorType } from './AuxChannelErrorTypes';
 import { AuxUser } from '../AuxUser';
 import { StoredAux } from '../StoredAux';
-import { ChannelActionResult, ChannelStateVersion } from './AuxChannel';
+import { ChannelActionResult } from './AuxChannel';
 
 /**
  * Defines an interface for an AUX that is run inside a virtual machine.
@@ -39,7 +40,7 @@ export interface AuxVM extends Initable {
     /**
      * Gets the observable list of version updates from the simulation.
      */
-    versionUpdated: Observable<ChannelStateVersion>;
+    versionUpdated: Observable<RuntimeStateVersion>;
 
     /**
      * Gets an observable that resolves whenever the connection state changes.

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -35,6 +35,7 @@ import {
     createCausalRepoPartition,
     MemoryPartitionImpl,
     MemoryPartitionStateConfig,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { AuxUser } from '../AuxUser';
 import { AuxConfig } from './AuxConfig';
@@ -43,7 +44,6 @@ import merge from 'lodash/merge';
 import { waitAsync } from '@casual-simulation/aux-common/test/TestHelpers';
 import { Subject } from 'rxjs';
 import { cloneDeep } from 'lodash';
-import { ChannelStateVersion } from './AuxChannel';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid/v4');
@@ -401,7 +401,7 @@ describe('BaseAuxChannel', () => {
             };
             channel = new AuxChannelImpl(user, device, config);
 
-            let versions = [] as ChannelStateVersion[];
+            let versions = [] as RuntimeStateVersion[];
 
             await channel.initAndWait();
 

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -1,10 +1,6 @@
 import { Subject, SubscriptionLike } from 'rxjs';
 import { tap, first } from 'rxjs/operators';
-import {
-    AuxChannel,
-    ChannelActionResult,
-    ChannelStateVersion,
-} from './AuxChannel';
+import { AuxChannel, ChannelActionResult } from './AuxChannel';
 import { AuxUser } from '../AuxUser';
 import {
     LocalActions,
@@ -25,6 +21,7 @@ import {
     hasValue,
     asyncResult,
     addDebugApi,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import { AuxHelper } from './AuxHelper';
 import { AuxConfig, buildVersionNumber } from './AuxConfig';
@@ -61,13 +58,13 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
     private _hasRegisteredSubs: boolean;
     private _eventBuffer: BotAction[];
     private _hasInitialState: boolean;
-    private _version: ChannelStateVersion;
+    private _version: RuntimeStateVersion;
 
     private _user: AuxUser;
     private _onLocalEvents: Subject<LocalActions[]>;
     private _onDeviceEvents: Subject<DeviceAction[]>;
     private _onStateUpdated: Subject<StateUpdatedEvent>;
-    private _onVersionUpdated: Subject<ChannelStateVersion>;
+    private _onVersionUpdated: Subject<RuntimeStateVersion>;
     private _onConnectionStateChanged: Subject<StatusUpdate>;
     private _onError: Subject<AuxChannelErrorType>;
 
@@ -112,7 +109,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         this._onLocalEvents = new Subject<LocalActions[]>();
         this._onDeviceEvents = new Subject<DeviceAction[]>();
         this._onStateUpdated = new Subject<StateUpdatedEvent>();
-        this._onVersionUpdated = new Subject<ChannelStateVersion>();
+        this._onVersionUpdated = new Subject<RuntimeStateVersion>();
         this._onConnectionStateChanged = new Subject<StatusUpdate>();
         this._onError = new Subject<AuxChannelErrorType>();
         this._eventBuffer = [];
@@ -154,7 +151,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: ChannelStateVersion) => void,
+        onVersionUpdated?: (version: RuntimeStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ): Promise<void> {
@@ -186,7 +183,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
         onLocalEvents?: (events: LocalActions[]) => void,
         onDeviceEvents?: (events: DeviceAction[]) => void,
         onStateUpdated?: (state: StateUpdatedEvent) => void,
-        onVersionUpdated?: (version: ChannelStateVersion) => void,
+        onVersionUpdated?: (version: RuntimeStateVersion) => void,
         onConnectionStateChanged?: (state: StatusUpdate) => void,
         onError?: (err: AuxChannelErrorType) => void
     ) {

--- a/src/aux-vm/vm/BaseAuxChannel.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.ts
@@ -424,13 +424,7 @@ export abstract class BaseAuxChannel implements AuxChannel, SubscriptionLike {
             partition.onVersionUpdated
                 .pipe(
                     tap((v) => {
-                        if (v.currentSite) {
-                            this._version.localSites[v.currentSite] = true;
-                        }
-                        this._version.vector = mergeVersions(
-                            this._version.vector,
-                            v.vector
-                        );
+                        this._version = this._runtime.versionUpdated(v);
                         this._onVersionUpdated.next(this._version);
                     })
                 )

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -14,6 +14,7 @@ import {
     StateUpdatedEvent,
     BotDependentInfo,
     AuxRuntime,
+    RuntimeStateVersion,
 } from '@casual-simulation/aux-common';
 import {
     StatusUpdate,
@@ -24,7 +25,7 @@ import values from 'lodash/values';
 import union from 'lodash/union';
 import { AuxUser } from '../../AuxUser';
 import { StoredAux } from '../../StoredAux';
-import { ChannelActionResult, ChannelStateVersion } from '../../vm';
+import { ChannelActionResult } from '../../vm';
 
 export class TestAuxVM implements AuxVM {
     private _stateUpdated: Subject<StateUpdatedEvent>;
@@ -40,7 +41,7 @@ export class TestAuxVM implements AuxVM {
     localEvents: Observable<LocalActions[]>;
     deviceEvents: Observable<DeviceAction[]>;
     connectionStateChanged: Subject<StatusUpdate>;
-    versionUpdated: Subject<ChannelStateVersion>;
+    versionUpdated: Subject<RuntimeStateVersion>;
     onError: Subject<AuxChannelErrorType>;
     grant: string;
     user: AuxUser;
@@ -72,7 +73,7 @@ export class TestAuxVM implements AuxVM {
         this._stateUpdated = new Subject<StateUpdatedEvent>();
         this.connectionStateChanged = new Subject<StatusUpdate>();
         this.onError = new Subject<AuxChannelErrorType>();
-        this.versionUpdated = new Subject<ChannelStateVersion>();
+        this.versionUpdated = new Subject<RuntimeStateVersion>();
     }
 
     async shout(


### PR DESCRIPTION
### :rocket: Improvements
-   Added the `insertTagText()`, `deleteTagText()`, `insertTagMaskText()`, and `deleteTagMaskText()` functions to allow scripts to work with multi-user text editing.
    -   `insertTagText(bot, tag, index, text)` inserts the given text at the index into the given tag on the given bot.
    -   `insertTagMaskText(bot, tag, index, text, space?)` inserts the given text at the index into the tag and bot. Optionally accepts the space of the tag mask.
    -   `deleteTagText(bot, tag, index, deleteCount)` deletes the given number of characters at the index from the tag and bot.
    -   `deleteTagMaskText(bot, tag, index, deleteCount, space?)` deletes the given number of characters at the index from the tag and bot. Optionally accepts the space of the tag mask.