### PR TITLE
Improve lines to support custom widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 #### Date: TBD
 
+### :boom: Breaking Changes
+
+-   `lineStyle` now defaults to `line` instead of `arrow`.
+
 ### :rocket: Improvements
 
 -   Updated the CasualOS Terms of Service.
+-   Improved `lineTo` and `strokeColor` to use lines that support custom widths.
 
 ## V2.0.18
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -363,11 +363,11 @@ The style of the lines.
 #### Possible values are:
 
 <PossibleValuesTable>
-  <PossibleValueCode value='arrow'>
-    Displays the line with an arrow at the tip pointing to the target bot. (default)
-  </PossibleValueCode>
   <PossibleValueCode value='line'>
-    Displays the line without additional decoration.
+    Displays the line without additional decoration. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='arrow'>
+    Displays the line with an arrow at the tip pointing to the target bot.
   </PossibleValueCode>
   <PossibleValueCode value='wall'>
     Displays the line as a vertical wall.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -350,7 +350,7 @@ The color of the bot's outline.
 
 ### `strokeWidth`
 
-The width of the bot's outline. Only works in Chrome.
+The width of the bot's outline.
 
 ### `lineTo`
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -376,7 +376,7 @@ The style of the lines.
 
 ### `lineWidth`
 
-The width of the walls from this bot. Only works when <TagLink tag='lineStyle'/> is set to `wall`.
+The width of the lines from this bot.
 
 #### Possible values are:
 
@@ -385,7 +385,7 @@ The width of the walls from this bot. Only works when <TagLink tag='lineStyle'/>
     The width of the line is 1 unit. (default)
   </PossibleValueCode>
   <PossibleValue value='Any Number > 0'>
-    The width of the wall is the given size.
+    The width of the line is the given size.
   </PossibleValue>
 </PossibleValuesTable>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
         '^@casual-simulation/three/examples/js/renderers/CSS3DRenderer$':
             '<rootDir>/__mocks__/CSS3DRendererMock.js',
         '^three\\-examples$': '<rootDir>/node_modules/three/examples/js',
+        '^three$': '<rootDir>/node_modules/@casual-simulation/three',
         '^esbuild-wasm/esbuild.wasm\\?url$':
             '<rootDir>/__mocks__/esbuild.wasm.js',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23900,6 +23900,11 @@
 				"thenify": ">= 3.1.0 < 4"
 			}
 		},
+		"three.meshline": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/three.meshline/-/three.meshline-1.3.0.tgz",
+			"integrity": "sha512-ZEb6cZiMh7RFPAQ0320aVBQx1CK4/wFffG9NNAArfX4KBPSJzjS19tYSuhNX7eZ1trU4blEHixz1EXkXN33++w=="
+		},
 		"throat": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",

