### PR TITLE
AR and VR scripting improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # CasualOS Changelog
 
+## v2.0.32
+
+#### Data: TBD
+
+### :rocket: Improvements
+
+-   Added the `os.arSupported()` and `os.vrSupported` functions to query device support for AR and VR respectively. Both of these are promises and must be awaited.
+
+    ```typescript
+    const arSupported = await os.arSupported();
+    if (arSupported) {
+        //...
+    }
+
+    const vrSupported = await os.vrSupported();
+    if (arSupported) {
+        //...
+    }
+    ```
+
+-   Added shouts for entering and exiting AR and VR:
+    -   `@onEnterAR` - Called when AR has been enabled.
+    -   `@onExitAR` - Called when AR has been disabled.
+    -   `@onEnterVR` - Called when VR has been enabled.
+    -   `@onExitVR` - Called when VR has been disabled.
+
 ## V2.0.31
 
 #### Date: 1/20/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### :rocket: Improvements
 
--   Added the `os.arSupported()` and `os.vrSupported` functions to query device support for AR and VR respectively. Both of these are promises and must be awaited.
+-   Added the `os.arSupported()` and `os.vrSupported()` functions to query device support for AR and VR respectively. Both of these are promises and must be awaited.
 
     ```typescript
     const arSupported = await os.arSupported();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
     }
 
     const vrSupported = await os.vrSupported();
-    if (arSupported) {
+    if (vrSupported) {
         //...
     }
     ```

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3577,6 +3577,26 @@ The only difference is that all bots in the shared space are included and the fi
 os.downloadInst();
 ```
 
+### `os.arSupported`
+
+Returns a promise that resolves with a flag indicating wether or not AR is supported by the device.
+
+#### Examples:
+1. Check if AR is supported:
+```typescript
+const supported = await os.arSupported();
+```
+
+### `os.vrSupported`
+
+Returns a promise that resolves with a flag indicating wether or not VR is supported by the device.
+
+#### Examples:
+1. Check if VR is supported:
+```typescript
+const supported = await os.vrSupported();
+```
+
 ### `os.enableAR()`
 
 
@@ -3614,7 +3634,6 @@ os.enableVR();
 ```
 
 ### `os.disableVR()`
-
 
 Disables virtual reality on the device.
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3577,9 +3577,9 @@ The only difference is that all bots in the shared space are included and the fi
 os.downloadInst();
 ```
 
-### `os.arSupported`
+### `os.arSupported()`
 
-Returns a promise that resolves with a flag indicating wether or not AR is supported by the device.
+Returns a promise that resolves with a flag indicating wether or not augmented reality is supported by the device.
 
 #### Examples:
 1. Check if AR is supported:
@@ -3587,9 +3587,9 @@ Returns a promise that resolves with a flag indicating wether or not AR is suppo
 const supported = await os.arSupported();
 ```
 
-### `os.vrSupported`
+### `os.vrSupported()`
 
-Returns a promise that resolves with a flag indicating wether or not VR is supported by the device.
+Returns a promise that resolves with a flag indicating wether or not virtual reality is supported by the device.
 
 #### Examples:
 1. Check if VR is supported:
@@ -3599,8 +3599,10 @@ const supported = await os.vrSupported();
 
 ### `os.enableAR()`
 
+Enables augmented reality on the device.  
+You can check for device support by calling <ActionLink action='os.arSupported()'/>.
 
-Enables augmented reality on the device.
+If enabled successfully, the <TagLink tag='@onEnterAR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
 
 #### Examples:
 
@@ -3611,8 +3613,9 @@ os.enableAR();
 
 ### `os.disableAR()`
 
-
 Disables augmented reality on the device.
+
+When disabled, <TagLink tag='@onExitAR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
 
 #### Examples:
 
@@ -3623,8 +3626,10 @@ os.disableAR();
 
 ### `os.enableVR()`
 
+Enables virtual reality on the device.  
+You can check for device support by calling <ActionLink action='os.vrSupported()'/>.
 
-Enables virtual reality on the device.
+If enabled successfully, the <TagLink tag='@onEnterVR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
 
 #### Examples:
 
@@ -3636,6 +3641,8 @@ os.enableVR();
 ### `os.disableVR()`
 
 Disables virtual reality on the device.
+
+When disabled, <TagLink tag='@onExitVR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
 
 #### Examples:
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3602,7 +3602,7 @@ const supported = await os.vrSupported();
 Enables augmented reality on the device.  
 You can check for device support by calling <ActionLink action='os.arSupported()'/>.
 
