### PR TITLE
Better Stack Traces

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macOS-latest, windows-latest]
-                node-version: [12.x]
+                node-version: [14.x]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
@@ -28,7 +28,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macOS-latest, windows-latest]
-                node-version: [12.x]
+                node-version: [14.x]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
@@ -48,7 +48,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macOS-latest, windows-latest]
-                node-version: [12.x]
+                node-version: [14.x]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 -   Added the `math.areClose(first, second)` function to determine if two numbers are within 2 decimal places of each other.
     -   For example, `math.areClose(1, 1.001)` will return true.
 -   Improved the `atPosition()` and `inStack()` bot filters to use `math.areClose()` internally when comparing bot positions.
+-   Improved handling of errors so they have correct line and column numbers in their stack traces.
+    -   Currently, this only functions correctly on Chrome-based browsers (Chrome, Edge, Opera, etc.). Part of this is due to differences between how web browsers generate stack traces and part is due to what browsers support for dynamically generated functions.
 
 ### :bug: Bug Fixes
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,9 +4,9 @@
 
 Make sure you have all the prerequisite tools installed:
 
--   [Node.js](https://nodejs.org/en/download/) 12.16.2 or later.
+-   [Node.js](https://nodejs.org/en/download/) v14.16.1 or later.
     -   If installing for the first time, it is reccommended that you install it via Node Version Manager. ([Mac][nvm-mac], [Windows][nvm-windows])
-    -   Once NVM is installed, you can install the correct version of Node by running `nvm install 12.16.2` in your favorite terminal.
+    -   Once NVM is installed, you can install the correct version of Node by running `nvm install v14.16.1` in your favorite terminal.
 -   [Deno](https://deno.land/).
 -   Docker ([Mac][docker-for-mac], [Windows][docker-for-windows])
     -   Used to make development with MongoDB easy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile.arm32
+++ b/Dockerfile.arm32
@@ -1,4 +1,4 @@
-FROM arm32v7/node:12
+FROM arm32v7/node:14
 
 WORKDIR /usr/src/app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     }
 
     tools {
-        nodejs('Node10.15.1')
+        nodejs('Node14.16.1')
     }
 
     stages {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1837,6 +1837,14 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
+		"@casual-simulation/error-stack-parser": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@casual-simulation/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+			"integrity": "sha512-an69t0bPOLl1mlxrHH/bDOEYEj75yaARfmzNhuzfM+klAzwUk2I5Y/INZ5iRE8ZHIH2/gieAVsLyFzzkygPMGg==",
+			"requires": {
+				"stackframe": "^1.2.0"
+			}
+		},
 		"@casual-simulation/three": {
 			"version": "0.125.4",
 			"resolved": "https://registry.npmjs.org/@casual-simulation/three/-/three-0.125.4.tgz",
@@ -28861,6 +28869,11 @@
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
 			"dev": true
+		},
+		"stackframe": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
 		},
 		"static-extend": {
 			"version": "0.1.2",

--- a/src/aux-common/package.json
+++ b/src/aux-common/package.json
@@ -38,6 +38,7 @@
         "@casual-simulation/three": "^0.125.4",
         "@casual-simulation/stacktrace": "^1.5.0",
         "@casual-simulation/error-stack-parser": "^2.0.7",
+        "stackframe": "^1.2.0",
         "@tweenjs/tween.js": "18.6.0",
         "@types/acorn": "^4.0.5",
         "@types/astring": "1.3.0",

--- a/src/aux-common/package.json
+++ b/src/aux-common/package.json
@@ -37,6 +37,7 @@
         "@casual-simulation/crypto": "^1.5.7",
         "@casual-simulation/three": "^0.125.4",
         "@casual-simulation/stacktrace": "^1.5.0",
+        "@casual-simulation/error-stack-parser": "^2.0.7",
         "@tweenjs/tween.js": "18.6.0",
         "@types/acorn": "^4.0.5",
         "@types/astring": "1.3.0",

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -1,5 +1,4 @@
 import { AuxCompiler, replaceSyntaxErrorLineNumber } from './AuxCompiler';
-import os from 'os';
 import ErrorStackParser from '@casual-simulation/error-stack-parser';
 
 describe('AuxCompiler', () => {

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -14,6 +14,8 @@ describe('AuxCompiler', () => {
         // for newer node.js versions.
         if (os.platform() === 'win32') {
             compiler.functionErrorLineOffset = 2;
+        } else if (os.platform() === 'linux') {
+            compiler.functionErrorLineOffset = 2;
         }
     });
 

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -420,7 +420,7 @@ describe('AuxCompiler', () => {
             });
 
             it('should be able to get the original location for errors on the second line', () => {
-                const script = 'let abc = 123;\nthrow new Error("abc");';
+                const script = 'let abc = 123;\r\nthrow new Error("abc");';
                 const func = compiler.compile(script, {
                     constants: {
                         num: -5,
@@ -485,7 +485,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -525,7 +525,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -565,7 +565,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -576,7 +576,7 @@ describe('AuxCompiler', () => {
 
             it('should support nested functions', () => {
                 const script =
-                    'let abc = 123;\nmyFunc();\n function myFunc() {\n throw new Error("test"); \n}';
+                    'let abc = 123;\r\nmyFunc();\r\n function myFunc() {\r\n throw new Error("test"); \r\n}';
                 const func = compiler.compile(script, {
                     constants: {
                         num: -5,
@@ -606,7 +606,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: test',
@@ -647,7 +647,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error',
@@ -689,7 +689,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -743,7 +743,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -800,7 +800,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -828,7 +828,7 @@ describe('AuxCompiler', () => {
                 let error = new Error('abc');
                 error.stack =
                     error.toString() +
-                    '\n' +
+                    '\r\n' +
                     [
                         '    at Object._ (eval at __constructFunction (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxCompiler.ts:424:24), <anonymous>:6:7)',
                         '    at __wrapperFunc (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxCompiler.ts:229:36)',
@@ -840,7 +840,7 @@ describe('AuxCompiler', () => {
                         '    at AuxRuntime._shout (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:373:50)',
                         '    at AuxRuntime._processAction (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:247:33)',
                         '    at AuxRuntime._processCore (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:241:18)',
-                    ].join('\n');
+                    ].join('\r\n');
 
                 expect(error).toBeTruthy();
 
@@ -849,7 +849,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\n');
+                const lines = stack.split('\r\n');
 
                 expect(lines).toEqual([
                     'Error: abc',

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -7,16 +7,6 @@ describe('AuxCompiler', () => {
 
     beforeEach(() => {
         compiler = new AuxCompiler();
-
-        // Fix for a bug that causes line numbers in error stack traces
-        // on Windows to be 2 less than they should be.
-        // This issue seems to be Node.js specific (it works correct in browser) so this might have to be removed
-        // for newer node.js versions.
-        if (os.platform() === 'win32') {
-            compiler.functionErrorLineOffset = 2;
-        } else if (os.platform() === 'linux') {
-            compiler.functionErrorLineOffset = 2;
-        }
     });
 
     describe('compile()', () => {

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -420,7 +420,7 @@ describe('AuxCompiler', () => {
             });
 
             it('should be able to get the original location for errors on the second line', () => {
-                const script = 'let abc = 123;\r\nthrow new Error("abc");';
+                const script = 'let abc = 123;\nthrow new Error("abc");';
                 const func = compiler.compile(script, {
                     constants: {
                         num: -5,
@@ -485,7 +485,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -525,7 +525,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -565,7 +565,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -576,7 +576,7 @@ describe('AuxCompiler', () => {
 
             it('should support nested functions', () => {
                 const script =
-                    'let abc = 123;\r\nmyFunc();\r\n function myFunc() {\r\n throw new Error("test"); \r\n}';
+                    'let abc = 123;\nmyFunc();\n function myFunc() {\n throw new Error("test"); \n}';
                 const func = compiler.compile(script, {
                     constants: {
                         num: -5,
@@ -606,7 +606,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: test',
@@ -647,7 +647,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error',
@@ -689,7 +689,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -743,7 +743,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -800,7 +800,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',
@@ -828,7 +828,7 @@ describe('AuxCompiler', () => {
                 let error = new Error('abc');
                 error.stack =
                     error.toString() +
-                    '\r\n' +
+                    '\n' +
                     [
                         '    at Object._ (eval at __constructFunction (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxCompiler.ts:424:24), <anonymous>:6:7)',
                         '    at __wrapperFunc (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxCompiler.ts:229:36)',
@@ -840,7 +840,7 @@ describe('AuxCompiler', () => {
                         '    at AuxRuntime._shout (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:373:50)',
                         '    at AuxRuntime._processAction (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:247:33)',
                         '    at AuxRuntime._processCore (E:\\Projects\\Yeti\\yeti-aux\\src\\aux-common\\runtime\\AuxRuntime.ts:241:18)',
-                    ].join('\r\n');
+                    ].join('\n');
 
                 expect(error).toBeTruthy();
 
@@ -849,7 +849,7 @@ describe('AuxCompiler', () => {
                     error
                 );
 
-                const lines = stack.split('\r\n');
+                const lines = stack.split('\n');
 
                 expect(lines).toEqual([
                     'Error: abc',

--- a/src/aux-common/runtime/AuxCompiler.ts
+++ b/src/aux-common/runtime/AuxCompiler.ts
@@ -15,9 +15,6 @@ import StackFrame from 'stackframe';
  */
 export const COMPILED_SCRIPT_SYMBOL = Symbol('compiled_script');
 
-// Use \r\n when in testing but just \n in production.
-const NEWLINE = typeof jest !== 'undefined' ? '\r\n' : '\n';
-
 /**
  * Defines a class that can compile scripts and formulas
  * into functions.
@@ -134,8 +131,8 @@ export class AuxCompiler {
 
         const stack = finalFrames
             .map((frame) => '   at ' + frame.toString())
-            .join(NEWLINE);
-        return error.toString() + NEWLINE + stack;
+            .join('\n');
+        return error.toString() + '\n' + stack;
     }
 
     /**
@@ -320,7 +317,7 @@ export class AuxCompiler {
             const lines = Object.keys(options.constants)
                 .filter((v) => v !== 'this')
                 .map((v) => `const ${v} = constants["${v}"];`);
-            constantsCode = lines.join(NEWLINE) + NEWLINE;
+            constantsCode = lines.join('\n') + '\n';
             constantsLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
@@ -329,7 +326,7 @@ export class AuxCompiler {
             const lines = Object.keys(options.variables)
                 .filter((v) => v !== 'this')
                 .map((v) => `const ${v} = variables["${v}"](context);`);
-            variablesCode = NEWLINE + lines.join(NEWLINE);
+            variablesCode = '\n' + lines.join('\n');
             scriptLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
@@ -345,19 +342,19 @@ export class AuxCompiler {
                     ),
                 ([v, i]) => v.map((name) => `const ${name} = args[${i}];`)
             );
-            argumentsCode = NEWLINE + lines.join(NEWLINE);
+            argumentsCode = '\n' + lines.join('\n');
             scriptLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
         let scriptCode: string;
-        scriptCode = `${NEWLINE} { ${NEWLINE}${script}${NEWLINE} }`;
+        scriptCode = `\n { \n${script}\n }`;
         scriptLineOffset += 2;
 
         // Function needs a name because acorn doesn't understand
         // that this function is allowed to be anonymous.
         let functionCode = `function ${
             options.functionName ?? '_'
-        }(...args) { ${argumentsCode}${variablesCode}${scriptCode}${NEWLINE} }`;
+        }(...args) { ${argumentsCode}${variablesCode}${scriptCode}\n }`;
         if (async) {
             functionCode = `async ` + functionCode;
         }

--- a/src/aux-common/runtime/AuxCompiler.ts
+++ b/src/aux-common/runtime/AuxCompiler.ts
@@ -15,6 +15,9 @@ import StackFrame from 'stackframe';
  */
 export const COMPILED_SCRIPT_SYMBOL = Symbol('compiled_script');
 
+// Use \r\n when in testing but just \n in production.
+const NEWLINE = typeof jest !== 'undefined' ? '\r\n' : '\n';
+
 /**
  * Defines a class that can compile scripts and formulas
  * into functions.
@@ -131,8 +134,8 @@ export class AuxCompiler {
 
         const stack = finalFrames
             .map((frame) => '   at ' + frame.toString())
-            .join('\n');
-        return error.toString() + '\n' + stack;
+            .join(NEWLINE);
+        return error.toString() + NEWLINE + stack;
     }
 
     /**
@@ -317,7 +320,7 @@ export class AuxCompiler {
             const lines = Object.keys(options.constants)
                 .filter((v) => v !== 'this')
                 .map((v) => `const ${v} = constants["${v}"];`);
-            constantsCode = lines.join('\n') + '\n';
+            constantsCode = lines.join(NEWLINE) + NEWLINE;
             constantsLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
@@ -326,7 +329,7 @@ export class AuxCompiler {
             const lines = Object.keys(options.variables)
                 .filter((v) => v !== 'this')
                 .map((v) => `const ${v} = variables["${v}"](context);`);
-            variablesCode = '\n' + lines.join('\n');
+            variablesCode = NEWLINE + lines.join(NEWLINE);
             scriptLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
@@ -342,19 +345,19 @@ export class AuxCompiler {
                     ),
                 ([v, i]) => v.map((name) => `const ${name} = args[${i}];`)
             );
-            argumentsCode = '\n' + lines.join('\n');
+            argumentsCode = NEWLINE + lines.join(NEWLINE);
             scriptLineOffset += 1 + Math.max(lines.length - 1, 0);
         }
 
         let scriptCode: string;
-        scriptCode = `\n { \n${script}\n }`;
+        scriptCode = `${NEWLINE} { ${NEWLINE}${script}${NEWLINE} }`;
         scriptLineOffset += 2;
 
         // Function needs a name because acorn doesn't understand
         // that this function is allowed to be anonymous.
         let functionCode = `function ${
             options.functionName ?? '_'
-        }(...args) { ${argumentsCode}${variablesCode}${scriptCode}\n }`;
+        }(...args) { ${argumentsCode}${variablesCode}${scriptCode}${NEWLINE} }`;
         if (async) {
             functionCode = `async ` + functionCode;
         }

--- a/src/aux-common/runtime/AuxCompiler.ts
+++ b/src/aux-common/runtime/AuxCompiler.ts
@@ -26,6 +26,9 @@ export class AuxCompiler {
     /**
      * The offset that should be applied to error line numbers when calculating their original
      * position. Needed because Node.js Windows produces different line numbers than Mac/Linux.
+     *
+     * Node.js versions greater than v12.14.0 have an issue with identifying the correct line number
+     * for errors and stack traces. This issue is fixed in Node.js v14 and later (possibly also fixed in v13 but I didn't check that).
      */
     functionErrorLineOffset: number = 0;
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -8609,6 +8609,28 @@ describe('AuxLibrary', () => {
             expect(context.errors).toEqual([new Error('abc')]);
         });
 
+        it('should handle exceptions on async listeners on a per-bot basis', async () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn(
+                async () => {}
+            ));
+            const sayHello2 = (bot2.listeners.sayHello = jest.fn(async () => {
+                throw new Error('abc');
+            }));
+            const sayHello3 = (bot3.listeners.sayHello = jest.fn());
+            const sayHello4 = (bot4.listeners.sayHello = jest.fn());
+            recordListeners();
+
+            library.api.shout('sayHello');
+
+            await waitAsync();
+
+            expect(sayHello1).toBeCalled();
+            expect(sayHello2).toBeCalled();
+            expect(sayHello3).toBeCalled();
+            expect(sayHello4).toBeCalled();
+            expect(context.errors).toEqual([new Error('abc')]);
+        });
+
         it('should send a onListen whisper to all the listening bots', () => {
             const sayHello1 = (bot1.listeners.sayHello = jest.fn(() => {}));
             const sayHello2 = (bot2.listeners.sayHello = jest.fn(() => {

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -5566,6 +5566,12 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 }
                 try {
                     const result = listener(arg);
+
+                    if (result instanceof Promise) {
+                        result.catch((ex) => {
+                            context.enqueueError(ex);
+                        });
+                    }
                     results.push(result);
                 } catch (ex) {
                     context.enqueueError(ex);

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -95,6 +95,7 @@ import { DefaultRealtimeEditModeProvider } from './AuxRealtimeEditModeProvider';
 import { DeepObjectError } from './Utils';
 import { del, edit, insert, preserve, tagValueHash } from '../aux-format-2';
 import { merge } from '../utils';
+import os from 'os';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid');
@@ -3365,6 +3366,16 @@ describe('AuxRuntime', () => {
         });
 
         describe('onError', () => {
+            beforeEach(() => {
+                // Fix for a bug that causes line numbers in error stack traces
+                // on Windows to be 2 less than they should be.
+                // This issue seems to be Node.js specific (it works correct in browser) so this might have to be removed
+                // for newer node.js versions.
+                if (os.platform() === 'win32') {
+                    (<any>runtime)._compiler.functionErrorLineOffset = 2;
+                }
+            });
+
             it('should emit a onError shout when an error in a script occurs', async () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({
@@ -3392,7 +3403,7 @@ describe('AuxRuntime', () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({
                         test1: createBot('test1', {
-                            hello: '@debugger;throw new Error("My Error");',
+                            hello: '@throw new Error("My Error");',
                         }),
                         test3: createBot('test3', {
                             onError: '@tags.error = that;',

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -3373,6 +3373,8 @@ describe('AuxRuntime', () => {
                 // for newer node.js versions.
                 if (os.platform() === 'win32') {
                     (<any>runtime)._compiler.functionErrorLineOffset = 2;
+                } else if (os.platform() === 'linux') {
+                    (<any>runtime)._compiler.functionErrorLineOffset = 2;
                 }
             });
 

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -3366,18 +3366,6 @@ describe('AuxRuntime', () => {
         });
 
         describe('onError', () => {
-            beforeEach(() => {
-                // Fix for a bug that causes line numbers in error stack traces
-                // on Windows to be 2 less than they should be.
-                // This issue seems to be Node.js specific (it works correct in browser) so this might have to be removed
-                // for newer node.js versions.
-                if (os.platform() === 'win32') {
-                    (<any>runtime)._compiler.functionErrorLineOffset = 2;
-                } else if (os.platform() === 'linux') {
-                    (<any>runtime)._compiler.functionErrorLineOffset = 2;
-                }
-            });
-
             it('should emit a onError shout when an error in a script occurs', async () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -95,7 +95,6 @@ import { DefaultRealtimeEditModeProvider } from './AuxRealtimeEditModeProvider';
 import { DeepObjectError } from './Utils';
 import { del, edit, insert, preserve, tagValueHash } from '../aux-format-2';
 import { merge } from '../utils';
-import os from 'os';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid');

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -3388,6 +3388,37 @@ describe('AuxRuntime', () => {
                 expect(error.error).toEqual(new Error('My Error'));
             });
 
+            it('should update the error stack trace to use the correct line numbers', async () => {
+                runtime.stateUpdated(
+                    stateUpdatedEvent({
+                        test1: createBot('test1', {
+                            hello: '@debugger;throw new Error("My Error");',
+                        }),
+                        test3: createBot('test3', {
+                            onError: '@tags.error = that;',
+                        }),
+                    })
+                );
+                runtime.process([action('hello')]);
+
+                await waitAsync();
+
+                const error = runtime.currentState['test3'].tags.error;
+
+                expect(error).toBeTruthy();
+                expect(isRuntimeBot(error.bot)).toBe(true);
+                expect(error.tag).toBe('hello');
+                expect(error.error).toEqual(new Error('My Error'));
+
+                const lines = error.error.stack.split('\n');
+
+                expect(lines).toEqual([
+                    'Error: My Error',
+                    '   at hello (test1.hello:1:7)',
+                    '   at <CasualOS> ([Native CasualOS Code]::)',
+                ]);
+            });
+
             it('should not emit errors that occur inside an onError tag', async () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({
@@ -6434,10 +6465,6 @@ describe('original action tests', () => {
                     error: new Error('abc'),
                     bot: expect.objectContaining(state['thisBot']),
                     tag: 'test',
-
-                    //  TODO: Improve to support correct column numbers
-                    line: expect.any(Number),
-                    column: expect.any(Number),
                 },
             ]);
         });

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -122,6 +122,21 @@ export class AuxRuntime
     private _processingErrors: boolean = false;
     private _portalBots: Map<string, string> = new Map();
 
+    /**
+     * The counter that is used to generate function names.
+     */
+    private _functionNameCounter = 0;
+
+    /**
+     * A map of function names to their respective functions.
+     */
+    private _functionMap: Map<string, AuxCompiledScript> = new Map();
+
+    /**
+     * A map of bot IDs to a list of function names.
+     */
+    private _botFunctionMap: Map<string, Set<string>> = new Map();
+
     get forceSignedScripts() {
         return this._forceSignedScripts;
     }
@@ -667,6 +682,13 @@ export class AuxRuntime
                 removeFromContext(this._globalContext, [bot.script]);
             }
             delete this._compiledState[id];
+            const list = this._getFunctionNamesForBot(id, false);
+            if (list) {
+                for (let name of list) {
+                    this._functionMap.delete(name);
+                }
+                this._botFunctionMap.delete(id);
+            }
             nextUpdate.state[id] = null;
             nextUpdate.removedBots.push(id);
         }
@@ -1295,8 +1317,23 @@ export class AuxRuntime
             }
         }
 
-        return this._compiler.compile(script, {
+        let functionName: string;
+        let diagnosticFunctionName: string;
+        let fileName: string;
+        if (hasValue(bot)) {
+            this._functionNameCounter += 1;
+            functionName = '_' + this._functionNameCounter;
+            diagnosticFunctionName = tag;
+            fileName = `${bot.id}.${diagnosticFunctionName}`;
+        }
+
+        const func = this._compiler.compile(script, {
             // TODO: Support all the weird features
+
+            functionName: functionName,
+            diagnosticFunctionName: diagnosticFunctionName,
+            fileName: fileName,
+
             context: {
                 bot,
                 tag,
@@ -1317,33 +1354,20 @@ export class AuxRuntime
                     tag: ctx.tag,
                 };
                 if (err instanceof Error) {
-                    if (Error.prepareStackTrace) {
-                        const prev = Error.prepareStackTrace;
-                        try {
-                            Error.prepareStackTrace = (err, stackTrace) => {
-                                const info = this._compiler.findLineInfo(
-                                    stackTrace,
-                                    meta
-                                );
-                                if (info) {
-                                    Object.assign(err, info);
-                                }
+                    try {
+                        const newStack = this._compiler.calculateOriginalStackTrace(
+                            this._functionMap,
+                            err
+                        );
 
-                                return prev(err, stackTrace);
-                            };
-
-                            // force the stack trace to be computed
-                            err.stack;
-                            const anyError = <any>err;
-                            if (hasValue(anyError.line)) {
-                                data.line = anyError.line;
-                            }
-                            if (hasValue(anyError.column)) {
-                                data.column = anyError.column;
-                            }
-                        } finally {
-                            Error.prepareStackTrace = prev;
+                        if (newStack) {
+                            err.stack = newStack;
                         }
+                    } catch (stackError) {
+                        console.error(
+                            '[AuxRuntime] Unable to transform error stack trace',
+                            stackError
+                        );
                     }
                 }
                 throw data;
@@ -1365,6 +1389,14 @@ export class AuxRuntime
             },
             arguments: [['that', 'data']],
         });
+
+        if (hasValue(bot)) {
+            this._functionMap.set(functionName, func);
+            const botFunctionNames = this._getFunctionNamesForBot(bot.id);
+            botFunctionNames.add(functionName);
+        }
+
+        return func;
     }
 
     private _getRuntimeBot(id: string): RuntimeBot {
@@ -1459,6 +1491,19 @@ export class AuxRuntime
 
     private _transformBotsToRuntimeBots(result: any, value: any, key: any) {
         result[key] = this._mapBotsToRuntimeBots(value);
+    }
+
+    private _getFunctionNamesForBot(
+        botId: string,
+        createIfDoesNotExist = true
+    ): Set<string> {
+        let list = this._botFunctionMap.get(botId);
+        if (!list && createIfDoesNotExist) {
+            list = new Set();
+            this._botFunctionMap.set(botId, list);
+        }
+
+        return list;
     }
 }
 

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -1361,6 +1361,7 @@ export class AuxRuntime
                         );
 
                         if (newStack) {
+                            (<any>err).oldStack = err.stack;
                             err.stack = newStack;
                         }
                     } catch (stackError) {

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -412,6 +412,15 @@ const locationCases = [
         },
         7,
     ],
+    [
+        'should support windows line endings',
+        'abcdef\r\nghijfk',
+        {
+            lineNumber: 1,
+            column: 0,
+        },
+        8,
+    ],
 ] as const;
 
 describe('calculateIndexFromLocation()', () => {

--- a/src/aux-custom-portals/bin/common.js
+++ b/src/aux-custom-portals/bin/common.js
@@ -20,6 +20,8 @@ module.exports = [
             ),
             plugins: [
                 emptyModulePlugin('@casual-simulation/three'),
+                emptyModulePlugin('@casual-simulation/error-stack-parser'),
+                emptyModulePlugin('stackframe'),
                 emptyModulePlugin('scrypt-js'),
                 emptyModulePlugin('base64-js'),
                 emptyModulePlugin('hash.js', /^hash\.js$/),
@@ -59,6 +61,8 @@ module.exports = [
                 'base64-js',
                 'hash.js',
                 '@casual-simulation/three',
+                '@casual-simulation/error-stack-parser',
+                'stackframe',
                 'scrypt-js',
                 'tweetnacl',
                 'astring',

--- a/src/aux-vm/vm/AuxHelper.ts
+++ b/src/aux-vm/vm/AuxHelper.ts
@@ -92,10 +92,17 @@ export class AuxHelper extends BaseHelper<Bot> {
                         if (error instanceof RanOutOfEnergyError) {
                             console.error(error);
                         } else {
-                            console.error(
-                                `An error occurred in ${error.bot.id}.${error.tag}:`,
-                                error.error
-                            );
+                            if (error.bot) {
+                                console.error(
+                                    `An error occurred in ${error.bot.id}.${error.tag}:`,
+                                    error.error
+                                );
+                            } else {
+                                console.error(
+                                    `An error occurred:`,
+                                    error.error
+                                );
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
### :rocket: Improvements

-   Improved handling of errors so they have correct line and column numbers in their stack traces.
    -   Currently, this only functions correctly on Chrome-based browsers (Chrome, Edge, Opera, etc.). Part of this is due to differences between how web browsers generate stack traces and part is due to what browsers support for dynamically generated functions.