### PR TITLE
Feature: global search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 #### Date: TBD
 
+### :rocket: Improvements
+
+-   Added global search to the systemPortal.
+    -   Useful for finding a word or phrase in the tags of all the bots in an inst.
+    -   For example, you can find all the places where a shout occurrs by typing "shout" into the search box.
+    -   Can be accessed by using `Ctrl+Shift+F` while the systemPortal is open or by selecting the eyeglass icon on the left side of the screen.
+
 ### :bug: Bug Fixes
 
 -   Fixed an issue with custom apps where HTML changes would stop propagating if an element was added to its own parent.

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -2598,6 +2598,16 @@ The space of the tag that is selected in the <GlossaryRef term="systemPortal">sy
 If null, then the tag space is the same as the <TagLink tag='systemPortalBot'/> space.
 Only available on the config bot.
 
+### `systemPortalSearch`
+
+<Badges>
+  <ConfigBotBadge/>
+</Badges>
+
+The value that should be used to search across all the tags in all the bots in the inst.
+The results of the search will be displayed in the <GlossaryRef term="systemPortal">systemPortal</GlossaryRef>.
+Only available on the config bot.
+
 ### `idePortal`
 
 <Badges>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1780,6 +1780,7 @@ export const KNOWN_TAGS: string[] = [
     SYSTEM_PORTAL_BOT,
     SYSTEM_PORTAL_TAG,
     SYSTEM_PORTAL_TAG_SPACE,
+    SYSTEM_PORTAL_SEARCH,
     SYSTEM_TAG,
     'inst',
     MINI_PORTAL,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1666,6 +1666,11 @@ export const SYSTEM_PORTAL: string = 'systemPortal';
 export const SYSTEM_TAG: string = 'system';
 
 /**
+ * The name of the tag that is used to search tags in the system portal.
+ */
+export const SYSTEM_PORTAL_SEARCH: string = 'systemPortalSearch';
+
+/**
  * The name of the tag used to keep track of the selected bot in the system portal..
  */
 export const SYSTEM_PORTAL_BOT: string = 'systemPortalBot';

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -65,6 +65,7 @@ import MonacoJSXHighlighter from './public/monaco-jsx-highlighter/index';
 import { triggerMonacoLoaded } from './MonacoAsync';
 import './public/monaco-editor/quick-open-file/quick-open-file';
 import './public/monaco-editor/quick-search-all/quick-search-all';
+import { getModelUriFromId } from './MonacoUtils';
 
 export function setup() {
     // Tell monaco how to create the web workers
@@ -1122,18 +1123,11 @@ function updateDecorators(
 }
 
 export function getModelUri(bot: Bot, tag: string, space: string) {
-    return getModelUriFromId(bot.id, tag, space);
+    return parseModelUriFromId(bot.id, tag, space);
 }
 
-export function getModelUriFromId(id: string, tag: string, space: string) {
-    let tagWithExtension = tag.indexOf('.') >= 0 ? tag : `${tag}.js`;
-    if (hasValue(space)) {
-        return monaco.Uri.parse(
-            encodeURI(`file:///${id}/${space}/${tagWithExtension}`)
-        );
-    } else {
-        return monaco.Uri.parse(encodeURI(`file:///${id}/${tagWithExtension}`));
-    }
+export function parseModelUriFromId(id: string, tag: string, space: string) {
+    return monaco.Uri.parse(getModelUriFromId(id, tag, space));
 }
 
 export function getScript(bot: Bot, tag: string, space: string) {

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -1121,11 +1121,11 @@ function updateDecorators(
     }
 }
 
-function getModelUri(bot: Bot, tag: string, space: string) {
+export function getModelUri(bot: Bot, tag: string, space: string) {
     return getModelUriFromId(bot.id, tag, space);
 }
 
-function getModelUriFromId(id: string, tag: string, space: string) {
+export function getModelUriFromId(id: string, tag: string, space: string) {
     let tagWithExtension = tag.indexOf('.') >= 0 ? tag : `${tag}.js`;
     if (hasValue(space)) {
         return monaco.Uri.parse(

--- a/src/aux-server/aux-web/shared/MonacoUtils.ts
+++ b/src/aux-server/aux-web/shared/MonacoUtils.ts
@@ -1,0 +1,14 @@
+import { hasValue } from '@casual-simulation/aux-common';
+
+export function getModelUriFromId(
+    id: string,
+    tag: string,
+    space: string
+): string {
+    let tagWithExtension = tag.indexOf('.') >= 0 ? tag : `${tag}.js`;
+    if (hasValue(space)) {
+        return encodeURI(`file:///${id}/${space}/${tagWithExtension}`);
+    } else {
+        return encodeURI(`file:///${id}/${tagWithExtension}`);
+    }
+}

--- a/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoEditor/MonacoEditor.ts
@@ -9,6 +9,7 @@ export default class MonacoEditor extends Vue {
     private _states: Map<string, monaco.editor.ICodeEditorViewState>;
     private _model: monaco.editor.ITextModel;
     private _resizeObserver: import('@juggle/resize-observer').ResizeObserver;
+    private _modelChangeObserver: monaco.IDisposable;
 
     get editor() {
         return this._editor;
@@ -64,6 +65,9 @@ export default class MonacoEditor extends Vue {
         });
         this._applyViewZones();
         this._watchSizeChanges();
+        this._modelChangeObserver = this._editor.onDidChangeModel((e) => {
+            this.$emit('modelChanged', e);
+        });
         this.$emit('editorMounted', this._editor);
     }
 
@@ -85,6 +89,9 @@ export default class MonacoEditor extends Vue {
     }
 
     beforeDestroy() {
+        if (this._modelChangeObserver) {
+            this._modelChangeObserver.dispose();
+        }
         if (this._editor) {
             this._editor.dispose();
         }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -215,6 +215,10 @@ export default class MonacoTagEditor extends Vue {
         this._sub.add(watchEditor(this._simulation, editor));
     }
 
+    onModelChanged(event: monaco.editor.IModelChangedEvent) {
+        this.$emit('modelChanged', event);
+    }
+
     destroyed() {
         if (this._sub) {
             this._sub.unsubscribe();

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -69,6 +69,7 @@
                 @focus="editorFocused"
                 @blur="editorBlured"
                 @editorMounted="onEditorMounted"
+                @modelChanged="onModelChanged"
             ></monaco-editor>
         </div>
     </div>

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
@@ -119,33 +119,8 @@
     background-color: #bbb;
 }
 
-.search {
-    margin-left: -8px;
-    margin-right: -8px;
-}
-
-.search-padding {
-    margin-bottom: 24px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #000;
-    width: 100%;
-    padding-right: 8px;
-}
-
-.search-bots {
-    display: flex;
-}
-
-.search-bots .md-field {
-    margin-bottom: 0;
-    max-height: initial;
-    padding: initial;
-}
-
-.search-title {
+.filter-field {
     margin-top: 0;
-    margin-bottom: 8px;
-    margin-left: 24px;
 }
 
 .search-tags {
@@ -157,20 +132,11 @@
     cursor: pointer;
 }
 
-.search-bots-input,
+.filter-bots-input,
 .search-tags-input {
     border: none;
     height: 24px;
     width: 100%;
-}
-
-.search-container {
-    flex: 1 1 auto;
-    display: flex;
-    flex-direction: column;
-    padding: 8px 0 0 0;
-
-    overflow: hidden;
 }
 
 .search-input-container {
@@ -199,6 +165,7 @@
     flex: 0 1 auto;
     border-right: 1px solid #000;
     padding: 8px;
+    padding-top: 0;
     background-color: var(--disabled-cell-color);
     min-width: 200px;
 
@@ -216,6 +183,43 @@
 
 .editor {
     flex: 1 1 1px;
+}
+
+.pane-options {
+    display: flex;
+    flex-direction: column;
+    background-color: #d5d5d5;
+}
+
+.pane-options .md-icon-button {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.pane-selection {
+    width: 48px;
+    height: 48px;
+}
+
+.pane-selection.selected {
+    border-left: 3px solid #333;
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.pane-selection.selected .md-icon-button {
+    margin-left: -3px;
+}
+
+/* .pane-options > button + button {
+    margin: 0 6px;
+} */
+
+.pane-icon {
+    width: 24px;
+    height: 24px;
+    fill: #333;
+    color: #333 !important;
 }
 
 .area {
@@ -238,7 +242,7 @@
     overflow: auto;
 }
 
-.search {
+.filter {
     flex: 0 0 auto;
 }
 

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
@@ -155,6 +155,80 @@
     font-size: 14px;
 }
 
+.search {
+    flex: 0 1 auto;
+    border-right: 1px solid #000;
+    padding: 8px;
+    background-color: var(--disabled-cell-color);
+    min-width: 200px;
+
+    display: flex;
+    flex-direction: column;
+}
+
+.search-list {
+    flex: 1 1 auto;
+    overflow: auto;
+    margin-top: 8px;
+}
+
+.search-area-title,
+.search-area-bot-title {
+    font-weight: 700;
+}
+
+.search-area-bot {
+    padding-inline-start: 8px;
+}
+
+.search-area-bot > .mini-bot {
+    display: inline-block;
+    padding: 0;
+    border-bottom: none;
+}
+
+.search-area-bot > .mini-bot > .mini-bot-search {
+    width: 32px;
+}
+
+.search-area-bot > .mini-bot > .mini-bot-search > img {
+    width: 32px;
+    height: 32px;
+}
+
+.search-area-tag {
+    padding-inline-start: 32px;
+}
+
+.search-area-match {
+    padding-inline-start: 16px;
+    font-family: Consolas, 'Courier New', monospace;
+}
+
+.search-area-match:hover {
+    background-color: #eee;
+    cursor: pointer;
+}
+
+.search:hover .search-area-bot {
+    border-left: 1px solid #999;
+    padding-inline-start: 7px;
+}
+
+/* .search:hover .search-area-tag {
+    border-left: 1px solid #999;
+    padding-inline-start: 31px;
+} */
+
+.search:hover .search-area-match {
+    border-left: 1px solid #999;
+    padding-inline-start: 15px;
+}
+
+.search-extra {
+    flex: 99 0 auto;
+}
+
 .panes {
     display: flex;
     width: 100%;

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.css
@@ -119,6 +119,51 @@
     background-color: #bbb;
 }
 
+.search {
+    margin-left: -8px;
+    margin-right: -8px;
+}
+
+.search-padding {
+    margin-bottom: 24px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #000;
+    width: 100%;
+    padding-right: 8px;
+}
+
+.search-bots {
+    display: flex;
+}
+
+.search-bots .md-field {
+    margin-bottom: 0;
+    max-height: initial;
+    padding: initial;
+}
+
+.search-title {
+    margin-top: 0;
+    margin-bottom: 8px;
+    margin-left: 24px;
+}
+
+.search-tags {
+    margin-left: 24px;
+    margin-top: 4px;
+}
+
+.search-tags-toggle {
+    cursor: pointer;
+}
+
+.search-bots-input,
+.search-tags-input {
+    border: none;
+    height: 24px;
+    width: 100%;
+}
+
 .search-container {
     flex: 1 1 auto;
     display: flex;
@@ -208,7 +253,7 @@
 }
 
 .area-bot {
-    padding-inline-start: 16px;
+    padding-inline-start: 8px;
     line-height: 32px;
 }
 

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
@@ -114,6 +114,8 @@ export default class SystemPortal extends Vue {
     searchTagsValue: string = '';
     selectedPane: 'bots' | 'search' = 'bots';
     searchResults: SystemPortalSearchItem[] = [];
+    numBotsInSearchResults: number = 0;
+    numMatchesInSearchResults: number = 0;
 
     private _focusEditorOnSelectionUpdate: boolean = false;
     private _tagSelectionEvents: Map<
@@ -184,6 +186,8 @@ export default class SystemPortal extends Vue {
             this.pinnedTags = [];
             this.recents = [];
             this.searchResults = [];
+            this.numBotsInSearchResults = 0;
+            this.numMatchesInSearchResults = 0;
             this.isMakingNewTag = false;
             this.newTag = '';
             this.isMakingNewBot = false;
@@ -250,6 +254,8 @@ export default class SystemPortal extends Vue {
                 this._simulation.systemPortal.onSearchResultsUpdated.subscribe(
                     (u) => {
                         this.searchResults = u.items;
+                        this.numBotsInSearchResults = u.numBots;
+                        this.numMatchesInSearchResults = u.numMatches;
                     }
                 ),
                 this._simulation.watcher

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
@@ -65,7 +65,7 @@ import TagEditor from '../TagEditor/TagEditor';
 import { EventBus, SvgIcon } from '@casual-simulation/aux-components';
 import ConfirmDialogOptions from '../../ConfirmDialogOptions';
 import BotID from '../BotID/BotID';
-import { getModelUriFromId } from '../../MonacoHelpers';
+import { getModelUriFromId } from '../../MonacoUtils';
 import type monaco from 'monaco-editor';
 
 @Component({

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
@@ -110,7 +110,7 @@ export default class SystemPortal extends Vue {
     newBotSystem: string = '';
     tagsVisible: boolean = true;
     pinnedTagsVisible: boolean = true;
-    searchTagsFocused: boolean = false;
+    isFocusingTagsSearch: boolean = false;
     searchTagsValue: string = '';
     selectedPane: 'bots' | 'search' = 'bots';
     searchResults: SystemPortalSearchItem[] = [];
@@ -270,6 +270,15 @@ export default class SystemPortal extends Vue {
                             this.botFilterValue =
                                 typeof value === 'string' ? value : '';
                         }
+                        if (this.isFocusingTagsSearch) {
+                            const value = calculateBotValue(
+                                null,
+                                bot,
+                                SYSTEM_PORTAL_SEARCH
+                            );
+                            this.searchTagsValue =
+                                typeof value === 'string' ? value : '';
+                        }
                     })
             );
             this._currentConfig = new SystemPortalConfig(
@@ -316,6 +325,14 @@ export default class SystemPortal extends Vue {
                 [SYSTEM_PORTAL_SEARCH]: value,
             },
         });
+    }
+
+    onFocusSearchTags() {
+        this.isFocusingTagsSearch = true;
+    }
+
+    onUnfocusSearchTags() {
+        this.isFocusingTagsSearch = false;
     }
 
     selectSearchMatch(

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
@@ -92,8 +92,8 @@ export default class SystemPortal extends Vue {
 
     isViewingTags: boolean = true;
 
-    searchValue: string = '';
-    isFocusingSearch: boolean = false;
+    botFilterValue: string = '';
+    isFocusingBotFilter: boolean = false;
     sortMode: TagSortMode = 'scripts-first';
     isMakingNewTag: boolean = false;
     newTag: string = '';
@@ -101,6 +101,7 @@ export default class SystemPortal extends Vue {
     newBotSystem: string = '';
     tagsVisible: boolean = true;
     pinnedTagsVisible: boolean = true;
+    searchTagsVisible: boolean = false;
 
     private _focusEditorOnSelectionUpdate: boolean = false;
     private _subs: SubscriptionLike[] = [];
@@ -146,6 +147,10 @@ export default class SystemPortal extends Vue {
 
     multilineEditor() {
         return this.$refs.multilineEditor as TagValueEditor;
+    }
+
+    toggleSearchTags() {
+        this.searchTagsVisible = !this.searchTagsVisible;
     }
 
     constructor() {
@@ -226,13 +231,13 @@ export default class SystemPortal extends Vue {
                 this._simulation.watcher
                     .botChanged(this._simulation.helper.userId)
                     .subscribe((bot) => {
-                        if (!this.isFocusingSearch) {
+                        if (!this.isFocusingBotFilter) {
                             const value = calculateBotValue(
                                 null,
                                 bot,
                                 SYSTEM_PORTAL
                             );
-                            this.searchValue =
+                            this.botFilterValue =
                                 typeof value === 'string' ? value : '';
                         }
                     })
@@ -367,21 +372,21 @@ export default class SystemPortal extends Vue {
         }
     }
 
-    onFocusSearch() {
-        this.isFocusingSearch = true;
+    onFocusBotFilter() {
+        this.isFocusingBotFilter = true;
     }
 
-    onUnfocusSearch() {
-        this.isFocusingSearch = false;
+    onUnfocusBotFilter() {
+        this.isFocusingBotFilter = false;
     }
 
-    changeSearchValue(value: string) {
-        if (this.isFocusingSearch) {
-            this.searchValue = value;
+    changeBotFilterValue(event: InputEvent) {
+        if (this.isFocusingBotFilter) {
+            this.botFilterValue = (event.target as HTMLInputElement).value;
             this._simulation.helper.updateBot(this._simulation.helper.userBot, {
                 tags: {
-                    [SYSTEM_PORTAL]: hasValue(this.searchValue)
-                        ? this.searchValue
+                    [SYSTEM_PORTAL]: hasValue(this.botFilterValue)
+                        ? this.botFilterValue
                         : true,
                 },
             });
@@ -403,7 +408,9 @@ export default class SystemPortal extends Vue {
 
     openNewBot() {
         this.isMakingNewBot = true;
-        this.newBotSystem = hasValue(this.searchValue) ? this.searchValue : '';
+        this.newBotSystem = hasValue(this.botFilterValue)
+            ? this.botFilterValue
+            : '';
     }
 
     cancelNewBot() {

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -31,6 +31,8 @@
                                 class="search-input"
                                 placeholder="Search"
                                 @input="updateSearch"
+                                @focus="onFocusSearchTags"
+                                @blur="onUnfocusSearchTags"
                             />
                             <div>
                                 {{ numMatchesInSearchResults }} results in

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -6,15 +6,27 @@
                 <div class="panes">
                     <div class="areas">
                         <div class="search">
-                            <md-field>
-                                <label>Filter</label>
-                                <md-input
-                                    @input="changeSearchValue"
-                                    :value="searchValue"
-                                    @focus="onFocusSearch"
-                                    @blur="onUnfocusSearch"
-                                ></md-input>
-                            </md-field>
+                            <div class="search-padding">
+                                <h3 class="search-title">Search</h3>
+                                <div class="search-bots">
+                                    <div @click="toggleSearchTags()" class="search-tags-toggle">
+                                        <md-icon>{{
+                                            searchTagsVisible ? 'expand_more' : 'chevron_right'
+                                        }}</md-icon>
+                                    </div>
+                                    <input
+                                        class="search-bots-input"
+                                        @input="changeBotFilterValue"
+                                        :value="botFilterValue"
+                                        @focus="onFocusBotFilter"
+                                        @blur="onUnfocusBotFilter"
+                                        placeholder="Filter Bots"
+                                    />
+                                </div>
+                                <div v-show="searchTagsVisible" class="search-tags">
+                                    <input class="search-tags-input" placeholder="Search Tags" />
+                                </div>
+                            </div>
                         </div>
                         <div class="areas-list">
                             <div v-for="item of items" :key="item.area" class="area">

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -1,32 +1,81 @@
 <template>
     <div v-if="hasPortal" class="system-portal" v-on:keydown.stop v-on:keyup.stop>
-        <!-- <hotkey :keys="['ctrl', 'shift', 'f']" @triggered="showSearch()" /> -->
+        <hotkey :keys="['ctrl', 'shift', 'f']" @triggered="showSearch()" />
         <md-card ref="card" class="portal-card">
             <md-card-content>
                 <div class="panes">
-                    <div class="areas">
-                        <div class="search">
-                            <div class="search-padding">
-                                <h3 class="search-title">Search</h3>
-                                <div class="search-bots">
-                                    <div @click="toggleSearchTags()" class="search-tags-toggle">
-                                        <md-icon>{{
-                                            searchTagsVisible ? 'expand_more' : 'chevron_right'
-                                        }}</md-icon>
-                                    </div>
-                                    <input
-                                        class="search-bots-input"
-                                        @input="changeBotFilterValue"
-                                        :value="botFilterValue"
-                                        @focus="onFocusBotFilter"
-                                        @blur="onUnfocusBotFilter"
-                                        placeholder="Filter Bots"
-                                    />
-                                </div>
-                                <div v-show="searchTagsVisible" class="search-tags">
-                                    <input class="search-tags-input" placeholder="Search Tags" />
+                    <div class="pane-options">
+                        <div class="pane-selection" :class="{ selected: selectedPane === 'bots' }">
+                            <md-button class="md-icon-button" @click="showBots()">
+                                <md-tooltip md-direction="right">Bots</md-tooltip>
+                                <svg-icon class="pane-icon" name="Cube"></svg-icon>
+                            </md-button>
+                        </div>
+                        <div
+                            class="pane-selection"
+                            :class="{ selected: selectedPane === 'search' }"
+                        >
+                            <md-button class="md-icon-button" @click="showSearch()">
+                                <md-tooltip md-direction="right">Search</md-tooltip>
+                                <md-icon class="pane-icon">search</md-icon>
+                            </md-button>
+                        </div>
+                    </div>
+                    <!-- <div class="search">
+
+                    </div> -->
+                    <div class="search" v-if="selectedPane === 'search'">
+                        <div class="search-container">
+                            <div class="search-input-container">
+                                <input
+                                    ref="searchTagsInput"
+                                    class="search-input"
+                                    placeholder="Search"
+                                    @input="updateSearch"
+                                />
+                            </div>
+                            <div class="items-list-items">
+                                <div
+                                    v-for="item in searchItems"
+                                    :key="item.key"
+                                    class="item"
+                                    @click="selectSearchItem(item)"
+                                >
+                                    <bot-tag
+                                        :tag="item.tag"
+                                        :isScript="item.isScript"
+                                        :isFormula="item.isFormula"
+                                        :prefix="item.prefix"
+                                    ></bot-tag>
+                                    <div class="search-item-hint">{{ item.text }}</div>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                    <div class="areas" v-else>
+                        <div class="search">
+                            <md-field class="filter-field">
+                                <label>Filter</label>
+                                <md-input
+                                    class="filter-bots-input"
+                                    @input="changeBotFilterValue"
+                                    :value="botFilterValue"
+                                    @focus="onFocusBotFilter"
+                                    @blur="onUnfocusBotFilter"
+                                ></md-input>
+                            </md-field>
+                            <!-- <div class="search-padding">
+                                <div v-show="searchTagsVisible" class="search-tags">
+                                    <input 
+                                        ref="searchTagsInput"
+                                        class="search-tags-input"
+                                        @input="changeSearchTagsValue"
+                                        :value="searchTagsValue"
+                                        @focus="onFocusSearchTags"
+                                        @blur="onUnfocusSearchTags"
+                                        placeholder="Search Tags"/>
+                                </div>
+                            </div> -->
                         </div>
                         <div class="areas-list">
                             <div v-for="item of items" :key="item.area" class="area">
@@ -55,7 +104,7 @@
                             </md-button>
                         </div>
                     </div>
-                    <div class="tags" v-if="hasSelection">
+                    <div class="tags" v-if="selectedPane === 'bots' && hasSelection">
                         <div class="tags-list">
                             <div @click="toggleTags()" class="tags-toggle">
                                 <md-icon>{{

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -25,35 +25,81 @@
 
                     </div> -->
                     <div class="search" v-if="selectedPane === 'search'">
-                        <div class="search-container">
-                            <div class="search-input-container">
-                                <input
-                                    ref="searchTagsInput"
-                                    class="search-input"
-                                    placeholder="Search"
-                                    @input="updateSearch"
-                                />
-                            </div>
-                            <div class="items-list-items">
-                                <div
-                                    v-for="item in searchItems"
-                                    :key="item.key"
-                                    class="item"
-                                    @click="selectSearchItem(item)"
-                                >
-                                    <bot-tag
-                                        :tag="item.tag"
-                                        :isScript="item.isScript"
-                                        :isFormula="item.isFormula"
-                                        :prefix="item.prefix"
-                                    ></bot-tag>
-                                    <div class="search-item-hint">{{ item.text }}</div>
+                        <div class="search-input-container">
+                            <input
+                                ref="searchTagsInput"
+                                class="search-input"
+                                placeholder="Search"
+                                @input="updateSearch"
+                            />
+                        </div>
+                        <div class="search-list">
+                            <div v-for="item of searchResults" :key="item.area" class="search-area">
+                                <div class="search-area-title">
+                                    <md-icon>folder</md-icon>
+                                    {{ item.area }}
+                                </div>
+                                <div class="search-area-bots">
+                                    <div
+                                        v-for="bot of item.bots"
+                                        :key="bot.bot.id"
+                                        class="search-area-bot"
+                                    >
+                                        <mini-bot :bot="bot.bot"></mini-bot>
+                                        <span class="search-area-bot-title">{{ bot.title }}</span>
+                                        <div
+                                            v-for="tag of bot.tags"
+                                            :key="`${tag.tag}-${tag.space}`"
+                                            class="search-area-tag"
+                                        >
+                                            <bot-tag
+                                                :tag="tag.tag"
+                                                :space="tag.space"
+                                                :isScript="tag.isScript"
+                                                :isFormula="tag.isFormula"
+                                                :isLink="tag.isLink"
+                                                :allowCloning="false"
+                                            ></bot-tag>
+
+                                            <div
+                                                v-for="match of tag.matches"
+                                                :key="match.index"
+                                                class="search-area-match"
+                                                @click="selectSearchMatch(bot, tag, match)"
+                                            >
+                                                {{ match.text.slice(0, match.highlightStartIndex)
+                                                }}<mark>{{
+                                                    match.text.slice(
+                                                        match.highlightStartIndex,
+                                                        match.highlightEndIndex
+                                                    )
+                                                }}</mark
+                                                >{{ match.text.slice(match.highlightEndIndex) }}
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
+
+                            <!-- <div
+                                v-for="item in searchResults"
+                                :key="item.area"
+                                class="item"
+                                @click="selectSearchItem(item)"
+                            >
+                                <bot-tag
+                                    :tag="item.tag"
+                                    :isScript="item.isScript"
+                                    :isFormula="item.isFormula"
+                                    :prefix="item.prefix"
+                                ></bot-tag>
+                                <div class="search-item-hint">{{ item.text }}</div>
+                            </div> -->
                         </div>
+                        <div class="search-extra"></div>
                     </div>
                     <div class="areas" v-else>
-                        <div class="search">
+                        <div class="filter">
                             <md-field class="filter-field">
                                 <label>Filter</label>
                                 <md-input
@@ -251,6 +297,7 @@
                                 :showDesktopEditor="true"
                                 :showResize="false"
                                 @onFocused="onEditorFocused($event)"
+                                @modelChanged="onEditorModelChanged($event)"
                             >
                             </tag-value-editor>
                         </div>

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -32,6 +32,10 @@
                                 placeholder="Search"
                                 @input="updateSearch"
                             />
+                            <div>
+                                {{ numMatchesInSearchResults }} results in
+                                {{ numBotsInSearchResults }} bots
+                            </div>
                         </div>
                         <div class="search-list">
                             <div v-for="item of searchResults" :key="item.area" class="search-area">

--- a/src/aux-server/aux-web/shared/vue-components/TagValueEditor/TagValueEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/TagValueEditor/TagValueEditor.ts
@@ -6,6 +6,7 @@ import SimpleTagEditor from '../SimpleTagEditor/SimpleTagEditor';
 import MonacoLoader from '../MonacoLoader/MonacoLoader';
 import MonacoLoaderError from '../MonacoLoaderError/MonacoLoaderError';
 import type MonacoTagEditor from '../MonacoTagEditor/MonacoTagEditor';
+import type monaco from 'monaco-editor';
 
 const MonacoAsync = () => ({
     component: import('../MonacoTagEditor/MonacoTagEditor').catch((err) => {
@@ -38,6 +39,10 @@ export default class TagValueEditor extends Vue {
 
     onFocused(focused: boolean) {
         this.$emit('onFocused', focused);
+    }
+
+    onModelChanged(event: monaco.editor.IModelChangedEvent) {
+        this.$emit('modelChanged', event);
     }
 
     /**

--- a/src/aux-server/aux-web/shared/vue-components/TagValueEditor/TagValueEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/TagValueEditor/TagValueEditor.vue
@@ -8,6 +8,7 @@
         :showResize="showResize"
         ref="monacoEditor"
         @onFocused="onFocused"
+        @modelChanged="onModelChanged"
     ></monaco-editor>
 </template>
 <script src="./TagValueEditor.ts"></script>

--- a/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
+++ b/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
@@ -2109,6 +2109,7 @@ describe('getBotTitle()', () => {
         ['.core.ui.menu.button', '', 'core.ui.menu.button'],
         ['..core.ui.menu.button', '', '.core.ui.menu.button'],
         ['', '', ''],
+        [null, '', ''],
     ];
 
     it.each(cases)('should map %s to %s', (given, area, expected) => {

--- a/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
+++ b/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
@@ -1949,6 +1949,8 @@ describe('SystemPortalManager', () => {
 
             expect(searchUpdates).toEqual([
                 {
+                    numMatches: 7,
+                    numBots: 4,
                     items: [
                         {
                             area: 'core.game',

--- a/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
+++ b/src/aux-vm-browser/managers/SystemPortalManager.spec.ts
@@ -1,8 +1,12 @@
 import {
+    getBotTitle,
     getSystemArea,
+    searchTag,
+    searchValue,
     SystemPortalHasRecentsUpdate,
     SystemPortalManager,
     SystemPortalRecentsUpdate,
+    SystemPortalSearchUpdate,
     SystemPortalSelectionUpdate,
     SystemPortalUpdate,
 } from './SystemPortalManager';
@@ -25,6 +29,7 @@ import {
     EDITING_BOT,
     EDITING_TAG_SPACE,
     SYSTEM_PORTAL_TAG,
+    SYSTEM_PORTAL_SEARCH,
 } from '@casual-simulation/aux-common';
 import { TestAuxVM } from '@casual-simulation/aux-vm/vm/test/TestAuxVM';
 import { Subject, Subscription } from 'rxjs';
@@ -45,6 +50,7 @@ describe('SystemPortalManager', () => {
     let updates: SystemPortalUpdate[];
     let selectionUpdates: SystemPortalSelectionUpdate[];
     let recentsUpdates: SystemPortalRecentsUpdate[];
+    let searchUpdates: SystemPortalSearchUpdate[];
     let sub: Subscription;
 
     beforeEach(async () => {
@@ -68,6 +74,7 @@ describe('SystemPortalManager', () => {
         updates = [];
         selectionUpdates = [];
         recentsUpdates = [];
+        searchUpdates = [];
         manager = new SystemPortalManager(watcher, helper, false);
         sub.add(
             manager.onItemsUpdated
@@ -83,6 +90,11 @@ describe('SystemPortalManager', () => {
             manager.onRecentsUpdated
                 .pipe(skip(1))
                 .subscribe((u) => recentsUpdates.push(u))
+        );
+        sub.add(
+            manager.onSearchResultsUpdated
+                .pipe(skip(1))
+                .subscribe((u) => searchUpdates.push(u))
         );
     });
 
@@ -1890,6 +1902,184 @@ describe('SystemPortalManager', () => {
             ).toHaveLength(10);
         });
     });
+
+    describe('onSearchResultsUpdated', () => {
+        it('should resolve when the user bot is updated with the portal tag', async () => {
+            await vm.sendEvents([
+                botAdded(
+                    createBot('test2', {
+                        system: 'core.game.test2',
+                        script1: '@abcdefghi',
+                    })
+                ),
+                botAdded(
+                    createBot('test1', {
+                        system: 'core.game.test1',
+                        script2: '@abcdefghiabcdef',
+                        script3: '@abcdefghi\nabcdefghi',
+                    })
+                ),
+                botAdded(
+                    createBot('test4', {
+                        system: 'core.other.test4',
+                        link1: '🔗abcdef',
+                    })
+                ),
+                botAdded(
+                    createBot('test3', {
+                        system: 'core.other.test3',
+                        normal1: 'abcdef',
+                    })
+                ),
+                botUpdated('user', {
+                    tags: {
+                        [SYSTEM_PORTAL]: 'core',
+                    },
+                }),
+            ]);
+            await vm.sendEvents([
+                botUpdated('user', {
+                    tags: {
+                        [SYSTEM_PORTAL_SEARCH]: 'abcdef',
+                    },
+                }),
+            ]);
+
+            await waitAsync();
+
+            expect(searchUpdates).toEqual([
+                {
+                    items: [
+                        {
+                            area: 'core.game',
+                            bots: [
+                                {
+                                    bot: createPrecalculatedBot('test1', {
+                                        system: 'core.game.test1',
+                                        script2: '@abcdefghiabcdef',
+                                        script3: '@abcdefghi\nabcdefghi',
+                                    }),
+                                    title: 'test1',
+                                    tags: [
+                                        {
+                                            tag: 'script2',
+                                            isScript: true,
+                                            matches: [
+                                                {
+                                                    text: 'abcdefghiabcdef',
+                                                    index: 1,
+                                                    endIndex: 7,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                                {
+                                                    text: 'abcdefghiabcdef',
+                                                    index: 10,
+                                                    endIndex: 16,
+                                                    highlightStartIndex: 9,
+                                                    highlightEndIndex: 15,
+                                                },
+                                            ],
+                                        },
+                                        {
+                                            tag: 'script3',
+                                            isScript: true,
+                                            matches: [
+                                                {
+                                                    text: 'abcdefghi',
+                                                    index: 1,
+                                                    endIndex: 7,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                                {
+                                                    text: 'abcdefghi',
+                                                    index: 11,
+                                                    endIndex: 17,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                {
+                                    bot: createPrecalculatedBot('test2', {
+                                        system: 'core.game.test2',
+                                        script1: '@abcdefghi',
+                                    }),
+                                    title: 'test2',
+                                    tags: [
+                                        {
+                                            tag: 'script1',
+                                            isScript: true,
+                                            matches: [
+                                                {
+                                                    text: 'abcdefghi',
+                                                    index: 1,
+                                                    endIndex: 7,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            area: 'core.other',
+                            bots: [
+                                {
+                                    bot: createPrecalculatedBot('test3', {
+                                        system: 'core.other.test3',
+                                        normal1: 'abcdef',
+                                    }),
+                                    title: 'test3',
+                                    tags: [
+                                        {
+                                            tag: 'normal1',
+                                            matches: [
+                                                {
+                                                    text: 'abcdef',
+                                                    index: 0,
+                                                    endIndex: 6,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                {
+                                    bot: createPrecalculatedBot('test4', {
+                                        system: 'core.other.test4',
+                                        link1: '🔗abcdef',
+                                    }),
+                                    title: 'test4',
+                                    tags: [
+                                        {
+                                            tag: 'link1',
+                                            isLink: true,
+                                            matches: [
+                                                {
+                                                    text: 'abcdef',
+                                                    index: 2,
+                                                    endIndex: 8,
+                                                    highlightStartIndex: 0,
+                                                    highlightEndIndex: 6,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+        });
+    });
 });
 
 describe('getSystemArea()', () => {
@@ -1900,9 +2090,166 @@ describe('getSystemArea()', () => {
         ['core.ui.menu.button', 'core.ui'],
         ['.core.ui.menu.button', '.core'],
         ['..core.ui.menu.button', '.'],
+        [null, ''],
     ];
 
     it.each(cases)('should map %s to %s', (given, expected) => {
         expect(getSystemArea(given)).toBe(expected);
+    });
+});
+
+describe('getBotTitle()', () => {
+    const cases = [
+        ['core', '', 'core'],
+        ['core.ui', 'core', 'ui'],
+        ['core.ui.menu', 'core', 'ui.menu'],
+        ['core.ui.menu.button', 'core.ui', 'menu.button'],
+        ['.core.ui.menu.button', '', 'core.ui.menu.button'],
+        ['..core.ui.menu.button', '', '.core.ui.menu.button'],
+        ['', '', ''],
+    ];
+
+    it.each(cases)('should map %s to %s', (given, area, expected) => {
+        expect(getBotTitle(given, area)).toBe(expected);
+    });
+});
+
+describe('searchValue()', () => {
+    it('should return a list of matches for the given value', () => {
+        expect(searchValue('abcdefghi\nghiabcdef', 0, 'abcdef')).toEqual([
+            {
+                text: 'abcdefghi',
+                index: 0,
+                endIndex: 6,
+                highlightStartIndex: 0,
+                highlightEndIndex: 6,
+            },
+            {
+                text: 'ghiabcdef',
+                index: 13,
+                endIndex: 19,
+                highlightStartIndex: 3,
+                highlightEndIndex: 9,
+            },
+        ]);
+    });
+
+    it('should add the given index offset value to the absolute indexes', () => {
+        expect(searchValue('abcdefghi\nghiabcdef', 5, 'abcdef')).toEqual([
+            {
+                text: 'abcdefghi',
+                index: 5,
+                endIndex: 11,
+                highlightStartIndex: 0,
+                highlightEndIndex: 6,
+            },
+            {
+                text: 'ghiabcdef',
+                index: 18,
+                endIndex: 24,
+                highlightStartIndex: 3,
+                highlightEndIndex: 9,
+            },
+        ]);
+    });
+});
+
+describe('searchTag()', () => {
+    it('should return an object if there are any matches', () => {
+        expect(searchTag('test', null, '@abcdefghi', 'abcdef')).toEqual({
+            tag: 'test',
+            isScript: true,
+            matches: [
+                {
+                    text: 'abcdefghi',
+                    index: 1,
+                    endIndex: 7,
+                    highlightStartIndex: 0,
+                    highlightEndIndex: 6,
+                },
+            ],
+        });
+    });
+
+    it('should support tag links', () => {
+        expect(searchTag('test', null, '🔗abcdefghi', 'abcdef')).toEqual({
+            tag: 'test',
+            isLink: true,
+            matches: [
+                {
+                    text: 'abcdefghi',
+                    index: 2,
+                    endIndex: 8,
+                    highlightStartIndex: 0,
+                    highlightEndIndex: 6,
+                },
+            ],
+        });
+    });
+
+    it('should support formulas', () => {
+        expect(searchTag('test', null, '🧬abcdefghi', 'abcdef')).toEqual({
+            tag: 'test',
+            isFormula: true,
+            matches: [
+                {
+                    text: 'abcdefghi',
+                    index: 2,
+                    endIndex: 8,
+                    highlightStartIndex: 0,
+                    highlightEndIndex: 6,
+                },
+            ],
+        });
+    });
+
+    it('should support normal tags', () => {
+        expect(searchTag('test', null, 'abcdefghi', 'abcdef')).toEqual({
+            tag: 'test',
+            matches: [
+                {
+                    text: 'abcdefghi',
+                    index: 0,
+                    endIndex: 6,
+                    highlightStartIndex: 0,
+                    highlightEndIndex: 6,
+                },
+            ],
+        });
+    });
+
+    it('should support spaces', () => {
+        expect(searchTag('test', 'mySpace', 'abcdefghi', 'abcdef')).toEqual({
+            tag: 'test',
+            space: 'mySpace',
+            matches: [
+                {
+                    text: 'abcdefghi',
+                    index: 0,
+                    endIndex: 6,
+                    highlightStartIndex: 0,
+                    highlightEndIndex: 6,
+                },
+            ],
+        });
+    });
+
+    it('should return null if there are no matches', () => {
+        expect(searchTag('test', null, '@abcdefghi', 'missing')).toEqual(null);
+    });
+
+    it('should convert objects to JSON', () => {
+        expect(searchTag('test', null, { test: 'abcdef' }, 'abcdef')).toEqual({
+            tag: 'test',
+            matches: [
+                {
+                    text: '{"test":"abcdef"}',
+                    index: 9,
+                    endIndex: 15,
+                    highlightStartIndex: 9,
+                    highlightEndIndex: 15,
+                },
+            ],
+        });
     });
 });

--- a/src/aux-vm-browser/managers/SystemPortalManager.ts
+++ b/src/aux-vm-browser/managers/SystemPortalManager.ts
@@ -144,6 +144,8 @@ export class SystemPortalManager implements SubscriptionLike {
             hasRecents: false,
         });
         this._searchUpdated = new BehaviorSubject<SystemPortalSearchUpdate>({
+            numMatches: 0,
+            numBots: 0,
             items: [],
         });
 
@@ -623,6 +625,8 @@ export class SystemPortalManager implements SubscriptionLike {
             let tagCounter = 0;
             let hasUpdate = false;
             let buffer = this._buffer;
+            let matchCount = 0;
+            let botCount = 0;
             const query = calculateStringTagValue(
                 null,
                 this._helper.userBot,
@@ -632,6 +636,8 @@ export class SystemPortalManager implements SubscriptionLike {
 
             if (!query) {
                 observer.next({
+                    numMatches: 0,
+                    numBots: 0,
                     items: [],
                 });
                 return;
@@ -647,6 +653,8 @@ export class SystemPortalManager implements SubscriptionLike {
                 }
 
                 return {
+                    numMatches: matchCount,
+                    numBots: botCount,
                     items: sortBy(items, (i) => i.area),
                 };
             }
@@ -688,6 +696,7 @@ export class SystemPortalManager implements SubscriptionLike {
                     const result = searchTag(tag, null, value, query);
                     if (result) {
                         tags.push(result);
+                        matchCount += result.matches.length;
                         tagCounter += 1;
                     }
                 }
@@ -699,6 +708,7 @@ export class SystemPortalManager implements SubscriptionLike {
                         const result = searchTag(tag, space, value, query);
                         if (result) {
                             tags.push(result);
+                            matchCount += result.matches.length;
                             tagCounter += 1;
                         }
                     }
@@ -711,6 +721,7 @@ export class SystemPortalManager implements SubscriptionLike {
                         arr = [];
                         areas.set(area, arr);
                     }
+                    botCount += 1;
 
                     arr.push({
                         bot,
@@ -995,6 +1006,8 @@ export interface SystemPortalRecentTag {
 }
 
 export interface SystemPortalSearchUpdate {
+    numMatches: number;
+    numBots: number;
     items: SystemPortalSearchItem[];
 }
 

--- a/src/aux-vm-browser/managers/SystemPortalManager.ts
+++ b/src/aux-vm-browser/managers/SystemPortalManager.ts
@@ -780,7 +780,7 @@ export function getSystemArea(system: string): string {
  * @param area The area for the system.
  */
 export function getBotTitle(system: string, area: string): string {
-    return system.substring(area.length).replace(/^[\.]/, '');
+    return (system ?? '').substring(area.length).replace(/^[\.]/, '');
 }
 
 /**


### PR DESCRIPTION
### :rocket: Improvements

-   Added global search to the systemPortal.
    -   Useful for finding a word or phrase in the tags of all the bots in an inst.
    -   For example, you can find all the places where a shout occurrs by typing "shout" into the search box.
    -   Can be accessed by using `Ctrl+Shift+F` while the systemPortal is open or by selecting the eyeglass icon on the left side of the screen.