### PR TITLE
Improve the transformer tag and tag portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     -   `insertTagMaskText(bot, tag, index, text, space?)` inserts the given text at the index into the tag and bot. Optionally accepts the space of the tag mask.
     -   `deleteTagText(bot, tag, index, deleteCount)` deletes the given number of characters at the index from the tag and bot.
     -   `deleteTagMaskText(bot, tag, index, deleteCount, space?)` deletes the given number of characters at the index from the tag and bot. Optionally accepts the space of the tag mask.
+-   Added the ability to use the `transformer` tag on the player bot to parent the player to a bot.
 
 ## V1.2.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     -   `deleteTagText(bot, tag, index, deleteCount)` deletes the given number of characters at the index from the tag and bot.
     -   `deleteTagMaskText(bot, tag, index, deleteCount, space?)` deletes the given number of characters at the index from the tag and bot. Optionally accepts the space of the tag mask.
 -   Added the ability to use the `transformer` tag on the player bot to parent the player to a bot.
+-   Added the ability to edit tag masks in the tag portal by setting the `tagPortalSpace` tag on the player bot.
 
 ## V1.2.21
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -771,6 +771,8 @@ When the minimum LOD is exited the <TagLink tag='@onMinLODExit'/> listener is tr
 The ID of the bot that should transform this bot in the page and inventory portals.
 When the transformer bot and this bot are in the same dimension, this bot will inherit the position and rotation of the transformer bot.
 
