### PR TITLE
JSX Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
     -   This function can parse a list of bot mods from JSON or from the contents of a PDF that was created with `os.downloadBots()`.
     -   It returns a list of bot mods (i.e. mods that have the structure of bots) which can in turn be passed to `create()` to add them to the server.
 -   Added the `os.unregisterApp(appID)` function to allow removing apps after they have been registered.
+-   Added the ability to use [JSX](https://reactjs.org/docs/introducing-jsx.html) for Apps instead of the `html` string helper.
+    -   JSX allows you to use a HTML-like language directly inside listeners. This provides some nice benefits including proper syntax highlighting and error messages.
+    -   For example:
+        ```javascript
+        let result = <h1>Hello, World!</h1>;
+        ```
+    -   Due to convienience this will probably become the preferred way to write HTML for apps, however the `html` string helper will still be available.
 
 ## V2.0.3
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -183,7 +183,8 @@ Here's a list of the tools and packages that we're using to build CasualOS.
     -   [Husky](https://github.com/typicode/husky) for pre-commit hooks.
 -   Dependencies
     -   AUX Common
-        -   [acorn](https://github.com/acornjs/acorn) for parsing AUX formulas.
+        -   [acorn](https://github.com/acornjs/acorn) for parsing listener functions.
+            -   [acorn-jsx](https://github.com/acornjs/acorn-jsx) for parsing JSX code in listeners.
         -   [astring](https://github.com/davidbonnet/astring) for generating JS from acorn trees.
         -   [estraverse](https://github.com/estools/estraverse) for traversing the acorn trees and transforming them.
         -   [lodash](https://lodash.com/) for easy array/object manipulation.

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -5950,8 +5950,16 @@ The **second parameter** is the bot that should represent the app. This is the b
 should generally be in charge of calling <ActionLink action='os.compileApp(appId, content)'/>.
 
 Apps work by running the HTML you give it by calling <ActionLink action='os.compileApp(appId, content)'/> with the HTML you want the app to show.
-CasualOS includes a helper called `html` that can be used to make HTML objects out of a string.
+Since JavaScript does not natively support HTML, we are using a special extension called [JSX](https://reactjs.org/docs/introducing-jsx.html) that adds HTML-like syntax to JavaScript.
+At the most basic, JSX is like writing HTML inside JavaScript:
+```typescript
+let htmlData = <div>
+    <h1>Hello World</h1>
+</div>;
+```
+See this article for more information: [Introducing JSX](https://reactjs.org/docs/introducing-jsx.html)
 
+CasualOS also includes a helper called `html` that can be used to make HTML objects out of a string.
 You can use it to convert a string into HTML by adding it before a string that uses backticks, like this:
 ```typescript
 let htmlData = html`
@@ -5961,32 +5969,32 @@ let htmlData = html`
 `;
 ```
 
+JSX is the preferred way to write HTML inside JavaScript since CasualOS can properly detect it and add helpful features like syntax highlighting and error messages.
+
 #### Examples:
 
 ```typescript title='Setup a basic app'
 await os.registerApp('basicApp', thisBot);
 
-os.compileApp('basicApp', html`
-    <h1>Hello World!</h1>
-`);
+os.compileApp('basicApp', <h1>Hello World!</h1>);
 ```
 
 ```typescript title='Setup an app with a button'
 await os.registerApp('buttonApp', thisBot);
 
-os.compileApp('buttonApp', html`
-    <button onClick=${ () => os.toast("You clicked the button!")}>
+os.compileApp('buttonApp', 
+    <button onClick={ () => os.toast("You clicked the button!") }>
         Click Me!
     </button>
-`);
+);
 ```
 
 ```typescript title='Setup an app with an input box'
 await os.registerApp('inputApp', thisBot);
 
-os.compileApp('inputApp', html`
-    <input onInput=${ (e) =>  tags.label = e.target.value }>
-`);
+os.compileApp('inputApp', 
+    <input onInput={ (e) => { tags.label = e.target.value } }>
+);
 ```
 
 ### `os.compileApp(appId, content)`
@@ -6003,29 +6011,27 @@ The **second parameter** is the content that the app should display.
 #### Examples:
 
 ```typescript title='Display a header'
-os.compileApp('myApp', html`
-    <h1>Hello World!</h1>
-`);
+os.compileApp('myApp', <h1>Hello World!</h1>);
 ```
 
 ```typescript title='Display a button'
-os.compileApp('myApp', html`
-    <button onClick=${ () => os.toast("You clicked the button!")}>
+os.compileApp('myApp', 
+    <button onClick={ () => os.toast("You clicked the button!")}>
         Click Me!
     </button>
-`);
+);
 ```
 
 ```typescript title='Display an input box'
-os.compileApp('myApp', html`
-    <input onInput=${ (e) => { tags.label = e.target.value } } />
-`);
+os.compileApp('myApp', 
+    <input onInput={ (e) => { tags.label = e.target.value } } />
+);
 ```
 
 ```typescript title='Display a slider input'
-os.compileApp('myApp', html`
-    <input type="range" min="0" max="100" onInput=${ (e) => { tags.label = e.target.value } } />
-`);
+os.compileApp('myApp', 
+    <input type="range" min="0" max="100" onInput={ (e) => { tags.label = e.target.value } } />
+);
 ```
 
 ### `os.unregisterApp(appId)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10446,6 +10446,11 @@
 				}
 			}
 		},
+		"acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+		},
 		"acorn-node": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
@@ -16931,28 +16936,28 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"optional": true,
@@ -16963,14 +16968,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
@@ -16981,35 +16986,35 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"optional": true,
@@ -17019,35 +17024,35 @@
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -17064,7 +17069,7 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"optional": true,
@@ -17079,14 +17084,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 					"dev": true,
 					"optional": true,
@@ -17096,7 +17101,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"optional": true,
@@ -17106,7 +17111,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -17117,14 +17122,14 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
@@ -17134,14 +17139,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
@@ -17151,14 +17156,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
@@ -17168,14 +17173,14 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
 					"dev": true,
 					"optional": true,
@@ -17187,7 +17192,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
 					"dev": true,
 					"optional": true,
@@ -17206,7 +17211,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -17217,14 +17222,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
 					"dev": true,
 					"optional": true,
@@ -17235,7 +17240,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -17248,21 +17253,21 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
@@ -17272,21 +17277,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -17297,21 +17302,21 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"dev": true,
 					"optional": true,
@@ -17324,7 +17329,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -17333,7 +17338,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
@@ -17349,7 +17354,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"dev": true,
 					"optional": true,
@@ -17359,49 +17364,49 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
@@ -17413,7 +17418,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -17423,7 +17428,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
@@ -17433,7 +17438,7 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
@@ -17465,14 +17470,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"optional": true,
@@ -17482,7 +17487,7 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -2613,6 +2613,12 @@ export interface RegisterHtmlAppAction extends AsyncAction {
      * The ID of the app.
      */
     appId: string;
+
+    /**
+     * The ID of the app instance.
+     * Used to distinguish between multiple instances of the same app.
+     */
+    instanceId: string;
 }
 
 /**
@@ -2625,6 +2631,12 @@ export interface UnregisterHtmlAppAction extends Action {
      * The ID of the app.
      */
     appId: string;
+
+    /**
+     * The ID of the app instance.
+     * Used to distinguish between multiple instances of the same app.
+     */
+    instanceId: string;
 }
 
 /**
@@ -5682,11 +5694,13 @@ export function setAppOutput(appId: string, output: any): SetAppOutputAction {
  */
 export function registerHtmlApp(
     appId: string,
+    instanceId: string,
     taskId?: string | number
 ): RegisterHtmlAppAction {
     return {
         type: 'register_html_app',
         appId,
+        instanceId,
         taskId,
     };
 }
@@ -5694,10 +5708,14 @@ export function registerHtmlApp(
 /**
  * Creates a UnregisterHtmlAppAction.
  */
-export function unregisterHtmlApp(appId: string): UnregisterHtmlAppAction {
+export function unregisterHtmlApp(
+    appId: string,
+    instanceId: string
+): UnregisterHtmlAppAction {
     return {
         type: 'unregister_html_app',
         appId,
+        instanceId,
     };
 }
 

--- a/src/aux-common/package.json
+++ b/src/aux-common/package.json
@@ -44,6 +44,7 @@
         "@types/estraverse": "^5.1.0",
         "@types/uuid": "^8.3.0",
         "acorn": "^8.0.1",
+        "acorn-jsx": "^5.3.2",
         "astring": "1.6.2",
         "estraverse": "^5.2.0",
         "fast-json-stable-stringify": "2.1.0",

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -358,6 +358,45 @@ describe('AuxCompiler', () => {
             expect(error).toEqual(new SyntaxError('Unexpected token (1:10)'));
         });
 
+        it('should compile JSX to point to html.h()', () => {
+            let symbol = Symbol('return value');
+            let fn = compiler.compile('return <div></div>', {
+                variables: {
+                    html: () => ({
+                        h: () => symbol,
+                    }),
+                },
+                constants: {
+                    myTest: 123,
+                    myOtherTest: 456,
+                },
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
+        it('should compile JSX fragments to point to html.f', () => {
+            let symbol = Symbol('return value');
+            let fn = compiler.compile('return <><h1></h1></>', {
+                variables: {
+                    html: () => ({
+                        h: (type: any) => type,
+                        f: symbol,
+                    }),
+                },
+                constants: {
+                    myTest: 123,
+                    myOtherTest: 456,
+                },
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
         describe('calculateOriginalLineLocation()', () => {
             it('should return (0, 0) if given a location before the user script actually starts', () => {
                 const script = 'return str + num + abc;';

--- a/src/aux-common/runtime/AuxCompiler.ts
+++ b/src/aux-common/runtime/AuxCompiler.ts
@@ -15,12 +15,18 @@ import StackFrame from 'stackframe';
  */
 export const COMPILED_SCRIPT_SYMBOL = Symbol('compiled_script');
 
+const JSX_FACTORY = 'html.h';
+const JSX_FRAGMENT_FACTORY = 'html.f';
+
 /**
  * Defines a class that can compile scripts and formulas
  * into functions.
  */
 export class AuxCompiler {
-    private _transpiler = new Transpiler();
+    private _transpiler = new Transpiler({
+        jsxFactory: JSX_FACTORY,
+        jsxFragment: JSX_FRAGMENT_FACTORY,
+    });
     private _functionCache = new Map<string, Function>();
 
     /**

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -195,6 +195,7 @@ import { Subscription, SubscriptionLike } from 'rxjs';
 import { waitAsync } from '../test/TestHelpers';
 import { embedBase64InPdf } from './Utils';
 import { fromByteArray, toByteArray } from 'base64-js';
+import { Fragment } from 'preact';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid');
@@ -12190,6 +12191,19 @@ describe('AuxLibrary', () => {
             `;
 
             expect(result).toMatchSnapshot();
+        });
+
+        describe('h()', () => {
+            it('should return a HTML VDOM element', () => {
+                const result = library.api.html.h('h1', null, 'Hello, World!');
+                expect(result).toMatchSnapshot();
+            });
+        });
+
+        describe('f', () => {
+            it('should be the Fragment element type', () => {
+                expect(library.api.html.f).toBe(Fragment);
+            });
         });
     });
 });

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -285,11 +285,26 @@ import './PerformanceNowPolyfill';
 import './BlobPolyfill';
 import { AuxDevice } from './AuxDevice';
 import { AuxVersion } from './AuxVersion';
-import { h } from 'preact';
+import { Fragment, h } from 'preact';
 import htm from 'htm';
 import { fromByteArray, toByteArray } from 'base64-js';
 
-const html = htm.bind(h);
+const _html: HtmlFunction = htm.bind(h) as any;
+
+const html: HtmlFunction = ((...args: any[]) => {
+    return _html(...args);
+}) as any;
+(<any>html).h = h;
+(<any>html).f = Fragment;
+
+/**
+ * Defines an interface for a function that provides HTML VDOM capabilities to bots.
+ */
+export interface HtmlFunction {
+    (...args: any[]): any;
+    h: (name: string | Function, props: any, ...children: any[]) => any;
+    f: any;
+}
 
 /**
  * Defines an interface for a library of functions and values that can be used by formulas and listeners.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2586,6 +2586,15 @@ export interface CodeBundle {
     modules: BundleModules;
 }
 
+/**
+ * Defines an interface for a function that provides HTML VDOM capabilities to bots.
+ */
+ export interface HtmlFunction {
+    (...args: any[]): any;
+    h: (name: string | Function, props: any, ...children: any[]) => any;
+    f: any;
+}
+
 declare global {
 
     /**
@@ -3274,7 +3283,7 @@ declare global {
      * Produces HTML from the given HTML strings and expressions.
      * Best used with a tagged template string.
      */
-    function html(strings: string[], ...expressions: any[]): any;
+    const html: HtmlFunction;
 
     /**
      * Defines a set of functions that relate to common OS operations.

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -4806,6 +4806,20 @@ describe('AuxRuntime', () => {
             ]);
         });
 
+        it('should compile listeners to use the html.h() function for JSX', async () => {
+            uuidMock.mockReturnValueOnce('uuid');
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test1: createBot('test1', {
+                        test: '@return (<div></div>)',
+                    }),
+                })
+            );
+            let result = runtime.shout('test');
+
+            expect(result.results).toMatchSnapshot();
+        });
+
         describe('bot_added', () => {
             it('should produce an event when a bot is created', async () => {
                 uuidMock.mockReturnValueOnce('uuid');

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -413,6 +413,54 @@ describe('Transpiler', () => {
                 expect(result).toBe(`h(Fragment,null,\`My Button\`,)`);
             });
 
+            it('should support fragments with multiple children', () => {
+                const result = transpiler.transpile(
+                    [`<>`, `<div></div>`, `<button></button>`, `</>`].join('')
+                );
+
+                expect(result).toBe(
+                    `h(Fragment,null,h("div",null,),h("button",null,),)`
+                );
+            });
+
+            it('should support the attribute spread syntax', () => {
+                const result = transpiler.transpile(
+                    `<div {...myAttribute}></div>`
+                );
+
+                expect(result).toBe(`h("div",{ ...myAttribute},)`);
+            });
+
+            it('should apply spread attributes in the order they are provided compared to normal attributes', () => {
+                const result = transpiler.transpile(
+                    `<div name="bob" {...myAttribute} value="123"></div>`
+                );
+
+                expect(result).toBe(
+                    `h("div",{ "name":"bob" ,...myAttribute ,"value":"123"},)`
+                );
+            });
+
+            it('should support additional expressions in a spread attribute', () => {
+                const result = transpiler.transpile(
+                    `<div {...{ bob: true, value: 123 }}></div>`
+                );
+
+                expect(result).toBe(
+                    `h("div",{ ...{ bob: true, value: 123 }},)`
+                );
+            });
+
+            it('should support elements in spread attributes', () => {
+                const result = transpiler.transpile(
+                    `<div {...{ bob: <button></button> }}></div>`
+                );
+
+                expect(result).toBe(
+                    `h("div",{ ...{ bob: h("button",null,) }},)`
+                );
+            });
+
             // const cases = [];
 
             // it.each(cases)('%s', (desc, given, expected) => {

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -461,6 +461,12 @@ describe('Transpiler', () => {
                 );
             });
 
+            it('should support attributes with no value', () => {
+                const result = transpiler.transpile(`<div bob></div>`);
+
+                expect(result).toBe(`h("div",{ "bob":true},)`);
+            });
+
             // const cases = [];
 
             // it.each(cases)('%s', (desc, given, expected) => {

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -481,6 +481,12 @@ describe('Transpiler', () => {
                 expect(result).toBe(`h("p",null,\`10 is &lt; 20\`,)`);
             });
 
+            it('should support self closing elements', () => {
+                const result = transpiler.transpile(`<span/>`);
+
+                expect(result).toBe(`h("span",null,)`);
+            });
+
             // const cases = [];
 
             // it.each(cases)('%s', (desc, given, expected) => {

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -475,6 +475,12 @@ describe('Transpiler', () => {
                 expect(result).toBe(`h(Html.Button,null,)`);
             });
 
+            it('should leave HTML escaped character sequences in text', () => {
+                const result = transpiler.transpile(`<p>10 is &lt; 20</p>`);
+
+                expect(result).toBe(`h("p",null,\`10 is &lt; 20\`,)`);
+            });
+
             // const cases = [];
 
             // it.each(cases)('%s', (desc, given, expected) => {

--- a/src/aux-common/runtime/Transpiler.spec.ts
+++ b/src/aux-common/runtime/Transpiler.spec.ts
@@ -467,6 +467,14 @@ describe('Transpiler', () => {
                 expect(result).toBe(`h("div",{ "bob":true},)`);
             });
 
+            it('should support dot notation in element names', () => {
+                const result = transpiler.transpile(
+                    `<Html.Button></Html.Button>`
+                );
+
+                expect(result).toBe(`h(Html.Button,null,)`);
+            });
+
             // const cases = [];
 
             // it.each(cases)('%s', (desc, given, expected) => {

--- a/src/aux-common/runtime/Transpiler.ts
+++ b/src/aux-common/runtime/Transpiler.ts
@@ -347,7 +347,7 @@ export class Transpiler {
         const end = createRelativePositionFromStateVector(
             text,
             version,
-            closeElement.end,
+            !!closeElement ? closeElement.end : node.end,
             -1,
             true
         );
@@ -662,24 +662,28 @@ export class Transpiler {
         const openEnd = createRelativePositionFromStateVector(
             text,
             version,
-            openElement.end - 1,
+            openElement.end - (closeElement ? 1 : 2),
             undefined,
             true
         );
-        const closingStart = createRelativePositionFromStateVector(
-            text,
-            version,
-            closeElement.start,
-            undefined,
-            true
-        );
-        const closingEnd = createRelativePositionFromStateVector(
-            text,
-            version,
-            closeElement.end,
-            -1,
-            true
-        );
+        const closingStart = !!closeElement
+            ? createRelativePositionFromStateVector(
+                  text,
+                  version,
+                  closeElement.start,
+                  undefined,
+                  true
+              )
+            : null;
+        const closingEnd = !!closeElement
+            ? createRelativePositionFromStateVector(
+                  text,
+                  version,
+                  closeElement.end,
+                  -1,
+                  true
+              )
+            : null;
 
         let attributePositions = [];
         for (let attribute of openElement.attributes) {
@@ -764,21 +768,23 @@ export class Transpiler {
             openEnd,
             doc
         );
-        text.delete(openEndAbsolute.index, 1);
+        text.delete(openEndAbsolute.index, closeElement ? 1 : 2);
 
-        // remove closing tag
-        const closingStartAbsolute = createAbsolutePositionFromRelativePosition(
-            closingStart,
-            doc
-        );
-        const closingEndAbsolute = createAbsolutePositionFromRelativePosition(
-            closingEnd,
-            doc
-        );
-        text.delete(
-            closingStartAbsolute.index,
-            closingEndAbsolute.index - closingStartAbsolute.index
-        );
+        if (closeElement) {
+            // remove closing tag
+            const closingStartAbsolute = createAbsolutePositionFromRelativePosition(
+                closingStart,
+                doc
+            );
+            const closingEndAbsolute = createAbsolutePositionFromRelativePosition(
+                closingEnd,
+                doc
+            );
+            text.delete(
+                closingStartAbsolute.index,
+                closingEndAbsolute.index - closingStartAbsolute.index
+            );
+        }
     }
 
     private _insertEnergyCheckIntoStatement(

--- a/src/aux-common/runtime/Transpiler.ts
+++ b/src/aux-common/runtime/Transpiler.ts
@@ -131,6 +131,12 @@ export class Transpiler {
         this._jsxFragment = options?.jsxFragment ?? 'Fragment';
     }
 
+    parse(code: string): any {
+        const macroed = replaceMacros(code);
+        const node = this._parse(macroed);
+        return node;
+    }
+
     /**
      * Transpiles the given code into ES6 JavaScript Code.
      */

--- a/src/aux-common/runtime/Transpiler.ts
+++ b/src/aux-common/runtime/Transpiler.ts
@@ -455,6 +455,10 @@ export class Transpiler {
             }
             if (attr.type !== 'JSXSpreadAttribute') {
                 val += `"${name}":`;
+
+                if (!attr.value) {
+                    val += 'true';
+                }
             }
             text.insert(pos.index, val);
             index++;
@@ -652,7 +656,9 @@ export class Transpiler {
                 const nameEnd = createRelativePositionFromStateVector(
                     text,
                     version,
-                    attribute.name.end + 1,
+                    !!attribute.value
+                        ? attribute.name.end + 1
+                        : attribute.name.end,
                     -1,
                     true
                 );

--- a/src/aux-common/runtime/__snapshots__/AuxLibrary.spec.ts.snap
+++ b/src/aux-common/runtime/__snapshots__/AuxLibrary.spec.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AuxLibrary html h() should return a HTML VDOM element 1`] = `
+Object {
+  "__": null,
+  "__b": 0,
+  "__c": null,
+  "__d": undefined,
+  "__e": null,
+  "__h": null,
+  "__k": null,
+  "__v": 2,
+  "constructor": undefined,
+  "key": undefined,
+  "props": Object {
+    "children": "Hello, World!",
+  },
+  "ref": undefined,
+  "type": "h1",
+}
+`;
+
 exports[`AuxLibrary html should return a HTML VDOM element 1`] = `
 Object {
   "__": null,

--- a/src/aux-common/runtime/__snapshots__/AuxRuntime.spec.ts.snap
+++ b/src/aux-common/runtime/__snapshots__/AuxRuntime.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuxRuntime shout() should compile listeners to use the html.h() function for JSX 1`] = `
+Array [
+  Object {
+    "__": null,
+    "__b": 0,
+    "__c": null,
+    "__d": undefined,
+    "__e": null,
+    "__h": null,
+    "__k": null,
+    "__v": 1,
+    "constructor": undefined,
+    "key": undefined,
+    "props": Object {},
+    "ref": undefined,
+    "type": "div",
+  },
+]
+`;

--- a/src/aux-common/yjs/YjsHelpers.spec.ts
+++ b/src/aux-common/yjs/YjsHelpers.spec.ts
@@ -191,6 +191,47 @@ describe('YjsHelpers', () => {
 
             expect(pos1).toEqual(expected1);
         });
+
+        it('should be able to find a position in deleted text', () => {
+            const doc1 = new Doc();
+            doc1.clientID = 1;
+            const doc2 = new Doc();
+            doc2.clientID = 2;
+            const text1 = doc1.getText();
+            const text2 = doc2.getText();
+            text1.insert(0, 'abcdef');
+            text2.insert(0, 'ghijfk');
+
+            const vector1 = getStateVector(doc1);
+            const vector2 = getStateVector(doc2);
+
+            const state1 = encodeStateAsUpdate(doc1);
+            const state2 = encodeStateAsUpdate(doc2);
+
+            applyUpdate(doc1, state2);
+            applyUpdate(doc2, state1);
+
+            expect(text1.toString()).toEqual('abcdefghijfk');
+            expect(text2.toString()).toEqual('abcdefghijfk');
+
+            text2.delete(0, 3);
+
+            const state3 = encodeStateAsUpdate(doc2);
+            applyUpdate(doc1, state3);
+
+            const pos1 = createRelativePositionFromStateVector(
+                text1,
+                vector1,
+                2,
+                undefined,
+                true
+            );
+
+            expect(pos1.item).toEqual({
+                client: 1,
+                clock: 2,
+            });
+        });
     });
 
     describe('yjs', () => {

--- a/src/aux-custom-portals/bin/common.js
+++ b/src/aux-custom-portals/bin/common.js
@@ -69,6 +69,7 @@ module.exports = [
                 'fast-json-stable-stringify',
                 'lru-cache',
                 'acorn',
+                'acorn-jsx',
                 'mime',
                 '@tweenjs/tween.js',
                 'estraverse',

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -65,8 +65,7 @@ import { CurrentVersion } from '@casual-simulation/causal-trees';
 import { Color } from '@casual-simulation/three';
 import { invertColor } from './scene/ColorUtils';
 import { getCursorColorClass, getCursorLabelClass } from './StyleHelpers';
-// import jscodeshift from 'jscodeshift';
-// import MonacoJSXHighlighter from './public/monaco-jsx-highlighter/index';
+import MonacoJSXHighlighter from './public/monaco-jsx-highlighter/index';
 import axios from 'axios';
 import { customPortalLanguageId } from './public/monaco-editor/custom-portal-typescript/custom-portal-typescript.contribution';
 import {
@@ -394,11 +393,10 @@ export function watchEditor(
     simulation: Simulation,
     editor: monaco.editor.ICodeEditor
 ): Subscription {
-    // const monacoJsxHighlighter = new MonacoJSXHighlighter(
-    //     monaco,
-    //     jscodeshift,
-    //     editor
-    // );
+    const monacoJsxHighlighter = new MonacoJSXHighlighter(
+        new Transpiler(),
+        editor
+    );
 
     const modelChangeObservable = new Observable<
         monaco.editor.IModelChangedEvent
@@ -591,35 +589,35 @@ export function watchEditor(
         )
     );
 
-    // const enableJsxHighlightingOnCorrectModels = modelInfos.pipe(
-    //     map(
-    //         (info) =>
-    //             info.language === 'javascript' || info.language === 'typescript'
-    //     ),
-    //     scan(
-    //         (acc, needsJsxHighlighting) => {
-    //             if (acc) {
-    //                 acc();
-    //             }
-    //             if (needsJsxHighlighting) {
-    //                 return monacoJsxHighlighter.highLightOnDidChangeModelContent(
-    //                     undefined,
-    //                     () => {},
-    //                     undefined,
-    //                     () => {}
-    //                 );
-    //             } else {
-    //                 return () => {};
-    //             }
-    //         },
-    //         () => {}
-    //     )
-    // );
+    const enableJsxHighlightingOnCorrectModels = modelInfos.pipe(
+        map(
+            (info) =>
+                info.language === 'javascript' || info.language === 'typescript'
+        ),
+        scan(
+            (acc, needsJsxHighlighting) => {
+                if (acc) {
+                    acc();
+                }
+                if (needsJsxHighlighting) {
+                    return monacoJsxHighlighter.highLightOnDidChangeModelContent(
+                        undefined,
+                        () => {},
+                        undefined,
+                        (err) => console.error(err)
+                    );
+                } else {
+                    return () => {};
+                }
+            },
+            () => {}
+        )
+    );
 
     const sub = new Subscription();
 
     sub.add(decorators.subscribe());
-    // sub.add(enableJsxHighlightingOnCorrectModels.subscribe());
+    sub.add(enableJsxHighlightingOnCorrectModels.subscribe());
 
     sub.add(
         toSubscription(

--- a/src/aux-server/aux-web/shared/public/monaco-jsx-highlighter/MonacoJSXHighlighter.css
+++ b/src/aux-server/aux-web/shared/public/monaco-jsx-highlighter/MonacoJSXHighlighter.css
@@ -1,25 +1,28 @@
 .mtk100.Identifier.JsxElement.Bracket {
-    color:#383838;
+    color:#2873c1;
 }
 
 .mtk1000.Identifier.JsxOpeningElement.Bracket {
-    color:#383838;
+    color:#2873c1;
 }
 
 .mtk1001.Identifier.JsxClosingElement.Bracket {
-    color:#383838;
+    color:#2873c1;
 }
 
 .mtk101.Identifier.JsxOpeningElement.Identifier {
-    color: #800000;
+    color: #2873c1;
+    font-weight: 800;
 }
 
 .mtk102.Identifier.JsxClosingElement.Identifier {
-    color: #800000;
+    color: #2873c1;
+    font-weight: 800;
 }
 
 .mtk103.Identifier.JsxAttribute.Identifier {
-    color: #FF0000;
+    color: #e87d20;
+    font-weight: initial;
 }
 
 .mtk104.JsxElement.JsxText {

--- a/src/aux-server/aux-web/shared/public/monaco-jsx-highlighter/MonacoJSXHighlighter.ts
+++ b/src/aux-server/aux-web/shared/public/monaco-jsx-highlighter/MonacoJSXHighlighter.ts
@@ -1,6 +1,7 @@
-// @ts-nocheck
-
-let monaco = null, j = null;
+import * as monaco from '../../MonacoLibs';
+import { Transpiler } from '@casual-simulation/aux-common';
+import { reject } from 'lodash';
+import estraverse from 'estraverse';
 
 const defaultOptions = {
     isHighlightGlyph: false,
@@ -54,7 +55,7 @@ export const JSXTypes = {
     },
     JSXElement: {
         highlightScope: HIGHLIGHT_SCOPE.EXTRA,
-        options: (elementName) => (
+        options: (elementName: string) => (
             {
                 glyphMarginClassName: 'mtk105.glyph.Identifier.JsxElement',
                 glyphMarginHoverMessage:
@@ -76,71 +77,99 @@ export const configureLocToMonacoRange = (
         case 'babylon':
         default:
             return (
-                loc,
+                node: NodeWithLocations,
                 startLineOffset = 0,
                 startColumnOffset = 0,
                 endLineOffset = 0,
                 endColumnOffset = 0,
             ) => {
-                if (!loc || !loc.start) {
+                if (!node || !node.start) {
                     return new _monaco.Range(1, 1, 1, 1);
                 }
                 return new _monaco.Range(
-                    startLineOffset + loc.start.line,
-                    startColumnOffset + loc.start.column + 1,
-                    endLineOffset + loc.end ?
-                        loc.end.line
-                        : loc.start.line,
-                    endColumnOffset + loc.end ?
-                        loc.end.column + 1
-                        : loc.start.column + 1,
+                    startLineOffset + node.loc.start.line,
+                    startColumnOffset + node.loc.start.column + 1,
+                    endLineOffset + node.end ?
+                        node.loc.end.line
+                        : node.loc.start.line,
+                    endColumnOffset + node.end ?
+                        node.loc.end.column + 1
+                        : node.loc.start.column + 1,
                 );
             };
     }
 };
 
+interface NodeWithLocations {
+    start: number;
+    end: number;
+    loc: LOC;
+}
+
+interface LOC {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+}
+
+interface MonacoJSXHighlighterOptions {
+    isHighlightGlyph: boolean,
+    iShowHover: boolean,
+    isUseSeparateElementStyles: boolean,
+}
+
 class MonacoJSXHighlighter {
     commentActionId = "editor.action.commentLine";
     commandActionId = "jsx-comment-edit";
-    _isHighlightBoundToModelContentChanges = false;
-    _isGetJSXCommentActive = false;
-    _isEditorDisposed = false;
+
+    options: MonacoJSXHighlighterOptions;
+
+    private _isHighlightBoundToModelContentChanges = false;
+    private _isGetJSXCommentActive = false;
+    private _isEditorDisposed = false;
+
+    private _transpiler: Transpiler;
+    private _monacoEditor: monaco.editor.ICodeEditor;
+    private _decoratorIds: string[];
+
+    private _locToMonacoRange: (loc: NodeWithLocations) => monaco.Range;
 
     constructor(
-        monacoRef,
-        jRef,
-        monacoEditor,
-        options = {},
+        transpiler: Transpiler,
+        monacoEditor: monaco.editor.ICodeEditor,
+        options: Partial<MonacoJSXHighlighterOptions> = {},
     ) {
-        monaco = monacoRef;
-        j = jRef;
-        this.locToMonacoRange = configureLocToMonacoRange(monaco);
-        this.monacoEditor = monacoEditor;
+        this._transpiler = transpiler;
+        this._locToMonacoRange = configureLocToMonacoRange(monaco);
+        this._monacoEditor = monacoEditor;
         this.options = {...defaultOptions, ...options};
     }
 
     getAstPromise = () => new Promise((resolve) => {
-        resolve(j(this.monacoEditor.getValue()));
+        try {
+            resolve(this._transpiler.parse(this._monacoEditor.getValue()));
+        } catch (e) {
+            reject(e);
+        }
     });
 
     highLightOnDidChangeModelContent = (
-        afterHighlight = ast => ast,
-        onError = error => console.error(error),
+        afterHighlight = (ast: any) => ast,
+        onError = (error: any) => console.error(error),
         getAstPromise = this.getAstPromise,
-        onJsCodeShiftErrors = error => console.log(error),
+        onJsCodeShiftErrors = (error: any) => console.log(error),
     ) => {
         this.highlightCode(
             afterHighlight, onError, getAstPromise, onJsCodeShiftErrors
         );
 
-        let highlighterDisposer = this.monacoEditor.onDidChangeModelContent(
+        let highlighterDisposer = this._monacoEditor.onDidChangeModelContent(
             () => this.highlightCode(
                 afterHighlight, onError, getAstPromise, onJsCodeShiftErrors
             )
         );
         this._isHighlightBoundToModelContentChanges = true;
 
-        this.monacoEditor.onDidDispose(() => {
+        this._monacoEditor.onDidDispose(() => {
             highlighterDisposer = null;
             this._isEditorDisposed = true;
             this._isHighlightBoundToModelContentChanges = false;
@@ -152,8 +181,8 @@ class MonacoJSXHighlighter {
                 return;
             }
             highlighterDisposer.dispose();
-            this.monacoEditor.deltaDecorations(
-                this.JSXDecoratorIds || [],
+            this._monacoEditor.deltaDecorations(
+                this._decoratorIds || [],
                 [],
             );
             highlighterDisposer = null;
@@ -162,10 +191,10 @@ class MonacoJSXHighlighter {
     };
 
     highlightCode = (
-        afterHighlight = ast => ast,
-        onError = error => console.error(error),
+        afterHighlight = (ast: any) => ast,
+        onError = (error: any) => console.error(error),
         getAstPromise = this.getAstPromise,
-        onJsCodeShiftErrors = error => error,
+        onJsCodeShiftErrors = (error: any) => error,
     ) =>
         (
             getAstPromise()
@@ -175,342 +204,165 @@ class MonacoJSXHighlighter {
             .then(afterHighlight)
             .catch(onError);
 
-    highlight = (ast) => {
+    highlight = (ast: any) => {
         return new Promise((resolve) => {
             if (ast) {
-                this.ast = ast;
-                this.decorators = this.extractAllDecorators(ast);
+                this.extractAllDecorators(ast);
                 resolve(ast);
             }
         });
-
     };
 
-    extractAllDecorators = (ast) => {
-        const decorators = this.createJSXElementDecorators(ast);
-        for (const jsxType in JSXTypes) {
-            this.createDecoratorsByType(
-                ast,
-                jsxType,
-                JSXTypes[jsxType].options,
-                JSXTypes[jsxType].highlightScope,
-                decorators,
-            );
-        }
-        this.JSXDecoratorIds =
-            this.monacoEditor.deltaDecorations(
-                this.JSXDecoratorIds || [],
+    private _traverse(node: any, enter: (node: any) => any) {
+        return estraverse.traverse(node, {
+            enter: (node: any) => {
+                return enter(node);
+            },
+
+            keys: {
+                JSXElement: ['openingElement', 'closingElement', 'children'],
+                JSXFragment: ['children'],
+                JSXOpeningElement: ['name', 'attributes'],
+                JSXClosingElement: ['name'],
+                JSXText: [],
+                JSXExpressionContainer: ['expression'],
+                JSXIdentifier: [],
+                JSXAttribute: ['name', 'value'],
+                JSXSpreadAttribute: []
+            },
+        });
+    }
+
+    extractAllDecorators = (ast: any) => {
+        let decorators = [] as monaco.editor.IModelDeltaDecoration[];
+
+        this._traverse(ast, (node) => {
+            if (node.type === 'JSXElement') {
+                this.createJSXElementDecorators(node, decorators);
+            }
+
+            if (node.type in JSXTypes) {
+                this.createDecoratorForType(node, node.type, (<any>JSXTypes)[node.type].options, (<any>JSXTypes)[node.type].highlightScope, decorators);
+            }
+        });
+
+        // for (const jsxType in JSXTypes) {
+        //     this.createDecoratorsByType(
+        //         ast,
+        //         jsxType,
+        //         JSXTypes[jsxType].options,
+        //         JSXTypes[jsxType].highlightScope,
+        //         decorators,
+        //     );
+        // }
+        this._decoratorIds =
+            this._monacoEditor.deltaDecorations(
+                this._decoratorIds || [],
                 decorators,
             );
         return decorators;
     }
 
-    createJSXElementDecorators = (
-        ast,
-        decorators = [],
-        highlighterOptions = this.options,
-    ) => {
-        ast
-            .findJSXElements()
-            .forEach(p => {
-                const loc = p.value.loc;
-                const openingElement = p.value.openingElement;
-                let elementName = null;
-                if (openingElement) {
-                    const oLoc = openingElement.loc;
-                    elementName = openingElement.name.name;
-                    decorators.push({
-                        range: new monaco.Range(
-                            oLoc.start.line,
-                            oLoc.start.column + 1,
-                            oLoc.start.line,
-                            oLoc.start.column + 2
-                        ),
-                        options: highlighterOptions.isUseSeparateElementStyles ?
-                            JSXTypes.JSXBracket.openingElementOptions
-                            : JSXTypes.JSXBracket.options,
-                    });
-                    decorators.push({
-                        range: new monaco.Range(
-                            oLoc.end.line,
-                            oLoc.end.column + (
-                                openingElement.selfClosing ? -1 : 0
-                            ),
-                            oLoc.end.line,
-                            oLoc.end.column + 1
-                        ),
-                        options: highlighterOptions.isUseSeparateElementStyles ?
-                            JSXTypes.JSXBracket.openingElementOptions
-                            : JSXTypes.JSXBracket.options,
-                    });
-                }
-                const closingElement = p.value.closingElement;
-                if (closingElement) {
-                    const cLoc = closingElement.loc;
-                    decorators.push({
-                        range: new monaco.Range(
-                            cLoc.start.line,
-                            cLoc.start.column + 1,
-                            cLoc.start.line,
-                            cLoc.start.column + 3
-                        ),
-                        options: highlighterOptions.isUseSeparateElementStyles ?
-                            JSXTypes.JSXBracket.closingElementOptions
-                            : JSXTypes.JSXBracket.options,
-                    });
-                    decorators.push({
-                        range: new monaco.Range(
-                            cLoc.end.line,
-                            cLoc.end.column,
-                            cLoc.end.line,
-                            cLoc.end.column + 1
-                        ),
-                        options: highlighterOptions.isUseSeparateElementStyles ?
-                            JSXTypes.JSXBracket.closingElementOptions
-                            : JSXTypes.JSXBracket.options,
-                    });
-                }
-
-                highlighterOptions.isHighlightGlyph && decorators.push({
-                    range: this.locToMonacoRange(loc),
-                    options: JSXTypes.JSXElement.options(elementName),
-                });
-            });
-        return decorators;
-    };
-
-    getJSXContext = (selection, ast, editor = this.monacoEditor) => {
-
-        const range = new monaco.Range(
-            selection.startLineNumber,
-            0,
-            selection.startLineNumber,
-            0
-        );
-
-
-        let minRange = null;
-        let path = null;
-
-        ast && ast.findJSXElements().forEach(p => {
-            const loc = p.value.loc;
-            const _range = this.locToMonacoRange(loc);
-
-            if (_range.intersectRanges(range)) {
-                if (!minRange || minRange.containsRange(_range)) {
-                    minRange = _range;
-                    path = p;
-                }
-            }
-        });
-        let leftmostNode = null;
-        let leftmostJsxTextNode = null;
-        let leftmostNodeRange = null;
-        let leftmostJsxTextNodeRange = null;
-
-        if (path) {
-            const {children = []} = path.value || {};
-            const getLeftMostNode = node => {
-                const loc = node && node.loc;
-                const _range = loc && this.locToMonacoRange(loc);
-
-                if (node.type === 'JSXText') {
-                    if (!leftmostNode && _range.containsRange(range)) {
-                        leftmostJsxTextNode = node;
-                        leftmostJsxTextNodeRange = _range;
-                    }
-                } else {
-                    if (_range &&
-                        _range.startLineNumber === range.startLineNumber) {
-                        if (
-                            !leftmostNode ||
-                            _range.startColumn < leftmostNodeRange.startColumn
-                        ) {
-                            leftmostNode = node;
-                            leftmostNodeRange = _range;
-
-                        }
-                    }
-
-                }
-            }
-            children.forEach(getLeftMostNode);
+    createJSXElementDecorators(node: any, decorators: monaco.editor.IModelDeltaDecoration[]) {
+        const openingElement = node.openingElement;
+        let elementName: string = null;
+        if (openingElement) {
+            elementName = this.createJSXOpeningElementDecorator(openingElement, decorators);
         }
-        let commentContext = leftmostNode || leftmostJsxTextNode ?
-            JSXCommentContexts.JSX : JSXCommentContexts.JS;
-        return commentContext;
-    };
-
-    getJSXCommentContext = (
-        selection,
-        getAstPromise = this.getAstPromise,
-        onJsCodeShiftErrors = error => error,
-        editor = this.monacoEditor
-    ) => {
-        return new Promise((resolve) => {
-                if (this._isHighlightBoundToModelContentChanges) {
-                    resolve(this.getJSXContext(selection, this.ast, editor));
-                } else {
-                    getAstPromise().then(ast => {
-                        resolve(this.getJSXContext(selection, ast, editor));
-                    })
-                        .catch(
-                            (error) => resolve(
-                                this.getJSXContext(selection, null, editor)
-                            ) || onJsCodeShiftErrors(error)
-                        )
-                }
-            }
-        ).catch(onJsCodeShiftErrors);
-    };
-
-    executeEditorEdits = (
-        range,
-        text,
-        editor = this.monacoEditor,
-        identifier = {major: 1, minor: 1},
-        forceMoveMarkers = true,
-        commandId = "jsx-comment-edit",
-    ) => {
-        const op = {
-            identifier: {major: 1, minor: 1},
-            range,
-            text,
-            forceMoveMarkers,
-        };
-        editor.executeEdits(commandId, [op]);
-    };
-
-    addJSXCommentCommand = (
-        getAstPromise = this.getAstPromise,
-        onJsCodeShiftErrors = error => error,
-        editor = this.monacoEditor,
-    ) => {
-        this._isGetJSXCommentActive = true;
-        this._editorCommandId = editor.addCommand(
-            monaco.KeyMod.CtrlCmd | monaco.KeyCode.US_SLASH,
-            () => {
-                if (!this._isGetJSXCommentActive) {
-                    editor.getAction(this.commentActionId).run();
-                    return;
-                }
-                const selection = editor.getSelection();
-                const model = editor.getModel();
-
-                this.getJSXCommentContext(
-                    selection,
-                    getAstPromise,
-                    onJsCodeShiftErrors,
-                    editor,
-                ).then((commentContext) => {
-
-
-                    let isUnCommentAction = true;
-
-                    const commentsData = [];
-
-                    for (let i = selection.startLineNumber;
-                         i <= selection.endLineNumber;
-                         i++) {
-                        const commentRange = new monaco.Range(
-                            i,
-                            model.getLineFirstNonWhitespaceColumn(i),
-                            i,
-                            model.getLineMaxColumn(i),
-                        );
-
-                        const commentText = model.getValueInRange(commentRange);
-
-                        commentsData.push({
-                            commentRange,
-                            commentText
-                        });
-
-                        isUnCommentAction = isUnCommentAction &&
-                            !!commentText.match(/{\/\*/);
-                    }
-
-
-                    if (commentContext !== JSXCommentContexts.JSX
-                        && !isUnCommentAction) {
-                        editor.getAction(this.commentActionId).run();
-                        return;
-                    }
-
-                    let editOperations = [];
-                    let commentsDataIndex = 0;
-
-                    for (let i = selection.startLineNumber;
-                         i <= selection.endLineNumber;
-                         i++) {
-                        let {
-                            commentText,
-                            commentRange,
-                        } = commentsData[commentsDataIndex++];
-
-                        if (isUnCommentAction) {
-                            commentText = commentText.replace(/{\/\*/, '');
-                            commentText = commentText.replace(/\*\/}/, '');
-                        } else {
-                            commentText = `{/*${commentText}*/}`;
-                        }
-
-                        editOperations.push({
-                            identifier: {major: 1, minor: 1},
-                            range: commentRange,
-                            text: commentText,
-                            forceMoveMarkers: true,
-                        });
-                    }
-                    editOperations.length &&
-                    editor.executeEdits(this._editorCommandId, editOperations);
-                    /*commandActionId*/
-                });
-
-            });
-
-        this.monacoEditor.onDidDispose(() => {
-            this._isEditorDisposed = true;
-            this._isGetJSXCommentActive = false;
-        });
-
-        return () => {
-            this._isGetJSXCommentActive = false;
+        const closingElement = node.closingElement;
+        if (closingElement) {
+            this.createJSXClosingElementDecorator(closingElement, decorators);
         }
-    }
 
-    createDecoratorsByType = (
-        ast,
-        jsxType,
-        jsxTypeOptions,
-        highlightScope,
-        decorators = [],
-        highlighterOptions = this.options,
-        extractDecorators = p => {
-            const loc = p.value.loc;
-            const options = highlighterOptions.iShowHover ?
-                {...jsxTypeOptions, ...{hoverMessage: `(${jsxType})`}}
-                : jsxTypeOptions;
+        if (elementName && this.options.isHighlightGlyph) {
             decorators.push({
-                range: this.locToMonacoRange(loc),
+                range: this._locToMonacoRange(node),
+                options: JSXTypes.JSXElement.options(elementName) as any,
+            })
+        }
+    }
+
+    createJSXOpeningElementDecorator(openingElement: any, decorators: monaco.editor.IModelDeltaDecoration[]): string {
+        const oLoc = openingElement.loc;
+        const elementName = openingElement.name.name;
+        decorators.push({
+            range: new monaco.Range(
+                oLoc.start.line,
+                oLoc.start.column + 1,
+                oLoc.start.line,
+                oLoc.start.column + 2
+            ),
+            options: this.options.isUseSeparateElementStyles ?
+                JSXTypes.JSXBracket.openingElementOptions
+                : JSXTypes.JSXBracket.options,
+        });
+        decorators.push({
+            range: new monaco.Range(
+                oLoc.end.line,
+                oLoc.end.column + (
+                    openingElement.selfClosing ? -1 : 0
+                ),
+                oLoc.end.line,
+                oLoc.end.column + 1
+            ),
+            options: this.options.isUseSeparateElementStyles ?
+                JSXTypes.JSXBracket.openingElementOptions
+                : JSXTypes.JSXBracket.options,
+        });
+        return elementName;
+    }
+
+    createJSXClosingElementDecorator(closingElement: any, decorators: monaco.editor.IModelDeltaDecoration[]) {
+        const cLoc = closingElement.loc;
+        decorators.push({
+            range: new monaco.Range(
+                cLoc.start.line,
+                cLoc.start.column + 1,
+                cLoc.start.line,
+                cLoc.start.column + 3
+            ),
+            options: this.options.isUseSeparateElementStyles ?
+                JSXTypes.JSXBracket.closingElementOptions
+                : JSXTypes.JSXBracket.options,
+        });
+        decorators.push({
+            range: new monaco.Range(
+                cLoc.end.line,
+                cLoc.end.column,
+                cLoc.end.line,
+                cLoc.end.column + 1
+            ),
+            options: this.options.isUseSeparateElementStyles ?
+                JSXTypes.JSXBracket.closingElementOptions
+                : JSXTypes.JSXBracket.options,
+        });
+    }
+
+    createDecoratorForType(node: any, jsxType: string, jsxOptions: any, highlightScope: keyof typeof HIGHLIGHT_SCOPE, decorators: monaco.editor.IModelDeltaDecoration[]) {
+        const extractDecorator = (node: any) => {
+            const options = this.options.iShowHover ?
+                {...jsxOptions, ...{hoverMessage: `(${jsxType})`}}
+                : jsxOptions;
+
+            decorators.push({
+                range: this._locToMonacoRange(node),
                 options
             });
+        };
+        
+        switch(highlightScope) {
+            case HIGHLIGHT_SCOPE.IDENTIFIER:
+                this._traverse(node, (child) => {
+                    if (child.type === 'JSXIdentifier') {
+                        extractDecorator(child);
+                    }
+                });
+            break;
+            case HIGHLIGHT_SCOPE.ALL:
+                extractDecorator(node);
+            break;
         }
-    ) => {
-        ast.find(j[jsxType])
-            .forEach(p => {
-                switch (highlightScope) {
-                    case HIGHLIGHT_SCOPE.IDENTIFIER:
-                        j(p).find(j.JSXIdentifier)
-                            .forEach(extractDecorators);
-                        break;
-                    case HIGHLIGHT_SCOPE.ALL:
-                        extractDecorators(p);
-                }
-            });
-
-        return decorators;
-    };
+    }
 }
 
 export default MonacoJSXHighlighter;

--- a/src/aux-server/aux-web/shared/vue-components/HtmlAppContainer/HtmlAppContainer.ts
+++ b/src/aux-server/aux-web/shared/vue-components/HtmlAppContainer/HtmlAppContainer.ts
@@ -43,7 +43,9 @@ export default class HtmlAppContainer extends Vue {
                     if (e.type === 'register_html_app') {
                         const index = this.apps.findIndex(
                             (p) =>
-                                p.simulationId === sim.id && p.appId === e.appId
+                                p.simulationId === sim.id &&
+                                p.appId === e.appId &&
+                                p.key === e.instanceId
                         );
 
                         if (index >= 0) {
@@ -56,14 +58,16 @@ export default class HtmlAppContainer extends Vue {
                                 type: 'html',
                                 simulationId: sim.id,
                                 appId: e.appId,
-                                key: uuid(),
+                                key: e.instanceId,
                                 taskId: e.taskId,
                             },
                         ];
                     } else if (e.type === 'unregister_html_app') {
                         const index = this.apps.findIndex(
                             (p) =>
-                                p.simulationId === sim.id && p.appId === e.appId
+                                p.simulationId === sim.id &&
+                                p.appId === e.appId &&
+                                p.key === e.instanceId
                         );
 
                         if (index >= 0) {

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -96,7 +96,6 @@
         "http-proxy": "1.18.1",
         "inherits": "2.0.4",
         "jsbarcode": "3.11.0",
-        "jscodeshift": "^0.11.0",
         "jsonwebtoken": "8.5.1",
         "jsqr": "1.2.0",
         "jszip": "3.2.2",

--- a/src/aux-server/typings/jscodeshift.d.ts
+++ b/src/aux-server/typings/jscodeshift.d.ts
@@ -1,1 +1,0 @@
-declare module 'jscodeshift';

--- a/src/aux-vm-browser/package.json
+++ b/src/aux-vm-browser/package.json
@@ -19,7 +19,8 @@
         "/LICENSE.txt",
         "**/*.js",
         "**/*.js.map",
-        "**/*.d.ts"
+        "**/*.d.ts",
+        "html/iframe_host.html"
     ],
     "repository": {
         "type": "git",

--- a/src/aux-vm/portals/HtmlAppBackend.spec.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.spec.ts
@@ -322,6 +322,52 @@ describe('HtmlAppBackend', () => {
             expect(h1Node.childNodes.length).toBe(1);
             expect(h1Node.childNodes[0].nodeName).toBe('#text');
         });
+
+        it('should render the most recent output when the app is setup', async () => {
+            const helper = createHelper({
+                shared: memory,
+            });
+
+            uuidMock.mockReturnValueOnce('uuid');
+
+            let portal = new HtmlAppBackend(
+                'testPortal',
+                'myBot',
+                helper,
+                undefined,
+                'appId'
+            );
+
+            await waitAsync();
+
+            const html = htm.bind(h);
+
+            portal.handleEvents([
+                setAppOutput('testPortal', html`<h1>Hello</h1>`),
+                asyncResult('uuid', null),
+            ]);
+
+            await waitAsync();
+
+            expect(actions.length).toBe(2);
+            expect(actions[0]).toEqual(
+                registerHtmlApp('testPortal', 'appId', 'uuid')
+            );
+
+            const updateAction = actions[1] as UpdateHtmlAppAction;
+
+            expect(updateAction).toMatchSnapshot();
+
+            expect(updateAction.type).toBe('update_html_app');
+            expect(updateAction.appId).toBe('testPortal');
+            expect(updateAction.updates.length).toBe(1);
+            expect(updateAction.updates[0].type).toBe('childList');
+            expect(updateAction.updates[0].addedNodes.length).toBe(1);
+            const h1Node = updateAction.updates[0].addedNodes[0] as any;
+            expect(h1Node.nodeName).toBe('H1');
+            expect(h1Node.childNodes.length).toBe(1);
+            expect(h1Node.childNodes[0].nodeName).toBe('#text');
+        });
     });
 
     describe('dispose()', () => {

--- a/src/aux-vm/portals/HtmlAppBackend.spec.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.spec.ts
@@ -110,11 +110,19 @@ describe('HtmlAppBackend', () => {
         });
         uuidMock.mockReturnValueOnce('uuid');
 
-        let portal = new HtmlAppBackend('testPortal', 'myBot', helper);
+        let portal = new HtmlAppBackend(
+            'testPortal',
+            'myBot',
+            helper,
+            undefined,
+            'appId'
+        );
 
         await waitAsync();
 
-        expect(actions).toEqual([registerHtmlApp('testPortal', 'uuid')]);
+        expect(actions).toEqual([
+            registerHtmlApp('testPortal', 'appId', 'uuid'),
+        ]);
     });
 
     describe('onAppSetup', () => {
@@ -160,7 +168,13 @@ describe('HtmlAppBackend', () => {
 
             uuidMock.mockReturnValueOnce('uuid');
 
-            let portal = new HtmlAppBackend('testPortal', 'myBot', helper);
+            let portal = new HtmlAppBackend(
+                'testPortal',
+                'myBot',
+                helper,
+                undefined,
+                'appId'
+            );
 
             await waitAsync();
 
@@ -169,7 +183,7 @@ describe('HtmlAppBackend', () => {
             await waitAsync();
 
             expect(actions.slice(1)).toEqual([
-                registerHtmlApp('testPortal', 'uuid'),
+                registerHtmlApp('testPortal', 'appId', 'uuid'),
                 updateHtmlApp('testPortal', [
                     {
                         type: 'childList',
@@ -270,7 +284,13 @@ describe('HtmlAppBackend', () => {
 
             uuidMock.mockReturnValueOnce('uuid');
 
-            let portal = new HtmlAppBackend('testPortal', 'myBot', helper);
+            let portal = new HtmlAppBackend(
+                'testPortal',
+                'myBot',
+                helper,
+                undefined,
+                'appId'
+            );
 
             await waitAsync();
 
@@ -284,7 +304,9 @@ describe('HtmlAppBackend', () => {
             await waitAsync();
 
             expect(actions.length).toBe(2);
-            expect(actions[0]).toEqual(registerHtmlApp('testPortal', 'uuid'));
+            expect(actions[0]).toEqual(
+                registerHtmlApp('testPortal', 'appId', 'uuid')
+            );
 
             const updateAction = actions[1] as UpdateHtmlAppAction;
 
@@ -309,9 +331,15 @@ describe('HtmlAppBackend', () => {
             });
             await helper.transaction(botAdded(createBot('myBot', {})));
 
-            uuidMock.mockReturnValueOnce('uuid');
+            uuidMock.mockReturnValueOnce('uuid').mockReturnValueOnce;
 
-            let portal = new HtmlAppBackend('testPortal', 'myBot', helper);
+            let portal = new HtmlAppBackend(
+                'testPortal',
+                'myBot',
+                helper,
+                undefined,
+                'appId'
+            );
 
             await waitAsync();
 
@@ -319,7 +347,9 @@ describe('HtmlAppBackend', () => {
 
             await waitAsync();
 
-            expect(actions.slice(2)).toEqual([unregisterHtmlApp('testPortal')]);
+            expect(actions.slice(2)).toEqual([
+                unregisterHtmlApp('testPortal', 'appId'),
+            ]);
         });
     });
 });

--- a/src/aux-vm/portals/HtmlAppBackend.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.ts
@@ -33,6 +33,7 @@ export class HtmlAppBackend implements AppBackend {
     private _helper: AuxHelper;
     private _initTaskId: string;
     private _registerTaskId: string | number;
+    private _instanceId: string;
     private _document: Document;
     private _mutationObserver: MutationObserver;
     private _nodes: Map<string, Node> = new Map<string, Node>();
@@ -70,7 +71,8 @@ export class HtmlAppBackend implements AppBackend {
         appId: string,
         botId: string,
         helper: AuxHelper,
-        registerTaskId?: string | number
+        registerTaskId?: string | number,
+        instanceId?: string
     ) {
         this.appId = appId;
         this.botId = botId;
@@ -79,7 +81,10 @@ export class HtmlAppBackend implements AppBackend {
         this._helper = helper;
 
         this._initTaskId = uuid();
-        this._helper.transaction(registerHtmlApp(this.appId, this._initTaskId));
+        this._instanceId = instanceId ?? uuid();
+        this._helper.transaction(
+            registerHtmlApp(this.appId, this._instanceId, this._initTaskId)
+        );
     }
 
     handleEvents(events: BotAction[]): void {
@@ -131,7 +136,9 @@ export class HtmlAppBackend implements AppBackend {
     }
 
     dispose(): void {
-        this._helper.transaction(unregisterHtmlApp(this.appId));
+        this._helper.transaction(
+            unregisterHtmlApp(this.appId, this._instanceId)
+        );
     }
 
     private _getNode(node: any): Node {

--- a/src/aux-vm/portals/HtmlAppBackend.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.ts
@@ -37,6 +37,7 @@ export class HtmlAppBackend implements AppBackend {
     private _document: Document;
     private _mutationObserver: MutationObserver;
     private _nodes: Map<string, Node> = new Map<string, Node>();
+    private _initialContent: any;
 
     /**
      * the list of properties that should be disallowed.
@@ -120,15 +121,12 @@ export class HtmlAppBackend implements AppBackend {
             } else if (event.type === 'set_app_output') {
                 if (event.appId === this.appId) {
                     if (typeof event.output === 'object') {
-                        let prevDocument = globalThis.document;
-                        try {
-                            globalThis.document = this._document;
-                            render(event.output, this._document.body);
-                        } catch (err) {
-                            console.error(err);
-                        } finally {
-                            globalThis.document = prevDocument;
+                        if (!this._document) {
+                            this._initialContent = event.output;
+                            continue;
                         }
+
+                        this._renderContent(event.output);
                     }
                 }
             }
@@ -139,6 +137,18 @@ export class HtmlAppBackend implements AppBackend {
         this._helper.transaction(
             unregisterHtmlApp(this.appId, this._instanceId)
         );
+    }
+
+    private _renderContent(content: any) {
+        let prevDocument = globalThis.document;
+        try {
+            globalThis.document = this._document;
+            render(content, this._document.body);
+        } catch (err) {
+            console.error(err);
+        } finally {
+            globalThis.document = prevDocument;
+        }
     }
 
     private _getNode(node: any): Node {
@@ -175,6 +185,10 @@ export class HtmlAppBackend implements AppBackend {
                 document: this._document,
             })
         );
+
+        if (this._initialContent) {
+            this._renderContent(this._initialContent);
+        }
 
         if (hasValue(this._registerTaskId)) {
             this._helper.transaction(asyncResult(this._registerTaskId, null));

--- a/src/aux-vm/portals/__snapshots__/HtmlAppBackend.spec.ts.snap
+++ b/src/aux-vm/portals/__snapshots__/HtmlAppBackend.spec.ts.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HtmlAppBackend set_app_output should render the most recent output when the app is setup 1`] = `
+Object {
+  "appId": "testPortal",
+  "type": "update_html_app",
+  "updates": Array [
+    Object {
+      "addedNodes": Array [
+        Object {
+          "__id": "1",
+          "attributes": Array [],
+          "childNodes": Array [
+            Object {
+              "__id": "2",
+              "childNodes": Array [],
+              "data": "Hello",
+              "nodeName": "#text",
+              "nodeType": 3,
+            },
+          ],
+          "nodeName": "H1",
+          "nodeType": 1,
+          "style": Object {},
+        },
+      ],
+      "nextSibling": undefined,
+      "previousSibling": undefined,
+      "removedNodes": Array [],
+      "target": Object {
+        "__id": "0",
+        "attributes": Array [],
+        "childNodes": Array [
+          Object {
+            "__id": "1",
+            "attributes": Array [],
+            "childNodes": Array [
+              Object {
+                "__id": "2",
+                "childNodes": Array [],
+                "data": "Hello",
+                "nodeName": "#text",
+                "nodeType": 3,
+              },
+            ],
+            "nodeName": "H1",
+            "nodeType": 1,
+            "style": Object {},
+          },
+        ],
+        "nodeName": "BODY",
+        "nodeType": 1,
+        "style": Object {},
+      },
+      "type": "childList",
+    },
+  ],
+}
+`;
+
 exports[`HtmlAppBackend set_app_output should render the output as a preact component 1`] = `
 Object {
   "appId": "testPortal",


### PR DESCRIPTION
### :rocket: Improvements
-   Added the ability to use [JSX](https://reactjs.org/docs/introducing-jsx.html) for Apps instead of the `html` string helper.
    -   JSX allows you to use a HTML-like language directly inside listeners. This provides some nice benefits including proper syntax highlighting and error messages.
    -   For example:
        ```javascript
        let result = <h1>Hello, World!</h1>;
        ```
    -   Due to convienience this will probably become the preferred way to write HTML for apps, however the `html` string helper will still be available.