-If enabled successfully, the <TagLink tag='@onEnterAR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
+If enabled successfully, the <TagLink tag='@onEnterAR'/> shout is sent to all bots.
 
 #### Examples:
 
@@ -3615,7 +3615,7 @@ os.enableAR();
 
 Disables augmented reality on the device.
 
-When disabled, <TagLink tag='@onExitAR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
+When disabled, <TagLink tag='@onExitAR'/> shout is sent to all bots.
 
 #### Examples:
 
@@ -3629,7 +3629,7 @@ os.disableAR();
 Enables virtual reality on the device.  
 You can check for device support by calling <ActionLink action='os.vrSupported()'/>.
 
-If enabled successfully, the <TagLink tag='@onEnterVR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
+If enabled successfully, the <TagLink tag='@onEnterVR'/> shout is sent to all bots.
 
 #### Examples:
 
@@ -3642,7 +3642,7 @@ os.enableVR();
 
 Disables virtual reality on the device.
 
-When disabled, <TagLink tag='@onExitVR'/> shout is sent to all bots in the <TagLink tag='gridPortal'/>.
+When disabled, <TagLink tag='@onExitVR'/> shout is sent to all bots.
 
 #### Examples:
 

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -1083,6 +1083,34 @@ If the data was streamed, `that` is `null`. Otherwise, `that` is a `Blob` object
 let that: Blob;
 ```
 
+### `@onEnterAR`
+
+A shout that is sent whenever the device enters augmented reality mode.  
+You can enter AR by calling <ActionLink action='os.enableAR()'/>.
+
+There are no arguments with this listener.
+
+### `@onExitAR`
+
+A shout that is sent whenever the device exits augmented reality mode.  
+You can exit AR by calling <ActionLink action='os.disableAR()'/>.
+
+There are no arguments with this listener.
+
+### `@onEnterVR`
+
+A shout that is sent whenever the device enters virtual reality mode.  
+You can exit VR by calling <ActionLink action='os.enterVR()'/>.
+
+There are no arguments with this listener.
+
+### `@onExitVR`
+
+A shout that is sent whenever the device exits virtual reality mode.  
+You can exit VR by calling <ActionLink action='os.disableVR()'/>.
+
+There are no arguments with this listener.
+
 ### `@onWebhook`
 
 A shout that is sent whenever a webhook is received.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1578,6 +1578,26 @@ export const ON_BEGIN_AUDIO_RECORDING: string = 'onBeginAudioRecording';
 export const ON_END_AUDIO_RECORDING: string = 'onEndAudioRecording';
 
 /**
+ * The name of the event that is triggered when VR is entered.
+ */
+export const ON_ENTER_VR: string = 'onEnterVR';
+
+/**
+ * The name of the event that is triggered when VR is exited.
+ */
+export const ON_EXIT_VR: string = 'onExitVR';
+
+/**
+ * The name of the event that is triggered when AR is entered.
+ */
+export const ON_ENTER_AR: string = 'onEnterAR';
+
+/**
+ * The name of the event that is triggered when AR is exited.
+ */
+export const ON_EXIT_AR: string = 'onExitAR';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -2051,6 +2071,10 @@ export const KNOWN_TAGS: string[] = [
     ON_BEGIN_AUDIO_RECORDING,
     ON_AUDIO_SAMPLE,
     ON_END_AUDIO_RECORDING,
+    ON_ENTER_VR,
+    ON_EXIT_VR,
+    ON_ENTER_AR,
+    ON_EXIT_AR,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -214,7 +214,9 @@ export type AsyncActions =
     | GetRecordDataAction
     | EraseRecordDataAction
     | RecordFileAction
-    | EraseFileAction;
+    | EraseFileAction
+    | ARSupportedAction
+    | VRSupportedAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -2433,6 +2435,20 @@ export interface EnableARAction {
      * Whether AR features should be enabled.
      */
     enabled: boolean;
+}
+
+/**
+ * Defines an event that checks for AR support on the device.
+ */
+export interface ARSupportedAction extends AsyncAction {
+    type: 'ar_supported';
+}
+
+/**
+ * Defines an event that checks for VR support on the device.
+ */
+export interface VRSupportedAction extends AsyncAction {
+    type: 'vr_supported';
 }
 
 /**
@@ -5232,6 +5248,28 @@ export function disableVR(): EnableVRAction {
     return {
         type: 'enable_vr',
         enabled: false,
+    };
+}
+
+/**
+ * Creates a new ARSupportedAction.
+ * @param taskId The ID of the async task.
+ */
+export function arSupported(taskId?: number | string): ARSupportedAction {
+    return {
+        type: 'ar_supported',
+        taskId,
+    };
+}
+
+/**
+ * Creates a new VRSupportedAction.
+ * @param taskId The ID of the async task.
+ */
+export function vrSupported(taskId?: number | string): VRSupportedAction {
+    return {
+        type: 'vr_supported',
+        taskId,
     };
 }
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -172,6 +172,8 @@ import {
     recordFile,
     eraseRecordData,
     eraseFile,
+    arSupported,
+    vrSupported,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -2607,6 +2609,24 @@ describe('AuxLibrary', () => {
                 const action = library.api.os.disableVR();
                 expect(action).toEqual(disableVR());
                 expect(context.actions).toEqual([disableVR()]);
+            });
+        });
+
+        describe('os.arSupported()', () => {
+            it('should emit a ARSupportedAction', () => {
+                const promise: any = library.api.os.arSupported();
+                const expected = arSupported(context.tasks.size);
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.vrSupported()', () => {
+            it('should emit a VRSupportedAction', () => {
+                const promise: any = library.api.os.vrSupported();
+                const expected = vrSupported(context.tasks.size);
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -29,6 +29,8 @@ import {
     disableAR as calcDisableAR,
     enableVR as calcEnableVR,
     disableVR as calcDisableVR,
+    arSupported as calcARSupported,
+    vrSupported as calcVRSupported,
     showUploadAuxFile as calcShowUploadAuxFile,
     openQRCodeScanner as calcOpenQRCodeScanner,
     showQRCode as calcShowQRCode,
@@ -1007,6 +1009,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 disableAR,
                 enableVR,
                 disableVR,
+                arSupported,
+                vrSupported,
                 enablePointOfView,
                 disablePointOfView,
                 download: downloadData,
@@ -2290,6 +2294,15 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     }
 
     /**
+     * Gets wether this device supported AR or not.
+     */
+    function arSupported() {
+        const task = context.createTask();
+        const event = calcARSupported(task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
      * Enables Virtual Reality features.
      */
     function enableVR(): EnableVRAction {
@@ -2301,6 +2314,15 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      */
     function disableVR(): EnableVRAction {
         return addAction(calcDisableVR());
+    }
+
+    /**
+     * Gets wether this device supported VR or not.
+     */
+    function vrSupported() {
+        const task = context.createTask();
+        const event = calcVRSupported(task.taskId);
+        return addAsyncAction(task, event);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1755,6 +1755,20 @@ declare interface EnableVRAction {
 }
 
 /**
+ * Defines an event that checks for AR support on the device.
+ */
+export interface ARSupportedAction extends AsyncAction {
+    type: 'ar_supported';
+}
+
+/**
+ * Defines an event that checks for VR support on the device.
+ */
+export interface VRSupportedAction extends AsyncAction {
+    type: 'vr_supported';
+}
+
+/**
  * Defines an event that enables POV on the device.
  */
  export interface EnablePOVAction {
@@ -4650,6 +4664,16 @@ interface Os {
       * Disables Virtual Reality features.
       */
      disableVR(): EnableVRAction;
+
+     /**
+      * Promise that returns wether or not AR is supported on the device.
+      */
+     arSupported(): Promise<boolean>;
+
+     /**
+      * Promise that returns wether or not VR is supported on the device.
+      */
+     vrSupported(): Promise<boolean>;
 
      /**
       * Enables Point-of-View mode.

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -725,6 +725,10 @@ export class PlayerGame extends Game {
                     } else {
                         this.stopVR();
                     }
+                } else if (e.type === 'ar_supported') {
+                    this.arSupported(sim, e);
+                } else if (e.type === 'vr_supported') {
+                    this.vrSupported(sim, e);
                 } else if (e.type === 'replace_drag_bot') {
                     this.dragBot(playerSim3D, miniPortalSim3D, e.bot);
                 } else if (e.type === 'focus_on') {


### PR DESCRIPTION
### :rocket: Improvements

-   Added the `os.arSupported()` and `os.vrSupported()` functions to query device support for AR and VR respectively. Both of these are promises and must be awaited.

    ```typescript
    const arSupported = await os.arSupported();
    if (arSupported) {
        //...
    }

    const vrSupported = await os.vrSupported();
    if (vrSupported) {
        //...
    }
    ```

-   Added shouts for entering and exiting AR and VR:
    -   `@onEnterAR` - Called when AR has been enabled.
    -   `@onExitAR` - Called when AR has been disabled.
    -   `@onEnterVR` - Called when VR has been enabled.
    -   `@onExitVR` - Called when VR has been disabled.