### PR TITLE
Scripting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@
 
 -   Updated the CasualOS Terms of Service.
 -   Improved `lineTo` and `strokeColor` to use lines that support custom widths.
+-   Added the `links` variable as a shortcut for `thisBot.links`.
+-   Added `bot.vars` and `os.vars` as an easy way to store and lookup variables by name.
+    -   `os.vars` works exactly the same as `globalThis`.
+    -   `bot.vars` allows you to store special values in a bot that cannot be stored in either `bot.tags` or `bot.masks`.
+-   Added the ability to whisper to a bot by using `bot.listener()` instead of `whisper(bot, "listener")`.
+    -   e.g.
+        ```typescript
+        let result = thisBot.myScript(argument);
+        ```
+        is equivalent to
+        ```typescript
+        let [result] = whisper(thisBot, 'myScript', argument);
+        ```
+-   Added the ability to shout to bots by using `shout.listener()` instead of `shout("listener")`.
+    -   e.g.
+        ```typescript
+        let results = shout.myScript(argument);
+        ```
+        is equivalent to
+        ```typescript
+        let results = shout('myScript', argument);
+        ```
 
 ## V2.0.18
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -135,6 +135,11 @@ export interface RuntimeBot {
         ops: TagEditOp[],
         space: string
     ) => any;
+
+    /**
+     * Gets the listener with the given name.
+     */
+    [listener: string]: CompiledBotListener | any;
 }
 
 /**

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -76,6 +76,11 @@ export interface RuntimeBot {
     links: RuntimeBotLinks;
 
     /**
+     * The variables that the bot contains.
+     */
+    vars: RuntimeBotVars;
+
+    /**
      * The changes that have been made to the bot.
      */
     changes: BotTags;
