### PR TITLE
Editing Fixes and GLTF Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CasualOS Changelog
 
+## V1.3.1
+
+#### Date: TBD
+
+### :bug: Bug Fixes
+
+-   Fixed an issue that prevented deleting the first character of a script/formula in the multi-line editor.
+-   Fixed an issue where tag edits on bots in the tempLocal and local spaces would be applied to the multi-line editor twice.
+
 ## V1.3.0
 
 #### Date: 11/11/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Date: TBD
 
+### :rocket: Improvements
+
+-   Added the ability to use the `color` tag on GLTF meshes to apply a color tint to the mesh.
+
 ### :bug: Bug Fixes
 
 -   Fixed an issue that prevented deleting the first character of a script/formula in the multi-line editor.

--- a/src/aux-common/partitions/MemoryPartition.spec.ts
+++ b/src/aux-common/partitions/MemoryPartition.spec.ts
@@ -1,6 +1,7 @@
 import { testPartitionImplementation } from './test/PartitionTests';
 import { createMemoryPartition } from './MemoryPartition';
 import { Bot, createBot } from '../bots';
+import { first } from 'rxjs/operators';
 
 describe('MemoryPartition', () => {
     testPartitionImplementation(async () => {
@@ -21,7 +22,7 @@ describe('MemoryPartition', () => {
             });
 
             let added: Bot[] = [];
-            mem.onBotsAdded.subscribe(e => added.push(...e));
+            mem.onBotsAdded.subscribe((e) => added.push(...e));
 
             expect(added).toEqual([createBot('test'), createBot('test2')]);
         });
@@ -36,6 +37,23 @@ describe('MemoryPartition', () => {
             });
 
             expect(mem.realtimeStrategy).toEqual('immediate');
+        });
+
+        it('should have a current site ID', async () => {
+            const mem = createMemoryPartition({
+                type: 'memory',
+                initialState: {
+                    test: createBot('test'),
+                    test2: createBot('test2'),
+                },
+            });
+
+            const version = await mem.onVersionUpdated
+                .pipe(first())
+                .toPromise();
+
+            expect(version.currentSite).not.toBe(null);
+            expect(version.currentSite).toBeDefined();
         });
     });
 });

--- a/src/aux-common/partitions/MemoryPartition.ts
+++ b/src/aux-common/partitions/MemoryPartition.ts
@@ -31,6 +31,7 @@ import flatMap from 'lodash/flatMap';
 import union from 'lodash/union';
 import { merge } from '../utils';
 import { applyEdit, isTagEdit } from '../aux-format-2';
