### PR TITLE
Expanded meetPortal scripting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@
     -   `@onExitAR` - Called when AR has been disabled.
     -   `@onEnterVR` - Called when VR has been enabled.
     -   `@onExitVR` - Called when VR has been disabled.
+-   Expanded `meetPortal` scripting:
+    -   Added shouts for loading and leaving the meet portal:
+        -   `@onMeetLoaded` - Called when the user has finished loading the meet portal.
+        -   `@onMeetLeave` - Called when the user leaves the meet portal.
+    -   Added the `os.meetCommand(command, ...args)` function that sends commands directly to the Jitsi Meet API. Supported commands can be found in the [Jitsi Meet Handbook](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#commands).
+    -   Added the following meet portal configuration tags. These must be set on the `meetPortalBot`:
+        -   `meetPortalPrejoinEnabled` - Whether the meet portal should have the prejoin screen enabled.
+            -   The prejoin screen is where the user can setup their display name, microphone, camera, and other settings, before actually joining the meet.
+        -   `meetPortalStartWithVideoMuted` - Whether the meet portal should start with video muted.
+        -   `meetPortalStartWithAudioMuted` - Whether the meet portal should start with audio muted.
+        -   `meetPortalRequireDisplayName` - Whether the meet portal should require the user define a display name.
 
 ## V2.0.31
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -4637,6 +4637,23 @@ const data = await os.endAudioRecording();
 os.download(data);
 ```
 
+### `os.meetCommand(command, ...args)`
+
+Send a command to the Jitsi Meet API. The commands are only valid if the meet portal is fully loaded (see <TagLink tag='@onMeetLoaded'/>).
+
+A full list of commands can be be found here in the [Jitsi Meet Handbook](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#commands)
+
+#### Examples:
+
+1. Change user's meet display name
+```typescript
+os.meetCommand('displayName', 'ABC123');
+```
+2. Close the meet.
+```typescript
+os.meetCommand('hangup')
+```
+
 ## Debug Actions
 
 Debug actions are actions that are either useful for automated testing/debugging or only available when run inside a debugger.

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -1220,6 +1220,35 @@ let that: {
 };
 ```
 
+### `@onMeetLoaded`
+
+A shout that is sent when the user finishes loading the meet portal.  
+It is safe to run <ActionLink action='os.meetCommand(command, ...args)'/> after this shout has been received.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The name of the room that the meet is loaded for.
+     */
+    roomName: string;
+}
+```
+
+### `@onMeetLeave`
+
+A shout that is sent when the user leaves the meet portal.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The name of the room that was left.
+     */
+    roomName: string;
+}
+```
+
 ### `@onRemoteData`
 
 A shout that is sent whenever a message is received from another remote device.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1838,6 +1838,24 @@ When setting this tag via the sheet, it is useful to utilize DNA tags to ensure 
 }
 ```
 
+### `meetPortalPrejoinEnabled`
+<Badges>
+    <MeetPortalBadge/>
+</Badges>
+
+Whether the meet portal should have the prejoin screen enabled.
+The prejoin screen is where the user can setup their display name, microphone, camera, and other settings, before actually joining the meet.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The prejoin screen is enabled. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The prejoin screen is disabled.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `tagPortalAnchorPoint`
 <Badges>
     <TagPortalBadge/>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1861,7 +1861,7 @@ The prejoin screen is where the user can setup their display name, microphone, c
     <MeetPortalBadge/>
 </Badges>
 
-Whether the meet portal should start with video muted.
+Whether the meet portal should start with video muted. Video in this context is equivalent to the user's camera.
 
 #### Possible values are:
 <PossibleValuesTable>
@@ -1870,6 +1870,23 @@ Whether the meet portal should start with video muted.
   </PossibleValueCode>
   <PossibleValueCode value='false'>
     The meet portal starts with video unmuted.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `meetPortalStartWithAudioMuted`
+<Badges>
+    <MeetPortalBadge/>
+</Badges>
+
+Whether the meet portal should start with audio muted. Audio in this context is equivalent to the user's microphone.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The meet portal starts with audio muted.
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The meet portal starts with audio unmuted. (Default)
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1856,6 +1856,23 @@ The prejoin screen is where the user can setup their display name, microphone, c
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `meetPortalStartWithVideoMuted`
+<Badges>
+    <MeetPortalBadge/>
+</Badges>
+
+Whether the meet portal should start with video muted.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The meet portal starts with video muted. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The meet portal starts with video unmuted.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `tagPortalAnchorPoint`
 <Badges>
     <TagPortalBadge/>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1890,6 +1890,23 @@ Whether the meet portal should start with audio muted. Audio in this context is 
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `meetPortalRequireDisplayName`
+<Badges>
+    <MeetPortalBadge/>
+</Badges>
+
+Whether the meet portal should require the user define a display name.
+
+#### Possible values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='true'>
+    The meet portal requires a user display name. (Default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The meet portal does not require a user display name. 
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `tagPortalAnchorPoint`
 <Badges>
     <TagPortalBadge/>

--- a/docs/docs/variables.mdx
+++ b/docs/docs/variables.mdx
@@ -341,4 +341,5 @@ Supports the following tags:
 - <TagLink tag='meetPortalStyle'/>
 - <TagLink tag='meetPortalPrejoinEnabled'/>
 - <TagLink tag='meetPortalStartWithVideoMuted'/>
+- <TagLink tag='meetPortalStartWithAudioMuted'/>
  

--- a/docs/docs/variables.mdx
+++ b/docs/docs/variables.mdx
@@ -339,4 +339,5 @@ Supports the following tags:
 - <TagLink tag='meetPortalVisible'/>
 - <TagLink tag='meetPortalAnchorPoint'/>
 - <TagLink tag='meetPortalStyle'/>
+- <TagLink tag='meetPortalPrejoinEnabled'/>
  

--- a/docs/docs/variables.mdx
+++ b/docs/docs/variables.mdx
@@ -342,4 +342,5 @@ Supports the following tags:
 - <TagLink tag='meetPortalPrejoinEnabled'/>
 - <TagLink tag='meetPortalStartWithVideoMuted'/>
 - <TagLink tag='meetPortalStartWithAudioMuted'/>
+- <TagLink tag='meetPortalRequireDisplayName'/>
  

--- a/docs/docs/variables.mdx
+++ b/docs/docs/variables.mdx
@@ -340,4 +340,5 @@ Supports the following tags:
 - <TagLink tag='meetPortalAnchorPoint'/>
 - <TagLink tag='meetPortalStyle'/>
 - <TagLink tag='meetPortalPrejoinEnabled'/>
+- <TagLink tag='meetPortalStartWithVideoMuted'/>
  

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1578,6 +1578,16 @@ export const ON_BEGIN_AUDIO_RECORDING: string = 'onBeginAudioRecording';
 export const ON_END_AUDIO_RECORDING: string = 'onEndAudioRecording';
 
 /**
+ * The name of the event that is triggered when the meet portal is finished loading.
+ */
+export const ON_MEET_LOADED: string = 'onMeetLoaded';
+
+/**
+ * The name of the event that is triggered when the user meet portal is closed.
+ */
+export const ON_MEET_LEAVE: string = 'onMeetLeave';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -2051,6 +2061,9 @@ export const KNOWN_TAGS: string[] = [
     ON_BEGIN_AUDIO_RECORDING,
     ON_AUDIO_SAMPLE,
     ON_END_AUDIO_RECORDING,
+
+    ON_MEET_LOADED,
+    ON_MEET_LEAVE,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1899,6 +1899,7 @@ export const KNOWN_TAGS: string[] = [
     'meetPortalStyle',
     'meetPortalPrejoinEnabled',
     'meetPortalStartWithVideoMuted',
+    'meetPortalStartWithAudioMuted',
     'mapPortalBasemap',
 
     'tagPortalAnchorPoint',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1898,6 +1898,7 @@ export const KNOWN_TAGS: string[] = [
     'meetPortalVisible',
     'meetPortalStyle',
     'meetPortalPrejoinEnabled',
+    'meetPortalStartWithVideoMuted',
     'mapPortalBasemap',
 
     'tagPortalAnchorPoint',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1900,6 +1900,7 @@ export const KNOWN_TAGS: string[] = [
     'meetPortalPrejoinEnabled',
     'meetPortalStartWithVideoMuted',
     'meetPortalStartWithAudioMuted',
+    'meetPortalRequireDisplayName',
     'mapPortalBasemap',
 
     'tagPortalAnchorPoint',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1897,6 +1897,7 @@ export const KNOWN_TAGS: string[] = [
     'meetPortalAnchorPoint',
     'meetPortalVisible',
     'meetPortalStyle',
+    'meetPortalPrejoinEnabled',
     'mapPortalBasemap',
 
     'tagPortalAnchorPoint',

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -107,7 +107,8 @@ export type ExtraActions =
     | UpdateHtmlAppAction
     | HtmlAppEventAction
     | SetAppOutputAction
-    | UnregisterHtmlAppAction;
+    | UnregisterHtmlAppAction
+    | MeetCommandAction;
 
 /**
  * Defines a set of possible async action types.
@@ -2918,6 +2919,23 @@ export interface BeginRecordingAction extends AsyncAction, RecordingOptions {
  */
 export interface EndRecordingAction extends AsyncAction {
     type: 'end_recording';
+}
+
+/**
+ * An event that is used to send a command to the Jitsi Meet API.
+ */
+export interface MeetCommandAction extends Action {
+    type: 'meet_command';
+
+    /**
+     * The name of the command to execute.
+     */
+    command: string;
+
+    /**
+     * The arguments for the command (if any).
+     */
+    args?: any[];
 }
 
 export interface SpeakTextOptions {
@@ -5802,6 +5820,21 @@ export function endRecording(taskId?: string | number): EndRecordingAction {
     return {
         type: 'end_recording',
         taskId,
+    };
+}
+
+/**
+ * Creates a MeetCommandAction.
+ * @param options The options that should be used.
+ */
+export function meetCommand(
+    command: string,
+    ...args: any[]
+): MeetCommandAction {
+    return {
+        type: 'meet_command',
+        command,
+        args,
     };
 }
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -174,6 +174,7 @@ import {
     eraseFile,
     arSupported,
     vrSupported,
+    meetCommand,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -8474,6 +8475,25 @@ describe('AuxLibrary', () => {
                 const expected = endAudioRecording(context.tasks.size);
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.meetCommand()', () => {
+            it('should issue a MeetCommandAction', () => {
+                const action: any = library.api.os.meetCommand('test1');
+                const expected = meetCommand('test1');
+
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support arguments', () => {
+                const action: any = library.api.os.meetCommand(
+                    'test2',
+                    'hello',
+                    'world'
+                );
+                expect(action.args).toEqual(['hello', 'world']);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -255,6 +255,8 @@ import {
     recordFile as calcRecordFile,
     BeginAudioRecordingAction,
     eraseFile as calcEraseFile,
+    meetCommand as calcMeetCommand,
+    MeetCommandAction,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -1107,6 +1109,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
                 beginAudioRecording,
                 endAudioRecording,
+
+                meetCommand,
 
                 get vars() {
                     return context.global;
@@ -5215,6 +5219,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const task = context.createTask();
         const action = calcEndRecording(task.taskId);
         return addAsyncAction(task, action);
+    }
+
+    function meetCommand(command: string, ...args: any): MeetCommandAction {
+        return addAction(calcMeetCommand(command, ...args));
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -1,4 +1,3 @@
-
 type MaskFunc<Func extends ((...args: any[]) => any)> = {
     (...args: Parameters<Func>): ReturnType<Func>;
 
@@ -233,7 +232,8 @@ declare type ExtraActions =
     | AddDropSnapTargetsAction
     | EnableCustomDraggingAction
     | EnablePOVAction
-    | SetAppOutputAction;
+    | SetAppOutputAction
+    | MeetCommandAction;
 
 /**
  * Defines a set of possible async action types.
@@ -258,7 +258,9 @@ declare type AsyncActions =
     | EndRecordingAction
     | SpeakTextAction
     | GetVoicesAction
-    | GetGeolocationAction;
+    | GetGeolocationAction
+    | ARSupportedAction
+    | VRSupportedAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -1757,21 +1759,21 @@ declare interface EnableVRAction {
 /**
  * Defines an event that checks for AR support on the device.
  */
-export interface ARSupportedAction extends AsyncAction {
+declare interface ARSupportedAction extends AsyncAction {
     type: 'ar_supported';
 }
 
 /**
  * Defines an event that checks for VR support on the device.
  */
-export interface VRSupportedAction extends AsyncAction {
+declare interface VRSupportedAction extends AsyncAction {
     type: 'vr_supported';
 }
 
 /**
  * Defines an event that enables POV on the device.
  */
- export interface EnablePOVAction {
+ declare interface EnablePOVAction {
     type: 'enable_pov';
 
     /**
@@ -1783,6 +1785,23 @@ export interface VRSupportedAction extends AsyncAction {
      * The point that the camera should be placed at for POV.
      */
     center?: { x: number, y: number, z: number };
+}
+
+/**
+ * An event that is used to send a command to the Jitsi Meet API.
+ */
+ declare interface MeetCommandAction{
+    type: 'meet_command',
+
+    /**
+     * The name of the command to execute.
+     */
+    command: string;
+
+    /**
+     * The arguments for the command (if any).
+     */
+    args?: any[];
 }
 
 /**
@@ -4848,6 +4867,13 @@ interface Os {
      * If the recording was streamed, then the resolved blob will be null.
      */
     endAudioRecording(): Promise<Blob>;
+
+    /**
+     * Sends a command to the Jitsi Meet API.
+     * @param command The name of the command to execute.
+     * @param args The arguments for the command (if any).
+     */
+    meetCommand(command: string, ...args: any[]): MeetCommandAction;
 
      /**
       * Shows a QR Code that contains a link to a inst and dimension.

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import { EventEmitter } from 'events';
 import { Prop } from 'vue-property-decorator';
+import { EventBus } from '@casual-simulation/aux-components';
 
 declare var JitsiMeetExternalAPI: {
     new (domain: string, options: JitsiMeetExternalAPIOptions): JitsiApi;
@@ -38,13 +39,16 @@ export default class JitsiMeet extends Vue {
             }
             this._embedJitsiWidget();
         });
+
+        EventBus.$on('jitsiCommand', this._executeCommand);
     }
 
     beforeDestroy() {
+        EventBus.$off('jitsiCommand', this._executeCommand);
         this._removeJitsiWidget();
     }
 
-    executeCommand(command: string, ...args: any[]) {
+    private _executeCommand(command: string, ...args: any[]) {
         this._jitsiApi.executeCommand(command, ...args);
     }
 

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
@@ -44,8 +44,8 @@ export default class JitsiMeet extends Vue {
         this._removeJitsiWidget();
     }
 
-    executeCommand(command: string, ...value: any[]) {
-        this._jitsiApi.executeCommand(command, ...value);
+    executeCommand(command: string, ...args: any[]) {
+        this._jitsiApi.executeCommand(command, ...args);
     }
 
     private _embedJitsiWidget() {

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -68,6 +68,7 @@ export default class MeetPortal extends Vue {
             // video feed to show it.
             startWithVideoMuted: this._currentConfig.startWithVideoMuted,
             startWithAudioMuted: this._currentConfig.startWithAudioMuted,
+            requireDisplayName: this._currentConfig.requireDisplayName,
             prejoinConfig: {
                 enabled: this._currentConfig.prejoinEnabled,
             },

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -67,6 +67,9 @@ export default class MeetPortal extends Vue {
             // Unlike startAudioOnly, this will let people unmute their
             // video feed to show it.
             startWithVideoMuted: true,
+            prejoinConfig: {
+                enabled: this._currentConfig.prejoinEnabled,
+            },
         };
     }
 
@@ -132,6 +135,10 @@ export default class MeetPortal extends Vue {
      */
     get othersElement(): HTMLElement {
         return <HTMLElement>this.$refs.otherContainer;
+    }
+
+    get jitsiMeet(): JitsiMeet {
+        return <JitsiMeet>this.$refs.jitsiMeet;
     }
 
     constructor() {
@@ -263,6 +270,14 @@ export default class MeetPortal extends Vue {
             userBotChanged(sim)
                 .pipe(tap((user) => this._onUserBotUpdated(sim, user)))
                 .subscribe()
+        );
+
+        sub.add(
+            sim.localEvents.subscribe((e) => {
+                if (e.type === 'meet_command') {
+                    this.jitsiMeet.executeCommand(e.command, ...e.args);
+                }
+            })
         );
     }
 

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -1,26 +1,19 @@
-import Vue, { ComponentOptions } from 'vue';
+import Vue from 'vue';
 import Component from 'vue-class-component';
-import { Provide, Prop, Inject, Watch } from 'vue-property-decorator';
 import {
-    Bot,
     hasValue,
-    BotTags,
     MEET_PORTAL,
     PrecalculatedBot,
-    calculateBotValue,
     calculateStringTagValue,
     calculateMeetPortalAnchorPointOffset,
     ON_MEET_LEAVE,
     ON_MEET_LOADED,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../AppManager';
-import { SubscriptionLike, Subscription, Observable } from 'rxjs';
+import { Subscription } from 'rxjs';
 import JitsiMeet from '../JitsiMeet/JitsiMeet';
-import { Simulation } from '@casual-simulation/aux-vm';
 import { tap } from 'rxjs/operators';
 import {
-    BotManager,
-    watchPortalConfigBot,
     BrowserSimulation,
     userBotChanged,
 } from '@casual-simulation/aux-vm-browser';
@@ -57,9 +50,11 @@ export default class MeetPortal extends Vue {
             configOverwrite: this.config,
             onload: () => {
                 if (this._currentSim) {
-                    this._currentSim.helper.action(ON_MEET_LOADED, null, { roomName: this.currentMeet });
+                    this._currentSim.helper.action(ON_MEET_LOADED, null, {
+                        roomName: this.currentMeet,
+                    });
                 }
-            }
+            },
         };
     }
 
@@ -288,7 +283,9 @@ export default class MeetPortal extends Vue {
         } else {
             const deleted = this._portals.delete(sim);
             if (deleted) {
-                sim.helper.action(ON_MEET_LEAVE, null, { roomName: this.currentMeet });
+                sim.helper.action(ON_MEET_LEAVE, null, {
+                    roomName: this.currentMeet,
+                });
             }
         }
         this._updateCurrentPortal();
@@ -345,9 +342,8 @@ export default class MeetPortal extends Vue {
             this._resize();
         } else {
             this.portalVisible = true;
-            this.extraStyle = calculateMeetPortalAnchorPointOffset(
-                'fullscreen'
-            );
+            this.extraStyle =
+                calculateMeetPortalAnchorPointOffset('fullscreen');
         }
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -66,7 +66,7 @@ export default class MeetPortal extends Vue {
             // Start with the video feed muted
             // Unlike startAudioOnly, this will let people unmute their
             // video feed to show it.
-            startWithVideoMuted: true,
+            startWithVideoMuted: this._currentConfig.startWithVideoMuted,
             prejoinConfig: {
                 enabled: this._currentConfig.prejoinEnabled,
             },

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -138,10 +138,6 @@ export default class MeetPortal extends Vue {
         return <HTMLElement>this.$refs.otherContainer;
     }
 
-    get jitsiMeet(): JitsiMeet {
-        return <JitsiMeet>this.$refs.jitsiMeet;
-    }
-
     constructor() {
         super();
     }
@@ -276,7 +272,7 @@ export default class MeetPortal extends Vue {
         sub.add(
             sim.localEvents.subscribe((e) => {
                 if (e.type === 'meet_command') {
-                    this.jitsiMeet.executeCommand(e.command, ...e.args);
+                    EventBus.$emit('jitsiCommand', e.command, ...e.args);
                 }
             })
         );

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -67,6 +67,7 @@ export default class MeetPortal extends Vue {
             // Unlike startAudioOnly, this will let people unmute their
             // video feed to show it.
             startWithVideoMuted: this._currentConfig.startWithVideoMuted,
+            startWithAudioMuted: this._currentConfig.startWithAudioMuted,
             prejoinConfig: {
                 enabled: this._currentConfig.prejoinEnabled,
             },

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -6,7 +6,12 @@
             :class="{ invisible: !portalVisible }"
             :style="extraStyle"
         >
-            <jitsi-meet v-if="hasPortal" :options="jitsiOptions" @closed="onClose"></jitsi-meet>
+            <jitsi-meet
+                ref="jitsiMeet"
+                v-if="hasPortal"
+                :options="jitsiOptions"
+                @closed="onClose"
+            ></jitsi-meet>
         </div>
         <div ref="otherContainer" class="other-container">
             <slot></slot>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -6,12 +6,7 @@
             :class="{ invisible: !portalVisible }"
             :style="extraStyle"
         >
-            <jitsi-meet
-                ref="jitsiMeet"
-                v-if="hasPortal"
-                :options="jitsiOptions"
-                @closed="onClose"
-            ></jitsi-meet>
+            <jitsi-meet v-if="hasPortal" :options="jitsiOptions" @closed="onClose" />
         </div>
         <div ref="otherContainer" class="other-container">
             <slot></slot>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -25,6 +25,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     private _visible: boolean;
     private _style: Object;
     private _prejoinEnabled: boolean;
+    private _startWithVideoMuted: boolean;
     private _updated: Subject<void>;
 
     /**
@@ -51,11 +52,21 @@ export class MeetPortalConfig implements SubscriptionLike {
     }
 
     /**
-     * Gets wether the meet should have the prejoin screen enabled or not.
+     * Gets whether the meet should have the prejoin screen enabled.
      */
     get prejoinEnabled(): boolean {
         if (hasValue(this._prejoinEnabled)) {
             return this._prejoinEnabled;
+        } else {
+            return true;
+        }
+    }
+    /**
+     * Gets whether the meet should start with video muted.
+     */
+    get startWithVideoMuted(): boolean {
+        if (hasValue(this._startWithVideoMuted)) {
+            return this._startWithVideoMuted;
         } else {
             return true;
         }
@@ -136,6 +147,13 @@ export class MeetPortalConfig implements SubscriptionLike {
             calc,
             bot,
             'meetPortalPrejoinEnabled',
+            null
+        );
+
+        this._startWithVideoMuted = calculateBooleanTagValue(
+            calc,
+            bot,
+            'meetPortalStartWithVideoMuted',
             null
         );
 

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -1,20 +1,13 @@
 import {
-    isDimensionLocked,
-    DEFAULT_PORTAL_ZOOMABLE,
-    DEFAULT_PORTAL_PANNABLE,
     hasValue,
     calculateBotValue,
     BotCalculationContext,
     PrecalculatedBot,
-    calculateGridScale,
     calculateBooleanTagValue,
-    calculateNumericalTagValue,
-    DEFAULT_PORTAL_ROTATABLE,
     getBotMeetPortalAnchorPointOffset,
     DEFAULT_MEET_PORTAL_ANCHOR_POINT,
     calculateMeetPortalAnchorPointOffset,
 } from '@casual-simulation/aux-common';
-import { Color } from '@casual-simulation/three';
 import {
     BrowserSimulation,
     watchPortalConfigBot,

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -27,6 +27,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     private _prejoinEnabled: boolean;
     private _startWithVideoMuted: boolean;
     private _startWithAudioMuted: boolean;
+    private _requireDisplayName: boolean;
     private _updated: Subject<void>;
 
     /**
@@ -82,6 +83,17 @@ export class MeetPortalConfig implements SubscriptionLike {
             return this._startWithAudioMuted;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Gets whether the meet should require the user define a display name.
+     */
+    get requireDisplayName(): boolean {
+        if (hasValue(this._requireDisplayName)) {
+            return this._requireDisplayName;
+        } else {
+            return true;
         }
     }
 
@@ -174,6 +186,13 @@ export class MeetPortalConfig implements SubscriptionLike {
             calc,
             bot,
             'meetPortalStartWithAudioMuted',
+            null
+        );
+
+        this._requireDisplayName = calculateBooleanTagValue(
+            calc,
+            bot,
+            'meetPortalRequireDisplayName',
             null
         );
 

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -24,6 +24,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     private _portalTag: string;
     private _visible: boolean;
     private _style: Object;
+    private _prejoinEnabled: boolean;
     private _updated: Subject<void>;
 
     /**
@@ -47,6 +48,17 @@ export class MeetPortalConfig implements SubscriptionLike {
         return calculateMeetPortalAnchorPointOffset(
             DEFAULT_MEET_PORTAL_ANCHOR_POINT
         );
+    }
+
+    /**
+     * Gets wether the meet should have the prejoin screen enabled or not.
+     */
+    get prejoinEnabled(): boolean {
+        if (hasValue(this._prejoinEnabled)) {
+            return this._prejoinEnabled;
+        } else {
+            return true;
+        }
     }
 
     unsubscribe(): void {
@@ -101,6 +113,7 @@ export class MeetPortalConfig implements SubscriptionLike {
             'auxMeetPortalVisible',
             null
         );
+
         this._style = calculateBotValue(calc, bot, 'meetPortalStyle');
         if (typeof this._style !== 'object') {
             this._style = null;
@@ -118,6 +131,14 @@ export class MeetPortalConfig implements SubscriptionLike {
             const offset = getBotMeetPortalAnchorPointOffset(calc, bot);
             merge(this._style, offset);
         }
+
+        this._prejoinEnabled = calculateBooleanTagValue(
+            calc,
+            bot,
+            'meetPortalPrejoinEnabled',
+            null
+        );
+
         this._updated.next();
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -26,6 +26,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     private _style: Object;
     private _prejoinEnabled: boolean;
     private _startWithVideoMuted: boolean;
+    private _startWithAudioMuted: boolean;
     private _updated: Subject<void>;
 
     /**
@@ -61,6 +62,7 @@ export class MeetPortalConfig implements SubscriptionLike {
             return true;
         }
     }
+
     /**
      * Gets whether the meet should start with video muted.
      */
@@ -69,6 +71,17 @@ export class MeetPortalConfig implements SubscriptionLike {
             return this._startWithVideoMuted;
         } else {
             return true;
+        }
+    }
+
+    /**
+     * Gets whether the meet should start with audio muted.
+     */
+    get startWithAudioMuted(): boolean {
+        if (hasValue(this._startWithAudioMuted)) {
+            return this._startWithAudioMuted;
+        } else {
+            return false;
         }
     }
 
@@ -154,6 +167,13 @@ export class MeetPortalConfig implements SubscriptionLike {
             calc,
             bot,
             'meetPortalStartWithVideoMuted',
+            null
+        );
+
+        this._startWithAudioMuted = calculateBooleanTagValue(
+            calc,
+            bot,
+            'meetPortalStartWithAudioMuted',
             null
         );
 


### PR DESCRIPTION
### :rocket: Improvements
-   Added shouts for loading and leaving the meet portal:
    -   `@onMeetLoaded` - Called when the user has finished loading the meet portal.
    -   `@onMeetLeave` - Called when the user leaves the meet portal.
-   Added the `os.meetCommand(command, ...args)` function that sends commands directly to the Jitsi Meet API. Supported commands can be found in the [Jitsi Meet Handbook](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe#commands).
-   Added the following meet portal configuration tags. These must be set on the `meetPortalBot`:
    -   `meetPortalPrejoinEnabled` - Whether the meet portal should have the prejoin screen enabled.
        -   The prejoin screen is where the user can setup their display name, microphone, camera, and other settings, before actually joining the meet.
    -   `meetPortalStartWithVideoMuted` - Whether the meet portal should start with video muted.
    -   `meetPortalStartWithAudioMuted` - Whether the meet portal should start with audio muted.
    -   `meetPortalRequireDisplayName` - Whether the meet portal should require the user define a display name.