### PR TITLE
Improve testing use cases for debuggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@
 
 #### Date: TBD
 
+### :rocket: Improvements
+
+-   Added several features to make testing asynchronous scripts easier.
+    -   Debuggers now automatically convert asynchronous scripts to synchronous scripts by default.
+        -   This makes testing easier because your test code no longer needs to be aware of if a script runs asynchronously in order to observe errors or results.
+        -   You can override this default behavior by setting `allowAsynchronousScripts` to `true` in the options object that is passed to `os.createDebugger()`.
+    -   Some functions are now "maskable".
+        -   Maskable functions are useful for testing and debugging because they let you modify how a function works simply by using `function.mask().returns()` instead of `function()`.
+            -   For example, the `web.get()` function sends an actual web request based on the options that you give it. When testing we don't want to send a real web request (since that takes time and can fail), so instead we can mask it with the following code:
+            ```typescript
+            web.get.mask('https://example.com').returns({
+                status: 200,
+                data: 'hello world!',
+            });
+            ```
+            Then, the next time we call `web.get()` with `https://example.com` it will return the value we have set:
+            ```typescript
+            console.log(web.get('https://example.com));
+            ```
+        -   Maskable functions currently only work when scripts are running inside a debugger with `allowAsychronousScripts` set to `false`.
+        -   Here is a list of maskable functions (more are coming):
+            -   `web.get()`
+            -   `web.post()`
+            -   `web.hook()`
+            -   `webhook()`
+            -   `webhook.post()`
+            -   `os.showInput()`
+            -   `os.getRecords()`
+            -   `os.publishRecord()`
+            -   `os.destroyRecord()`
+            -   `os.requestPermanentAuthToken()`
+    -   Properties added to `globalThis` are now separated per-debugger.
+        -   This means that you can set `globalThis.myVariable = 123;` and it won't affect debuggers.
+        -   It also means that testing with global variables are easier because you don't have to set and reset them before each test anymore.
+    -   Debuggers now automatically setup `tempLocal` bots for built-in portals.
+        -   This means that the portal bots like `gridPortalBot`, `mapPortalBot`, etc. are available in debuggers.
+    -   Debuggers now automatically setup a `configBot`.
+        -   You can override this configBot by using the `configBot` property in the options object that is passed to `os.createDebugger()`.
+
 ### :bug: Bug Fixes
 
 -   Fixed an issue where floating labels on billboarded bots did not work.

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4249,6 +4249,38 @@ const actions = debug.getCommonActions();
 os.toast(actions);
 ```
 
+```typescript title='Create a debugger with a custom configBot'
+const debug = os.createDebugger({
+    configBot: {
+        test: '@console.log("Hello, World!");'
+    }
+});
+debug.shout('test');
+```
+
+```typescript title='Mask the web.get() function.'
+const debug = os.createDebugger();
+let url = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/The_star_formation_region_Messier_17.jpg/1200px-The_star_formation_region_Messier_17.jpg";
+const debuggerBot = debug.create({
+    url,
+    test: '@return await web.get(tags.url)'
+});
+
+debug.web.get.mask(url)
+    .returns({
+        data: 'test data',
+        status: 200
+    });
+
+const [result] = debug.shout('test');
+
+assertEqual(result, {
+    data: 'test data',
+    status: 200
+});
+os.toast("Success!");
+```
+
 ### `server.backupAsDownload(target)`
 
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4199,6 +4199,20 @@ let options: {
      * Defaults to false.
      */
     useRealUUIDs?: boolean;
+
+    /**
+     * Whether to allow scripts to be asynchronous.
+     * If false, then all scripts will be forced to be synchronous.
+     * Defaults to false.
+     * Synchronous scripts are easier to test because they don't rely on back-and-forth (two-way) communication to handle things like web.hook().
+     */
+     allowAsynchronousScripts: boolean;
+
+     /**
+     * The data that the configBot should be created from.
+     * Can be a mod or another bot.
+     */
+    configBot: Bot | BotTags;
 };
 ```
 

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -441,6 +441,58 @@ describe('AuxCompiler', () => {
             expect(await result2).toBe(symbol);
         });
 