+import uuid from 'uuid/v4';
 
 /**
  * Attempts to create a MemoryPartition from the given config.
@@ -54,13 +55,11 @@ export class MemoryPartitionImpl implements MemoryPartition {
     private _onBotsRemoved = new Subject<string[]>();
     private _onBotsUpdated = new Subject<UpdatedBot[]>();
     private _onStateUpdated = new Subject<StateUpdatedEvent>();
-    private _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
-        currentSite: null,
-        vector: {},
-    });
+    private _onVersionUpdated: Subject<CurrentVersion>;
     private _onError = new Subject<any>();
     private _onEvents = new Subject<Action[]>();
     private _onStatusUpdated = new Subject<StatusUpdate>();
+    private _siteId: string = uuid();
 
     type = 'memory' as const;
     state: BotsState;
@@ -108,6 +107,10 @@ export class MemoryPartitionImpl implements MemoryPartition {
     constructor(config: MemoryPartitionStateConfig) {
         this.private = config.private || false;
         this.state = config.initialState;
+        this._onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+            currentSite: this._siteId,
+            vector: {},
+        });
     }
 
     async applyEvents(events: BotAction[]): Promise<BotAction[]> {

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -740,6 +740,9 @@ function watchModel(
         model: model,
         sub: sub,
     };
+
+    // TODO: Improve to support additional partitions being added dynamically.
+    // This would require recieving an update whenever a new local site is available.
     let lastVersion = simulation.watcher.latestVersion;
     let applyingEdits: boolean = false;
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -578,6 +578,8 @@ export class BotShapeDecorator
         this.scene = gltf.scene;
         this.container.add(gltf.scene);
 
+        this.mesh = this.scene.children.find((c) => c instanceof Mesh) as Mesh;
+
         // Collider
         const collider = (this.collider = createCube(1));
         this.collider.scale.copy(size);
@@ -601,6 +603,7 @@ export class BotShapeDecorator
             this._updateAnimation(null, true);
         }
 
+        this._updateColor(null);
         this.bot3D.updateMatrixWorld(true);
     }
 

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.spec.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.spec.ts
@@ -7,7 +7,7 @@ import {
     createBot,
     StateUpdatedEvent,
 } from '@casual-simulation/aux-common';
-import { skip } from 'rxjs/operators';
+import { first, skip } from 'rxjs/operators';
 import { waitAsync } from '@casual-simulation/aux-common/test/TestHelpers';
 
 describe('LocalStoragePartition', () => {
@@ -55,6 +55,20 @@ describe('LocalStoragePartition', () => {
             });
 
             expect(mem.realtimeStrategy).toEqual('immediate');
+        });
+
+        it('should have a current site ID', async () => {
+            const mem = new LocalStoragePartitionImpl({
+                type: 'local_storage',
+                namespace: 'namespace',
+            });
+
+            const version = await mem.onVersionUpdated
+                .pipe(first())
+                .toPromise();
+
+            expect(version.currentSite).not.toBe(null);
+            expect(version.currentSite).toBeDefined();
         });
     });
 

--- a/src/aux-vm-browser/partitions/LocalStoragePartition.ts
+++ b/src/aux-vm-browser/partitions/LocalStoragePartition.ts
@@ -44,16 +44,14 @@ import {
     applyEdit,
     isTagEdit,
 } from '@casual-simulation/aux-common/aux-format-2';
+import uuid from 'uuid/v4';
 
 export class LocalStoragePartitionImpl implements LocalStoragePartition {
     protected _onBotsAdded = new Subject<Bot[]>();
     protected _onBotsRemoved = new Subject<string[]>();
     protected _onBotsUpdated = new Subject<UpdatedBot[]>();
     protected _onStateUpdated = new Subject<StateUpdatedEvent>();
-    protected _onVersionUpdated = new BehaviorSubject<CurrentVersion>({
-        currentSite: null,
-        vector: {},
-    });
+    protected _onVersionUpdated: Subject<CurrentVersion>;
 
     protected _onError = new Subject<any>();
     protected _onEvents = new Subject<Action[]>();
@@ -61,6 +59,7 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
     protected _hasRegisteredSubs = false;
     private _state: BotsState = {};
     private _sub = new Subscription();
+    private _siteId: string = uuid();
 
     get realtimeStrategy(): AuxPartitionRealtimeStrategy {
         return 'immediate';
@@ -120,6 +119,10 @@ export class LocalStoragePartitionImpl implements LocalStoragePartition {
     constructor(config: LocalStoragePartitionConfig) {
         this.private = config.private || false;
         this.namespace = config.namespace;
+        this._onVersionUpdated = new BehaviorSubject<CurrentVersion>({
+            currentSite: this._siteId,
+            vector: {},
+        });
     }
 
     async applyEvents(events: BotAction[]): Promise<BotAction[]> {

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -91,6 +91,10 @@ describe('BaseAuxChannel', () => {
         channel = new AuxChannelImpl(user, device, config);
     });
 
+    afterEach(() => {
+        uuidMock.mockReset();
+    });
+
     describe('init()', () => {
         it('should create a bot for the user', async () => {
             await channel.initAndWait();
@@ -677,17 +681,13 @@ describe('BaseAuxChannel', () => {
                 `return getBot("abc", "def").tags.abc`
             );
 
-            expect(memory.state).toEqual({
-                userId: expect.anything(),
-                dimensionBot: expect.anything(),
-                test: {
-                    id: 'test',
-                    space: 'shared',
-                    tags: {},
-                    masks: {
-                        shared: {
-                            abc: 'def',
-                        },
+            expect(memory.state.test).toEqual({
+                id: 'test',
+                space: 'shared',
+                tags: {},
+                masks: {
+                    shared: {
+                        abc: 'def',
                     },
                 },
             });

--- a/src/causal-trees/core2/CausalTree2.ts
+++ b/src/causal-trees/core2/CausalTree2.ts
@@ -54,11 +54,12 @@ export interface TreeResult {
  * @param id The ID to use for the site.
  */
 export function tree<T>(id?: string, time?: number): CausalTree<T> {
+    const site = newSite(id, time);
     return {
         weave: new Weave(),
-        site: newSite(id, time),
+        site: site,
         version: {
-            [id]: time,
+            [site.id]: site.time,
         },
     };
 }


### PR DESCRIPTION
### :rocket: Improvements

-   Added the ability to use the `color` tag on GLTF meshes to apply a color tint to the mesh.

### :bug: Bug Fixes

-   Fixed an issue that prevented deleting the first character of a script/formula in the multi-line editor.
-   Fixed an issue where tag edits on bots in the tempLocal and local spaces would be applied to the multi-line editor twice.