+When set on the player bot, this will transform the portal camera by the specified bot.
+
 <PossibleValuesTable>
   <PossibleValueCode value='null'>
     The bot is positioned on the grid. (default)

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1662,6 +1662,28 @@ const tag = "abc";
 playerBot.tags.tagPortal = getID(playerBot) + "." + tag;
 ```
 
+### `tagPortalSpace`
+
+<Badges>
+  <UserBotBadge/>
+</Badges>
+
+The space of the tag mask that should be edited in the tag portal.
+If not set, then the tag on the bot will be edited.
+If set, then the tag mask in the given space will be edited.
+
+Only available on the player bot.
+
+#### Examples:
+
+1. Open the tag portal for the `abc` tag mask in the `tempLocal` space on the player bot.
+```typescript
+const playerBot = player.getBot();
+const tag = "abc";
+playerBot.tags.tagPortal = getID(playerBot) + "." + tag;
+playerBot.tags.tagPortalSpace = "tempLocal";
+```
+
 ### `dataPortal`
 
 The data portal is a special portal that can be used in a web request to get bot data directly from the server.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1183,6 +1183,11 @@ export const ON_SHEET_BOT_ID_CLICK = 'onSheetBotIDClick';
 export const ON_SHEET_BOT_CLICK = 'onSheetBotClick';
 
 /**
+ * The tag used to set the space that the tag portal operates in.
+ */
+export const TAG_PORTAL_SPACE: string = 'tagPortalSpace';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -1232,6 +1237,7 @@ export const QUERY_PORTALS: string[] = [
     'sheetPortal',
     MEET_PORTAL,
     TAG_PORTAL,
+    TAG_PORTAL_SPACE,
 ];
 
 /*
@@ -1257,6 +1263,7 @@ export const KNOWN_TAGS: string[] = [
     `${MEET_PORTAL}ConfigBot`,
     DATA_PORTAL,
     TAG_PORTAL,
+    TAG_PORTAL_SPACE,
     `${TAG_PORTAL}ConfigBot`,
 
     'pageCameraPositionX',

--- a/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
@@ -30,6 +30,7 @@ import {
     isBot,
     addDebugApi,
     onPointerUpDownArg,
+    getBotTransformer,
 } from '@casual-simulation/aux-common';
 import { IOperation } from '../../shared/interaction/IOperation';
 import { BaseInteractionManager } from '../../shared/interaction/BaseInteractionManager';
@@ -51,6 +52,7 @@ import { InventoryContextGroup3D } from '../scene/InventoryContextGroup3D';
 import {
     isObjectVisible,
     objectForwardRay,
+    safeSetParent,
 } from '../../shared/scene/SceneUtils';
 import { CameraRigControls } from '../../shared/interaction/CameraRigControls';
 import { CameraControls } from '../../shared/interaction/CameraControls';
@@ -441,6 +443,29 @@ export class PlayerInteractionManager extends BaseInteractionManager {
                 `${portal}CameraRotationOffsetY`,
                 0
             );
+
+            const transformer = getBotTransformer(null, userBot);
+            let hasParent = false;
+            if (transformer) {
+                const bots = sim.findBotsById(transformer);
+
+                if (bots.length > 0) {
+                    const parentBot = bots[0];
+                    if (parentBot instanceof AuxBot3D) {
+                        if (
+                            safeSetParent(
+                                rig.cameraParent,
+                                parentBot.transformContainer
+                            )
+                        ) {
+                            hasParent = true;
+                        }
+                    }
+                }
+            }
+            if (!hasParent) {
+                safeSetParent(rig.cameraParent, sim.scene);
+            }
 
             if (
                 rig.cameraParent.position.x !== targetXPos ||

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -724,6 +724,9 @@ export function percentOfScreen(
  * @param parent The parent.
  */
 export function safeSetParent(obj: Object3D, parent: Object3D): boolean {
+    if (obj.parent === parent) {
+        return true;
+    }
     let grandparent = parent;
     while (grandparent) {
         if (grandparent === obj) {

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -1,4 +1,4 @@
-import { Object3D, Texture, Color, Vector2 } from 'three';
+import { Object3D, Texture, Color, Vector2, Scene } from 'three';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import {
     Bot,
@@ -34,7 +34,8 @@ import { PortalConfig } from 'aux-web/aux-player/scene/PortalConfig';
 /**
  * Defines a class that is able to render a simulation.
  */
-export abstract class Simulation3D extends Object3D
+export abstract class Simulation3D
+    extends Object3D
     implements SubscriptionLike, AuxBotVisualizerFinder {
     protected _subs: SubscriptionLike[];
 
@@ -133,6 +134,18 @@ export abstract class Simulation3D extends Object3D
     }
 
     /**
+     * Gets the scene that this simulation is attached to.
+     */
+    get scene(): Scene {
+        let parent = this.parent;
+        while (parent && !(parent instanceof Scene)) {
+            parent = parent.parent;
+        }
+
+        return parent as Scene;
+    }
+
+    /**
      * Creates a new Simulation3D object that can be used to render the given simulation.
      * @param game The game.
      * @param simulation The simulation to render.
@@ -159,7 +172,7 @@ export abstract class Simulation3D extends Object3D
         this._subs.push(
             this.simulation.localEvents
                 .pipe(
-                    tap(e => {
+                    tap((e) => {
                         if (e.type === 'tween_to') {
                             const foundBotIn3D =
                                 this.findBotsById(e.botId).length > 0;
@@ -186,29 +199,29 @@ export abstract class Simulation3D extends Object3D
         this._subs.push(
             this.simulation.dimensions
                 .watchDimensions(...this._getDimensionTags())
-                .pipe(tap(update => this._dimensionsUpdated(update)))
-                .subscribe(null, err => console.log(err))
+                .pipe(tap((update) => this._dimensionsUpdated(update)))
+                .subscribe(null, (err) => console.log(err))
         );
 
         // Subscriptions to bot events.
         this._subs.push(
             this.simulation.watcher.botsDiscovered
-                .pipe(tap(bot => this._botsAdded(bot)))
+                .pipe(tap((bot) => this._botsAdded(bot)))
                 .subscribe()
         );
         this._subs.push(
             this.simulation.watcher.botsRemoved
-                .pipe(tap(bot => this._botsRemoved(bot)))
+                .pipe(tap((bot) => this._botsRemoved(bot)))
                 .subscribe()
         );
         this._subs.push(
             this.simulation.watcher.botTagsUpdated
-                .pipe(tap(update => this._botsUpdated(update, false)))
+                .pipe(tap((update) => this._botsUpdated(update, false)))
                 .subscribe()
         );
         this._subs.push(
             this.simulation.localEvents
-                .pipe(tap(e => this._localEvent(e)))
+                .pipe(tap((e) => this._localEvent(e)))
                 .subscribe()
         );
     }
@@ -533,9 +546,7 @@ export abstract class Simulation3D extends Object3D
         }
 
         console.log(
-            `[Simulation3D] Added ${
-                botsInDimension.length
-            } bots to ${dimension}`
+            `[Simulation3D] Added ${botsInDimension.length} bots to ${dimension}`
         );
     }
 
@@ -683,7 +694,7 @@ export abstract class Simulation3D extends Object3D
     abstract getGridScale(bot: AuxBot3D): number;
 
     unsubscribe(): void {
-        this._subs.forEach(s => s.unsubscribe());
+        this._subs.forEach((s) => s.unsubscribe());
         this.remove(...this.children);
         this.dimensions.splice(0, this.dimensions.length);
         this.closed = true;

--- a/src/aux-server/aux-web/shared/vue-components/TagPortal/TagPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/TagPortal/TagPortal.vue
@@ -11,7 +11,7 @@
                     ref="multilineEditor"
                     :bot="currentBot"
                     :tag="currentTag"
-                    :space="null"
+                    :space="currentSpace"
                     :showDesktopEditor="true"
                     :showResize="false"
                 ></tag-value-editor>


### PR DESCRIPTION
### :rocket: Improvements

-   Added the ability to use the `transformer` tag on the player bot to parent the player to a bot.
-   Added the ability to edit tag masks in the tag portal by setting the `tagPortalSpace` tag on the player bot.