+        it('should be able to compile with a custom global object', async () => {
+            let symbol = Symbol('return value');
+            let globalObj = {
+                value: symbol,
+            };
+            let fn = compiler.compile('return value;', {
+                constants: {
+                    globalThis: globalObj,
+                },
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
+        it('should not override other constants with the custom global object', async () => {
+            let symbol = Symbol('return value');
+            let globalObj = {
+                value: 123,
+            };
+            let fn = compiler.compile('return value;', {
+                constants: {
+                    value: symbol,
+                    globalThis: globalObj,
+                },
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
+        it('should not override other variables with the custom global object', async () => {
+            let symbol = Symbol('return value');
+            let globalObj = {
+                value: 123,
+            };
+            let fn = compiler.compile('return value;', {
+                constants: {
+                    globalThis: globalObj,
+                },
+                variables: {
+                    value: () => symbol,
+                },
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
         describe('calculateOriginalLineLocation()', () => {
             it('should return (0, 0) if given a location before the user script actually starts', () => {
                 const script = 'return str + num + abc;';

--- a/src/aux-common/runtime/AuxCompiler.spec.ts
+++ b/src/aux-common/runtime/AuxCompiler.spec.ts
@@ -397,6 +397,50 @@ describe('AuxCompiler', () => {
             expect(result).toBe(symbol);
         });
 
+        it('should be able to compile scripts without async', () => {
+            let symbol = Symbol('return value');
+            let fn = compiler.compile('return await value;', {
+                invoke(fn, ctx) {
+                    return fn();
+                },
+                constants: {
+                    value: symbol,
+                },
+                forceSync: true,
+            });
+
+            const result = fn();
+
+            expect(result).toBe(symbol);
+        });
+
+        it('should be able to compile normal functions after sync functions', async () => {
+            let symbol = Symbol('return value');
+            let fn = compiler.compile('return await value;', {
+                invoke(fn, ctx) {
+                    return fn();
+                },
+                constants: {
+                    value: symbol,
+                },
+                forceSync: true,
+            });
+
+            let fn2 = compiler.compile('return await abc;', {
+                variables: {
+                    abc: () => symbol,
+                },
+                forceSync: false,
+            });
+
+            const result = fn();
+            const result2 = fn2();
+
+            expect(result).toBe(symbol);
+            expect(result2).toBeInstanceOf(Promise);
+            expect(await result2).toBe(symbol);
+        });
+
         describe('calculateOriginalLineLocation()', () => {
             it('should return (0, 0) if given a location before the user script actually starts', () => {
                 const script = 'return str + num + abc;';

--- a/src/aux-common/runtime/AuxCompiler.ts
+++ b/src/aux-common/runtime/AuxCompiler.ts
@@ -386,6 +386,10 @@ export class AuxCompiler {
             functionCode = `async ` + functionCode;
         }
         try {
+            if (options.forceSync) {
+                async = false;
+            }
+            this._transpiler.forceSync = options.forceSync ?? false;
             const transpiled = this._transpiler.transpileWithMetadata(
                 functionCode
             );
@@ -628,6 +632,12 @@ export interface AuxCompileOptions<T> {
      * The file name that should be used for transformed error stack traces.
      */
     fileName?: string;
+
+    /**
+     * Whether to force the output function to be synchronous.
+     * This will compile out any async/await code.
+     */
+    forceSync?: boolean;
 }
 
 // export class CompiledScriptError extends Error {

--- a/src/aux-common/runtime/AuxGlobalContext.spec.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.spec.ts
@@ -797,4 +797,77 @@ describe('AuxGlobalContext', () => {
             ]);
         });
     });
+
+    describe('mockAsyncActions', () => {
+        it('should return true if the context is configured to use syncronous actions', () => {
+            context.mockAsyncActions = true;
+            expect(context.mockAsyncActions).toBe(true);
+        });
+
+        it('should return false if the context is configured to use asyncronous actions', () => {
+            context.mockAsyncActions = false;
+            expect(context.mockAsyncActions).toBe(false);
+        });
+    });
+
+    describe('mocks', () => {
+        it('should set the list of values that should be used to mock the given function', () => {
+            let func = jest.fn();
+            context.setMockReturns(func, [123, 'abc']);
+
+            expect(context.getNextMockReturn(func, 'func', [])).toBe(123);
+            expect(context.getNextMockReturn(func, 'func', [])).toBe('abc');
+        });
+
+        it('should be able to set a return value for a specific set of inputs', () => {
+            let func = jest.fn();
+            context.setMockReturn(func, [123, 'abc'], 'return value');
+
+            expect(context.getNextMockReturn(func, 'func', [123, 'abc'])).toBe(
+                'return value'
+            );
+            expect(() => {
+                context.getNextMockReturn(func, 'func', [
+                    'wrong',
+                    'also wrong',
+                ]);
+            }).toThrowError(
+                'No mock data for function (no matching input): func("wrong", "also wrong")'
+            );
+        });
+
+        it('should pretty print the argument list for missing functions', () => {
+            let func = jest.fn();
+
+            expect(() => {
+                context.getNextMockReturn(func, 'func', [
+                    'wrong',
+                    { abc: 'def' },
+                ]);
+            }).toThrowError(
+                'No mock data for function: func("wrong", {\n  "abc": "def"\n})'
+            );
+        });
+
+        it('should fail when getting mocks for a function that has nothing set', () => {
+            let func = jest.fn();
+
+            expect(() => {
+                context.getNextMockReturn(func, 'func', []);
+            }).toThrowError('No mock data for function: func()');
+        });
+
+        it('should fail when the return value list has been exhausted', () => {
+            let func = jest.fn();
+            context.setMockReturns(func, [123, 'abc']);
+
+            expect(context.getNextMockReturn(func, 'func', [])).toBe(123);
+            expect(context.getNextMockReturn(func, 'func', [])).toBe('abc');
+            expect(() => {
+                context.getNextMockReturn(func, 'func', []);
+            }).toThrowError(
+                'No mock data for function (out of return values): func()'
+            );
+        });
+    });
 });

--- a/src/aux-common/runtime/AuxGlobalContext.spec.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.spec.ts
@@ -833,7 +833,7 @@ describe('AuxGlobalContext', () => {
                     'also wrong',
                 ]);
             }).toThrowError(
-                'No mock data for function (no matching input): func("wrong", "also wrong")'
+                'No mask data for function (no matching input): func("wrong", "also wrong")'
             );
         });
 
@@ -846,7 +846,7 @@ describe('AuxGlobalContext', () => {
                     { abc: 'def' },
                 ]);
             }).toThrowError(
-                'No mock data for function: func("wrong", {\n  "abc": "def"\n})'
+                'No mask data for function: func("wrong", {\n  "abc": "def"\n})'
             );
         });
 
@@ -858,7 +858,7 @@ describe('AuxGlobalContext', () => {
                     'wrong',
                     { abc: 'def', [DEBUG_STRING]: 'abc()' },
                 ]);
-            }).toThrowError('No mock data for function: func("wrong", abc())');
+            }).toThrowError('No mask data for function: func("wrong", abc())');
         });
 
         it('should fail when getting mocks for a function that has nothing set', () => {
@@ -866,7 +866,7 @@ describe('AuxGlobalContext', () => {
 
             expect(() => {
                 context.getNextMockReturn(func, 'func', []);
-            }).toThrowError('No mock data for function: func()');
+            }).toThrowError('No mask data for function: func()');
         });
 
         it('should fail when the return value list has been exhausted', () => {
@@ -878,7 +878,7 @@ describe('AuxGlobalContext', () => {
             expect(() => {
                 context.getNextMockReturn(func, 'func', []);
             }).toThrowError(
-                'No mock data for function (out of return values): func()'
+                'No mask data for function (out of return values): func()'
             );
         });
     });

--- a/src/aux-common/runtime/AuxGlobalContext.spec.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.spec.ts
@@ -3,6 +3,7 @@ import {
     addToContext,
     MemoryGlobalContext,
     removeFromContext,
+    DEBUG_STRING,
 } from './AuxGlobalContext';
 import {
     createDummyRuntimeBot,
@@ -847,6 +848,17 @@ describe('AuxGlobalContext', () => {
             }).toThrowError(
                 'No mock data for function: func("wrong", {\n  "abc": "def"\n})'
             );
+        });
+
+        it('should be able to use debug strings that are specified on arguments', () => {
+            let func = jest.fn();
+
+            expect(() => {
+                context.getNextMockReturn(func, 'func', [
+                    'wrong',
+                    { abc: 'def', [DEBUG_STRING]: 'abc()' },
+                ]);
+            }).toThrowError('No mock data for function: func("wrong", abc())');
         });
 
         it('should fail when getting mocks for a function that has nothing set', () => {

--- a/src/aux-common/runtime/AuxGlobalContext.ts
+++ b/src/aux-common/runtime/AuxGlobalContext.ts
@@ -1041,7 +1041,7 @@ export class MemoryGlobalContext implements AuxGlobalContext {
         }
         if (!this._mocks.has(func)) {
             throw new Error(
-                `No mock data for function: ${debugStringifyFunction(
+                `No mask data for function: ${debugStringifyFunction(
                     functionName,
                     args
                 )}`
@@ -1054,7 +1054,7 @@ export class MemoryGlobalContext implements AuxGlobalContext {
                 return arrayOrMap.get(argJson);
             } else {
                 throw new Error(
-                    `No mock data for function (no matching input): ${debugStringifyFunction(
+                    `No mask data for function (no matching input): ${debugStringifyFunction(
                         functionName,
                         args
                     )}`
@@ -1065,7 +1065,7 @@ export class MemoryGlobalContext implements AuxGlobalContext {
                 return arrayOrMap.shift();
             } else {
                 throw new Error(
-                    `No mock data for function (out of return values): ${debugStringifyFunction(
+                    `No mask data for function (out of return values): ${debugStringifyFunction(
                         functionName,
                         args
                     )}`

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -3736,6 +3736,22 @@ describe('AuxLibrary', () => {
 
                 expect(result).toBe('abc.def');
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    library.api.os.requestPermanentAuthToken
+                        .mask()
+                        .returns('mocked');
+                    const result: any = library.api.os.requestPermanentAuthToken();
+
+                    expect(result).toEqual('mocked');
+                });
+            });
         });
 
         describe('os.publishRecord()', () => {

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -267,6 +267,24 @@ describe('AuxLibrary', () => {
         ['@ symbol and parenthesis', '@sayHello()'] as const,
     ];
 
+    describe('<mock func>.mask().returns()', () => {
+        beforeEach(() => {
+            context.mockAsyncActions = true;
+            library = createDefaultLibrary(context);
+        });
+
+        it('should setup a mock for the given arguments that returns the given value', () => {
+            library.api.webhook.mask('hello').returns('world');
+
+            const value = context.getNextMockReturn(
+                library.api.webhook,
+                'webhook',
+                ['hello']
+            );
+            expect(value).toBe('world');
+        });
+    });
+
     describe('getBots()', () => {
         let bot1: RuntimeBot;
         let bot2: RuntimeBot;
@@ -2945,23 +2963,10 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.os.showInput, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.os.showInput('test');
-                    const result2: any = library.api.os.showInput('test');
+                    library.api.os.showInput.mask('test').returns('mocked');
+                    const result: any = library.api.os.showInput('test');
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('mocked');
                 });
             });
         });
@@ -6360,33 +6365,14 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.web.get, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.web.get(
-                        'https://example.com',
-                        {
-                            responseShout: 'test.response()',
-                        }
-                    );
-                    const result2: any = library.api.web.get(
-                        'https://example.com',
-                        {
-                            responseShout: 'test.response()',
-                        }
+                    library.api.web.get
+                        .mask('https://example.com')
+                        .returns('masked');
+                    const result: any = library.api.web.get(
+                        'https://example.com'
                     );
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('masked');
                 });
             });
         });
@@ -6420,22 +6406,17 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.web.post, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.web.post(
-                        'https://example.com',
-                        { data: true },
-                        {
-                            responseShout: 'test.response()',
-                        }
-                    );
-                    const result2: any = library.api.web.post(
+                    library.api.web.post
+                        .mask(
+                            'https://example.com',
+                            { data: true },
+                            {
+                                responseShout: 'test.response()',
+                            }
+                        )
+                        .returns('masked');
+
+                    const result: any = library.api.web.post(
                         'https://example.com',
                         { data: true },
                         {
@@ -6443,12 +6424,7 @@ describe('AuxLibrary', () => {
                         }
                     );
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('masked');
                 });
             });
         });
@@ -6481,33 +6457,22 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.web.hook, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.web.hook({
-                        method: 'TEST',
-                        data: { myData: 'abc' },
-                        url: 'https://example.com',
-                        responseShout: 'test.response()',
-                    });
-                    const result2: any = library.api.web.hook({
+                    library.api.web.hook
+                        .mask({
+                            method: 'TEST',
+                            data: { myData: 'abc' },
+                            url: 'https://example.com',
+                            responseShout: 'test.response()',
+                        })
+                        .returns('masked');
+                    const result: any = library.api.web.hook({
                         method: 'TEST',
                         data: { myData: 'abc' },
                         url: 'https://example.com',
                         responseShout: 'test.response()',
                     });
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('masked');
                 });
             });
         });
@@ -6544,23 +6509,18 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.webhook, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.webhook({
-                        method: 'POST',
-                        url: 'https://example.com',
-                        data: {
-                            test: 'abc',
-                        },
-                        responseShout: 'test.response()',
-                    });
-                    const result2: any = library.api.webhook({
+                    library.api.webhook
+                        .mask({
+                            method: 'POST',
+                            url: 'https://example.com',
+                            data: {
+                                test: 'abc',
+                            },
+                            responseShout: 'test.response()',
+                        })
+                        .returns('masked');
+
+                    const result: any = library.api.webhook({
                         method: 'POST',
                         url: 'https://example.com',
                         data: {
@@ -6569,12 +6529,7 @@ describe('AuxLibrary', () => {
                         responseShout: 'test.response()',
                     });
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('masked');
                 });
             });
         });
@@ -6610,22 +6565,16 @@ describe('AuxLibrary', () => {
                 });
 
                 it('should return the mocked value when setup to mock', () => {
-                    context.setMockReturns(library.api.webhook.post, [
-                        {
-                            test: 123,
-                        },
-                        {
-                            abc: 'def',
-                        },
-                    ]);
-                    const result1: any = library.api.webhook.post(
-                        'https://example.com',
-                        { test: 'abc' },
-                        {
-                            responseShout: 'test.response()',
-                        }
-                    );
-                    const result2: any = library.api.webhook.post(
+                    library.api.webhook.post
+                        .mask(
+                            'https://example.com',
+                            { test: 'abc' },
+                            {
+                                responseShout: 'test.response()',
+                            }
+                        )
+                        .returns('masked');
+                    const result: any = library.api.webhook.post(
                         'https://example.com',
                         { test: 'abc' },
                         {
@@ -6633,12 +6582,7 @@ describe('AuxLibrary', () => {
                         }
                     );
 
-                    expect(result1).toEqual({
-                        test: 123,
-                    });
-                    expect(result2).toEqual({
-                        abc: 'def',
-                    });
+                    expect(result).toEqual('masked');
                 });
             });
         });

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -2937,6 +2937,33 @@ describe('AuxLibrary', () => {
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.os.showInput, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.os.showInput('test');
+                    const result2: any = library.api.os.showInput('test');
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
+            });
         });
 
         describe('os.goToDimension()', () => {
@@ -6325,6 +6352,43 @@ describe('AuxLibrary', () => {
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.web.get, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.web.get(
+                        'https://example.com',
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+                    const result2: any = library.api.web.get(
+                        'https://example.com',
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
+            });
         });
 
         describe('web.post()', () => {
@@ -6348,6 +6412,45 @@ describe('AuxLibrary', () => {
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.web.post, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.web.post(
+                        'https://example.com',
+                        { data: true },
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+                    const result2: any = library.api.web.post(
+                        'https://example.com',
+                        { data: true },
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
+            });
         });
 
         describe('web.hook()', () => {
@@ -6369,6 +6472,43 @@ describe('AuxLibrary', () => {
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.web.hook, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.web.hook({
+                        method: 'TEST',
+                        data: { myData: 'abc' },
+                        url: 'https://example.com',
+                        responseShout: 'test.response()',
+                    });
+                    const result2: any = library.api.web.hook({
+                        method: 'TEST',
+                        data: { myData: 'abc' },
+                        url: 'https://example.com',
+                        responseShout: 'test.response()',
+                    });
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
             });
         });
 
@@ -6396,6 +6536,47 @@ describe('AuxLibrary', () => {
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.webhook, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.webhook({
+                        method: 'POST',
+                        url: 'https://example.com',
+                        data: {
+                            test: 'abc',
+                        },
+                        responseShout: 'test.response()',
+                    });
+                    const result2: any = library.api.webhook({
+                        method: 'POST',
+                        url: 'https://example.com',
+                        data: {
+                            test: 'abc',
+                        },
+                        responseShout: 'test.response()',
+                    });
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
+            });
         });
 
         describe('webhook.post()', () => {
@@ -6420,6 +6601,45 @@ describe('AuxLibrary', () => {
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    context.setMockReturns(library.api.webhook.post, [
+                        {
+                            test: 123,
+                        },
+                        {
+                            abc: 'def',
+                        },
+                    ]);
+                    const result1: any = library.api.webhook.post(
+                        'https://example.com',
+                        { test: 'abc' },
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+                    const result2: any = library.api.webhook.post(
+                        'https://example.com',
+                        { test: 'abc' },
+                        {
+                            responseShout: 'test.response()',
+                        }
+                    );
+
+                    expect(result1).toEqual({
+                        test: 123,
+                    });
+                    expect(result2).toEqual({
+                        abc: 'def',
+                    });
+                });
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -3922,6 +3922,30 @@ describe('AuxLibrary', () => {
                     });
                 }).toThrowError();
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    library.api.os.publishRecord
+                        .mask({
+                            address: 'myAddress',
+                            record: null,
+                            authToken: 'myToken',
+                        })
+                        .returns('mocked');
+                    const result: any = library.api.os.publishRecord({
+                        address: 'myAddress',
+                        record: null,
+                        authToken: 'myToken',
+                    });
+
+                    expect(result).toEqual('mocked');
+                });
+            });
         });
 
         describe('os.getRecords()', () => {
@@ -4311,6 +4335,36 @@ describe('AuxLibrary', () => {
                     },
                 ]);
             });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    library.api.os.getRecords
+                        .mask(
+                            library.api.withAuthToken('myToken'),
+                            library.api.byAuthID('myID'),
+                            library.api.bySpace('permanentGlobal'),
+                            library.api.byPrefix('myPrefix'),
+                            library.api.byID('id'),
+                            library.api.byAddress('address')
+                        )
+                        .returns('mocked');
+                    const result: any = library.api.os.getRecords(
+                        { recordFilter: true, authToken: 'myToken' },
+                        { recordFilter: true, authID: 'myID' },
+                        { recordFilter: true, space: 'permanentGlobal' } as any,
+                        { recordFilter: true, prefix: 'myPrefix' },
+                        { recordFilter: true, id: 'id' } as any,
+                        { recordFilter: true, address: 'address' }
+                    );
+
+                    expect(result).toEqual('mocked');
+                });
+            });
         });
 
         describe('os.destroyRecord()', () => {
@@ -4373,6 +4427,30 @@ describe('AuxLibrary', () => {
                 } finally {
                     delete (<any>globalThis).authBot;
                 }
+            });
+
+            describe('mock', () => {
+                beforeEach(() => {
+                    context.mockAsyncActions = true;
+                    library = createDefaultLibrary(context);
+                });
+
+                it('should return the mocked value when setup to mock', () => {
+                    library.api.os.destroyRecord
+                        .mask({
+                            space: 'tempRestricted',
+                            address: 'myAddress',
+                            authToken: 'myToken',
+                        })
+                        .returns('mocked');
+                    const result: any = library.api.os.destroyRecord({
+                        space: 'tempRestricted',
+                        address: 'myAddress',
+                        authToken: 'myToken',
+                    });
+
+                    expect(result).toEqual('mocked');
+                });
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -10,6 +10,7 @@ import {
     MemoryGlobalContext,
     SET_INTERVAL_ANIMATION_FRAME_TIME,
     WatchBotTimer,
+    DEBUG_STRING,
 } from './AuxGlobalContext';
 import {
     toast,
@@ -731,6 +732,17 @@ describe('AuxLibrary', () => {
             it('should return false if the bot has a different ID', () => {
                 const filter = library.api.byID('wrong');
                 expect(filter(bot1)).toBe(false);
+            });
+
+            it('should contain a toJSON() function that returns the record filter object', () => {
+                const result: any = library.api.byID('myID');
+
+                expect(result.toJSON).toBeInstanceOf(Function);
+                expect(result[DEBUG_STRING]).toBe('byID("myID")');
+                expect(result.toJSON()).toEqual({
+                    recordFilter: true,
+                    id: 'myID',
+                });
             });
         });
 
@@ -3920,6 +3932,7 @@ describe('AuxLibrary', () => {
                     expect(result).toEqual({
                         recordFilter: true,
                         authID: 'myAuthID',
+                        [DEBUG_STRING]: 'byAuthID("myAuthID")',
                     });
                 });
             });
@@ -3937,6 +3950,17 @@ describe('AuxLibrary', () => {
                     expect(result1.recordFilter).toBe(true);
                     expect(result1.space).toBe('mySpace');
                 });
+
+                it('should contain a toJSON() function that returns the record filter object', () => {
+                    const result: any = library.api.bySpace('mySpace');
+
+                    expect(result[DEBUG_STRING]).toBe('bySpace("mySpace")');
+                    expect(result.toJSON).toBeInstanceOf(Function);
+                    expect(result.toJSON()).toEqual({
+                        recordFilter: true,
+                        space: 'mySpace',
+                    });
+                });
             });
 
             describe('byAddress()', () => {
@@ -3946,6 +3970,7 @@ describe('AuxLibrary', () => {
                     expect(result).toEqual({
                         recordFilter: true,
                         address: 'byAddress',
+                        [DEBUG_STRING]: 'byAddress("byAddress")',
                     });
                 });
             });
@@ -3957,6 +3982,7 @@ describe('AuxLibrary', () => {
                     expect(result).toEqual({
                         recordFilter: true,
                         authToken: 'myToken',
+                        [DEBUG_STRING]: 'withAuthToken("myToken")',
                     });
                 });
             });
@@ -3968,6 +3994,7 @@ describe('AuxLibrary', () => {
                     expect(result).toEqual({
                         recordFilter: true,
                         prefix: 'myPrefix',
+                        [DEBUG_STRING]: 'byPrefix("myPrefix")',
                     });
                 });
             });

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3,6 +3,8 @@ import {
     AsyncTask,
     BotTimer,
     TimeoutOrIntervalTimer,
+    DEBUG_STRING,
+    debugStringifyFunction,
 } from './AuxGlobalContext';
 import {
     hasValue,
@@ -515,10 +517,12 @@ export interface AnimateTagFunctionOptions {
 export interface BotFilterFunction {
     (bot: Bot): boolean;
     sort?: (bot: Bot) => any;
+    [DEBUG_STRING]?: string;
 }
 
 export interface RecordFilter {
     recordFilter: true;
+    [DEBUG_STRING]?: string;
 }
 
 export interface AuthIdRecordFilter extends RecordFilter {
@@ -527,6 +531,7 @@ export interface AuthIdRecordFilter extends RecordFilter {
 
 export interface SpaceFilter extends BotFilterFunction, RecordFilter {
     space: string;
+    toJSON: () => RecordFilter;
 }
 
 export interface AddressRecordFilter extends RecordFilter {
@@ -543,6 +548,7 @@ export interface PrefixRecordFilter extends RecordFilter {
 
 export interface IDRecordFilter extends BotFilterFunction, RecordFilter {
     id: string;
+    toJSON: () => RecordFilter;
 }
 
 export type RecordFilters =
@@ -1454,6 +1460,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
         filter.recordFilter = true;
         filter.id = id;
+        filter.toJSON = () => {
+            return {
+                recordFilter: true,
+                id: id,
+            };
+        };
+        filter[DEBUG_STRING] = debugStringifyFunction('byID', [id]);
 
         return filter;
     }
@@ -1582,6 +1595,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         let func = byTag(BOT_SPACE_TAG, space) as SpaceFilter;
         func.recordFilter = true;
         func.space = space;
+        func.toJSON = () => {
+            return {
+                recordFilter: true,
+                space: space,
+            };
+        };
+        func[DEBUG_STRING] = debugStringifyFunction('bySpace', [space]);
         return func;
     }
 
@@ -1636,6 +1656,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         return {
             recordFilter: true,
             authID,
+            [DEBUG_STRING]: debugStringifyFunction('byAuthID', [authID]),
         };
     }
 
@@ -1647,6 +1668,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         return {
             recordFilter: true,
             address,
+            [DEBUG_STRING]: debugStringifyFunction('byAddress', [address]),
         };
     }
 
@@ -1658,6 +1680,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         return {
             recordFilter: true,
             authToken: token,
+            [DEBUG_STRING]: debugStringifyFunction('withAuthToken', [token]),
         };
     }
 
@@ -1669,6 +1692,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         return {
             recordFilter: true,
             prefix,
+            [DEBUG_STRING]: debugStringifyFunction('byPrefix', [prefix]),
         };
     }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -696,6 +696,12 @@ export interface AuxDebuggerOptions {
      * Defaults to false.
      */
     allowAsynchronousScripts: boolean;
+
+    /**
+     * The data that the configBot should be created from.
+     * Can be a mod or another bot.
+     */
+    configBot: Bot | BotTags;
 }
 
 export interface MaskableFunction {

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -917,9 +917,15 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 requestAuthBot,
                 requestPermanentAuthToken,
 
-                publishRecord,
-                getRecords,
-                destroyRecord,
+                publishRecord: makeMockableFunction(
+                    publishRecord,
+                    'os.publishRecord'
+                ),
+                getRecords: makeMockableFunction(getRecords, 'os.getRecords'),
+                destroyRecord: makeMockableFunction(
+                    destroyRecord,
+                    'os.destroyRecord'
+                ),
 
                 setupInst: setupServer,
                 remotes,

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -915,7 +915,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 unregisterApp,
                 compileApp: setAppContent,
                 requestAuthBot,
-                requestPermanentAuthToken,
+                requestPermanentAuthToken: makeMockableFunction(
+                    requestPermanentAuthToken,
+                    'os.requestPermanentAuthToken'
+                ),
 
                 publishRecord: makeMockableFunction(
                     publishRecord,

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -689,6 +689,13 @@ export interface AuxDebuggerOptions {
      * Whether to use "real" UUIDs instead of predictable ones.
      */
     useRealUUIDs: boolean;
+
+    /**
+     * Whether to allow scripts to be asynchronous.
+     * If false, then all scripts will be forced to be synchronous.
+     * Defaults to false.
+     */
+    allowAsynchronousScripts: boolean;
 }
 
 export interface MaskableFunction {

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -4956,7 +4956,7 @@ interface Os {
      /**
       * Requests an auth token that does not expire and can be used to authorize other app bundles to publish records for this app bundle.
       */
-     requestPermanentAuthToken(): Promise<string>;
+     requestPermanentAuthToken: MaskFunc<() => Promise<string>>;
 
      /**
       * Publishes a record that can be used across instances.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2833,6 +2833,13 @@ export interface DebuggerOptions {
      * Whether to use "real" UUIDs instead of predictable ones.
      */
     useRealUUIDs: boolean;
+
+    /**
+     * Whether to allow scripts to be asynchronous.
+     * If false, then all scripts will be forced to be synchronous.
+     * Defaults to false.
+     */
+     allowAsynchronousScripts: boolean;
 }
 
 declare global {

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2840,6 +2840,12 @@ export interface DebuggerOptions {
      * Defaults to false.
      */
      allowAsynchronousScripts: boolean;
+
+     /**
+     * The data that the configBot should be created from.
+     * Can be a mod or another bot.
+     */
+    configBot: Bot | BotTags;
 }
 
 declare global {

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1,3 +1,22 @@
+
+type MaskFunc<Func extends ((...args: any[]) => any)> = {
+    (...args: Parameters<Func>): ReturnType<Func>;
+
+    /**
+     * Masks this function so that it can return a value when called with the specified parameters.
+     */
+    mask(...args: Parameters<Func>): MaskedFunction;
+}
+
+
+export interface MaskedFunction {
+    /**
+     * Specifies the value that should be returned when this function is called with the parameters specified to mask().
+     * @param value The value that should be returned.
+     */
+    returns(value: any): void;
+}
+
 /**
  * Contains information about the version of AUX that is running.
  */
@@ -3820,7 +3839,7 @@ interface Debugger {
        * @param bot The bot or list of bots that should be animated.
        * @param options The options for the animation. fromValue should be an object which contains the starting tag values and toValue should be an object that contains the ending tag values.
        */
-       animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
+      animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
       /**
        * Animates the given tag. Returns a promise when the animation is finished.
        * @param bot The bot or list of bots that should be animated.
@@ -4838,10 +4857,10 @@ interface Os {
       *    type: "text"
       * });
       */
-     showInput(
+     showInput: MaskFunc<(
          currentValue?: any,
          options?: Partial<ShowInputOptions>
-     ): Promise<string>;
+     ) => Promise<string>>;
 
      /**
       * Shows a checkout screen that lets the user purchase something.
@@ -4943,19 +4962,19 @@ interface Os {
       * Publishes a record that can be used across instances.
       * @param recordDefinition The data that should be used to publish the record.
       */
-     publishRecord(recordDefinition: PublishableRecord): Promise<void>;
+     publishRecord: MaskFunc<(recordDefinition: PublishableRecord) => Promise<void>>;
 
      /**
       * Retrives a list of records using the given filters.
       * @param filters The list of filters that should be used to retrieve some records.
       */
-     getRecords(...filters: RecordFilters[]): Promise<GetRecordsResult>;
+     getRecords: MaskFunc<(...filters: RecordFilters[]) => Promise<GetRecordsResult>>;
 
      /**
       * Requests that the given record be destroyed.
       * @param record The record that should be deleted.
       */
-     destroyRecord(record: DeletableRecord): Promise<void>;
+     destroyRecord: MaskFunc<(record: DeletableRecord) => Promise<void>>;
 
      /**
       * Specifies that the given prefix should be interpreted as code.
@@ -5540,7 +5559,7 @@ interface Web {
      * // Send a HTTP GET request for https://www.example.com
      * const result = await web.get('https://www.example.com');
      */
-    get(url: string, options?: WebhookOptions): Promise<WebhookResult>;
+    get: MaskFunc<(url: string, options?: WebhookOptions) => Promise<WebhookResult>>;
 
     /**
      * Sends a HTTP POST request to the given URL with the given data.
@@ -5557,7 +5576,7 @@ interface Web {
      * });
      * 
      */
-    post(url: string, data?: any, options?: WebhookOptions): Promise<WebhookResult>;
+    post: MaskFunc<(url: string, data?: any, options?: WebhookOptions) => Promise<WebhookResult>>;
 
     /**
      * Sends a web request based on the given options.
@@ -5573,7 +5592,7 @@ interface Web {
      * 
      * os.toast(result);
      */
-    hook(options: WebhookOptions): Promise<WebhookResult>;
+    hook: MaskFunc<(options: WebhookOptions) => Promise<WebhookResult>>;
 };
 
 

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -7267,6 +7267,61 @@ describe('AuxRuntime', () => {
             ]);
         });
 
+        it('should be able to create the configBot with specific tags', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        error: '@action.perform(configBot.tags.abc)',
+                        test: `@let d = os.createDebugger({
+                            configBot: {
+                                abc: 'def'
+                            }
+                        }); let b = d.create({ test: tags.error }); d.shout('test'); return d.getAllActions()`,
+                    }),
+                })
+            );
+
+            const result = runtime.shout('test');
+            let actions = result.results[0];
+
+            expect(actions).toEqual([
+                botAdded(
+                    createBot('uuid-1', {
+                        test: '@action.perform(configBot.tags.abc)',
+                    })
+                ),
+                'def',
+            ]);
+        });
+
+        it('should be able to create the configBot with another bot', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    other: createBot('other', {
+                        abc: 'def',
+                    }),
+                    test: createBot('test', {
+                        error: '@action.perform(configBot.tags.abc)',
+                        test: `@let d = os.createDebugger({
+                            configBot: getBot('id', 'other')
+                        }); let b = d.create({ test: tags.error }); d.shout('test'); return d.getAllActions()`,
+                    }),
+                })
+            );
+
+            const result = runtime.shout('test');
+            let actions = result.results[0];
+
+            expect(actions).toEqual([
+                botAdded(
+                    createBot('uuid-1', {
+                        test: '@action.perform(configBot.tags.abc)',
+                    })
+                ),
+                'def',
+            ]);
+        });
+
         it('should allow setting globalThis variables without affecting everything else', () => {
             runtime.stateUpdated(
                 stateUpdatedEvent({

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -6926,7 +6926,9 @@ describe('AuxRuntime', () => {
         });
 
         it('should use real UUIDs when specified', () => {
-            uuidMock.mockReturnValueOnce('myUUID');
+            uuidMock
+                .mockReturnValueOnce('configBotId')
+                .mockReturnValueOnce('myUUID');
             runtime.stateUpdated(
                 stateUpdatedEvent({
                     test: createBot('test', {
@@ -7162,6 +7164,33 @@ describe('AuxRuntime', () => {
                             '@tags.hasBot = typeof testPortalBot !== "undefined";',
                     })
                 ),
+            ]);
+        });
+
+        it('should define a configBot', () => {
+            runtime.stateUpdated(
+                stateUpdatedEvent({
+                    test: createBot('test', {
+                        error: '@configBot.tags.hit = true;',
+                        test: `@let d = os.createDebugger(); let b = d.create({ test: tags.error }); d.shout('test'); return d.getAllActions()`,
+                    }),
+                })
+            );
+
+            const result = runtime.shout('test');
+            let actions = result.results[0];
+
+            expect(actions).toEqual([
+                botAdded(
+                    createBot('uuid-1', {
+                        test: '@configBot.tags.hit = true;',
+                    })
+                ),
+                botUpdated('uuid-0', {
+                    tags: {
+                        hit: true,
+                    },
+                }),
             ]);
         });
     });

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -4010,9 +4010,8 @@ describe('AuxRuntime', () => {
                     botAdded(createBot('uuid', {}, 'tempLocal')),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['uuid']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['uuid']);
             });
 
             it('should not override previous variables', async () => {
@@ -4030,9 +4029,8 @@ describe('AuxRuntime', () => {
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
 
                 runtime.process([registerBuiltinPortal('grid')]);
 
@@ -4041,25 +4039,41 @@ describe('AuxRuntime', () => {
                 expect(allEvents).toEqual([
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+
+                const result2 = runtime.execute('return gridBot;');
+                expect(result2.result).toBe(runtime.context.state['test1']);
             });
 
-            it('should remove the global variables that were created by the runtime', () => {
+            it('should not create global variables', () => {
                 uuidMock.mockReturnValueOnce('uuid');
 
                 runtime.process([registerBuiltinPortal('grid')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['uuid']
-                );
-
-                runtime.unsubscribe();
-
                 expect(
                     Object.getOwnPropertyDescriptor(globalThis, 'gridBot')
                 ).toBeUndefined();
+            });
+
+            it('should recompile scripts when a new portal bot is registered', async () => {
+                uuidMock.mockReturnValueOnce('uuid');
+                runtime.stateUpdated(
+                    stateUpdatedEvent({
+                        test: createBot('test', {
+                            run: '@return gridBot;',
+                        }),
+                    })
+                );
+
+                const result1 = runtime.shout('run');
+
+                expect(result1.results[0]).toBeUndefined();
+
+                runtime.process([registerBuiltinPortal('grid')]);
+
+                await waitAsync();
+
+                const result2 = runtime.shout('run');
+                expect(result2.results[0]).toBe(runtime.context.state['uuid']);
             });
         });
 
@@ -4076,9 +4090,8 @@ describe('AuxRuntime', () => {
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
             });
 
             it('should override previous variables', () => {
@@ -4096,17 +4109,15 @@ describe('AuxRuntime', () => {
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
 
                 runtime.process([
                     openCustomPortal('grid', 'test2', 'myTag', {}),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test2']
-                );
+                const result2 = runtime.execute('return gridBot;');
+                expect(result2.result).toBe(runtime.context.state['test2']);
             });
 
             it('should remove the variable if given no bot to use for configuration', () => {
@@ -4121,16 +4132,16 @@ describe('AuxRuntime', () => {
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
 
                 runtime.process([openCustomPortal('grid', null, 'myTag', {})]);
 
-                expect((<any>globalThis).gridBot).toBeUndefined();
+                const result2 = runtime.execute('return gridBot;');
+                expect(result2.result).toBeUndefined();
             });
 
-            it('should remove the global variables that were created by the runtime', () => {
+            it('should not create variables on globalThis', () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({
                         test1: createBot('test1', {
@@ -4141,12 +4152,6 @@ describe('AuxRuntime', () => {
                 runtime.process([
                     openCustomPortal('grid', 'test1', 'myTag', {}),
                 ]);
-
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
-
-                runtime.unsubscribe();
 
                 expect(
                     Object.getOwnPropertyDescriptor(globalThis, 'gridBot')
@@ -4180,9 +4185,8 @@ describe('AuxRuntime', () => {
                 );
                 runtime.process([registerCustomApp('grid', 'test1')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
             });
 
             it('should override previous variables', () => {
@@ -4198,15 +4202,13 @@ describe('AuxRuntime', () => {
                 );
                 runtime.process([registerCustomApp('grid', 'test1')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
 
                 runtime.process([registerCustomApp('grid', 'test2')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test2']
-                );
+                const result2 = runtime.execute('return gridBot;');
+                expect(result2.result).toBe(runtime.context.state['test2']);
             });
 
             it('should remove the variable if given no bot to use for configuration', () => {
@@ -4219,16 +4221,16 @@ describe('AuxRuntime', () => {
                 );
                 runtime.process([registerCustomApp('grid', 'test1')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
 
                 runtime.process([registerCustomApp('grid', null)]);
 
-                expect((<any>globalThis).gridBot).toBeUndefined();
+                const result2 = runtime.execute('return gridBot;');
+                expect(result2.result).toBeUndefined();
             });
 
-            it('should remove the global variables that were created by the runtime', () => {
+            it('should not create variables on globalThis', () => {
                 runtime.stateUpdated(
                     stateUpdatedEvent({
                         test1: createBot('test1', {
@@ -4237,12 +4239,6 @@ describe('AuxRuntime', () => {
                     })
                 );
                 runtime.process([registerCustomApp('grid', 'test1')]);
-
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
-
-                runtime.unsubscribe();
 
                 expect(
                     Object.getOwnPropertyDescriptor(globalThis, 'gridBot')
@@ -4272,9 +4268,8 @@ describe('AuxRuntime', () => {
                 );
                 runtime.process([defineGlobalBot('grid', 'test1')]);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
             });
 
             it('should resolve the task when the bot is defined', async () => {
@@ -4299,9 +4294,8 @@ describe('AuxRuntime', () => {
                 await waitAsync();
 
                 expect(resolved).toBe(true);
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
             });
 
             it('should resolve the task even if the bot is already globally defined', async () => {
@@ -4328,9 +4322,8 @@ describe('AuxRuntime', () => {
                 await waitAsync();
 
                 expect(resolved).toBe(true);
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test1']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test1']);
             });
 
             it('should be able to re-define a global bot', async () => {
@@ -4361,9 +4354,8 @@ describe('AuxRuntime', () => {
 
                 expect(resolved).toBe(true);
 
-                expect((<any>globalThis).gridBot).toBe(
-                    runtime.context.state['test2']
-                );
+                const result = runtime.execute('return gridBot;');
+                expect(result.result).toBe(runtime.context.state['test2']);
             });
 
             it('should be able to resolve the task when completed via an async result', async () => {

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -53,6 +53,7 @@ import {
     asyncResult,
     BotActions,
     registerBuiltinPortal,
+    botAdded,
 } from '../bots';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -343,9 +344,15 @@ export class AuxRuntime
             return allActions;
         };
 
+        // The config bot is always ID 0 in debuggers
+        const configBotId = options?.useRealUUIDs
+            ? runtime.context.uuid()
+            : 'uuid-0';
+        runtime.context.createBot(createBot(configBotId, {}, 'tempLocal'));
         runtime.process(
             this._builtinPortalBots.map((b) => registerBuiltinPortal(b))
         );
+        runtime.userId = configBotId;
 
         return {
             ...runtime._library.api,

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -385,7 +385,14 @@ export class AuxRuntime
         const configBotId = options?.useRealUUIDs
             ? runtime.context.uuid()
             : 'uuid-0';
-        runtime.context.createBot(createBot(configBotId, {}, 'tempLocal'));
+        const configBotTags = options?.configBot
+            ? isBot(options?.configBot)
+                ? options.configBot.tags
+                : options.configBot
+            : {};
+        runtime.context.createBot(
+            createBot(configBotId, configBotTags, 'tempLocal')
+        );
         runtime.process(
             this._builtinPortalBots.map((b) => registerBuiltinPortal(b))
         );

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -153,6 +153,8 @@ export class AuxRuntime
      */
     private _autoBatch: boolean = true;
 
+    private _forceSyncScripts: boolean = false;
+
     private _libraryFactory: (context: AuxGlobalContext) => AuxLibrary;
 
     get forceSignedScripts() {
@@ -181,7 +183,8 @@ export class AuxRuntime
         ) => AuxLibrary = createDefaultLibrary,
         editModeProvider: AuxRealtimeEditModeProvider = new DefaultRealtimeEditModeProvider(),
         forceSignedScripts: boolean = false,
-        exemptSpaces: BotSpace[] = ['local', 'tempLocal']
+        exemptSpaces: BotSpace[] = ['local', 'tempLocal'],
+        forceSyncScripts: boolean = false
     ) {
         this._libraryFactory = libraryFactory;
         this._globalContext = new MemoryGlobalContext(
@@ -190,6 +193,8 @@ export class AuxRuntime
             this,
             this
         );
+        this._forceSyncScripts = forceSyncScripts;
+        this._globalContext.mockAsyncActions = forceSyncScripts;
         this._library = merge(libraryFactory(this._globalContext), {
             api: {
                 os: {
@@ -299,7 +304,8 @@ export class AuxRuntime
             this._libraryFactory,
             this._editModeProvider,
             this._forceSignedScripts,
-            this._exemptSpaces
+            this._exemptSpaces,
+            !options?.allowAsynchronousScripts
         );
         runtime._autoBatch = false;
         let idCount = 0;
@@ -1600,7 +1606,7 @@ export class AuxRuntime
             functionName: functionName,
             diagnosticFunctionName: diagnosticFunctionName,
             fileName: fileName,
-
+            forceSync: this._forceSyncScripts,
             context: {
                 bot,
                 tag,

--- a/src/aux-common/runtime/Transpiler.ts
+++ b/src/aux-common/runtime/Transpiler.ts
@@ -110,6 +110,12 @@ export function replaceMacros(text: string) {
     return text;
 }
 
+export interface TranspilerOptions {
+    jsxFactory?: string;
+    jsxFragment?: string;
+    forceSync?: boolean;
+}
+
 /**
  * Defines a class that is able to compile code from AUX's custom JavaScript dialect
  * into pure ES6 JavaScript. Does not preserve spacing or comments.
@@ -120,15 +126,25 @@ export class Transpiler {
     private _parser: typeof Acorn.Parser;
     private _jsxFactory: string;
     private _jsxFragment: string;
+    private _forceSync: boolean;
     private _cache: LRU.Cache<string, TranspilerResult>;
 
-    constructor(options?: { jsxFactory?: string; jsxFragment?: string }) {
+    get forceSync() {
+        return this._forceSync;
+    }
+
+    set forceSync(value: boolean) {
+        this._forceSync = value;
+    }
+
+    constructor(options?: TranspilerOptions) {
         this._cache = new LRU<string, TranspilerResult>({
             max: 1000,
         });
         this._parser = Acorn.Parser.extend(AcornJSX());
         this._jsxFactory = options?.jsxFactory ?? 'h';
         this._jsxFragment = options?.jsxFragment ?? 'Fragment';
+        this._forceSync = options?.forceSync ?? false;
     }
 
     parse(code: string): any {
@@ -261,6 +277,30 @@ export class Transpiler {
                     this._replaceJSXExpressionContainer(n, doc, text);
                 } else if (n.type === 'JSXFragment') {
                     this._replaceJSXFragment(n, doc, text);
+                } else if (
+                    this._forceSync &&
+                    n.type === 'FunctionDeclaration' &&
+                    n.async
+                ) {
+                    this._replaceAsyncFunction(n, doc, text);
+                } else if (
+                    this._forceSync &&
+                    n.type === 'ArrowFunctionExpression' &&
+                    n.async
+                ) {
+                    this._replaceAsyncFunction(n, doc, text);
+                } else if (
+                    this._forceSync &&
+                    n.type === 'FunctionExpression' &&
+                    n.async
+                ) {
+                    if (parent.type === 'Property' && parent.method) {
+                        this._replaceAsyncFunction(parent, doc, text);
+                    } else {
+                        this._replaceAsyncFunction(n, doc, text);
+                    }
+                } else if (this._forceSync && n.type === 'AwaitExpression') {
+                    this._replaceAwaitExpression(n, doc, text);
                 }
             }),
 
@@ -880,6 +920,44 @@ export class Transpiler {
             );
             text.insert(absolute.index, '}');
         }
+    }
+
+    private _replaceAsyncFunction(node: any, doc: Doc, text: Text) {
+        doc.clientID += 1;
+        const version = { '0': getClock(doc, 0) };
+
+        const functionStart = createRelativePositionFromStateVector(
+            text,
+            version,
+            node.start,
+            undefined,
+            true
+        );
+        const functionStartAbsolute = createAbsolutePositionFromRelativePosition(
+            functionStart,
+            doc
+        );
+
+        text.delete(functionStartAbsolute.index, 'async '.length);
+    }
+
+    private _replaceAwaitExpression(node: any, doc: Doc, text: Text) {
+        doc.clientID += 1;
+        const version = { '0': getClock(doc, 0) };
+
+        const keywordStart = createRelativePositionFromStateVector(
+            text,
+            version,
+            node.start,
+            undefined,
+            true
+        );
+        const keywordStartAbsolute = createAbsolutePositionFromRelativePosition(
+            keywordStart,
+            doc
+        );
+
+        text.delete(keywordStartAbsolute.index, 'await '.length);
     }
 }
 

--- a/src/aux-common/runtime/__snapshots__/AuxRuntime.spec.ts.snap
+++ b/src/aux-common/runtime/__snapshots__/AuxRuntime.spec.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AuxRuntime shout() globalThis should not allow deleting properties from globalThis 1`] = `
+Object {
+  "actions": Array [],
+  "errors": Array [],
+  "listeners": Array [],
+  "results": Array [
+    undefined,
+  ],
+}
+`;
+
 exports[`AuxRuntime shout() should compile listeners to use the html.h() function for JSX 1`] = `
 Array [
   Object {


### PR DESCRIPTION
### :rocket: Improvements

-   Added several features to make testing asynchronous scripts easier.
    -   Debuggers now automatically convert asynchronous scripts to synchronous scripts by default.
        -   This makes testing easier because your test code no longer needs to be aware of if a script runs asynchronously in order to observe errors or results.
        -   You can override this default behavior by setting `allowAsynchronousScripts` to `true` in the options object that is passed to `os.createDebugger()`.
    -   Some functions are now "maskable".
        -   Maskable functions are useful for testing and debugging because they let you modify how a function works simply by using `function.mask().returns()` instead of `function()`.
            -   For example, the `web.get()` function sends an actual web request based on the options that you give it. When testing we don't want to send a real web request (since that takes time and can fail), so instead we can mask it with the following code:
            ```typescript
            web.get.mask('https://example.com').returns({
                status: 200,
                data: 'hello world!',
            });
            ```
            Then, the next time we call `web.get()` with `https://example.com` it will return the value we have set:
            ```typescript
            console.log(web.get('https://example.com));
            ```
        -   Maskable functions currently only work when scripts are running inside a debugger with `allowAsychronousScripts` set to `false`.
        -   Here is a list of maskable functions (more are coming):
            -   `web.get()`
            -   `web.post()`
            -   `web.hook()`
            -   `webhook()`
            -   `webhook.post()`
            -   `os.showInput()`
            -   `os.getRecords()`
            -   `os.publishRecord()`
            -   `os.destroyRecord()`
            -   `os.requestPermanentAuthToken()`
    -   Properties added to `globalThis` are now separated per-debugger.
        -   This means that you can set `globalThis.myVariable = 123;` and it won't affect debuggers.
        -   It also means that testing with global variables are easier because you don't have to set and reset them before each test anymore.
    -   Debuggers now automatically setup `tempLocal` bots for built-in portals.
        -   This means that the portal bots like `gridPortalBot`, `mapPortalBot`, etc. are available in debuggers.
    -   Debuggers now automatically setup a `configBot`.
        -   You can override this configBot by using the `configBot` property in the options object that is passed to `os.createDebugger()`.