--- a/src/aux-server/aux-web/shared/scene/Arrow3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Arrow3D.ts
@@ -1,10 +1,5 @@
-import {
-    Object3D,
-    Color,
-    Vector3,
-    ArrowHelper,
-    Sphere,
-} from '@casual-simulation/three';
+import { Object3D, Color, Vector3, Sphere } from '@casual-simulation/three';
+import { ArrowHelper } from './ArrowHelper';
 
 import {
     isMinimized,
@@ -19,6 +14,7 @@ export class Arrow3D extends Object3D {
     public static DefaultColor: Color = buildSRGBColor(1, 1, 1);
     public static DefaultHeadWidth = 0.15;
     public static DefaultHeadLength = 0.3;
+    public static DefaultLineWidth = 0.015;
 
     /**
      * Three JS helper that draws arrows.
@@ -57,7 +53,10 @@ export class Arrow3D extends Object3D {
             new Vector3(0, 0, 0),
             new Vector3(0, 0, 0),
             0,
-            Arrow3D.DefaultColor.getHex()
+            Arrow3D.DefaultColor.getHex(),
+            undefined,
+            undefined,
+            Arrow3D.DefaultLineWidth
         );
         this.add(this._arrowHelper);
     }
@@ -99,6 +98,12 @@ export class Arrow3D extends Object3D {
         }
 
         this._arrowHelper.setLength(length, headLength, headWidth);
+    }
+
+    public setWidth(width: number) {
+        if (!this._arrowHelper) return;
+
+        this._arrowHelper.setLineWidth(width * Arrow3D.DefaultLineWidth);
     }
 
     public update(calc: BotCalculationContext) {

--- a/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
@@ -34,6 +34,8 @@ import {
     Vector3,
     Color,
 } from '@casual-simulation/three';
+
+// @ts-ignore
 import { MeshLine, MeshLineMaterial } from 'three.meshline';
 
 const _axis = /*@__PURE__*/ new Vector3();

--- a/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
@@ -1,0 +1,161 @@
+// The MIT License
+
+// Copyright © 2010-2021 three.js authors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Modified to utilize three.meshline (https://github.com/spite/THREE.MeshLine/tree/v1.3.0)
+
+import {
+    Float32BufferAttribute,
+    BufferGeometry,
+    Object3D,
+    CylinderGeometry,
+    MeshBasicMaterial,
+    LineBasicMaterial,
+    Mesh,
+    Line,
+    Vector3,
+    Color,
+} from '@casual-simulation/three';
+import { MeshLine, MeshLineMaterial } from 'three.meshline';
+
+const _axis = /*@__PURE__*/ new Vector3();
+// let _lineGeometry: BufferGeometry;
+let _coneGeometry: CylinderGeometry;
+
+export class ArrowHelper extends Object3D {
+    line: Mesh;
+    lineMaterial: MeshLineMaterial;
+    cone: Mesh;
+    coneMaterial: MeshBasicMaterial;
+
+    meshLine: MeshLine;
+
+    constructor(
+        dir?: Vector3,
+        origin?: Vector3,
+        length?: number,
+        color?: number,
+        headLength?: number,
+        headWidth?: number,
+        lineWidth?: number
+    ) {
+        super();
+        // dir is assumed to be normalized
+
+        this.type = 'ArrowHelper';
+
+        if (dir === undefined) dir = new Vector3(0, 0, 1);
+        if (origin === undefined) origin = new Vector3(0, 0, 0);
+        if (length === undefined) length = 1;
+        if (color === undefined) color = 0xffff00;
+        if (headLength === undefined) headLength = 0.2 * length;
+        if (headWidth === undefined) headWidth = 0.2 * headLength;
+
+        if (_coneGeometry === undefined) {
+            _coneGeometry = new CylinderGeometry(0, 0.5, 1, 5, 1);
+            _coneGeometry.translate(0, -0.5, 0);
+        }
+
+        this.position.copy(origin);
+
+        this.meshLine = new MeshLine();
+        this.lineMaterial = new MeshLineMaterial();
+        // this.lineMaterial.
+        this.lineMaterial.color = new Color(color);
+        this.lineMaterial.toneMapped = false;
+        this.lineMaterial.sizeAttenuation = true;
+        this.lineMaterial.lineWidth = 1;
+        this.lineMaterial.fog = false;
+
+        this.line = new Mesh(this.meshLine, this.lineMaterial);
+        // this.line = new Line( _lineGeometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+        this.line.matrixAutoUpdate = false;
+        this.add(this.line);
+
+        this.coneMaterial = new MeshBasicMaterial({
+            color: color,
+            toneMapped: false,
+        });
+        this.cone = new Mesh(_coneGeometry, this.coneMaterial);
+        this.cone.matrixAutoUpdate = false;
+        this.add(this.cone);
+
+        this.setDirection(dir);
+        this.setLength(length, headLength, headWidth);
+    }
+
+    setDirection(dir: Vector3) {
+        // dir is assumed to be normalized
+
+        if (dir.y > 0.99999) {
+            this.quaternion.set(0, 0, 0, 1);
+        } else if (dir.y < -0.99999) {
+            this.quaternion.set(1, 0, 0, 0);
+        } else {
+            _axis.set(dir.z, 0, -dir.x).normalize();
+
+            const radians = Math.acos(dir.y);
+
+            this.quaternion.setFromAxisAngle(_axis, radians);
+        }
+    }
+
+    setLength(length: number, headLength: number, headWidth: number) {
+        if (headLength === undefined) headLength = 0.2 * length;
+        if (headWidth === undefined) headWidth = 0.2 * headLength;
+
+        let points = [0, 0, 0, 0, Math.max(0.0001, length - headLength), 0];
+
+        this.meshLine.setPoints(points);
+        // this.line.scale.set( 1, , 1 ); // see #17458
+        this.line.updateMatrix();
+
+        this.cone.scale.set(headWidth, headLength, headWidth);
+        this.cone.position.y = length;
+        this.cone.updateMatrix();
+    }
+
+    setLineWidth(width: number) {
+        this.lineMaterial.lineWidth = width;
+    }
+
+    setColor(color: number | Color) {
+        this.lineMaterial.color.set(color);
+
+        // Convert to SRGB manually because the MeshLineMaterial
+        // does not convert the colors to the renderer output encoding.
+        this.lineMaterial.color.convertLinearToSRGB();
+
+        this.coneMaterial.color.set(color);
+    }
+
+    copy(source: this) {
+        super.copy(source, false);
+
+        this.line.copy(source.line);
+        this.lineMaterial.copy(source.lineMaterial);
+        this.meshLine.copy(source.meshLine);
+        this.cone.copy(source.cone);
+        this.coneMaterial.copy(source.coneMaterial);
+
+        return this;
+    }
+}

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -24,7 +24,6 @@ import { AuxBot3DDecoratorFactory } from './decorators/AuxBot3DDecoratorFactory'
 import { DebugObjectManager } from './debugobjectmanager/DebugObjectManager';
 import { AuxBotVisualizer } from './AuxBotVisualizer';
 import { buildSRGBColor, safeSetParent } from './SceneUtils';
-import { MapSimulation3D } from 'aux-web/aux-player/scene/MapSimulation3D';
 import { CoordinateSystem } from './CoordinateSystem';
 
 /**

--- a/src/aux-server/aux-web/shared/scene/LineSegments.ts
+++ b/src/aux-server/aux-web/shared/scene/LineSegments.ts
@@ -1,0 +1,63 @@
+import {
+    Object3D,
+    Color,
+    Vector3,
+    Sphere,
+    Mesh,
+} from '@casual-simulation/three';
+import { MeshLineMaterial, MeshLine } from 'three.meshline';
+import { disposeMaterial, buildSRGBColor } from './SceneUtils';
+import { Arrow3D } from './Arrow3D';
+
+export class LineSegments extends Object3D {
+    private _meshes: Mesh[] = [];
+    private _meshLines: MeshLine[] = [];
+    private _lineMaterial: MeshLineMaterial;
+
+    get material() {
+        return this._lineMaterial;
+    }
+
+    constructor(lines: number[]) {
+        super();
+
+        this._lineMaterial = new MeshLineMaterial();
+        this._lineMaterial.color = Arrow3D.DefaultColor.clone();
+        this._lineMaterial.toneMapped = false;
+        this._lineMaterial.sizeAttenuation = true;
+        this._lineMaterial.lineWidth = Arrow3D.DefaultLineWidth;
+
+        for (let i = 0; i + 5 < lines.length; i += 6) {
+            let points = lines.slice(i, i + 6);
+
+            let meshLine = new MeshLine();
+            meshLine.setPoints(points);
+            let mesh = new Mesh(meshLine, this._lineMaterial);
+            mesh.matrixAutoUpdate = false;
+            this._meshLines.push(meshLine);
+            this._meshes.push(mesh);
+            this.add(mesh);
+        }
+    }
+
+    public setLineWidth(width: number) {
+        this._lineMaterial.lineWidth = width * Arrow3D.DefaultLineWidth;
+    }
+
+    public setColor(color: number | Color) {
+        this._lineMaterial.color = new Color(color);
+        this._lineMaterial.color.convertLinearToSRGB();
+    }
+
+    public dispose() {
+        for (let i = 0; i < this._meshes.length; i++) {
+            let mesh = this._meshes[0];
+            this.remove(mesh);
+            mesh.geometry.dispose();
+        }
+        disposeMaterial(this._lineMaterial);
+        this._meshes = null;
+        this._meshLines = null;
+        this._lineMaterial = null;
+    }
+}

--- a/src/aux-server/aux-web/shared/scene/LineSegments.ts
+++ b/src/aux-server/aux-web/shared/scene/LineSegments.ts
@@ -5,6 +5,8 @@ import {
     Sphere,
     Mesh,
 } from '@casual-simulation/three';
+
+// @ts-ignore This import is not picked up by Jest
 import { MeshLineMaterial, MeshLine } from 'three.meshline';
 import { disposeMaterial, buildSRGBColor } from './SceneUtils';
 import { Arrow3D } from './Arrow3D';

--- a/src/aux-server/aux-web/shared/scene/MeshUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/MeshUtils.ts
@@ -1,0 +1,38 @@
+import { LineSegments } from './LineSegments';
+import { flatMap } from 'lodash';
+
+export function createCubeStroke() {
+    const lines = new LineSegments(createCubeStrokeLines());
+    return lines;
+}
+
+function createCubeStrokeLines(): number[] {
+    let verticies: number[][] = [
+        [-0.5, -0.5, -0.5], // left  bottom back  - 0
+        [0.5, -0.5, -0.5], // right bottom back  - 1
+        [-0.5, 0.5, -0.5], // left  top    back  - 2
+        [0.5, 0.5, -0.5], // right top    back  - 3
+        [-0.5, -0.5, 0.5], // left  bottom front - 4
+        [0.5, -0.5, 0.5], // right bottom front - 5
+        [-0.5, 0.5, 0.5], // left  top    front - 6
+        [0.5, 0.5, 0.5], // right top    front - 7
+    ];
+
+    const indicies = [
+        0, 1, 0, 2, 0, 4,
+
+        4, 5, 4, 6,
+
+        5, 7, 5, 1,
+
+        1, 3,
+
+        2, 3, 2, 6,
+
+        3, 7,
+
+        6, 7,
+    ];
+    const lines: number[] = flatMap(indicies, (i) => verticies[i]);
+    return lines;
+}

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -31,11 +31,12 @@ import {
     Sphere,
     PerspectiveCamera,
     Group,
-    LineSegments,
+    LineSegments as ThreeLineSegments,
     LineBasicMaterial,
     MeshToonMaterial,
     Intersection,
 } from '@casual-simulation/three';
+import { LineSegments } from './LineSegments';
 import { flatMap } from 'lodash';
 import {
     BotCalculationContext,
@@ -166,9 +167,12 @@ export function createPlane(size: number): Mesh {
     return plane;
 }
 
-export function createCubeStrokeGeometry(): BufferGeometry {
-    const geo = new BufferGeometry();
+export function createCubeStroke() {
+    const lines = new LineSegments(createCubeStrokeLines());
+    return lines;
+}
 
+function createCubeStrokeLines(): number[] {
     let verticies: number[][] = [
         [-0.5, -0.5, -0.5], // left  bottom back  - 0
         [0.5, -0.5, -0.5], // right bottom back  - 1
@@ -181,42 +185,22 @@ export function createCubeStrokeGeometry(): BufferGeometry {
     ];
 
     const indicies = [
-        0,
-        1,
-        0,
-        2,
-        0,
-        4,
+        0, 1, 0, 2, 0, 4,
 
-        4,
-        5,
-        4,
-        6,
+        4, 5, 4, 6,
 
-        5,
-        7,
-        5,
-        1,
+        5, 7, 5, 1,
 
-        1,
-        3,
+        1, 3,
 
-        2,
-        3,
-        2,
-        6,
+        2, 3, 2, 6,
 
-        3,
-        7,
+        3, 7,
 
-        6,
-        7,
+        6, 7,
     ];
     const lines: number[] = flatMap(indicies, (i) => verticies[i]);
-    const array = new Float32Array(lines);
-    geo.setAttribute('position', new BufferAttribute(array, 3));
-
-    return geo;
+    return lines;
 }
 
 /**
@@ -600,7 +584,10 @@ export function buildSRGBColor(...args: (string | number)[]): Color {
  * @param mesh The mesh.
  * @param color The color in sRGB space.
  */
-export function setColor(mesh: Mesh | Sprite | LineSegments, color: string) {
+export function setColor(
+    mesh: Mesh | Sprite | ThreeLineSegments | LineSegments,
+    color: string
+) {
     if (!mesh) {
         return;
     }
@@ -610,7 +597,10 @@ export function setColor(mesh: Mesh | Sprite | LineSegments, color: string) {
     if (color) {
         shapeMat.visible = !isTransparent(color);
         if (shapeMat.visible) {
-            shapeMat.color = buildSRGBColor(color);
+            shapeMat.color =
+                mesh instanceof LineSegments
+                    ? new Color(color)
+                    : buildSRGBColor(color);
         }
     } else {
         shapeMat.visible = true;

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -36,7 +36,6 @@ import {
     MeshToonMaterial,
     Intersection,
 } from '@casual-simulation/three';
-import { LineSegments } from './LineSegments';
 import { flatMap } from 'lodash';
 import {
     BotCalculationContext,
@@ -165,42 +164,6 @@ export function createPlane(size: number): Mesh {
     plane.castShadow = false;
     plane.receiveShadow = false;
     return plane;
-}
-
-export function createCubeStroke() {
-    const lines = new LineSegments(createCubeStrokeLines());
-    return lines;
-}
-
-function createCubeStrokeLines(): number[] {
-    let verticies: number[][] = [
-        [-0.5, -0.5, -0.5], // left  bottom back  - 0
-        [0.5, -0.5, -0.5], // right bottom back  - 1
-        [-0.5, 0.5, -0.5], // left  top    back  - 2
-        [0.5, 0.5, -0.5], // right top    back  - 3
-        [-0.5, -0.5, 0.5], // left  bottom front - 4
-        [0.5, -0.5, 0.5], // right bottom front - 5
-        [-0.5, 0.5, 0.5], // left  top    front - 6
-        [0.5, 0.5, 0.5], // right top    front - 7
-    ];
-
-    const indicies = [
-        0, 1, 0, 2, 0, 4,
-
-        4, 5, 4, 6,
-
-        5, 7, 5, 1,
-
-        1, 3,
-
-        2, 3, 2, 6,
-
-        3, 7,
-
-        6, 7,
-    ];
-    const lines: number[] = flatMap(indicies, (i) => verticies[i]);
-    return lines;
 }
 
 /**
@@ -585,7 +548,7 @@ export function buildSRGBColor(...args: (string | number)[]): Color {
  * @param color The color in sRGB space.
  */
 export function setColor(
-    mesh: Mesh | Sprite | ThreeLineSegments | LineSegments,
+    mesh: Mesh | Sprite | ThreeLineSegments,
     color: string
 ) {
     if (!mesh) {
@@ -597,10 +560,7 @@ export function setColor(
     if (color) {
         shapeMat.visible = !isTransparent(color);
         if (shapeMat.visible) {
-            shapeMat.color =
-                mesh instanceof LineSegments
-                    ? new Color(color)
-                    : buildSRGBColor(color);
+            shapeMat.color = buildSRGBColor(color);
         }
     } else {
         shapeMat.visible = true;

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -17,8 +17,6 @@ import {
 } from '@casual-simulation/aux-common';
 import {
     Mesh,
-    LineSegments,
-    LineBasicMaterial,
     Group,
     Vector3,
     Box3,
@@ -31,7 +29,6 @@ import {
 } from '@casual-simulation/three';
 import {
     createCube,
-    createCubeStrokeGeometry,
     isTransparent,
     disposeMesh,
     createSphere,
@@ -42,7 +39,9 @@ import {
     buildSRGBColor,
     calculateScale,
     baseAuxMeshMaterial,
+    createCubeStroke,
 } from '../SceneUtils';
+import { LineSegments } from '../LineSegments';
 import { IMeshDecorator } from './IMeshDecorator';
 import { ArgEvent } from '@casual-simulation/aux-common/Events';
 import { GLTF } from '@casual-simulation/three/examples/jsm/loaders/GLTFLoader';
@@ -56,12 +55,15 @@ import EggUrl from '../../public/meshes/egg.glb';
 import { Axial, HexMesh } from '../hex';
 import { sortBy } from 'lodash';
 import { SubscriptionLike } from 'rxjs';
+import { MeshLineMaterial } from 'three.meshline';
+import { Arrow3D } from '../Arrow3D';
 
 const gltfPool = getGLTFPool('main');
 
 export class BotShapeDecorator
     extends AuxBot3DDecoratorBase
-    implements IMeshDecorator {
+    implements IMeshDecorator
+{
     private _shape: BotShape = null;
     private _subShape: BotSubShape = null;
     private _gltfVersion: number = null;
@@ -233,7 +235,7 @@ export class BotShapeDecorator
             this.container.add(this.stroke);
         } else if (!hasStroke) {
             if (this.stroke) {
-                disposeMesh(this.stroke);
+                this.stroke.dispose();
                 this.container.remove(this.stroke);
 
                 this.stroke = null;
@@ -242,19 +244,19 @@ export class BotShapeDecorator
         }
 
         this.stroke.visible = true;
-        const strokeMat = <LineBasicMaterial>this.stroke.material;
+        const strokeMat = <MeshLineMaterial>this.stroke.material;
         if (typeof strokeColorValue !== 'undefined') {
             strokeMat.visible = !isTransparent(strokeColorValue);
             if (strokeMat.visible) {
-                strokeMat.color = buildSRGBColor(strokeColorValue);
+                this.stroke.setColor(buildSRGBColor(strokeColorValue));
             }
         } else {
             strokeMat.visible = false;
         }
         if (typeof strokeWidth !== 'undefined') {
-            strokeMat.linewidth = strokeWidth;
+            strokeMat.lineWidth = Arrow3D.DefaultLineWidth * strokeWidth;
         } else {
-            strokeMat.linewidth = 1;
+            strokeMat.lineWidth = Arrow3D.DefaultLineWidth;
         }
     }
 
@@ -428,7 +430,7 @@ export class BotShapeDecorator
 
         this.bot3D.display.remove(this.container);
         disposeMesh(this.mesh);
-        disposeMesh(this.stroke);
+        this.stroke.dispose();
         disposeObject3D(this.collider);
         if (this._iframe) {
             this.container.remove(this._iframe.object3d);
@@ -534,9 +536,8 @@ export class BotShapeDecorator
         if (!mixerContext) {
             return false;
         }
-        const domElement = HtmlMixerHelpers.createIframeDomElement(
-            'about:blank'
-        );
+        const domElement =
+            HtmlMixerHelpers.createIframeDomElement('about:blank');
 
         this._iframe = new HtmlMixer.Plane(mixerContext, domElement, {
             elementW: 768,
@@ -748,12 +749,9 @@ export class BotShapeDecorator
 }
 
 function createStroke() {
-    const geo = createCubeStrokeGeometry();
-    const material = new LineBasicMaterial({
-        color: 0x000000,
-    });
-
-    return new LineSegments(geo, material);
+    const stroke = createCubeStroke();
+    stroke.setColor(0x000000);
+    return stroke;
 }
 
 function findFirstMesh(obj: Object3D): Mesh {

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -39,8 +39,8 @@ import {
     buildSRGBColor,
     calculateScale,
     baseAuxMeshMaterial,
-    createCubeStroke,
 } from '../SceneUtils';
+import { createCubeStroke } from '../MeshUtils';
 import { LineSegments } from '../LineSegments';
 import { IMeshDecorator } from './IMeshDecorator';
 import { ArgEvent } from '@casual-simulation/aux-common/Events';

--- a/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
@@ -8,6 +8,7 @@ import {
     isBot,
     calculateStringTagValue,
     calculateBotIds,
+    calculateNumericalTagValue,
 } from '@casual-simulation/aux-common';
 import { Arrow3D } from '../Arrow3D';
 import { Color } from '@casual-simulation/three';
@@ -27,6 +28,7 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
     private _finder: AuxBotVisualizerFinder;
     private _lineColor: Color;
     private _lineColorValue: any;
+    private _lineWidth: number;
 
     constructor(bot3D: AuxBot3D, botFinder: AuxBotVisualizerFinder) {
         super(bot3D);
@@ -92,8 +94,21 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
                 }
             }
 
+            this._lineWidth = calculateNumericalTagValue(
+                calc,
+                this.bot3D.bot,
+                'auxLineWidth',
+                1
+            );
+
             for (let id of lineTo) {
-                this._trySetupLines(calc, id, validLineIds, this._lineColor);
+                this._trySetupLines(
+                    calc,
+                    id,
+                    validLineIds,
+                    this._lineColor,
+                    this._lineWidth
+                );
             }
         }
 
@@ -174,7 +189,8 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
         calc: BotCalculationContext,
         targetBotId: string,
         validLineIds: number[],
-        color?: Color
+        color?: Color,
+        lineWidth?: number
     ) {
         // Undefined target botd id.
         if (!targetBotId) return;
@@ -185,7 +201,13 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
 
         const bots = this._finder.findBotsById(targetBotId);
         bots.forEach((f) =>
-            this._trySetupLine(calc, <AuxBot3D>f, validLineIds, color)
+            this._trySetupLine(
+                calc,
+                <AuxBot3D>f,
+                validLineIds,
+                color,
+                lineWidth
+            )
         );
     }
 
@@ -193,7 +215,8 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
         calc: BotCalculationContext,
         targetBot: AuxBot3D,
         validLineIds: number[],
-        color?: Color
+        color?: Color,
+        lineWidth?: number
     ) {
         if (!targetBot) {
             // No bot found.
@@ -254,6 +277,7 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
             if (targetArrow) {
                 targetArrow.setColor(color);
                 targetArrow.setTipState(hasArrowTip);
+                targetArrow.setWidth(lineWidth ?? 1);
                 targetArrow.update(calc);
                 // Add the target bot id to the valid ids list.
                 validLineIds.push(targetBot.id);

--- a/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/LineToDecorator.ts
@@ -260,7 +260,7 @@ export class LineToDecorator extends AuxBot3DDecoratorBase {
             // Initialize arrows array if needed.
             if (!this.arrows) this.arrows = [];
 
-            let hasArrowTip = style !== 'line';
+            let hasArrowTip = style === 'arrow';
 
             let targetArrow: Arrow3D = this._arrows.get(targetBot);
 

--- a/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
+++ b/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
@@ -1,6 +1,6 @@
-import { disposeObject3D, disposeMesh, createCubeStroke } from '../SceneUtils';
-import { LineSegments } from '../LineSegments';
+import type { LineSegments } from '../LineSegments';
 import { ObjectPool } from './ObjectPool';
+import { createCubeStroke } from '../MeshUtils';
 
 export class CubeHelperPool extends ObjectPool<LineSegments> {
     constructor(name?: string, poolEmptyWarn?: boolean) {

--- a/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
+++ b/src/aux-server/aux-web/shared/scene/objectpools/CubeHelperPool.ts
@@ -1,15 +1,6 @@
-import {
-    disposeObject3D,
-    disposeMesh,
-    createCubeStrokeGeometry,
-} from '../SceneUtils';
+import { disposeObject3D, disposeMesh, createCubeStroke } from '../SceneUtils';
+import { LineSegments } from '../LineSegments';
 import { ObjectPool } from './ObjectPool';
-import {
-    Vector3,
-    Mesh,
-    LineSegments,
-    LineBasicMaterial,
-} from '@casual-simulation/three';
 
 export class CubeHelperPool extends ObjectPool<LineSegments> {
     constructor(name?: string, poolEmptyWarn?: boolean) {
@@ -29,12 +20,9 @@ export class CubeHelperPool extends ObjectPool<LineSegments> {
     }
 
     createPoolObject(): LineSegments {
-        const geo = createCubeStrokeGeometry();
-        const material = new LineBasicMaterial({
-            color: 0x000000,
-        });
-
-        return new LineSegments(geo, material);
+        const lines = createCubeStroke();
+        lines.setColor(0x000000);
+        return lines;
     }
 
     getPoolObjectId(obj: LineSegments): string {
@@ -42,6 +30,6 @@ export class CubeHelperPool extends ObjectPool<LineSegments> {
     }
 
     disposePoolObject(obj: LineSegments): void {
-        disposeMesh(obj);
+        obj.dispose();
     }
 }

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -117,7 +117,8 @@
         "vue-material": "^1.0.0-beta-10.2",
         "vue-property-decorator": "^7.2.0",
         "vue-router": "^3.0.1",
-        "vue-shortkey": "^3.1.6"
+        "vue-shortkey": "^3.1.6",
+        "three.meshline": "1.3.0"
     },
     "devDependencies": {
         "@casual-simulation/aux-components": "^2.0.18",

--- a/src/aux-server/typings/three.meshline.d.ts
+++ b/src/aux-server/typings/three.meshline.d.ts
@@ -1,0 +1,25 @@
+declare module 'three.meshline' {
+    import { Material, Color, BufferGeometry } from '@casual-simulation/three';
+
+    export class MeshLine extends BufferGeometry {
+        setPoints(
+            points: number[],
+            getPointWidth?: (percent: number) => number
+        ): void;
+        setPoints(
+            geometry: BufferGeometry,
+            getPointWidth?: (percent: number) => number
+        ): void;
+    }
+
+    export class MeshLineMaterial extends Material {
+        color: Color;
+        lineWidth: number;
+        sizeAttenuation: boolean;
+
+        dashArray: number;
+        dashRatio: number;
+
+        constructor(parameters?: any);
+    }
+}


### PR DESCRIPTION
### :boom: Breaking Changes

-   `lineStyle` now defaults to `line` instead of `arrow`.

### :rocket: Improvements

-   Improved `lineTo` and `strokeColor` to use lines that support custom widths.