@@ -152,6 +157,13 @@ export interface ParsedBotLink {
  */
 export interface RuntimeBotLinks {
     [tag: string]: RuntimeBot | RuntimeBot[];
+}
+
+/**
+ * Defines an interface that represents the variables a bot can have.
+ */
+export interface RuntimeBotVars {
+    [variable: string]: any;
 }
 
 /**

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -11497,6 +11497,22 @@ describe('AuxLibrary', () => {
                 ]);
             });
         });
+
+        it('should support using dot syntax', () => {
+            const sayHello1 = (bot1.listeners.sayHello = jest.fn());
+            const sayHello2 = (bot2.listeners.sayHello = jest.fn());
+            recordListeners();
+
+            library.api.shout.sayHello({
+                abc: 'def',
+            });
+            expect(sayHello1).toBeCalledWith({
+                abc: 'def',
+            });
+            expect(sayHello2).toBeCalledWith({
+                abc: 'def',
+            });
+        });
     });
 
     describe('whisper()', () => {

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -10017,6 +10017,7 @@ describe('AuxLibrary', () => {
                 masks: {},
                 maskChanges: {},
                 links: {},
+                vars: {},
                 listeners: {},
                 signatures: {},
             });
@@ -10054,6 +10055,7 @@ describe('AuxLibrary', () => {
                 maskChanges: {},
                 changes: {},
                 links: {},
+                vars: {},
                 listeners: {
                     onCreate: expect.any(Function),
                 },
@@ -12950,6 +12952,12 @@ describe('AuxLibrary', () => {
             const result = library.api.os.getInputList();
 
             expect(result).toEqual(['abc', 'def', 'ghi']);
+        });
+    });
+
+    describe('os.vars', () => {
+        it('should return the global object from the context', () => {
+            expect(library.api.os.vars).toBe(context.global);
         });
     });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1064,6 +1064,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 remoteCount: serverRemoteCount,
                 totalRemoteCount: totalRemoteCount,
                 instStatuses: serverStatuses,
+
+                get vars() {
+                    return context.global;
+                },
             },
 
             portal: {

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -873,6 +873,19 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     const webhookFunc = makeMockableFunction(webhook, 'webhook');
     webhookFunc.post = makeMockableFunction(webhook.post, 'webhook.post');
 
+    const shoutImpl: {
+        (name: string, arg?: any): any[];
+        [name: string]: (arg?: any) => any[];
+    } = shout as any;
+
+    const shoutProxy = new Proxy(shoutImpl, {
+        get(target, name: string, reciever) {
+            return (arg?: any) => {
+                return shout(name, arg);
+            };
+        },
+    });
+
     return {
         api: {
             getBots,
@@ -907,7 +920,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             updateBotLinks,
             superShout,
             priorityShout,
-            shout,
+            shout: shoutProxy,
             whisper,
 
             byTag,

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -5150,6 +5150,11 @@ interface Os {
       * Gets the debugger that this script is currently running in.
       */
      getExecutingDebugger(): Debugger;
+
+     /**
+      * The global variables that are stored in the OS.
+      */
+     vars: typeof globalThis;
 }
 
 interface Server {

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -2472,6 +2472,10 @@ declare interface ParsedBotLink {
     botIDs: string[];
 }
 
+declare interface BotVars {
+    [variable: string]: any;
+}
+
 /**
  * Defines an interface that represents the bot links a bot can have.
  */
@@ -2512,6 +2516,11 @@ export interface Bot {
      * The links that this bot has to other bots.
      */
     links: BotLinks;
+
+    /**
+     * THe variables that are stored in this bot.
+     */
+    vars: BotVars;
 
     /**
      * The raw tag values that the bot contains.
@@ -3072,7 +3081,39 @@ declare global {
      * // Tell every bot say "Hi" to you.
      * shout("sayHi()", "My Name");
      */
-    function shout(name: string, arg?: any): any[];
+    const shout: {
+        /**
+         * Asks every bot in the inst to run the given action.
+         * In effect, this is like shouting to a bunch of people in a room.
+         *
+         * @param name The event name.
+         * @param arg The optional argument to include in the shout.
+         * @returns Returns a list which contains the values returned from each script that was run for the shout.
+         *
+         * @example
+         * // Tell every bot to reset themselves.
+         * shout("reset()");
+         *
+         * @example
+         * // Ask every bot for its name.
+         * const names = shout("getName()");
+         *
+         * @example
+         * // Tell every bot say "Hi" to you.
+         * shout("sayHi()", "My Name");
+         */
+        (name: string, arg?: any): any[],
+        [name: string]: {
+            /**
+             * Asks every bot in the inst to run the given action.
+             * In effect, this is like shouting to a bunch of people in a room.
+             *
+             * @param arg The optional argument to include in the shout.
+             * @returns Returns a list which contains the values returned from each script that was run for the shout.
+             */
+            (arg?: any): any[]
+        }
+    };
 
     /**
      * Asks the given bots to run the given action.

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -77,6 +77,7 @@ import {
     defineGlobalBot,
     updateAuthData,
     RuntimeBot,
+    createBotLink,
 } from '../bots';
 import { v4 as uuid } from 'uuid';
 import { waitAsync } from '../test/TestHelpers';
@@ -8207,6 +8208,38 @@ describe('original action tests', () => {
                 botUpdated('thisBot', {
                     tags: {
                         runningTag: 'test',
+                    },
+                }),
+            ]);
+        });
+    });
+
+    describe('links', () => {
+        it('should pass in a links variable which is bot.links', () => {
+            const state: BotsState = {
+                thisBot: {
+                    id: 'thisBot',
+                    tags: {
+                        otherBot: createBotLink(['otherBot']),
+                        test: '@setTag(links.otherBot, "hit", true)',
+                    },
+                },
+
+                otherBot: {
+                    id: 'otherBot',
+                    tags: {},
+                },
+            };
+
+            // specify the UUID to use next
+            uuidMock.mockReturnValue('uuid-0');
+            const botAction = action('test', ['thisBot']);
+            const result = calculateActionResults(state, botAction);
+
+            expect(result.actions).toEqual([
+                botUpdated('otherBot', {
+                    tags: {
+                        hit: true,
                     },
                 }),
             ]);

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -1722,6 +1722,7 @@ export class AuxRuntime
                 masks: (ctx) => (ctx.bot ? ctx.bot.script.masks : null),
                 creatorBot: (ctx) => ctx.creator,
                 configBot: () => this.context.playerBot,
+                links: (ctx) => (ctx.bot ? ctx.bot.script.links : null),
             },
             arguments: [['that', 'data']],
         });

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -1448,6 +1448,13 @@ describe('RuntimeBot', () => {
         });
     });
 
+    describe('vars', () => {
+        it('should contain a normal object that can store variables', () => {
+            expect(script.vars).toEqual({});
+            expect(script.vars.constructor).toBe(Object);
+        });
+    });
+
     describe('clear_changes', () => {
         it('should be able to clear changes from the script bot', () => {
             script.tags.abc = 123;

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -900,6 +900,46 @@ describe('RuntimeBot', () => {
             const listener = script.listeners.abc;
             expect(listener).toBe(func);
         });
+
+        describe('listener shortcut', () => {
+            it('should support getting listeners directly from the runtime bot', () => {
+                let func = () => {};
+                getListenerMock.mockReturnValueOnce(func);
+                const listener = script.abc;
+
+                expect(listener).toBe(func);
+                expect(getListenerMock).toHaveBeenCalledWith(precalc, 'abc');
+            });
+
+            it('should return undefined if the listener doesnt exist', () => {
+                const listener = script.abc;
+
+                expect(listener).toBeUndefined();
+            });
+
+            it('should not break the ability to iterate over bot properties', () => {
+                let func = () => {};
+                getListenerMock.mockReturnValueOnce(func);
+
+                let props = Object.keys(script);
+                props.sort();
+
+                expect(props).toEqual([
+                    'changes',
+                    'id',
+                    'link',
+                    'links',
+                    'listeners',
+                    'maskChanges',
+                    'masks',
+                    'raw',
+                    'signatures',
+                    'space',
+                    'tags',
+                    'vars',
+                ]);
+            });
+        });
     });
 
     describe('masks', () => {
@@ -1882,6 +1922,23 @@ describe('RuntimeBot', () => {
                         insert('111'),
                         del(1)
                     ),
+                },
+            });
+        });
+    });
+
+    describe('toJSON()', () => {
+        it('should return the bot object with ID, space, and tags', () => {
+            script.tags.abc = 'def';
+
+            expect(script.toJSON()).toEqual({
+                id: script.id,
+                space: 'shared',
+                tags: {
+                    abc: 'def',
+                    bool: true,
+                    ghi: 123,
+                    different: 'string',
                 },
             });
         });

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -571,7 +571,21 @@ export function createRuntimeBot(
         script.space = bot.space;
     }
 
-    return script;
+    const scriptProxy = new Proxy(script, {
+        get(target, prop: string, reciever) {
+            if (prop in target) {
+                return Reflect.get(target, prop, reciever);
+            } else if (typeof prop === 'string') {
+                const listener = manager.getListener(bot, prop);
+                if (listener) {
+                    return listener;
+                }
+            }
+            return undefined;
+        },
+    });
+
+    return scriptProxy;
 
     function updateTag(tag: string, value: any) {
         const mode = manager.updateTag(bot, tag, value);

--- a/src/aux-common/runtime/RuntimeBot.ts
+++ b/src/aux-common/runtime/RuntimeBot.ts
@@ -410,6 +410,7 @@ export function createRuntimeBot(
         raw: rawProxy,
         masks: maskProxy,
         links: linkProxy,
+        vars: {},
         changes: changedRawTags,
         maskChanges: changedMasks,
         listeners: listenersProxy,


### PR DESCRIPTION
### :rocket: Improvements

-   Added the `links` variable as a shortcut for `thisBot.links`.
-   Added `bot.vars` and `os.vars` as an easy way to store and lookup variables by name.
    -   `os.vars` works exactly the same as `globalThis`.
    -   `bot.vars` allows you to store special values in a bot that cannot be stored in either `bot.tags` or `bot.masks`.
-   Added the ability to whisper to a bot by using `bot.listener()` instead of `whisper(bot, "listener")`.
    -   e.g.
        ```typescript
        let result = thisBot.myScript(argument);
        ```
        is equivalent to
        ```typescript
        let [result] = whisper(thisBot, 'myScript', argument);
        ```
-   Added the ability to shout to bots by using `shout.listener()` instead of `shout("listener")`.
    -   e.g.
        ```typescript
        let results = shout.myScript(argument);
        ```
        is equivalent to
        ```typescript
        let results = shout('myScript', argument);
        ```