### PR TITLE
Better date time support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@
             };
             ```
 
+-   Added the ability to store dates in tags by prefixing them with `📅`.
+    -   Dates must be formatted similarly to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+        -   `2012-02-06` (year-month-day in UTC-0 time zone)
+        -   `2015-08-16T08:45:00` (year-month-day + hour:minute:second in UTC-0 time zone)
+        -   `2015-08-16T08:45:00 America/New_York` (year-month-day + hour:minute:second in specified time zone)
+        -   `2015-08-16T08:45:00 local` (year-month-day + hour:minute:second + in local time zone)
+    -   In scripts, date tags are automatically parsed and converted to DateTime objects.
+        -   DateTime objects are easy-to-use representations of date and time with respect to a specific time zone.
+        -   They work better than the built-in [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) class because DateTime supports time zones whereas Date does not.
+        -   You can learn more about them by checking out the [documentation](https://docs.casualos.com/docs/actions#datetime).
+-   Added the `getDateTime(value)` function to make parsing strings into DateTime objects easy.
+    -   Parses the given value and returns a new DateTime that represents the date that was contained in the value.
+    -   Returns null if the value could not be parsed.
+
 ## V3.0.0
 
 #### Date: 2/10/2022

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -540,6 +540,135 @@ const id = uuid();
 os.toast(id);
 ```
 
+### `DateTime`
+
+DateTime is a class that makes representing, manipulating, and comparing date information easier than what is possible with the normal JavaScript [Date class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date).
+Internally, CasualOS uses a library called [luxon](https://moment.github.io/luxon/#/tour) to provide the `DateTime` class to scripts.
+
+When you save a DateTime to a tag, CasualOS will automatically format it so that it is automatically detectable as a date and will always be represented the same no matter where in the world you are.
+To do this, CasualOS uses the `📅` emoji as a prefix for date + time values and automatically parses them into DateTime objects.
+
+For example, saving `📅2022-10-03` to the `date` tag will make `tags.date` be a DateTime value that represents midnight on the 3rd of October in 2022 in the UTC-0 time zone.
+If you want your date to represend midnight in another time zone, you can add the [IANA time zone](https://nodatime.org/TimeZones) you want to the end of the value.
+This is midnight in Tokyo: `📅2022-10-03 Asia/Tokyo`.
+
+See [luxon](https://moment.github.io/luxon/#/tour) for more information and examples.
+
+#### Examples:
+
+```typescript title='Toast the current time in the local timezone'
+os.toast(DateTime.now());
+```
+
+```typescript title='Toast the current time in the UTC-0 timezone'
+os.toast(DateTime.utc());
+```
+
+```typescript title='Toast a specific time in the local timezone'
+os.toast(DateTime.local(2020, 6, 5, 4, 3, 2));
+```
+
+```typescript title='Toast a specific time in the UTC-0 timezone'
+os.toast(DateTime.utc(2020, 6, 5, 4, 3, 2));
+```
+
+```typescript title='Toast the current date in a nicely formated string'
+os.toast(DateTime.now().toLocaleString()); // => '2/15/2022'
+```
+
+```typescript title='Toast the current date and time in a nicely formated string'
+os.toast(DateTime.now().toLocaleString(DateTime.DATETIME_FULL)); // => 'April 20, 2017, 11:32 AM EDT'
+```
+
+```typescript title='Toast the current date and time in a nicely formated string'
+os.toast(DateTime.now().toLocaleString(DateTime.DATETIME_FULL)); // => 'April 20, 2017, 11:32 AM EDT'
+```
+
+```typescript title='Toast a date in a nice relative format to now'
+os.toast(DateTime.utc(2021, 6, 5, 4, 3, 2).toRelative()); // => '8 months ago'
+```
+
+```typescript title='Compare two dates to each other in hours'
+const date1 = DateTime.utc(2021, 6, 5, 4, 3, 2);
+const date2 = DateTime.local(2021, 6, 5, 4, 3, 2);
+const duration = date1.diff(date2, 'hours');
+os.toast(duration.toHuman()); // => '-4 hours'
+```
+
+```typescript title='Check if one date is before another date'
+const date1 = DateTime.utc(2021, 6, 5, 4, 3, 2);
+const date2 = DateTime.local(2021, 6, 5, 4, 3, 2);
+const date3 = DateTime.local(2021, 6, 5, 4, 3, 2);
+
+// Is date1 before date2?
+os.toast(date1 < date2); // => 'true'
+
+// Is date2 equal to date3?
+os.toast(date2.toMillis() === date3.toMillis()); // => 'true'
+```
+
+```typescript title='Check if one date has the same month as another date'
+const date1 = DateTime.utc(2021, 6, 5, 4, 3, 2);
+const date2 = DateTime.local(2021, 6, 5, 4, 3, 2);
+
+os.toast(date1.hasSame(date2, 'month')); // => 'true'
+```
+
+
+### `getDateTime(value)`
+
+Attempts to create a new [DateTime](#DateTime) object from the given value.
+Returns a DateTime object if successful. Returns null otherwise.
+
+See [DateTime](#DateTime) for more information.
+
+The **first parameter** is the value that should be converted into a DateTime.
+If it is a string, then CasualOS will attempt to parse the string.
+If it is a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) then it will be converted to a DateTime by assuming the Date represents the local time zone.
+
+Supported [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Formats:
+```
+2022 # Just the year
+2022-05 # Year + Month
+2022-10-03 # Year + Month + Day
+2022-10-03T07:30:00 # Year + Month + Day + Hour + Minute + Second
+2022-10-03T07:30:00Z # Year + Month + Day + Hour + Minute + Second + explicit UTC-0 marker
+2022-10-03T07:30:00.123Z # Year + Month + Day + Hour + Minute + Second + Milisecond + explicit UTC-0 marker
+2022-10-03T07:30:00.123-05:00 # Year + Month + Day + Hour + Minute + Second + -5 hour time offset from UTC-0
+```
+Note that unless a time-zone offset is explicitly specified, the date will always be interpreted as UTC-0 time.
+
+Supported CasualOS-specific formats:
+```
+# ISO-like formats
+📅2022 # Just the year
+📅2022-05 # Year + Month
+📅2022-10-03 # Year + Month + Day
+📅2022-10-03T07:30:00 # Date + Time (UTC-0 is assumed)
+📅2022-10-03T07:30:00Z # Date + Time + explicit UTC-0 marker
+📅2022-10-03T07:30:00.123Z # Date + Time + Milisecond + explicit UTC-0 marker
+📅2022-10-03T07:30:00.123-05:00 # Date + Time + -5 hour time offset from UTC-0
+
+# CasualOS formats
+📅2022-10-03T07:30:00 America/New_York # Date + Time + IANA time zone that date was recorded in
+📅2022-10-03T07:30:00+05:00 America/Chicago # Date + Time + +5 hour time offset from UTC-0 + IANA time zone that date should be displayed in
+📅2022-10-03T07:30:00+05:00 local # Date + Time + +5 hour time offset from UTC-0 + time zone should be displayed in local time
+```
+
+#### Examples:
+
+```typescript title='Create a DateTime from a string'
+os.toast(getDateTime('📅2022-10-03T07:30:00 America/Detroit'));
+```
+
+```typescript title='Display the given time in a nice format'
+os.toast(getDateTime('📅2022-10-03T07:30:00 America/Detroit').toLocaleString());
+```
+
+```typescript title='Convert a Date object to a DateTime'
+os.toast(getDateTime(new Date()));
+```
+
 ## Web Actions
 
 ### `web.hook(options)`

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -617,10 +617,10 @@ os.toast(date1.hasSame(date2, 'month')); // => 'true'
 
 ### `getDateTime(value)`
 
-Attempts to create a new [DateTime](#DateTime) object from the given value.
+Attempts to create a new [DateTime](#datetime) object from the given value.
 Returns a DateTime object if successful. Returns null otherwise.
 
-See [DateTime](#DateTime) for more information.
+See [DateTime](#datetime) for more information.
 
 The **first parameter** is the value that should be converted into a DateTime.
 If it is a string, then CasualOS will attempt to parse the string.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6444,6 +6444,12 @@
 			"integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
 			"dev": true
 		},
+		"@types/luxon": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.9.tgz",
+			"integrity": "sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA==",
+			"dev": true
+		},
 		"@types/mime": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -18645,6 +18651,11 @@
 			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
+		},
+		"luxon": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+			"integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
 		},
 		"lz-string": {
 			"version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "@types/arcgis-js-api": "^4.21.0",
         "@types/bson": "4.0.5",
         "@types/offscreencanvas": "^2019.6.4",
+        "@types/luxon": "2.0.9",
         "braces": "^2.3.2",
         "chai": "^4.2.0",
         "concurrently": "^4.0.1",

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -507,7 +507,18 @@ describe('BotCalculations', () => {
                     },
                     { zone: 'local' }
                 ),
-                '📅2022-01-01T14:32:12.234-05:00 local',
+                `📅${DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'local' }
+                ).toISO()} local`,
             ] as const,
             [
                 DateTime.fromObject({
@@ -519,7 +530,15 @@ describe('BotCalculations', () => {
                     second: 12,
                     millisecond: 234,
                 }),
-                '📅2022-01-01T14:32:12.234-05:00 local',
+                `📅${DateTime.fromObject({
+                    year: 2022,
+                    month: 1,
+                    day: 1,
+                    hour: 14,
+                    minute: 32,
+                    second: 12,
+                    millisecond: 234,
+                })} local`,
             ] as const,
         ];
 

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -43,6 +43,9 @@ import {
     calculateBotIds,
     createPrecalculatedBot,
     getBotTransformer,
+    isBotDate,
+    parseBotDate,
+    formatBotDate,
 } from './BotCalculations';
 import { Bot, BotsState, DNA_TAG_PREFIX } from './Bot';
 import { v4 as uuid } from 'uuid';
@@ -50,10 +53,12 @@ import { botCalculationContextTests } from './test/BotCalculationContextTests';
 import { BotLookupTableHelper } from './BotLookupTableHelper';
 import { BotCalculationContext } from './BotCalculationContext';
 import { createPrecalculatedContext } from './BotCalculationContextFactory';
+import { DateTime, FixedOffsetZone, Zone } from 'luxon';
 
 const uuidMock: jest.Mock = <any>uuid;
 jest.mock('uuid');
 
+const originalDateNow = Date.now;
 const dateNowMock = (Date.now = jest.fn());
 
 describe('BotCalculations', () => {
@@ -126,6 +131,406 @@ describe('BotCalculations', () => {
             ]);
             expect(parseBotLink(createBotLink(['abc']))).toEqual(['abc']);
             expect(parseBotLink(createBotLink([]))).toEqual([]);
+        });
+    });
+
+    describe('isBotDate()', () => {
+        it('should be true when the value starts with a 📅 symbol', () => {
+            expect(isBotDate('📅')).toBeTruthy();
+            expect(isBotDate('a📅')).toBeFalsy();
+        });
+    });
+
+    describe('parseBotDate()', () => {
+        beforeEach(() => {
+            Date.now = originalDateNow;
+        });
+
+        afterEach(() => {
+            Date.now = dateNowMock;
+        });
+
+        it('should parse the given date into a DateTime value', () => {
+            // Parse as UTC if not specified
+            expect(parseBotDate('📅2022')).toEqual(DateTime.utc(2022, 1, 1));
+            expect(parseBotDate('📅2022-02')).toEqual(DateTime.utc(2022, 2, 1));
+            expect(parseBotDate('📅2022-02-03')).toEqual(
+                DateTime.utc(2022, 2, 3)
+            );
+            expect(parseBotDate('📅2022-02-03T04')).toEqual(
+                DateTime.utc(2022, 2, 3, 4)
+            );
+            expect(parseBotDate('📅2022-02-03T04:05')).toEqual(
+                DateTime.utc(2022, 2, 3, 4, 5)
+            );
+            expect(parseBotDate('📅2022-02-03T04:05:06')).toEqual(
+                DateTime.utc(2022, 2, 3, 4, 5, 6)
+            );
+            expect(parseBotDate('📅2022-02-03T04:05:06.007')).toEqual(
+                DateTime.utc(2022, 2, 3, 4, 5, 6, 7)
+            );
+            expect(parseBotDate('📅2022-01-01T00:00:00Z')).toEqual(
+                DateTime.utc(2022, 1, 1)
+            );
+            expect(parseBotDate('📅2022-01-01T14:32:12Z')).toEqual(
+                DateTime.utc(2022, 1, 1, 14, 32, 12)
+            );
+            expect(parseBotDate('📅2022-01-01T14:32:12.234Z')).toEqual(
+                DateTime.utc(2022, 1, 1, 14, 32, 12, 234)
+            );
+
+            // Parse with Time Zone
+            expect(parseBotDate('📅2022 America/New_York')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 1, day: 1 },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(parseBotDate('📅2022-02 America/New_York')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 1 },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03 America/New_York')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3 },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04 America/New_York')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3, hour: 4 },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04:05 America/New_York')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3, hour: 4, minute: 5 },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(
+                parseBotDate('📅2022-02-03T04:05:06 America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 2,
+                        day: 3,
+                        hour: 4,
+                        minute: 5,
+                        second: 6,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(
+                parseBotDate('📅2022-02-03T04:05:06.007 America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 2,
+                        day: 3,
+                        hour: 4,
+                        minute: 5,
+                        second: 6,
+                        millisecond: 7,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+
+            // Parse as local
+            expect(parseBotDate('📅2022 local')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 1, day: 1 },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02 local')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 1 },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03 local')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3 },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04 local')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3, hour: 4 },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04:05 local')).toEqual(
+                DateTime.fromObject(
+                    { year: 2022, month: 2, day: 3, hour: 4, minute: 5 },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04:05:06 local')).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 2,
+                        day: 3,
+                        hour: 4,
+                        minute: 5,
+                        second: 6,
+                    },
+                    { zone: 'local' }
+                )
+            );
+            expect(parseBotDate('📅2022-02-03T04:05:06.007 local')).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 2,
+                        day: 3,
+                        hour: 4,
+                        minute: 5,
+                        second: 6,
+                        millisecond: 7,
+                    },
+                    { zone: 'local' }
+                )
+            );
+
+            // Time offset
+            expect(parseBotDate('📅2022-01-01T14:32:12-05:00')).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                    },
+                    { zone: FixedOffsetZone.parseSpecifier('UTC-05:00') }
+                )
+            );
+            expect(parseBotDate('📅2022-01-01T14:32:12.234-05:00')).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: FixedOffsetZone.parseSpecifier('UTC-05:00') }
+                )
+            );
+
+            // With Time Zone
+            expect(
+                parseBotDate('📅2022-01-01T14:32:12.234 America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+
+            // With offset plus Time zone
+            // (i.e. Parse as given offset, convert to time zone)
+            expect(
+                parseBotDate('📅2022-01-01T14:32:12.234-05:00 America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+            expect(
+                parseBotDate('📅2022-01-01T14:32:12.234+05:00 America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 4,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+
+            // UTC + Time zone
+            // (i.e. parse as UTC, convert to time zone)
+            expect(
+                parseBotDate('📅2022-01-01T14:32:12.234Z America/New_York')
+            ).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 9,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'America/New_York' }
+                )
+            );
+
+            // UTC + local time
+            // (i.e. parse as UTC, convert to local)
+            expect(parseBotDate('📅2022-01-01T14:32:12.234Z local')).toEqual(
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'utc' }
+                ).setZone('local')
+            );
+        });
+
+        it('should return null if given an invalid date', () => {
+            expect(parseBotDate('📅2022-02-29')).toBe(null);
+            expect(parseBotDate('📅Tuesday 11 Jan 2021')).toBe(null);
+        });
+    });
+
+    describe('formatBotDate()', () => {
+        beforeEach(() => {
+            Date.now = originalDateNow;
+        });
+
+        afterEach(() => {
+            Date.now = dateNowMock;
+        });
+
+        Date.now = originalDateNow;
+
+        const cases = [
+            // Format as UTC
+            [DateTime.utc(2022, 1, 1), '📅2022-01-01T00:00:00Z'] as const,
+            [DateTime.utc(2022, 2, 1), '📅2022-02-01T00:00:00Z'] as const,
+            [DateTime.utc(2022, 2, 3), '📅2022-02-03T00:00:00Z'] as const,
+            [DateTime.utc(2022, 2, 3, 4), '📅2022-02-03T04:00:00Z'] as const,
+            [DateTime.utc(2022, 2, 3, 4, 5), '📅2022-02-03T04:05:00Z'] as const,
+            [
+                DateTime.utc(2022, 2, 3, 4, 5, 6),
+                '📅2022-02-03T04:05:06Z',
+            ] as const,
+            [
+                DateTime.utc(2022, 2, 3, 4, 5, 6, 7),
+                '📅2022-02-03T04:05:06.007Z',
+            ] as const,
+            [
+                DateTime.utc(2022, 1, 1, 14, 32, 12),
+                '📅2022-01-01T14:32:12Z',
+            ] as const,
+            [
+                DateTime.utc(2022, 1, 1, 14, 32, 12, 234),
+                '📅2022-01-01T14:32:12.234Z',
+            ] as const,
+
+            // // Format with Time Zone
+            [
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'America/New_York' }
+                ),
+                '📅2022-01-01T14:32:12.234-05:00 America/New_York',
+            ] as const,
+            [
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'utc' }
+                ),
+                '📅2022-01-01T14:32:12.234Z',
+            ] as const,
+
+            // Format with local time
+            [
+                DateTime.fromObject(
+                    {
+                        year: 2022,
+                        month: 1,
+                        day: 1,
+                        hour: 14,
+                        minute: 32,
+                        second: 12,
+                        millisecond: 234,
+                    },
+                    { zone: 'local' }
+                ),
+                '📅2022-01-01T14:32:12.234-05:00 local',
+            ] as const,
+            [
+                DateTime.fromObject({
+                    year: 2022,
+                    month: 1,
+                    day: 1,
+                    hour: 14,
+                    minute: 32,
+                    second: 12,
+                    millisecond: 234,
+                }),
+                '📅2022-01-01T14:32:12.234-05:00 local',
+            ] as const,
+        ];
+
+        Date.now = dateNowMock;
+
+        describe.each(cases)('%s - %s', (date, expected) => {
+            it('should support formatting', () => {
+                const formatted = formatBotDate(date);
+                expect(formatted).toEqual(expected);
+                expect(parseBotDate(formatted)).toEqual(date);
+            });
         });
     });
 

--- a/src/aux-common/package.json
+++ b/src/aux-common/package.json
@@ -58,7 +58,8 @@
         "stackframe": "^1.2.0",
         "uuid": "^8.3.2",
         "yjs": "13.5.24",
-        "seedrandom": "3.0.5"
+        "seedrandom": "3.0.5",
+        "luxon": "2.3.0"
     },
     "devDependencies": {
         "benchmark": "2.1.4",

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -266,6 +266,9 @@ import {
     openImageClassifier as calcOpenImageClassifier,
     OpenImageClassifierAction,
     ImageClassifierOptions,
+    isBotDate,
+    DATE_TAG_PREFIX,
+    parseBotDate,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -333,6 +336,7 @@ import {
     GetCountResult,
 } from '@casual-simulation/aux-records';
 import SeedRandom from 'seedrandom';
+import { DateTime } from 'luxon';
 
 const _html: HtmlFunction = htm.bind(h) as any;
 
@@ -991,6 +995,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             getLink: createBotLinkApi,
             getBotLinks,
             updateBotLinks,
+
+            getDateTime,
+            DateTime,
+
             superShout,
             priorityShout,
             shout: shoutProxy,
@@ -6865,6 +6873,27 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 });
                 bot.tags[tag] = createBotLink(mapped);
             }
+        }
+    }
+
+    /**
+     * Parses the given value into a date time object.
+     * Returns null if the value could not be parsed into a date time.
+     * @param value The value to parse.
+     */
+    function getDateTime(value: unknown): DateTime {
+        if (typeof value === 'string') {
+            if (!isBotDate(value)) {
+                value = DATE_TAG_PREFIX + value;
+            }
+
+            return parseBotDate(value);
+        } else if (value instanceof DateTime) {
+            return value;
+        } else if (value instanceof Date) {
+            return DateTime.fromJSDate(value);
+        } else {
+            return null;
         }
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -3200,6 +3200,2875 @@ export interface PseudoRandomNumberGenerator {
     randomInt(min: number, max: number): number;
 }
 
+
+// Luxon Types Copyright
+// MIT License
+
+// Copyright (c) Microsoft Corporation.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE
+
+export interface ZoneOffsetOptions {
+    /**
+     * What style of offset to return.
+     */
+    format?: 'short' | 'long' | undefined;
+    /**
+     * What locale to return the offset name in.
+     */
+    locale?: string | undefined;
+}
+
+/**
+ * What style of offset to return.
+ * Returning '+6', '+06:00', or '+0600' respectively
+ */
+export type ZoneOffsetFormat = 'narrow' | 'short' | 'techie';
+
+declare class Zone {
+    /**
+     * The type of zone
+     */
+    get type(): string;
+
+    /**
+     * The name of this zone.
+     */
+    get name(): string;
+
+    /**
+     * Returns whether the offset is known to be fixed for the whole year.
+     */
+    get isUniversal(): boolean;
+
+    /**
+     * Returns the offset's common name (such as EST) at the specified timestamp
+     *
+     * @param ts - Epoch milliseconds for which to get the name
+     * @param options - Options to affect the format
+     * @param options.format - What style of offset to return.
+     * @param options.locale - What locale to return the offset name in.
+     */
+    offsetName(ts: number, options: ZoneOffsetOptions): string;
+
+    /**
+     * Returns the offset's value as a string
+     *
+     * @param ts - Epoch milliseconds for which to get the offset
+     * @param format - What style of offset to return.
+     *                 Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
+     */
+    formatOffset(ts: number, format: ZoneOffsetFormat): string;
+
+    /**
+     * Return the offset in minutes for this zone at the specified timestamp.
+     *
+     * @param ts - Epoch milliseconds for which to compute the offset
+     */
+    offset(ts: number): number;
+
+    /**
+     * Return whether this Zone is equal to another zone
+     *
+     * @param other - the zone to compare
+     */
+    equals(other: Zone): boolean;
+
+    /**
+     * Return whether this Zone is valid.
+     */
+    get isValid(): boolean;
+}
+
+/**
+ * A zone identified by an IANA identifier, like America/New_York
+ */
+declare class IANAZone extends Zone {
+    /**
+     * Same as constructor but has caching.
+     */
+    static create(name: string): IANAZone;
+
+    /**
+     * Reset local caches. Should only be necessary in testing scenarios.
+     */
+    static resetCache(): void;
+
+    /**
+     * Returns whether the provided string is a valid specifier.
+     * This only checks the string's format, not that the specifier
+     * identifies a known zone; see {@link isValidZone} for that.
+     *
+     * @param s - The string to check validity on
+     *
+     * @example
+     * IANAZone.isValidSpecifier("America/New_York") //=> true
+     * @example
+     * IANAZone.isValidSpecifier("Fantasia/Castle") //=> true
+     * @example
+     * IANAZone.isValidSpecifier("Sport~~blorp") //=> false
+     */
+    static isValidSpecifier(s: string): boolean;
+
+    /**
+     * Returns whether the provided string identifies a real zone
+     *
+     * @param zone - The string to check
+     *
+     * @example
+     * IANAZone.isValidZone("America/New_York") //=> true
+     * @example
+     * IANAZone.isValidZone("Fantasia/Castle") //=> false
+     * @example
+     * IANAZone.isValidZone("Sport~~blorp") //=> false
+     */
+    static isValidZone(zone: string): boolean;
+
+    constructor(name: string);
+}
+
+/**
+ * A zone with a fixed offset (meaning no DST)
+ */
+declare class FixedOffsetZone extends Zone {
+    /**
+     * Get a singleton instance of UTC
+     */
+    static get utcInstance(): FixedOffsetZone;
+
+    /**
+     * Get an instance with a specified offset
+     *
+     * @param offset - The offset in minutes
+     */
+    static instance(offset: number): FixedOffsetZone;
+
+    /**
+     * Get an instance of FixedOffsetZone from a UTC offset string, like "UTC+6"
+     *
+     * @param s - The offset string to parse
+     *
+     * @example
+     * FixedOffsetZone.parseSpecifier("UTC+6")
+     * @example
+     * FixedOffsetZone.parseSpecifier("UTC+06")
+     * @example
+     * FixedOffsetZone.parseSpecifier("UTC-6:00")
+     */
+    static parseSpecifier(s: string): FixedOffsetZone;
+}
+
+/**
+ * A zone that failed to parse. You should never need to instantiate this.
+ */
+declare class InvalidZone extends Zone {}
+
+/**
+ * Represents the system zone for this JavaScript environment.
+ */
+declare class SystemZone extends Zone {
+    /**
+     * Get a singleton instance of the system zone
+     */
+    static get instance(): SystemZone;
+}
+
+export interface IntervalObject {
+    start?: DateTime | undefined;
+    end?: DateTime | undefined;
+}
+
+export type DateInput = DateTime | DateObjectUnits | Date;
+
+/**
+ * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}. Conceptually, it's a container for those two endpoints, accompanied by methods for
+ * creating, parsing, interrogating, comparing, transforming, and formatting them.
+ *
+ * Here is a brief overview of the most commonly used methods and getters in Interval:
+ *
+ * * **Creation** To create an Interval, use {@link Interval.fromDateTimes}, {@link Interval.after}, {@link Interval.before}, or {@link Interval.fromISO}.
+ * * **Accessors** Use {@link Interval#start} and {@link Interval#end} to get the start and end.
+ * * **Interrogation** To analyze the Interval, use {@link Interval#count}, {@link Interval#length}, {@link Interval#hasSame},
+ * * {@link Interval#contains}, {@link Interval#isAfter}, or {@link Interval#isBefore}.
+ * * **Transformation** To create other Intervals out of this one, use {@link Interval#set}, {@link Interval#splitAt}, {@link Interval#splitBy}, {@link Interval#divideEqually},
+ * * {@link Interval#merge}, {@link Interval#xor}, {@link Interval#union}, {@link Interval#intersection}, or {@link Interval#difference}.
+ * * **Comparison** To compare this Interval to another one, use {@link Interval#equals}, {@link Interval#overlaps}, {@link Interval#abutsStart}, {@link Interval#abutsEnd}, {@link Interval#engulfs}
+ * * **Output** To convert the Interval into other representations, see {@link Interval#toString}, {@link Interval#toISO}, {@link Interval#toISODate}, {@link Interval#toISOTime},
+ * * {@link Interval#toFormat}, and {@link Interval#toDuration}.
+ */
+declare class Interval {
+    /**
+     * Create an invalid Interval.
+     *
+     * @param reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
+     * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
+     */
+    static invalid(reason: string, explanation?: string): Interval;
+
+    /**
+     * Create an Interval from a start DateTime and an end DateTime. Inclusive of the start but not the end.
+     *
+     * @param start
+     * @param end
+     */
+    static fromDateTimes(start: DateInput, end: DateInput): Interval;
+
+    /**
+     * Create an Interval from a start DateTime and a Duration to extend to.
+     *
+     * @param start
+     * @param duration - the length of the Interval.
+     */
+    static after(start: DateInput, duration: DurationLike): Interval;
+
+    /**
+     * Create an Interval from an end DateTime and a Duration to extend backwards to.
+     *
+     * @param end
+     * @param duration - the length of the Interval.
+     */
+    static before(end: DateInput, duration: DurationLike): Interval;
+
+    /**
+     * Create an Interval from an ISO 8601 string.
+     * Accepts `<start>/<end>`, `<start>/<duration>`, and `<duration>/<end>` formats.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+     *
+     * @param text - the ISO string to parse
+     * @param opts - options to pass {@link DateTime.fromISO} and optionally {@link Duration.fromISO}
+     */
+    static fromISO(text: string, opts?: DateTimeOptions): Interval;
+
+    /**
+     * Check if an object is an Interval. Works across context boundaries
+     *
+     * @param o
+     */
+    static isInterval(o: unknown): o is Interval;
+
+    /**
+     * Returns the start of the Interval
+     */
+    get start(): DateTime;
+
+    /**
+     * Returns the end of the Interval
+     */
+    get end(): DateTime;
+
+    /**
+     * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.
+     */
+    get isValid(): boolean;
+
+    /**
+     * Returns an error code if this Interval is invalid, or null if the Interval is valid
+     */
+    get invalidReason(): string;
+
+    /**
+     * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
+     */
+    get invalidExplanation(): string;
+
+    /**
+     * Returns the length of the Interval in the specified unit.
+     *
+     * @param unit - the unit (such as 'hours' or 'days') to return the length in.
+     */
+    length(unit?: DurationUnit): number;
+
+    /**
+     * Returns the count of minutes, hours, days, months, or years included in the Interval, even in part.
+     * Unlike {@link Interval#length} this counts sections of the calendar, not periods of time, e.g. specifying 'day'
+     * asks 'what dates are included in this interval?', not 'how many days long is this interval?'
+     *
+     * @param unit - the unit of time to count. Defaults to 'milliseconds'.
+     */
+    count(unit?: DurationUnit): number;
+
+    /**
+     * Returns whether this Interval's start and end are both in the same unit of time
+     *
+     * @param unit - the unit of time to check sameness on
+     */
+    hasSame(unit: DurationUnit): boolean;
+
+    /**
+     * Return whether this Interval has the same start and end DateTimes.
+     */
+    isEmpty(): boolean;
+
+    /**
+     * Return whether this Interval's start is after the specified DateTime.
+     *
+     * @param dateTime
+     */
+    isAfter(dateTime: DateTime): boolean;
+
+    /**
+     * Return whether this Interval's end is before the specified DateTime.
+     *
+     * @param dateTime
+     */
+    isBefore(dateTime: DateTime): boolean;
+
+    /**
+     * Return whether this Interval contains the specified DateTime.
+     *
+     * @param dateTime
+     */
+    contains(dateTime: DateTime): boolean;
+
+    /**
+     * "Sets" the start and/or end dates. Returns a newly-constructed Interval.
+     *
+     * @param values - the values to set
+     * @param values.start - the starting DateTime
+     * @param values.end - the ending DateTime
+     */
+    set(values?: IntervalObject): Interval;
+
+    /**
+     * Split this Interval at each of the specified DateTimes
+     *
+     * @param dateTimes - the unit of time to count.
+     */
+    splitAt(...dateTimes: DateTime[]): Interval[];
+
+    /**
+     * Split this Interval into smaller Intervals, each of the specified length.
+     * Left over time is grouped into a smaller interval
+     *
+     * @param duration - The length of each resulting interval.
+     */
+    splitBy(duration: DurationLike): Interval[];
+
+    /**
+     * Split this Interval into the specified number of smaller intervals.
+     *
+     * @param numberOfParts - The number of Intervals to divide the Interval into.
+     */
+    divideEqually(numberOfParts: number): Interval[];
+
+    /**
+     * Return whether this Interval overlaps with the specified Interval
+     *
+     * @param other
+     */
+    overlaps(other: Interval): boolean;
+
+    /**
+     * Return whether this Interval's end is adjacent to the specified Interval's start.
+     *
+     * @param other
+     */
+    abutsStart(other: Interval): boolean;
+
+    /**
+     * Return whether this Interval's start is adjacent to the specified Interval's end.
+     *
+     * @param other
+     */
+    abutsEnd(other: Interval): boolean;
+
+    /**
+     * Return whether this Interval engulfs the start and end of the specified Interval.
+     *
+     * @param other
+     */
+    engulfs(other: Interval): boolean;
+
+    /**
+     * Return whether this Interval has the same start and end as the specified Interval.
+     *
+     * @param other
+     */
+    equals(other: Interval): boolean;
+
+    /**
+     * Return an Interval representing the intersection of this Interval and the specified Interval.
+     * Specifically, the resulting Interval has the maximum start time and the minimum end time of the two Intervals.
+     * Returns null if the intersection is empty, meaning, the intervals don't intersect.
+     *
+     * @param other
+     */
+    intersection(other: Interval): Interval | null;
+
+    /**
+     * Return an Interval representing the union of this Interval and the specified Interval.
+     * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
+     *
+     * @param other
+     */
+    union(other: Interval): Interval;
+
+    /**
+     * Merge an array of Intervals into a equivalent minimal set of Intervals.
+     * Combines overlapping and adjacent Intervals.
+     *
+     * @param intervals
+     */
+    static merge(intervals: Interval[]): Interval[];
+
+    /**
+     * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
+     *
+     *  @param intervals
+     */
+    static xor(intervals: Interval[]): Interval[];
+
+    /**
+     * Return an Interval representing the span of time in this Interval that doesn't overlap with any of the specified Intervals.
+     *
+     * @param intervals
+     */
+    difference(...intervals: Interval[]): Interval[];
+
+    /**
+     * Returns a string representation of this Interval appropriate for debugging.
+     */
+    toString(): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this Interval.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+     *
+     * @param opts - The same options as {@link DateTime#toISO}
+     */
+    toISO(opts?: ToISOTimeOptions): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of date of this Interval.
+     * The time components are ignored.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+     */
+    toISODate(): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of time of this Interval.
+     * The date components are ignored.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+     *
+     * @param opts - The same options as {@link DateTime.toISO}
+     */
+    toISOTime(opts?: ToISOTimeOptions): string;
+
+    /**
+     * Returns a string representation of this Interval formatted according to the specified format string.
+     *
+     * @param dateFormat - the format string. This string formats the start and end time. See {@link DateTime.toFormat} for details.
+     * @param opts - options
+     * @param opts.separator - a separator to place between the start and end representations. Defaults to ' - '.
+     */
+    toFormat(
+        dateFormat: string,
+        opts?: {
+            separator?: string | undefined;
+        },
+    ): string;
+
+    /**
+     * Return a Duration representing the time spanned by this interval.
+     *
+     * @param unit - the unit or units (such as 'hours' or 'days') to include in the duration. Defaults to ['milliseconds'].
+     * @param opts - options that affect the creation of the Duration
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     *
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).toDuration().toObject() //=> { milliseconds: 88489257 }
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).toDuration('days').toObject() //=> { days: 1.0241812152777778 }
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).toDuration(['hours', 'minutes']).toObject() //=> { hours: 24, minutes: 34.82095 }
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).toDuration(['hours', 'minutes', 'seconds']).toObject() //=> { hours: 24, minutes: 34, seconds: 49.257 }
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).toDuration('seconds').toObject() //=> { seconds: 88489.257 }
+     */
+    toDuration(unit?: DurationUnit | DurationUnit[], opts?: DiffOptions): Duration;
+
+    /**
+     * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
+     *
+     * @param mapFn
+     *
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.toUTC())
+     * @example
+     * Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.plus({ hours: 2 }))
+     */
+    mapEndpoints(mapFn: (d: DateTime) => DateTime): Interval;
+}
+
+export interface InfoOptions {
+    locale?: string | undefined;
+}
+
+export interface InfoUnitOptions extends InfoOptions {
+    numberingSystem?: NumberingSystem | undefined;
+}
+
+/** @deprecated */
+export type UnitOptions = InfoUnitOptions;
+
+export interface InfoCalendarOptions extends InfoUnitOptions {
+    outputCalendar?: CalendarSystem | undefined;
+}
+
+/**
+ * The set of available features in this environment. Some features of Luxon are not available in all environments.
+ */
+export interface Features {
+    /**
+     * Whether this environment supports relative time formatting
+     */
+    relative: boolean;
+}
+
+/**
+ * The Info class contains static methods for retrieving general time and date related data. For example, it has methods for finding out if a time zone has a DST, for listing the months in any
+ * supported locale, and for discovering which of Luxon features are available in the current environment.
+ */
+declare namespace Info {
+    /**
+     * Return whether the specified zone contains a DST.
+     *
+     * @param zone - Zone to check. Defaults to the environment's local zone. Defaults to 'local'.
+     */
+    function hasDST(zone?: string | Zone): boolean;
+
+    /**
+     * Return whether the specified zone is a valid IANA specifier.
+     *
+     * @param zone - Zone to check
+     */
+    function isValidIANAZone(zone: string): boolean;
+
+    /**
+     * Converts the input into a {@link Zone} instance.
+     *
+     * * If `input` is already a Zone instance, it is returned unchanged.
+     * * If `input` is a string containing a valid time zone name, a Zone instance
+     *   with that name is returned.
+     * * If `input` is a string that doesn't refer to a known time zone, a Zone
+     *   instance with {@link Zone.isValid} == false is returned.
+     * * If `input is a number, a Zone instance with the specified fixed offset
+     *   in minutes is returned.
+     * * If `input` is `null` or `undefined`, the default zone is returned.
+     *
+     * @param input - the value to be converted
+     */
+    function normalizeZone(input?: string | Zone | number): Zone;
+
+    /**
+     * Return an array of standalone month names.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+     *
+     * @param length - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long". Defaults to 'long'.
+     * @param opts - options
+     * @param opts.locale - the locale code
+     * @param opts.numberingSystem - the numbering system. Defaults to null.
+     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.outputCalendar - the calendar. Defaults to 'gregory'.
+     *
+     * @example
+     * Info.months()[0] //=> 'January'
+     * @example
+     * Info.months('short')[0] //=> 'Jan'
+     * @example
+     * Info.months('numeric')[0] //=> '1'
+     * @example
+     * Info.months('short', { locale: 'fr-CA' } )[0] //=> 'janv.'
+     * @example
+     * Info.months('numeric', { locale: 'ar' })[0] //=> '١'
+     * @example
+     * Info.months('long', { outputCalendar: 'islamic' })[0] //=> 'Rabiʻ I'
+     */
+    function months(length?: UnitLength, opts?: InfoCalendarOptions): string[];
+
+    /**
+     * Return an array of format month names.
+     * Format months differ from standalone months in that they're meant to appear next to the day of the month. In some languages, that
+     * changes the string.
+     * See {@link Info#months}
+     *
+     * @param length - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long". Defaults to 'long'.
+     * @param opts - options
+     * @param opts.locale - the locale code
+     * @param opts.numberingSystem - the numbering system. Defaults to null.
+     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.outputCalendar - the calendar. Defaults to 'gregory'.
+     */
+    function monthsFormat(length?: UnitLength, options?: InfoCalendarOptions): string[];
+
+    /**
+     * Return an array of standalone week names.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+     *
+     * @param length - the length of the weekday representation, such as "narrow", "short", "long". Defaults to 'long'.
+     * @param opts - options
+     * @param opts.locale - the locale code
+     * @param opts.numberingSystem - the numbering system. Defaults to null.
+     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     *
+     * @example
+     * Info.weekdays()[0] //=> 'Monday'
+     * @example
+     * Info.weekdays('short')[0] //=> 'Mon'
+     * @example
+     * Info.weekdays('short', { locale: 'fr-CA' })[0] //=> 'lun.'
+     * @example
+     * Info.weekdays('short', { locale: 'ar' })[0] //=> 'الاثنين'
+     */
+    function weekdays(length?: StringUnitLength, options?: InfoUnitOptions): string[];
+
+    /**
+     * Return an array of format week names.
+     * Format weekdays differ from standalone weekdays in that they're meant to appear next to more date information. In some languages, that
+     * changes the string.
+     * See {@link Info#weekdays}
+     *
+     * @param length - the length of the month representation, such as "narrow", "short", "long". Defaults to 'long'.
+     * @param opts - options
+     * @param opts.locale - the locale code. Defaults to null.
+     * @param opts.numberingSystem - the numbering system. Defaults to null.
+     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     */
+    function weekdaysFormat(length?: StringUnitLength, options?: InfoUnitOptions): string[];
+
+    /**
+     * Return an array of meridiems.
+     *
+     * @param opts - options
+     * @param opts.locale - the locale code
+     *
+     * @example
+     * Info.meridiems() //=> [ 'AM', 'PM' ]
+     * @example
+     * Info.meridiems({ locale: 'my' }) //=> [ 'နံနက်', 'ညနေ' ]
+     */
+    function meridiems(options?: InfoOptions): string[];
+
+    /**
+     * Return an array of eras, such as ['BC', 'AD']. The locale can be specified, but the calendar system is always Gregorian.
+     *
+     * @param length - the length of the era representation, such as "short" or "long". Defaults to 'short'.
+     * @param opts - options
+     * @param opts.locale - the locale code
+     *
+     * @example
+     * Info.eras() //=> [ 'BC', 'AD' ]
+     * @example
+     * Info.eras('long') //=> [ 'Before Christ', 'Anno Domini' ]
+     * @example
+     * Info.eras('long', { locale: 'fr' }) //=> [ 'avant Jésus-Christ', 'après Jésus-Christ' ]
+     */
+    function eras(length?: StringUnitLength, options?: InfoOptions): string[];
+
+    /**
+     * Return the set of available features in this environment.
+     * Some features of Luxon are not available in all environments. For example, on older browsers, timezone support is not available. Use this function to figure out if that's the case.
+     * Keys:
+     * * `relative`: whether this environment supports relative time formatting
+     *
+     * @example
+     * Info.features() //=> { intl: true, intlTokens: false, zones: true, relative: false }
+     */
+    function features(): Features;
+}
+
+export interface DurationOptions {
+    locale?: string | undefined;
+    numberingSystem?: NumberingSystem | undefined;
+    conversionAccuracy?: ConversionAccuracy | undefined;
+}
+
+export interface DurationObjectUnits {
+    years?: number | undefined;
+    quarters?: number | undefined;
+    months?: number | undefined;
+    weeks?: number | undefined;
+    days?: number | undefined;
+    hours?: number | undefined;
+    minutes?: number | undefined;
+    seconds?: number | undefined;
+    milliseconds?: number | undefined;
+}
+
+export interface DurationLikeObject extends DurationObjectUnits {
+    year?: number | undefined;
+    quarter?: number | undefined;
+    month?: number | undefined;
+    week?: number | undefined;
+    day?: number | undefined;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
+}
+
+export type DurationUnit = keyof DurationLikeObject;
+export type DurationUnits = DurationUnit | DurationUnit[];
+
+export type ToISOFormat = 'basic' | 'extended';
+
+export interface ToISOTimeDurationOptions {
+    /**
+     * Include the `T` prefix
+     * @default false
+     */
+    includePrefix?: boolean | undefined;
+    /**
+     * Exclude milliseconds from the format if they're 0
+     * @default false
+     */
+    suppressMilliseconds?: boolean | undefined;
+    /**
+     * Exclude seconds from the format if they're 0
+     * @default false
+     */
+    suppressSeconds?: boolean | undefined;
+    /**
+     * Choose between the basic and extended format
+     * @default 'extended'
+     */
+    format?: ToISOFormat | undefined;
+}
+
+export interface ToHumanDurationOptions extends Intl.NumberFormatOptions {
+    listStyle?: 'long' | 'short' | 'narrow' | undefined;
+}
+
+/**
+ * Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+ *
+ * @deprecated Use DurationLike instead.
+ */
+export type DurationInput = Duration | number | DurationLikeObject;
+
+/**
+ * Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+ */
+export type DurationLike = Duration | DurationLikeObject | number;
+
+/**
+ * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour".
+ * Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them.
+ * They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime.plus} to add a Duration object to a DateTime, producing another DateTime.
+ *
+ * Here is a brief overview of commonly used methods and getters in Duration:
+ *
+ * * **Creation** To create a Duration, use {@link Duration.fromMillis}, {@link Duration.fromObject}, or {@link Duration.fromISO}.
+ * * **Unit values** See the {@link Duration#years}, {@link Duration.months}, {@link Duration#weeks}, {@link Duration#days}, {@link Duration#hours}, {@link Duration#minutes},
+ * * {@link Duration#seconds}, {@link Duration#milliseconds} accessors.
+ * * **Configuration** See  {@link Duration#locale} and {@link Duration#numberingSystem} accessors.
+ * * **Transformation** To create new Durations out of old ones use {@link Duration#plus}, {@link Duration#minus}, {@link Duration#normalize}, {@link Duration#set}, {@link Duration#reconfigure},
+ * * {@link Duration#shiftTo}, and {@link Duration#negate}.
+ * * **Output** To convert the Duration into other representations, see {@link Duration#as}, {@link Duration#toISO}, {@link Duration#toFormat}, and {@link Duration#toJSON}
+ *
+ * There's are more methods documented below. In addition, for more information on subtler topics like internationalization and validity, see the external documentation.
+ */
+declare class Duration {
+    /**
+     * Create Duration from a number of milliseconds.
+     *
+     * @param count - of milliseconds
+     * @param opts - options for parsing
+     * @param opts.locale - the locale to use
+     * @param opts.numberingSystem - the numbering system to use
+     * @param opts.conversionAccuracy - the conversion system to use
+     */
+    static fromMillis(count: number, opts?: DurationOptions): Duration;
+
+    /**
+     * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
+     * If this object is empty then a zero milliseconds duration is returned.
+     *
+     * @param obj - the object to create the DateTime from
+     * @param obj.years
+     * @param obj.quarters
+     * @param obj.months
+     * @param obj.weeks
+     * @param obj.days
+     * @param obj.hours
+     * @param obj.minutes
+     * @param obj.seconds
+     * @param obj.milliseconds
+     * @param opts - options for creating this Duration. Defaults to {}.
+     * @param opts.locale - the locale to use. Defaults to 'en-US'.
+     * @param opts.numberingSystem - the numbering system to use
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     */
+    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration;
+
+    /**
+     * Create a Duration from DurationLike.
+     *
+     * @param durationLike
+     * Either a Luxon Duration, a number of milliseconds, or the object argument to Duration.fromObject()
+     */
+    static fromDurationLike(durationLike: DurationLike): Duration;
+
+    /**
+     * Create a Duration from an ISO 8601 duration string.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
+     *
+     * @param text - text to parse
+     * @param opts - options for parsing
+     * @param opts.locale - the locale to use. Defaults to 'en-US'.
+     * @param opts.numberingSystem - the numbering system to use
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     *
+     * @example
+     * Duration.fromISO('P3Y6M1W4DT12H30M5S').toObject() //=> { years: 3, months: 6, weeks: 1, days: 4, hours: 12, minutes: 30, seconds: 5 }
+     * @example
+     * Duration.fromISO('PT23H').toObject() //=> { hours: 23 }
+     * @example
+     * Duration.fromISO('P5Y3M').toObject() //=> { years: 5, months: 3 }
+     */
+    static fromISO(text: string, opts?: DurationOptions): Duration;
+
+    /**
+     * Create a Duration from an ISO 8601 time string.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Times
+     *
+     * @param text - text to parse
+     * @param opts - options for parsing
+     * @param opts.locale - the locale to use. Defaults to 'en-US'.
+     * @param opts.numberingSystem - the numbering system to use
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     *
+     * @example
+     * Duration.fromISOTime('11:22:33.444').toObject() //=> { hours: 11, minutes: 22, seconds: 33, milliseconds: 444 }
+     * @example
+     * Duration.fromISOTime('11:00').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+     * @example
+     * Duration.fromISOTime('T11:00').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+     * @example
+     * Duration.fromISOTime('1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+     * @example
+     * Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+     */
+    static fromISOTime(text: string, opts?: DurationOptions): Duration;
+
+    /**
+     * Create an invalid Duration.
+     *
+     * @param reason - simple string of why this datetime is invalid. Should not contain parameters or anything else data-dependent
+     * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
+     */
+    static invalid(reason: string, explanation?: string): Duration;
+
+    /**
+     * Check if an object is a Duration. Works across context boundaries
+     *
+     * @param o
+     */
+    static isDuration(o: unknown): o is Duration;
+
+    /**
+     * Get  the locale of a Duration, such 'en-GB'
+     */
+    get locale(): string;
+
+    /**
+     * Get the numbering system of a Duration, such 'beng'. The numbering system is used when formatting the Duration
+     */
+    get numberingSystem(): string;
+
+    /**
+     * Returns a string representation of this Duration formatted according to the specified format string. You may use these tokens:
+     * * `S` for milliseconds
+     * * `s` for seconds
+     * * `m` for minutes
+     * * `h` for hours
+     * * `d` for days
+     * * `M` for months
+     * * `y` for years
+     * Notes:
+     * * Add padding by repeating the token, e.g. "yy" pads the years to two digits, "hhhh" pads the hours out to four digits
+     * * The duration will be converted to the set of units in the format string using {@link Duration.shiftTo} and the Durations's conversion accuracy setting.
+     *
+     * @param fmt - the format string
+     * @param opts - options
+     * @param opts.floor - floor numerical values. Defaults to true.
+     *
+     * @example
+     * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("y d s") //=> "1 6 2"
+     * @example
+     * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("yy dd sss") //=> "01 06 002"
+     * @example
+     * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("M S") //=> "12 518402000"
+     */
+    toFormat(fmt: string, opts?: { floor?: boolean | undefined }): string;
+
+    /**
+     * Returns a string representation of a Duration with all units included
+     * To modify its behavior use the `listStyle` and any Intl.NumberFormat option, though `unitDisplay` is especially relevant. See {@link Intl.NumberFormat}.
+     * @param opts - On option object to override the formatting. Accepts the same keys as the options parameter of the native `Int.NumberFormat` constructor, as well as `listStyle`.
+     * @example
+     * ```js
+     * var dur = Duration.fromObject({ days: 1, hours: 5, minutes: 6 })
+     * dur.toHuman() //=> '1 day, 5 hours, 6 minutes'
+     * dur.toHuman({ listStyle: "long" }) //=> '1 day, 5 hours, and 6 minutes'
+     * dur.toHuman({ unitDisplay: "short" }) //=> '1 day, 5 hr, 6 min'
+     * ```
+     */
+    toHuman(opts?: ToHumanDurationOptions): string;
+
+    /**
+     * Returns a JavaScript object with this Duration's values.
+     *
+     * @example
+     * Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toObject() //=> { years: 1, days: 6, seconds: 2 }
+     */
+    toObject(): DurationObjectUnits;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this Duration.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
+     *
+     * @example
+     * Duration.fromObject({ years: 3, seconds: 45 }).toISO() //=> 'P3YT45S'
+     * @example
+     * Duration.fromObject({ months: 4, seconds: 45 }).toISO() //=> 'P4MT45S'
+     * @example
+     * Duration.fromObject({ months: 5 }).toISO() //=> 'P5M'
+     * @example
+     * Duration.fromObject({ minutes: 5 }).toISO() //=> 'PT5M'
+     * @example
+     * Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
+     */
+    toISO(): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Times
+     *
+     * @param opts - options
+     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they're 0. Defaults to false.
+     * @param opts.suppressSeconds - exclude seconds from the format if they're 0. Defaults to false.
+     * @param opts.includePrefix - include the `T` prefix. Defaults to false.
+     * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
+     *
+     * @example
+     * Duration.fromObject({ hours: 11 }).toISOTime() //=> '11:00:00.000'
+     * @example
+     * Duration.fromObject({ hours: 11 }).toISOTime({ suppressMilliseconds: true }) //=> '11:00:00'
+     * @example
+     * Duration.fromObject({ hours: 11 }).toISOTime({ suppressSeconds: true }) //=> '11:00'
+     * @example
+     * Duration.fromObject({ hours: 11 }).toISOTime({ includePrefix: true }) //=> 'T11:00:00.000'
+     * @example
+     * Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
+     */
+    toISOTime(opts?: ToISOTimeDurationOptions): string;
+
+    /**
+     * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
+     */
+    toJSON(): string;
+
+    /**
+     * Returns an ISO 8601 representation of this Duration appropriate for use in debugging.
+     */
+    toString(): string;
+
+    /**
+     * Returns an milliseconds value of this Duration.
+     */
+    toMillis(): number;
+
+    /**
+     * Returns an milliseconds value of this Duration. Alias of {@link toMillis}
+     */
+    valueOf(): number;
+
+    /**
+     * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
+     *
+     * @param duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+     */
+    plus(duration: DurationLike): Duration;
+
+    /**
+     * Make this Duration shorter by the specified amount. Return a newly-constructed Duration.
+     *
+     * @param duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+     */
+    minus(duration: DurationLike): Duration;
+
+    /**
+     * Scale this Duration by the specified amount. Return a newly-constructed Duration.
+     *
+     * @example
+     * Duration.fromObject({ hours: 1, minutes: 30 }).mapUnit(x => x * 2) //=> { hours: 2, minutes: 60 }
+     * @example
+     * Duration.fromObject({ hours: 1, minutes: 30 }).mapUnit((x, u) => u === "hour" ? x * 2 : x) //=> { hours: 2, minutes: 30 }
+     */
+    mapUnits(fn: (x: number, u?: DurationUnit) => number): Duration;
+
+    /**
+     * Get the value of unit.
+     *
+     * @param unit - a unit such as 'minute' or 'day'
+     *
+     * @example
+     * Duration.fromObject({years: 2, days: 3}).get('years') //=> 2
+     * @example
+     * Duration.fromObject({years: 2, days: 3}).get('months') //=> 0
+     * @example
+     * Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
+     */
+    get(unit: DurationUnit): number;
+
+    /**
+     * "Set" the values of specified units. Return a newly-constructed Duration.
+     *
+     * @param values - a mapping of units to numbers
+     *
+     * @example
+     * dur.set({ years: 2017 })
+     * @example
+     * dur.set({ hours: 8, minutes: 30 })
+     */
+    set(values: DurationLikeObject): Duration;
+
+    /**
+     * "Set" the locale and/or numberingSystem.  Returns a newly-constructed Duration.
+     *
+     * @example
+     * dur.reconfigure({ locale: 'en-GB' })
+     */
+    reconfigure(opts?: DurationOptions): Duration;
+
+    /**
+     * Return the length of the duration in the specified unit.
+     *
+     * @param unit - a unit such as 'minutes' or 'days'
+     *
+     * @example
+     * Duration.fromObject({years: 1}).as('days') //=> 365
+     * @example
+     * Duration.fromObject({years: 1}).as('months') //=> 12
+     * @example
+     * Duration.fromObject({hours: 60}).as('days') //=> 2.5
+     */
+    as(unit: DurationUnit): number;
+
+    /**
+     * Reduce this Duration to its canonical representation in its current units.
+     *
+     * @example
+     * Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
+     * @example
+     * Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
+     */
+    normalize(): Duration;
+
+    /**
+     * Convert this Duration into its representation in a different set of units.
+     *
+     * @example
+     * Duration.fromObject({ hours: 1, seconds: 30 }).shiftTo('minutes', 'milliseconds').toObject() //=> { minutes: 60, milliseconds: 30000 }
+     */
+    shiftTo(...units: DurationUnit[]): Duration;
+
+    /**
+     * Return the negative of this Duration.
+     *
+     * @example
+     * Duration.fromObject({ hours: 1, seconds: 30 }).negate().toObject() //=> { hours: -1, seconds: -30 }
+     */
+    negate(): Duration;
+
+    /**
+     * Get the years.
+     */
+    get years(): number;
+
+    /**
+     * Get the quarters.
+     */
+    get quarters(): number;
+
+    /**
+     * Get the months.
+     */
+    get months(): number;
+
+    /**
+     * Get the weeks
+     */
+    get weeks(): number;
+
+    /**
+     * Get the days.
+     */
+    get days(): number;
+
+    /**
+     * Get the hours.
+     */
+    get hours(): number;
+
+    /**
+     * Get the minutes.
+     */
+    get minutes(): number;
+
+    /**
+     * Get the seconds.
+     */
+    get seconds(): number;
+
+    /**
+     * Get the milliseconds.
+     */
+    get milliseconds(): number;
+
+    /**
+     * Returns whether the Duration is invalid. Invalid durations are returned by diff operations
+     * on invalid DateTimes or Intervals.
+     */
+    get isValid(): boolean;
+
+    /**
+     * Returns an error code if this Duration became invalid, or null if the Duration is valid
+     */
+    get invalidReason(): string;
+
+    /**
+     * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
+     */
+    get invalidExplanation(): string;
+
+    /**
+     * Equality check
+     * Two Durations are equal iff they have the same units and the same values for each unit.
+     *
+     * @param other
+     */
+    equals(other: Duration): boolean;
+}
+
+
+export type DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+
+export interface ZoneOptions {
+    /**
+     * If true, adjust the underlying time so that the local time stays the same, but in the target zone.
+     * You should rarely need this.
+     * Defaults to false.
+     */
+    keepLocalTime?: boolean | undefined;
+    /**
+     * @deprecated since 0.2.12. Use keepLocalTime instead
+     */
+    keepCalendarTime?: boolean | undefined;
+}
+
+/** @deprecated */
+export type EraLength = StringUnitLength;
+
+export type NumberingSystem = Intl.DateTimeFormatOptions extends { numberingSystem?: infer T }
+    ? T
+    :
+          | 'arab'
+          | 'arabext'
+          | 'bali'
+          | 'beng'
+          | 'deva'
+          | 'fullwide'
+          | 'gujr'
+          | 'guru'
+          | 'hanidec'
+          | 'khmr'
+          | 'knda'
+          | 'laoo'
+          | 'latn'
+          | 'limb'
+          | 'mlym'
+          | 'mong'
+          | 'mymr'
+          | 'orya'
+          | 'tamldec'
+          | 'telu'
+          | 'thai'
+          | 'tibt';
+
+export type CalendarSystem = Intl.DateTimeFormatOptions extends { calendar?: infer T }
+    ? T
+    :
+          | 'buddhist'
+          | 'chinese'
+          | 'coptic'
+          | 'ethioaa'
+          | 'ethiopic'
+          | 'gregory'
+          | 'hebrew'
+          | 'indian'
+          | 'islamic'
+          | 'islamicc'
+          | 'iso8601'
+          | 'japanese'
+          | 'persian'
+          | 'roc';
+
+export type HourCycle = 'h11' | 'h12' | 'h23' | 'h24';
+
+export type StringUnitLength = 'narrow' | 'short' | 'long';
+export type NumberUnitLength = 'numeric' | '2-digit';
+export type UnitLength = StringUnitLength | NumberUnitLength;
+
+
+export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
+export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
+
+export type MonthNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type WeekdayNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type DayNumbers =
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31;
+
+export type SecondNumbers =
+    | 0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31
+    | 32
+    | 33
+    | 34
+    | 35
+    | 36
+    | 37
+    | 38
+    | 39
+    | 40
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+    | 53
+    | 54
+    | 55
+    | 56
+    | 57
+    | 58
+    | 59;
+
+export type MinuteNumbers = SecondNumbers;
+
+export type HourNumbers =
+    | 0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23;
+
+export type WeekNumbers =
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31
+    | 32
+    | 33
+    | 34
+    | 35
+    | 36
+    | 37
+    | 38
+    | 39
+    | 40
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+    | 53;
+
+export type QuarterNumbers = 1 | 2 | 3 | 4;
+
+export type PossibleDaysInMonth = 28 | 29 | 30 | 31;
+export type PossibleDaysInYear = 365 | 366;
+export type PossibleWeeksInYear = 52 | 53;
+
+export interface ToObjectOutput extends DateTimeJSOptions {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+}
+
+export interface ToRelativeOptions extends Omit<ToRelativeCalendarOptions, 'unit'> {
+    /**
+     * @default long
+     */
+    style?: StringUnitLength | undefined;
+    /** @default true */
+    round?: boolean | undefined;
+    /**
+     * Padding in milliseconds. This allows you to round up the result if it fits inside the threshold.
+     * Don't use in combination with {round: false} because the decimal output will include the padding.
+     * @default 0
+     */
+    padding?: number | undefined;
+    /**
+     * A single unit or an array of units. If an array is supplied, the method will pick the best one
+     * to use from the array. If omitted, the method will pick the unit from a default set.
+     */
+    unit?: ToRelativeUnit | ToRelativeUnit[] | undefined;
+}
+
+export interface ToRelativeCalendarOptions {
+    /**
+     * The DateTime to use as the basis to which this time is compared
+     * @default now
+     */
+    base?: DateTime | undefined;
+    /**
+     * Override the locale of this DateTime
+     */
+    locale?: string | undefined;
+    /** If omitted, the method will pick the unit. */
+    unit?: ToRelativeUnit | undefined;
+    /**
+     * Override the numberingSystem of this DateTime.
+     * The Intl system may choose not to honor this.
+     */
+    numberingSystem?: NumberingSystem | undefined;
+}
+
+export interface ToSQLOptions {
+    /**
+     * Include the offset, such as 'Z' or '-04:00'
+     * @default true
+     */
+    includeOffset?: boolean | undefined;
+    /**
+     * Include the zone, such as 'America/New_York'. Overrides includeOffset.
+     * @default false
+     */
+    includeZone?: boolean | undefined;
+}
+
+export interface ToISODateOptions {
+    /**
+     * Choose between the basic and extended format
+     * @default 'extended'
+     */
+    format?: ToISOFormat | undefined;
+}
+
+export interface ToISOTimeOptions extends ToISOTimeDurationOptions {
+    /**
+     * Include the offset, such as 'Z' or '-04:00'
+     * @default true
+     */
+    includeOffset?: boolean | undefined;
+}
+
+/** @deprecated alias for backwards compatibility */
+export type ISOTimeOptions = ToISOTimeOptions;
+
+export interface LocaleOptions {
+    /**
+     * @default system's locale
+     */
+    locale?: string | undefined;
+    outputCalendar?: CalendarSystem | undefined;
+    numberingSystem?: NumberingSystem | undefined;
+}
+
+export type ResolvedLocaleOptions = Required<LocaleOptions>;
+
+export interface DateTimeOptions extends LocaleOptions {
+    /**
+     * Use this zone if no offset is specified in the input string itself. Will also convert the time to this zone.
+     * @default local
+     */
+    zone?: string | Zone | undefined;
+    /**
+     * Override the zone with a fixed-offset zone specified in the string itself, if it specifies one.
+     * @default false
+     */
+    setZone?: boolean | undefined;
+}
+
+export type DateTimeJSOptions = Omit<DateTimeOptions, 'setZone'>;
+
+export interface DateObjectUnits {
+    // a year, such as 1987
+    year?: number | undefined;
+    // a month, 1-12
+    month?: number | undefined;
+    // a day of the month, 1-31, depending on the month
+    day?: number | undefined;
+    // day of the year, 1-365 or 366
+    ordinal?: number | undefined;
+    // an ISO week year
+    weekYear?: number | undefined;
+    // an ISO week number, between 1 and 52 or 53, depending on the year
+    weekNumber?: number | undefined;
+    // an ISO weekday, 1-7, where 1 is Monday and 7 is Sunday
+    weekday?: number | undefined;
+    // hour of the day, 0-23
+    hour?: number | undefined;
+    // minute of the hour, 0-59
+    minute?: number | undefined;
+    // second of the minute, 0-59
+    second?: number | undefined;
+    // millisecond of the second, 0-999
+    millisecond?: number | undefined;
+}
+
+export type ConversionAccuracy = 'casual' | 'longterm';
+
+/**
+ * @deprecated You should use Intl.DateTimeFormatOptions' fields and values instead.
+ */
+export type DateTimeFormatPresetValue = 'numeric' | 'short' | 'long';
+/**
+ * @deprecated Use Intl.DateTimeFormatOptions instead.
+ */
+export type DateTimeFormatPreset = Intl.DateTimeFormatOptions;
+
+export interface DiffOptions {
+    conversionAccuracy?: ConversionAccuracy | undefined;
+}
+
+export interface ExplainedFormat {
+    input: string;
+    tokens: Array<{ literal: boolean; val: string }>;
+    regex?: RegExp | undefined;
+    rawMatches?: RegExpMatchArray | null | undefined;
+    matches?: { [k: string]: any } | undefined;
+    result?: { [k: string]: any } | null | undefined;
+    zone?: Zone | null | undefined;
+    invalidReason?: string | undefined;
+}
+
+/**
+ * A DateTime is an immutable data structure representing a specific date and time and accompanying methods.
+ * It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
+ *
+ * A DateTime comprises of:
+ * * A timestamp. Each DateTime instance refers to a specific millisecond of the Unix epoch.
+ * * A time zone. Each instance is considered in the context of a specific zone (by default the local system's zone).
+ * * Configuration properties that effect how output strings are formatted, such as `locale`, `numberingSystem`, and `outputCalendar`.
+ *
+ * Here is a brief overview of the most commonly used functionality it provides:
+ *
+ * * **Creation**: To create a DateTime from its components, use one of its factory class methods: {@link DateTime.local}, {@link DateTime.utc}, and (most flexibly) {@link DateTime.fromObject}.
+ * To create one from a standard string format, use {@link DateTime.fromISO}, {@link DateTime.fromHTTP}, and {@link DateTime.fromRFC2822}.
+ * To create one from a custom string format, use {@link DateTime.fromFormat}. To create one from a native JS date, use {@link DateTime.fromJSDate}.
+ * * **Gregorian calendar and time**: To examine the Gregorian properties of a DateTime individually (i.e as opposed to collectively through {@link DateTime#toObject}), use the {@link DateTime#year},
+ * {@link DateTime#month}, {@link DateTime#day}, {@link DateTime#hour}, {@link DateTime#minute}, {@link DateTime#second}, {@link DateTime#millisecond} accessors.
+ * * **Week calendar**: For ISO week calendar attributes, see the {@link DateTime#weekYear}, {@link DateTime#weekNumber}, and {@link DateTime#weekday} accessors.
+ * * **Configuration** See the {@link DateTime#locale} and {@link DateTime#numberingSystem} accessors.
+ * * **Transformation**: To transform the DateTime into other DateTimes, use {@link DateTime#set}, {@link DateTime#reconfigure}, {@link DateTime#setZone}, {@link DateTime#setLocale},
+ * {@link DateTime.plus}, {@link DateTime#minus}, {@link DateTime#endOf}, {@link DateTime#startOf}, {@link DateTime#toUTC}, and {@link DateTime#toLocal}.
+ * * **Output**: To convert the DateTime to other representations, use the {@link DateTime#toRelative}, {@link DateTime#toRelativeCalendar}, {@link DateTime#toJSON}, {@link DateTime#toISO},
+ * {@link DateTime#toHTTP}, {@link DateTime#toObject}, {@link DateTime#toRFC2822}, {@link DateTime#toString}, {@link DateTime#toLocaleString}, {@link DateTime#toFormat},
+ * {@link DateTime#toMillis} and {@link DateTime#toJSDate}.
+ *
+ * There's plenty others documented below. In addition, for more information on subtler topics
+ * like internationalization, time zones, alternative calendars, validity, and so on, see the external documentation.
+ */
+declare class DateTime {
+    /**
+     * Create a DateTime for the current instant, in the system's time zone.
+     *
+     * Use Settings to override these default values if needed.
+     * @example
+     * DateTime.now().toISO() //~> now in the ISO format
+     */
+    static now(): DateTime;
+
+    /**
+     * Create a local DateTime
+     *
+     * @param year - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
+     * @param month - The month, 1-indexed
+     * @param day - The day of the month, 1-indexed
+     * @param hour - The hour of the day, in 24-hour time
+     * @param minute - The minute of the hour, meaning a number between 0 and 59
+     * @param second - The second of the minute, meaning a number between 0 and 59
+     * @param millisecond - The millisecond of the second, meaning a number between 0 and 999
+     *
+     * @example
+     * DateTime.local()                                  //~> now
+     * @example
+     * DateTime.local({ zone: "America/New_York" })      //~> now, in US east coast time
+     * @example
+     * DateTime.local(2017)                              //~> 2017-01-01T00:00:00
+     * @example
+     * DateTime.local(2017, 3)                           //~> 2017-03-01T00:00:00
+     * @example
+     * DateTime.local(2017, 3, 12, { locale: "fr")       //~> 2017-03-12T00:00:00, with a French locale
+     * @example
+     * DateTime.local(2017, 3, 12, 5)                    //~> 2017-03-12T05:00:00
+     * @example
+     * DateTime.local(2017, 3, 12, 5, { zone: "utc" })   //~> 2017-03-12T05:00:00, in UTC
+     * @example
+     * DateTime.local(2017, 3, 12, 5, 45)                //~> 2017-03-12T05:45:00
+     * @example
+     * DateTime.local(2017, 3, 12, 5, 45, 10)            //~> 2017-03-12T05:45:10
+     * @example
+     * DateTime.local(2017, 3, 12, 5, 45, 10, 765)       //~> 2017-03-12T05:45:10.765
+     */
+    static local(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        millisecond: number,
+        opts?: DateTimeJSOptions,
+    ): DateTime;
+    static local(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        opts?: DateTimeJSOptions,
+    ): DateTime;
+    static local(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        opts?: DateTimeJSOptions,
+    ): DateTime;
+    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTime;
+    static local(year: number, opts?: DateTimeJSOptions): DateTime;
+    static local(opts?: DateTimeJSOptions): DateTime;
+
+    /**
+     * Create a DateTime in UTC
+     *
+     * @param year - The calendar year. If omitted (as in, call `utc()` with no arguments), the current time will be used
+     * @param month - The month, 1-indexed
+     * @param day - The day of the month
+     * @param hour - The hour of the day, in 24-hour time
+     * @param minute - The minute of the hour, meaning a number between 0 and 59
+     * @param second - The second of the minute, meaning a number between 0 and 59
+     * @param millisecond - The millisecond of the second, meaning a number between 0 and 999
+     * @param options - configuration options for the DateTime
+     * @param options.locale - a locale to set on the resulting DateTime instance
+     * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.utc()                                            //~> now
+     * @example
+     * DateTime.utc(2017)                                        //~> 2017-01-01T00:00:00Z
+     * @example
+     * DateTime.utc(2017, 3)                                     //~> 2017-03-01T00:00:00Z
+     * @example
+     * DateTime.utc(2017, 3, 12)                                 //~> 2017-03-12T00:00:00Z
+     * @example
+     * DateTime.utc(2017, 3, 12, 5)                              //~> 2017-03-12T05:00:00Z
+     * @example
+     * DateTime.utc(2017, 3, 12, 5, 45)                          //~> 2017-03-12T05:45:00Z
+     * @example
+     * DateTime.utc(2017, 3, 12, 5, 45, { locale: "fr" } )       //~> 2017-03-12T05:45:00Z with a French locale
+     * @example
+     * DateTime.utc(2017, 3, 12, 5, 45, 10)                      //~> 2017-03-12T05:45:10Z
+     * @example
+     * DateTime.utc(2017, 3, 12, 5, 45, 10, 765, { locale: "fr") //~> 2017-03-12T05:45:10.765Z with a French locale
+     */
+    static utc(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        millisecond: number,
+        options?: LocaleOptions,
+    ): DateTime;
+    static utc(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        second: number,
+        options?: LocaleOptions,
+    ): DateTime;
+    static utc(
+        year: number,
+        month: number,
+        day: number,
+        hour: number,
+        minute: number,
+        options?: LocaleOptions,
+    ): DateTime;
+    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, month: number, options?: LocaleOptions): DateTime;
+    static utc(year: number, options?: LocaleOptions): DateTime;
+    static utc(options?: LocaleOptions): DateTime;
+
+    /**
+     * Create a DateTime from a JavaScript Date object. Uses the default zone.
+     *
+     * @param date - a JavaScript Date object
+     * @param options - configuration options for the DateTime
+     * @param options.zone - the zone to place the DateTime into
+     */
+    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTime;
+
+    /**
+     * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
+     *
+     * @param milliseconds - a number of milliseconds since 1970 UTC
+     * @param options - configuration options for the DateTime
+     * @param options.zone - the zone to place the DateTime into. Defaults to 'local'.
+     * @param options.locale - a locale to set on the resulting DateTime instance
+     * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
+     */
+    static fromMillis(milliseconds: number, options?: DateTimeJSOptions): DateTime;
+
+    /**
+     * Create a DateTime from a number of seconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
+     *
+     * @param seconds - a number of seconds since 1970 UTC
+     * @param options - configuration options for the DateTime
+     * @param options.zone - the zone to place the DateTime into. Defaults to 'local'.
+     * @param options.locale - a locale to set on the resulting DateTime instance
+     * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
+     */
+    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTime;
+
+    /**
+     * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
+     *
+     * @param obj - the object to create the DateTime from
+     * @param obj.year - a year, such as 1987
+     * @param obj.month - a month, 1-12
+     * @param obj.day - a day of the month, 1-31, depending on the month
+     * @param obj.ordinal - day of the year, 1-365 or 366
+     * @param obj.weekYear - an ISO week year
+     * @param obj.weekNumber - an ISO week number, between 1 and 52 or 53, depending on the year
+     * @param obj.weekday - an ISO weekday, 1-7, where 1 is Monday and 7 is Sunday
+     * @param obj.hour - hour of the day, 0-23
+     * @param obj.minute - minute of the hour, 0-59
+     * @param obj.second - second of the minute, 0-59
+     * @param obj.millisecond - millisecond of the second, 0-999
+     * @param opts - options for creating this DateTime
+     * @param opts.zone - interpret the numbers in the context of a particular zone. Can take any value taken as the first argument to setZone(). Defaults to 'local'.
+     * @param opts.locale - a locale to set on the resulting DateTime instance. Defaults to 'system's locale'.
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.fromObject({ year: 1982, month: 5, day: 25}).toISODate() //=> '1982-05-25'
+     * @example
+     * DateTime.fromObject({ year: 1982 }).toISODate() //=> '1982-01-01'
+     * @example
+     * DateTime.fromObject({ hour: 10, minute: 26, second: 6 }) //~> today at 10:26:06
+     * @example
+     * DateTime.fromObject({ hour: 10, minute: 26, second: 6 }, { zone: 'utc' }),
+     * @example
+     * DateTime.fromObject({ hour: 10, minute: 26, second: 6 }, { zone: 'local' })
+     * @example
+     * DateTime.fromObject({ hour: 10, minute: 26, second: 6 }, { }zone: 'America/New_York' })
+     * @example
+     * DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
+     */
+    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
+
+    /**
+     * Create a DateTime from an ISO 8601 string
+     *
+     * @param text - the ISO string
+     * @param opts - options to affect the creation
+     * @param opts.zone - use this zone if no offset is specified in the input string itself. Will also convert the time to this zone. Defaults to 'local'.
+     * @param opts.setZone - override the zone with a fixed-offset zone specified in the string itself, if it specifies one. Defaults to false.
+     * @param opts.locale - a locale to set on the resulting DateTime instance. Defaults to 'system's locale'.
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.fromISO('2016-05-25T09:08:34.123')
+     * @example
+     * DateTime.fromISO('2016-05-25T09:08:34.123+06:00')
+     * @example
+     * DateTime.fromISO('2016-05-25T09:08:34.123+06:00', {setZone: true})
+     * @example
+     * DateTime.fromISO('2016-05-25T09:08:34.123', {zone: 'utc'})
+     * @example
+     * DateTime.fromISO('2016-W05-4')
+     */
+    static fromISO(text: string, opts?: DateTimeOptions): DateTime;
+
+    /**
+     * Create a DateTime from an RFC 2822 string
+     *
+     * @param text - the RFC 2822 string
+     * @param opts - options to affect the creation
+     * @param opts.zone - convert the time to this zone. Since the offset is always specified in the string itself,
+     * this has no effect on the interpretation of string, merely the zone the resulting DateTime is expressed in. Defaults to 'local'
+     * @param opts.setZone - override the zone with a fixed-offset zone specified in the string itself, if it specifies one. Defaults to false.
+     * @param opts.locale - a locale to set on the resulting DateTime instance. Defaults to 'system's locale'.
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.fromRFC2822('25 Nov 2016 13:23:12 GMT')
+     * @example
+     * DateTime.fromRFC2822('Fri, 25 Nov 2016 13:23:12 +0600')
+     * @example
+     * DateTime.fromRFC2822('25 Nov 2016 13:23 Z')
+     */
+    static fromRFC2822(text: string, opts?: DateTimeOptions): DateTime;
+
+    /**
+     * Create a DateTime from an HTTP header date
+     *
+     * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
+     *
+     * @param text - the HTTP header date
+     * @param opts - options to affect the creation
+     * @param opts.zone - convert the time to this zone. Since HTTP dates are always in UTC,
+     * this has no effect on the interpretation of string,merely the zone the resulting DateTime is expressed in. Defaults to 'local'.
+     * @param opts.setZone - override the zone with the fixed-offset zone specified in the string. For HTTP dates, this is always UTC,
+     * so this option is equivalent to setting the `zone` option to 'utc', but this option is included for consistency with similar methods. Defaults to false.
+     * @param opts.locale - a locale to set on the resulting DateTime instance. Defaults to 'system's locale'.
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     * @param opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.fromHTTP('Sun, 06 Nov 1994 08:49:37 GMT')
+     * @example
+     * DateTime.fromHTTP('Sunday, 06-Nov-94 08:49:37 GMT')
+     * @example
+     * DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
+     */
+    static fromHTTP(text: string, opts?: DateTimeOptions): DateTime;
+
+    /**
+     * Create a DateTime from an input string and format string.
+     * Defaults to en-US if no locale has been specified, regardless of the system's locale. For a table of tokens and their interpretations,
+     * see [here](https://moment.github.io/luxon/#/parsing?id=table-of-tokens).
+     *
+     * @param text - the string to parse
+     * @param fmt - the format the string is expected to be in (see the link below for the formats)
+     * @param opts - options to affect the creation
+     * @param opts.zone - use this zone if no offset is specified in the input string itself. Will also convert the DateTime to this zone. Defaults to 'local'.
+     * @param opts.setZone - override the zone with a zone specified in the string itself, if it specifies one. Defaults to false.
+     * @param opts.locale - a locale string to use when parsing. Will also set the DateTime to this locale. Defaults to 'en-US'.
+     * @param opts.numberingSystem - the numbering system to use when parsing. Will also set the resulting DateTime to this numbering system
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     */
+    static fromFormat(text: string, fmt: string, opts?: DateTimeOptions): DateTime;
+
+    /**
+     * @deprecated use fromFormat instead
+     */
+    static fromString(text: string, format: string, options?: DateTimeOptions): DateTime;
+
+    /**
+     * Create a DateTime from a SQL date, time, or datetime
+     * Defaults to en-US if no locale has been specified, regardless of the system's locale
+     *
+     * @param text - the string to parse
+     * @param opts - options to affect the creation
+     * @param opts.zone - use this zone if no offset is specified in the input string itself. Will also convert the DateTime to this zone. Defaults to 'local'.
+     * @param opts.setZone - override the zone with a zone specified in the string itself, if it specifies one. Defaults to false.
+     * @param opts.locale - a locale string to use when parsing. Will also set the DateTime to this locale. Defaults to 'en-US'.
+     * @param opts.numberingSystem - the numbering system to use when parsing. Will also set the resulting DateTime to this numbering system
+     * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
+     *
+     * @example
+     * DateTime.fromSQL('2017-05-15')
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34')
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34.342')
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34.342+06:00')
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34.342 America/Los_Angeles')
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34.342 America/Los_Angeles', { setZone: true })
+     * @example
+     * DateTime.fromSQL('2017-05-15 09:12:34.342', { zone: 'America/Los_Angeles' })
+     * @example
+     * DateTime.fromSQL('09:12:34.342')
+     */
+    static fromSQL(text: string, opts?: DateTimeOptions): DateTime;
+
+    /**
+     * Create an invalid DateTime.
+     *
+     * @param reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent
+     * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
+     */
+    static invalid(reason: string, explanation?: string): DateTime;
+
+    /**
+     * Check if an object is a DateTime. Works across context boundaries
+     *
+     * @param o
+     */
+    static isDateTime(o: unknown): o is DateTime;
+
+    // INFO
+
+    /**
+     * Get the value of unit.
+     *
+     * @param unit - a unit such as 'minute' or 'day'
+     *
+     * @example
+     * DateTime.local(2017, 7, 4).get('month'); //=> 7
+     * @example
+     * DateTime.local(2017, 7, 4).get('day'); //=> 4
+     */
+    get(unit: keyof DateTime): number;
+
+    /**
+     * Returns whether the DateTime is valid. Invalid DateTimes occur when:
+     * * The DateTime was created from invalid calendar information, such as the 13th month or February 30
+     * * The DateTime was created by an operation on another invalid date
+     */
+    get isValid(): boolean;
+
+    /**
+     * Returns an error code if this DateTime is invalid, or null if the DateTime is valid
+     */
+    get invalidReason(): string | null;
+
+    /**
+     * Returns an explanation of why this DateTime became invalid, or null if the DateTime is valid
+     */
+    get invalidExplanation(): string | null;
+
+    /**
+     * Get the locale of a DateTime, such 'en-GB'. The locale is used when formatting the DateTime
+     */
+    get locale(): string;
+
+    /**
+     * Get the numbering system of a DateTime, such 'beng'. The numbering system is used when formatting the DateTime
+     */
+    get numberingSystem(): string;
+
+    /**
+     * Get the output calendar of a DateTime, such 'islamic'. The output calendar is used when formatting the DateTime
+     */
+    get outputCalendar(): string;
+
+    /**
+     * Get the time zone associated with this DateTime.
+     */
+    get zone(): Zone;
+
+    /**
+     * Get the name of the time zone.
+     */
+    get zoneName(): string;
+
+    /**
+     * Get the year
+     *
+     * @example DateTime.local(2017, 5, 25).year //=> 2017
+     */
+    get year(): number;
+
+    /**
+     * Get the quarter
+     *
+     * @example DateTime.local(2017, 5, 25).quarter //=> 2
+     */
+    get quarter(): QuarterNumbers;
+
+    /**
+     * Get the month (1-12).
+     *
+     * @example DateTime.local(2017, 5, 25).month //=> 5
+     */
+    get month(): MonthNumbers;
+
+    /**
+     * Get the day of the month (1-30ish).
+     *
+     * @example DateTime.local(2017, 5, 25).day //=> 25
+     */
+    get day(): DayNumbers;
+
+    /**
+     * Get the hour of the day (0-23).
+     *
+     * @example DateTime.local(2017, 5, 25, 9).hour //=> 9
+     */
+    get hour(): HourNumbers;
+
+    /**
+     * Get the minute of the hour (0-59).
+     *
+     * @example
+     * DateTime.local(2017, 5, 25, 9, 30).minute //=> 30
+     */
+    get minute(): MinuteNumbers;
+
+    /**
+     * Get the second of the minute (0-59).
+     *
+     * @example
+     * DateTime.local(2017, 5, 25, 9, 30, 52).second //=> 52
+     */
+    get second(): SecondNumbers;
+
+    /**
+     * Get the millisecond of the second (0-999).
+     *
+     * @example
+     * DateTime.local(2017, 5, 25, 9, 30, 52, 654).millisecond //=> 654
+     */
+    get millisecond(): number;
+
+    /**
+     * Get the week year
+     * @see https://en.wikipedia.org/wiki/ISO_week_date
+     *
+     * @example
+     * DateTime.local(2014, 12, 31).weekYear //=> 2015
+     */
+    get weekYear(): number;
+
+    /**
+     * Get the week number of the week year (1-52ish).
+     * @see https://en.wikipedia.org/wiki/ISO_week_date
+     *
+     * @example
+     * DateTime.local(2017, 5, 25).weekNumber //=> 21
+     */
+    get weekNumber(): WeekNumbers;
+
+    /**
+     * Get the day of the week.
+     * 1 is Monday and 7 is Sunday
+     * @see https://en.wikipedia.org/wiki/ISO_week_date
+     *
+     * @example
+     * DateTime.local(2014, 11, 31).weekday //=> 4
+     */
+    get weekday(): WeekdayNumbers;
+
+    /**
+     * Get the ordinal (meaning the day of the year)
+     *
+     * @example
+     * DateTime.local(2017, 5, 25).ordinal //=> 145
+     */
+    get ordinal(): number;
+
+    /**
+     * Get the human readable short month name, such as 'Oct'.
+     * Defaults to the system's locale if no locale has been specified
+     *
+     * @example
+     * DateTime.local(2017, 10, 30).monthShort //=> Oct
+     */
+    get monthShort(): string;
+
+    /**
+     * Get the human readable long month name, such as 'October'.
+     * Defaults to the system's locale if no locale has been specified
+     *
+     * @example
+     * DateTime.local(2017, 10, 30).monthLong //=> October
+     */
+    get monthLong(): string;
+
+    /**
+     * Get the human readable short weekday, such as 'Mon'.
+     * Defaults to the system's locale if no locale has been specified
+     *
+     * @example
+     * DateTime.local(2017, 10, 30).weekdayShort //=> Mon
+     */
+    get weekdayShort(): string;
+
+    /**
+     * Get the human readable long weekday, such as 'Monday'.
+     * Defaults to the system's locale if no locale has been specified
+     *
+     * @example
+     * DateTime.local(2017, 10, 30).weekdayLong //=> Monday
+     */
+    get weekdayLong(): string;
+
+    /**
+     * Get the UTC offset of this DateTime in minutes
+     *
+     * @example
+     * DateTime.now().offset //=> -240
+     * @example
+     * DateTime.utc().offset //=> 0
+     */
+    get offset(): number;
+
+    /**
+     * Get the short human name for the zone's current offset, for example "EST" or "EDT".
+     * Defaults to the system's locale if no locale has been specified
+     */
+    get offsetNameShort(): string;
+
+    /**
+     * Get the long human name for the zone's current offset, for example "Eastern Standard Time" or "Eastern Daylight Time".
+     * Defaults to the system's locale if no locale has been specified
+     */
+    get offsetNameLong(): string;
+
+    /**
+     * Get whether this zone's offset ever changes, as in a DST.
+     */
+    get isOffsetFixed(): boolean;
+
+    /**
+     * Get whether the DateTime is in a DST.
+     */
+    get isInDST(): boolean;
+
+    /**
+     * Returns true if this DateTime is in a leap year, false otherwise
+     *
+     * @example
+     * DateTime.local(2016).isInLeapYear //=> true
+     * @example
+     * DateTime.local(2013).isInLeapYear //=> false
+     */
+    get isInLeapYear(): boolean;
+
+    /**
+     * Returns the number of days in this DateTime's month
+     *
+     * @example
+     * DateTime.local(2016, 2).daysInMonth //=> 29
+     * @example
+     * DateTime.local(2016, 3).daysInMonth //=> 31
+     */
+    get daysInMonth(): PossibleDaysInMonth;
+
+    /**
+     * Returns the number of days in this DateTime's year
+     *
+     * @example
+     * DateTime.local(2016).daysInYear //=> 366
+     * @example
+     * DateTime.local(2013).daysInYear //=> 365
+     */
+    get daysInYear(): PossibleDaysInYear;
+
+    /**
+     * Returns the number of weeks in this DateTime's year
+     * @see https://en.wikipedia.org/wiki/ISO_week_date
+     *
+     * @example
+     * DateTime.local(2004).weeksInWeekYear //=> 53
+     * @example
+     * DateTime.local(2013).weeksInWeekYear //=> 52
+     */
+    get weeksInWeekYear(): PossibleWeeksInYear;
+
+    /**
+     * Returns the resolved Intl options for this DateTime.
+     * This is useful in understanding the behavior of formatting methods
+     *
+     * @param opts - the same options as toLocaleString
+     */
+    resolvedLocaleOptions(opts?: LocaleOptions | DateTimeFormatOptions): ResolvedLocaleOptions;
+
+    // TRANSFORM
+
+    /**
+     * "Set" the DateTime's zone to UTC. Returns a newly-constructed DateTime.
+     *
+     * Equivalent to {@link DateTime.setZone}('utc')
+     *
+     * @param offset - optionally, an offset from UTC in minutes. Defaults to 0.
+     * @param opts - options to pass to `setZone()`. Defaults to {}.
+     */
+    toUTC(offset?: number, opts?: ZoneOptions): DateTime;
+
+    /**
+     * "Set" the DateTime's zone to the host's local zone. Returns a newly-constructed DateTime.
+     *
+     * Equivalent to `setZone('local')`
+     */
+    toLocal(): DateTime;
+
+    /**
+     * "Set" the DateTime's zone to specified zone. Returns a newly-constructed DateTime.
+     *
+     * By default, the setter keeps the underlying time the same (as in, the same timestamp), but the new instance will report different local times and consider DSTs when making computations,
+     * as with {@link DateTime.plus}. You may wish to use {@link DateTime.toLocal} and {@link DateTime.toUTC} which provide simple convenience wrappers for commonly used zones.
+     *
+     * @param zone - a zone identifier. As a string, that can be any IANA zone supported by the host environment, or a fixed-offset name of the form 'UTC+3', or the strings 'local' or 'utc'.
+     * You may also supply an instance of a {@link DateTime.Zone} class. Defaults to 'local'.
+     * @param opts - options
+     * @param opts.keepLocalTime - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this. Defaults to false.
+     */
+    setZone(zone?: string | Zone, opts?: ZoneOptions): DateTime;
+
+    /**
+     * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
+     *
+     * @param properties - the properties to set
+     *
+     * @example
+     * DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
+     */
+    reconfigure(properties: LocaleOptions): DateTime;
+
+    /**
+     * "Set" the locale. Returns a newly-constructed DateTime.
+     * Just a convenient alias for reconfigure({ locale })
+     *
+     * @example
+     * DateTime.local(2017, 5, 25).setLocale('en-GB')
+     */
+    setLocale(locale: string): DateTime;
+
+    /**
+     * "Set" the values of specified units. Returns a newly-constructed DateTime.
+     * You can only set units with this method; for "setting" metadata, see {@link DateTime.reconfigure} and {@link DateTime.setZone}.
+     *
+     * @param values - a mapping of units to numbers
+     *
+     * @example
+     * dt.set({ year: 2017 })
+     * @example
+     * dt.set({ hour: 8, minute: 30 })
+     * @example
+     * dt.set({ weekday: 5 })
+     * @example
+     * dt.set({ year: 2005, ordinal: 234 })
+     */
+    set(values: DateObjectUnits): DateTime;
+
+    /**
+     * Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar,
+     * accounting for DSTs and leap years along the way. Thus, `dt.plus({ hours: 24 })` may result in a different time than `dt.plus({ days: 1 })` if there's a DST shift in between.
+     *
+     * @param duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+     *
+     * @example
+     * DateTime.now().plus(123) //~> in 123 milliseconds
+     * @example
+     * DateTime.now().plus({ minutes: 15 }) //~> in 15 minutes
+     * @example
+     * DateTime.now().plus({ days: 1 }) //~> this time tomorrow
+     * @example
+     * DateTime.now().plus({ days: -1 }) //~> this time yesterday
+     * @example
+     * DateTime.now().plus({ hours: 3, minutes: 13 }) //~> in 3 hr, 13 min
+     * @example
+     * DateTime.now().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
+     */
+    plus(duration: DurationLike): DateTime;
+
+    /**
+     * See {@link DateTime.plus}
+     *
+     * @param duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
+     */
+    minus(duration: DurationLike): DateTime;
+
+    /**
+     * "Set" this DateTime to the beginning of a unit of time.
+     *
+     * @param unit - The unit to go to the beginning of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
+     *
+     * @example
+     * DateTime.local(2014, 3, 3).startOf('month').toISODate(); //=> '2014-03-01'
+     * @example
+     * DateTime.local(2014, 3, 3).startOf('year').toISODate(); //=> '2014-01-01'
+     * @example
+     * DateTime.local(2014, 3, 3).startOf('week').toISODate(); //=> '2014-03-03', weeks always start on Mondays
+     * @example
+     * DateTime.local(2014, 3, 3, 5, 30).startOf('day').toISOTime(); //=> '00:00.000-05:00'
+     * @example
+     * DateTime.local(2014, 3, 3, 5, 30).startOf('hour').toISOTime(); //=> '05:00:00.000-05:00'
+     */
+    startOf(unit: DateTimeUnit): DateTime;
+
+    /**
+     * "Set" this DateTime to the end (meaning the last millisecond) of a unit of time
+     *
+     * @param unit - The unit to go to the end of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
+     *
+     * @example
+     * DateTime.local(2014, 3, 3).endOf('month').toISO(); //=> '2014-03-31T23:59:59.999-05:00'
+     * @example
+     * DateTime.local(2014, 3, 3).endOf('year').toISO(); //=> '2014-12-31T23:59:59.999-05:00'
+     * @example
+     * DateTime.local(2014, 3, 3).endOf('week').toISO(); // => '2014-03-09T23:59:59.999-05:00', weeks start on Mondays
+     * @example
+     * DateTime.local(2014, 3, 3, 5, 30).endOf('day').toISO(); //=> '2014-03-03T23:59:59.999-05:00'
+     * @example
+     * DateTime.local(2014, 3, 3, 5, 30).endOf('hour').toISO(); //=> '2014-03-03T05:59:59.999-05:00'
+     */
+    endOf(unit: DateTimeUnit): DateTime;
+
+    // OUTPUT
+
+    /**
+     * Returns a string representation of this DateTime formatted according to the specified format string.
+     * **You may not want this.** See {@link DateTime.toLocaleString} for a more flexible formatting tool. For a table of tokens and their interpretations,
+     * see [here](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).
+     * Defaults to en-US if no locale has been specified, regardless of the system's locale.
+     *
+     * @param fmt - the format string
+     * @param opts - opts to override the configuration options on this DateTime
+     *
+     * @example
+     * DateTime.now().toFormat('yyyy LLL dd') //=> '2017 Apr 22'
+     * @example
+     * DateTime.now().setLocale('fr').toFormat('yyyy LLL dd') //=> '2017 avr. 22'
+     * @example
+     * DateTime.now().toFormat('yyyy LLL dd', { locale: "fr" }) //=> '2017 avr. 22'
+     * @example
+     * DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
+     */
+    toFormat(fmt: string, opts?: LocaleOptions): string;
+
+    /**
+     * Returns a localized string representing this date. Accepts the same options as the Intl.DateTimeFormat constructor and any presets defined by Luxon,
+     * such as `DateTime.DATE_FULL` or `DateTime.TIME_SIMPLE` of the DateTime in the assigned locale.
+     * Defaults to the system's locale if no locale has been specified
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+     *
+     * @param formatOpts - Intl.DateTimeFormat constructor options and configuration options
+     * @param opts - opts to override the configuration options on this DateTime
+     *
+     * @example
+     * DateTime.now().toLocaleString(); //=> 4/20/2017
+     * @example
+     * DateTime.now().setLocale('en-gb').toLocaleString(); //=> '20/04/2017'
+     * @example
+     * DateTime.now().toLocaleString({ locale: 'en-gb' }); //=> '20/04/2017'
+     * @example
+     * DateTime.now().toLocaleString(DateTime.DATE_FULL); //=> 'April 20, 2017'
+     * @example
+     * DateTime.now().toLocaleString(DateTime.TIME_SIMPLE); //=> '11:32 AM'
+     * @example
+     * DateTime.now().toLocaleString(DateTime.DATETIME_SHORT); //=> '4/20/2017, 11:32 AM'
+     * @example
+     * DateTime.now().toLocaleString({ weekday: 'long', month: 'long', day: '2-digit' }); //=> 'Thursday, April 20'
+     * @example
+     * DateTime.now().toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> 'Thu, Apr 20, 11:27 AM'
+     * @example
+     * DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }); //=> '11:32'
+     */
+    toLocaleString(formatOpts?: DateTimeFormatOptions, opts?: LocaleOptions): string;
+
+    /**
+     * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
+     * Defaults to the system's locale if no locale has been specified
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts
+     *
+     * @param opts - Intl.DateTimeFormat constructor options, same as `toLocaleString`.
+     *
+     * @example
+     * DateTime.now().toLocaleParts(); //=> [
+     *                                 //=>   { type: 'day', value: '25' },
+     *                                 //=>   { type: 'literal', value: '/' },
+     *                                 //=>   { type: 'month', value: '05' },
+     *                                 //=>   { type: 'literal', value: '/' },
+     *                                 //=>   { type: 'year', value: '1982' }
+     *                                 //=> ]
+     */
+    toLocaleParts(opts?: DateTimeFormatOptions): Intl.DateTimeFormatPart[];
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this DateTime
+     *
+     * @param opts - options
+     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they're 0. Defaults to false.
+     * @param opts.suppressSeconds - exclude seconds from the format if they're 0. Defaults to false.
+     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
+     * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
+     *
+     * @example
+     * DateTime.utc(1982, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
+     * @example
+     * DateTime.now().toISO() //=> '2017-04-22T20:47:05.335-04:00'
+     * @example
+     * DateTime.now().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
+     * @example
+     * DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
+     */
+    toISO(opts?: ToISOTimeOptions): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this DateTime's date component
+     *
+     * @param opts - options
+     * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
+     *
+     * @example
+     * DateTime.utc(1982, 5, 25).toISODate() //=> '1982-05-25'
+     * @example
+     * DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
+     */
+    toISODate(opts?: ToISODateOptions): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this DateTime's week date
+     *
+     * @example
+     * DateTime.utc(1982, 5, 25).toISOWeekDate() //=> '1982-W21-2'
+     */
+    toISOWeekDate(): string;
+
+    /**
+     * Returns an ISO 8601-compliant string representation of this DateTime's time component
+     *
+     * @param opts - options
+     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they're 0. Defaults to false.
+     * @param opts.suppressSeconds - exclude seconds from the format if they're 0. Defaults to false.
+     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
+     * @param opts.includePrefix - include the `T` prefix. Defaults to false.
+     * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
+     *
+     * @example
+     * DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime() //=> '07:34:19.361Z'
+     * @example
+     * DateTime.utc().set({ hour: 7, minute: 34, seconds: 0, milliseconds: 0 }).toISOTime({ suppressSeconds: true }) //=> '07:34Z'
+     * @example
+     * DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ format: 'basic' }) //=> '073419.361Z'
+     * @example
+     * DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
+     */
+    toISOTime(ops?: ToISOTimeOptions): string;
+
+    /**
+     * Returns an RFC 2822-compatible string representation of this DateTime, always in UTC
+     *
+     * @example
+     * DateTime.utc(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 +0000'
+     * @example
+     * DateTime.local(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 -0400'
+     */
+    toRFC2822(): string;
+
+    /**
+     * Returns a string representation of this DateTime appropriate for use in HTTP headers.
+     * Specifically, the string conforms to RFC 1123.
+     * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
+     *
+     * @example
+     * DateTime.utc(2014, 7, 13).toHTTP() //=> 'Sun, 13 Jul 2014 00:00:00 GMT'
+     * @example
+     * DateTime.utc(2014, 7, 13, 19).toHTTP() //=> 'Sun, 13 Jul 2014 19:00:00 GMT'
+     */
+    toHTTP(): string;
+
+    /**
+     * Returns a string representation of this DateTime appropriate for use in SQL Date
+     *
+     * @example
+     * DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
+     */
+    toSQLDate(): string;
+
+    /**
+     * Returns a string representation of this DateTime appropriate for use in SQL Time
+     *
+     * @param opts - options
+     * @param opts.includeZone - include the zone, such as 'America/New_York'. Overrides includeOffset. Defaults to false.
+     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
+     *
+     * @example
+     * DateTime.utc().toSQL() //=> '05:15:16.345'
+     * @example
+     * DateTime.now().toSQL() //=> '05:15:16.345 -04:00'
+     * @example
+     * DateTime.now().toSQL({ includeOffset: false }) //=> '05:15:16.345'
+     * @example
+     * DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
+     */
+    toSQLTime(opts?: ToSQLOptions): string;
+
+    /**
+     * Returns a string representation of this DateTime appropriate for use in SQL DateTime
+     *
+     * @param opts - options
+     * @param opts.includeZone - include the zone, such as 'America/New_York'. Overrides includeOffset. Defaults to false.
+     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
+     *
+     * @example
+     * DateTime.utc(2014, 7, 13).toSQL() //=> '2014-07-13 00:00:00.000 Z'
+     * @example
+     * DateTime.local(2014, 7, 13).toSQL() //=> '2014-07-13 00:00:00.000 -04:00'
+     * @example
+     * DateTime.local(2014, 7, 13).toSQL({ includeOffset: false }) //=> '2014-07-13 00:00:00.000'
+     * @example
+     * DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
+     */
+    toSQL(opts?: ToSQLOptions): string;
+
+    /**
+     * Returns a string representation of this DateTime appropriate for debugging
+     */
+    toString(): string;
+
+    /**
+     * Returns the epoch milliseconds of this DateTime. Alias of {@link DateTime.toMillis}
+     */
+    valueOf(): number;
+
+    /**
+     * Returns the epoch milliseconds of this DateTime.
+     */
+    toMillis(): number;
+
+    /**
+     * Returns the epoch seconds of this DateTime.
+     */
+    toSeconds(): number;
+
+    /**
+     * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
+     */
+    toJSON(): string;
+
+    /**
+     * Returns a BSON serializable equivalent to this DateTime.
+     */
+    toBSON(): Date;
+
+    /**
+     * Returns a JavaScript object with this DateTime's year, month, day, and so on.
+     *
+     * @param opts - options for generating the object
+     * @param opts.includeConfig - include configuration attributes in the output. Defaults to false.
+     *
+     * @example
+     * DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
+     */
+    toObject(opts?: {
+        /**
+         * Include configuration attributes in the output
+         * @defaultValue false
+         */
+        includeConfig?: boolean | undefined;
+    }): ToObjectOutput;
+
+    /**
+     * Returns a JavaScript Date equivalent to this DateTime.
+     */
+    toJSDate(): Date;
+
+    // COMPARE
+
+    /**
+     * Return the difference between two DateTimes as a Duration.
+     *
+     * @param otherDateTime - the DateTime to compare this one to
+     * @param unit- the unit or array of units (such as 'hours' or 'days') to include in the duration. Defaults to ['milliseconds'].
+     * @param opts - options that affect the creation of the Duration
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     *
+     * @example
+     * var i1 = DateTime.fromISO('1982-05-25T09:45'),
+     *     i2 = DateTime.fromISO('1983-10-14T10:30');
+     * i2.diff(i1).toObject() //=> { milliseconds: 43807500000 }
+     * i2.diff(i1, 'hours').toObject() //=> { hours: 12168.75 }
+     * i2.diff(i1, ['months', 'days']).toObject() //=> { months: 16, days: 19.03125 }
+     * i2.diff(i1, ['months', 'days', 'hours']).toObject() //=> { months: 16, days: 19, hours: 0.75 }
+     */
+    diff(otherDateTime: DateTime, unit?: DurationUnits, opts?: DiffOptions): Duration;
+
+    /**
+     * Return the difference between this DateTime and right now.
+     * See {@link DateTime.diff}
+     *
+     * @param unit - the unit or units units (such as 'hours' or 'days') to include in the duration. Defaults to ['milliseconds'].
+     * @param opts - options that affect the creation of the Duration
+     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     */
+    diffNow(unit?: DurationUnits, opts?: DiffOptions): Duration;
+
+    /**
+     * Return an Interval spanning between this DateTime and another DateTime
+     *
+     * @param otherDateTime - the other end point of the Interval
+     */
+    until(otherDateTime: DateTime): Interval;
+
+    /**
+     * Return whether this DateTime is in the same unit of time as another DateTime.
+     * Note that time zones are **ignored** in this comparison, which compares the **local** calendar time. Use {@link DateTime.setZone} to convert one of the dates if needed.
+     *
+     * @param otherDateTime - the other DateTime
+     * @param unit - the unit of time to check sameness on
+     *
+     * @example
+     * DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
+     */
+    hasSame(otherDateTime: DateTime, unit: DateTimeUnit): boolean;
+
+    /**
+     * Equality check
+     * Two DateTimes are equal iff they represent the same millisecond, have the same zone and location, and are both valid.
+     * To compare just the millisecond values, use `+dt1 === +dt2`.
+     *
+     * @param other - the other DateTime
+     */
+    equals(other: DateTime): boolean;
+
+    /**
+     * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
+     * platform supports Intl.RelativeTimeFormat. Rounds down by default.
+     *
+     * @param options - options that affect the output
+     * @param options.base - the DateTime to use as the basis to which this time is compared. Defaults to now.
+     * @param options.style - the style of units, must be "long", "short", or "narrow". Defaults to long.
+     * @param options.unit - use a specific unit or array of units; if omitted, or an array, the method will pick the best unit.
+     * Use an array or one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
+     * @param options.round - whether to round the numbers in the output. Defaults to true.
+     * @param options.padding - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false}
+     * because the decimal output will include the padding. Defaults to 0.
+     * @param options.locale - override the locale of this DateTime
+     * @param options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
+     *
+     * @example
+     * DateTime.now().plus({ days: 1 }).toRelative() //=> "in 1 day"
+     * @example
+     * DateTime.now().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
+     * @example
+     * DateTime.now().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
+     * @example
+     * DateTime.now().minus({ days: 2 }).toRelative() //=> "2 days ago"
+     * @example
+     * DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
+     * @example
+     * DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
+     */
+    toRelative(options?: ToRelativeOptions): string | null;
+
+    /**
+     * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
+     * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
+     *
+     * @param options - options that affect the output
+     * @param options.base - the DateTime to use as the basis to which this time is compared. Defaults to now.
+     * @param options.locale - override the locale of this DateTime
+     * @param options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", or "days"
+     * @param options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
+     *
+     * @example
+     * DateTime.now().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"
+     * @example
+     * DateTime.now().setLocale("es").plus({ days: 1 }).toRelative() //=> ""mañana"
+     * @example
+     * DateTime.now().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
+     * @example
+     * DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
+     */
+    toRelativeCalendar(options?: ToRelativeCalendarOptions): string | null;
+
+    /**
+     * Return the min of several date times
+     *
+     * @param dateTimes - the DateTimes from which to choose the minimum
+     */
+    static min(...dateTimes: DateTime[]): DateTime;
+
+    /**
+     * Return the max of several date times
+     *
+     * @param dateTimes - the DateTimes from which to choose the maximum
+     */
+    static max(...dateTimes: DateTime[]): DateTime;
+
+    // MISC
+
+    /**
+     * Explain how a string would be parsed by fromFormat()
+     *
+     * @param text - the string to parse
+     * @param fmt - the format the string is expected to be in (see description)
+     * @param options - options taken by fromFormat()
+     */
+    static fromFormatExplain(text: string, fmt: string, options?: DateTimeOptions): ExplainedFormat;
+
+    /**
+     * @deprecated use fromFormatExplain instead
+     */
+    static fromStringExplain(text: string, fmt: string, options?: DateTimeOptions): ExplainedFormat;
+
+    // FORMAT PRESETS
+
+    /**
+     * {@link DateTime.toLocaleString} format like 10/14/1983
+     */
+    static get DATE_SHORT(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Oct 14, 1983'
+     */
+    static get DATE_MED(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Fri, Oct 14, 1983'
+     */
+    static get DATE_MED_WITH_WEEKDAY(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'October 14, 1983'
+     */
+    static get DATE_FULL(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Tuesday, October 14, 1983'
+     */
+    static get DATE_HUGE(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30 AM'. Only 12-hour if the locale is.
+     */
+    static get TIME_SIMPLE(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23 AM'. Only 12-hour if the locale is.
+     */
+    static get TIME_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23 AM EDT'. Only 12-hour if the locale is.
+     */
+    static get TIME_WITH_SHORT_OFFSET(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23 AM Eastern Daylight Time'. Only 12-hour if the locale is.
+     */
+    static get TIME_WITH_LONG_OFFSET(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30', always 24-hour.
+     */
+    static get TIME_24_SIMPLE(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23', always 24-hour.
+     */
+    static get TIME_24_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23 EDT', always 24-hour.
+     */
+    static get TIME_24_WITH_SHORT_OFFSET(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '09:30:23 Eastern Daylight Time', always 24-hour.
+     */
+    static get TIME_24_WITH_LONG_OFFSET(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '10/14/1983, 9:30 AM'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_SHORT(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like '10/14/1983, 9:30:33 AM'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_SHORT_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Oct 14, 1983, 9:30 AM'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_MED(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Oct 14, 1983, 9:30:33 AM'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_MED_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Fri, 14 Oct 1983, 9:30 AM'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_MED_WITH_WEEKDAY(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'October 14, 1983, 9:30 AM EDT'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_FULL(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'October 14, 1983, 9:30:33 AM EDT'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_FULL_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Friday, October 14, 1983, 9:30 AM Eastern Daylight Time'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_HUGE(): Intl.DateTimeFormatOptions;
+
+    /**
+     * {@link DateTime.toLocaleString} format like 'Friday, October 14, 1983, 9:30:33 AM Eastern Daylight Time'. Only 12-hour if the locale is.
+     */
+    static get DATETIME_HUGE_WITH_SECONDS(): Intl.DateTimeFormatOptions;
+}
+
+declare type DateTimeClass = typeof DateTime;
+// End Luxon Types
+
+
 declare global {
 
     /**
@@ -3246,6 +6115,35 @@ declare global {
      * The links that this bot has to other bots.
      */
     const links: BotLinks;
+
+    /**
+     * A DateTime is an immutable data structure representing a specific date and time and accompanying methods.
+     * It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
+     *
+     * A DateTime comprises of:
+     * * A timestamp. Each DateTime instance refers to a specific millisecond of the Unix epoch.
+     * * A time zone. Each instance is considered in the context of a specific zone (by default the local system's zone).
+     * * Configuration properties that effect how output strings are formatted, such as `locale`, `numberingSystem`, and `outputCalendar`.
+     *
+     * Here is a brief overview of the most commonly used functionality it provides:
+     *
+     * * **Creation**: To create a DateTime from its components, use one of its factory class methods: {@link DateTimeClass.local}, {@link DateTimeClass.utc}, and (most flexibly) {@link DateTimeClass.fromObject}.
+     * To create one from a standard string format, use {@link DateTimeClass.fromISO}, {@link DateTimeClass.fromHTTP}, and {@link DateTimeClass.fromRFC2822}.
+     * To create one from a custom string format, use {@link DateTimeClass.fromFormat}. To create one from a native JS date, use {@link DateTimeClass.fromJSDate}.
+     * * **Gregorian calendar and time**: To examine the Gregorian properties of a DateTimeClass individually (i.e as opposed to collectively through {@link DateTimeClass#toObject}), use the {@link DateTimeClass#year},
+     * {@link DateTimeClass#month}, {@link DateTimeClass#day}, {@link DateTimeClass#hour}, {@link DateTimeClass#minute}, {@link DateTimeClass#second}, {@link DateTimeClass#millisecond} accessors.
+     * * **Week calendar**: For ISO week calendar attributes, see the {@link DateTimeClass#weekYear}, {@link DateTimeClass#weekNumber}, and {@link DateTimeClass#weekday} accessors.
+     * * **Configuration** See the {@link DateTimeClass#locale} and {@link DateTimeClass#numberingSystem} accessors.
+     * * **Transformation**: To transform the DateTimeClass into other DateTimeClasss, use {@link DateTimeClass#set}, {@link DateTimeClass#reconfigure}, {@link DateTimeClass#setZone}, {@link DateTimeClass#setLocale},
+     * {@link DateTimeClass.plus}, {@link DateTimeClass#minus}, {@link DateTimeClass#endOf}, {@link DateTimeClass#startOf}, {@link DateTimeClass#toUTC}, and {@link DateTimeClass#toLocal}.
+     * * **Output**: To convert the DateTimeClass to other representations, use the {@link DateTimeClass#toRelative}, {@link DateTimeClass#toRelativeCalendar}, {@link DateTimeClass#toJSON}, {@link DateTimeClass#toISO},
+     * {@link DateTimeClass#toHTTP}, {@link DateTimeClass#toObject}, {@link DateTimeClass#toRFC2822}, {@link DateTimeClass#toString}, {@link DateTimeClass#toLocaleString}, {@link DateTimeClass#toFormat},
+     * {@link DateTimeClass#toMillis} and {@link DateTimeClass#toJSDate}.
+     *
+     * There's plenty others documented below. In addition, for more information on subtler topics
+     * like internationalization, time zones, alternative calendars, validity, and so on, see the external documentation.
+     */
+    const DateTime: DateTimeClass;
 
     /**
      * Creates a new bot and returns it.
@@ -3369,6 +6267,13 @@ declare global {
      * @param idMap The map of old IDs to new IDs that should be used.
      */
     function updateBotLinks(bot: Bot, idMap: Map<string, string | Bot> | { [id: string]: string | Bot }): void;
+
+    /**
+     * Parses the given value into a date time object.
+     * Returns null if the value could not be parsed into a date time.
+     * @param value The value to parse.
+     */
+    function getDateTime(value: unknown): DateTime;
 
     /**
      * Asks every bot in the inst to run the given action.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -349,7 +349,7 @@ export interface CreateCertificateOptions {
  */
 export interface CreateCertificateAction
     extends AsyncAction,
-        CreateCertificateOptions {
+    CreateCertificateOptions {
     type: 'create_certificate';
 }
 
@@ -703,7 +703,7 @@ declare interface HideHtmlAction extends Action {
 /**
  * Options for the os.tweenTo(), os.moveTo(), and os.focusOn() actions.
  */
- export interface FocusOnOptions {
+export interface FocusOnOptions {
     /*
      * The zoom value to use.
      */
@@ -720,7 +720,7 @@ declare interface HideHtmlAction extends Action {
          * Whether to normalize the rotation values to between 0 and 2*PI.
          * Defaults to true. Setting this to false can be useful for rotating around a bot multiple times.
          */
-         normalize?: boolean;
+        normalize?: boolean;
     };
 
     /**
@@ -733,13 +733,13 @@ declare interface HideHtmlAction extends Action {
      * The type of easing to use.
      * If not specified then "quadratic" "inout" will be used.
      */
-     easing?: EaseType | Easing;
+    easing?: EaseType | Easing;
 
-     /**
-      * The portal that the bot should be focused in.
-      * If not specified, then the bot will be focused in all supported portals. (bot, mini and menu)
-      */
-     portal?: PortalType;
+    /**
+     * The portal that the bot should be focused in.
+     * If not specified, then the bot will be focused in all supported portals. (bot, mini and menu)
+     */
+    portal?: PortalType;
 }
 
 /**
@@ -757,7 +757,7 @@ export interface FocusOnBotAction extends AsyncAction, FocusOnOptions {
 /**
  * An event that is used to focus the camera on a specific position.
  */
- export interface FocusOnPositionAction extends AsyncAction, FocusOnOptions {
+export interface FocusOnPositionAction extends AsyncAction, FocusOnOptions {
     type: 'focus_on_position';
 
     /**
@@ -876,7 +876,7 @@ declare interface ShowBarcodeAction extends Action {
 /**
  * An event that is used to show or hide an image classifier on screen.
  */
- export interface OpenImageClassifierAction extends AsyncAction {
+export interface OpenImageClassifierAction extends AsyncAction {
     type: 'show_image_classifier';
 
     /**
@@ -1460,7 +1460,7 @@ declare interface ShowChatBarAction {
     /**
      * The color to use for the foreground (text).
      */
-     foregroundColor?: string;
+    foregroundColor?: string;
 }
 
 /**
@@ -1485,12 +1485,12 @@ declare interface ShowChatOptions {
     /**
      * The color to use for the background.
      */
-     backgroundColor?: string;
+    backgroundColor?: string;
 
-     /**
-     * The color to use for the foreground (text).
-     */
-      foregroundColor?: string;
+    /**
+    * The color to use for the foreground (text).
+    */
+    foregroundColor?: string;
 }
 
 /**
@@ -1813,7 +1813,7 @@ declare interface VRSupportedAction extends AsyncAction {
 /**
  * Defines an event that enables POV on the device.
  */
- declare interface EnablePOVAction {
+declare interface EnablePOVAction {
     type: 'enable_pov';
 
     /**
@@ -1830,7 +1830,7 @@ declare interface VRSupportedAction extends AsyncAction {
 /**
  * An event that is used to send a command to the Jitsi Meet API.
  */
- declare interface MeetCommandAction{
+declare interface MeetCommandAction {
     type: 'meet_command',
 
     /**
@@ -1907,7 +1907,7 @@ declare interface ShareAction extends AsyncAction, ShareOptions {
 /**
  * An event that is used to show or hide the circle wipe.
  */
- declare interface OpenCircleWipeAction extends AsyncAction {
+declare interface OpenCircleWipeAction extends AsyncAction {
     type: 'show_circle_wipe';
 
     /**
@@ -1924,7 +1924,7 @@ declare interface ShareAction extends AsyncAction, ShareOptions {
 /**
  * The options for the circle wipe.
  */
- declare interface OpenCircleWipeOptions {
+declare interface OpenCircleWipeOptions {
     /**
      * The duration of this half of the circle wipe animation in seconds.
      */
@@ -1939,7 +1939,7 @@ declare interface ShareAction extends AsyncAction, ShareOptions {
 /**
  * An event that is used to add some snap points for a drag operation.
  */
- declare interface AddDropSnapTargetsAction extends Action {
+declare interface AddDropSnapTargetsAction extends Action {
     type: 'add_drop_snap_targets';
 
     /**
@@ -1958,7 +1958,7 @@ declare interface ShareAction extends AsyncAction, ShareOptions {
  * Defines an interface that represents a snap point.
  * That is, a point in 3D space with an associated snap distance.
  */
- declare interface SnapPoint {
+declare interface SnapPoint {
     /**
      * The 3D position for the point.
      */
@@ -1974,7 +1974,7 @@ declare interface ShareAction extends AsyncAction, ShareOptions {
  * Defines an interface that represents a snap axis.
  * That is, a ray in 3D space with an associated snap distance.
  */
- export interface SnapAxis {
+export interface SnapAxis {
     /**
      * The 3D direction that the axis ray travels along.
      */
@@ -2004,70 +2004,70 @@ declare type SnapTarget = 'ground' | 'grid' | 'face' | 'bots' | SnapPoint | Snap
  * An event that is used to disable the default dragging logic (moving the bot) and enable
  * "onDragging" shouts and whispers.
  */
- export interface EnableCustomDraggingAction extends Action {
+export interface EnableCustomDraggingAction extends Action {
     type: 'enable_custom_dragging';
 }
 
 /**
  * The list of types of output that custom portals support.
  */
- export type CustomAppOutputType = 'html';
+export type CustomAppOutputType = 'html';
 
- /**
-  * the list of modes that custom portals support.
-  */
- export type CustomPortalOutputMode = 'push' | 'pull';
- 
- /**
-  * Defines an event that registers a custom portal.
-  */
- export interface RegisterCustomAppAction extends AsyncAction {
-     type: 'register_custom_app';
- 
-     /**
-      * The ID of the portal.
-      */
-     portalId: string;
- 
-     /**
-      * The ID of the bot that should be used to configure the portal.
-      */
-     botId: string;
- 
-     /**
-      * Options that should be used to configure the custom portal.
-      */
-     options: RegisterCustomAppOptions;
- }
- 
- /**
-  * The options for a register custom portal action.
-  */
- export interface RegisterCustomAppOptions {
-     /**
-      * The type of the custom portal.
-      * Used by CasualOS to determine how CasualOS should consume the rendered output and display it.
-      */
-     type: CustomAppOutputType;
- 
-     /**
-      * The kind of the custom portal.
-      * Used to make it easy to register multiple custom portals that rely on the same kind of renderers.
-      */
-     kind?: string;
- 
-     /**
-      * The output mode of the custom portal.
-      * Used to make it easy to control how a custom portal recieves updates.
-      */
-     outputMode?: CustomPortalOutputMode;
- }
+/**
+ * the list of modes that custom portals support.
+ */
+export type CustomPortalOutputMode = 'push' | 'pull';
+
+/**
+ * Defines an event that registers a custom portal.
+ */
+export interface RegisterCustomAppAction extends AsyncAction {
+    type: 'register_custom_app';
+
+    /**
+     * The ID of the portal.
+     */
+    portalId: string;
+
+    /**
+     * The ID of the bot that should be used to configure the portal.
+     */
+    botId: string;
+
+    /**
+     * Options that should be used to configure the custom portal.
+     */
+    options: RegisterCustomAppOptions;
+}
+
+/**
+ * The options for a register custom portal action.
+ */
+export interface RegisterCustomAppOptions {
+    /**
+     * The type of the custom portal.
+     * Used by CasualOS to determine how CasualOS should consume the rendered output and display it.
+     */
+    type: CustomAppOutputType;
+
+    /**
+     * The kind of the custom portal.
+     * Used to make it easy to register multiple custom portals that rely on the same kind of renderers.
+     */
+    kind?: string;
+
+    /**
+     * The output mode of the custom portal.
+     * Used to make it easy to control how a custom portal recieves updates.
+     */
+    outputMode?: CustomPortalOutputMode;
+}
 
 
 /**
  * Defines an event that notifies that the output of a portal should be updated with the given data.
  */
- export interface SetAppOutputAction extends Action {
+export interface SetAppOutputAction extends Action {
     type: 'set_app_output';
 
     /**
@@ -2093,7 +2093,7 @@ declare interface RegisterPrefixAction extends AsyncAction {
      * The prefix that should be registered.
      */
     prefix: string;
-    
+
     /**
      * The options that should be used for the prefix.
      */
@@ -2161,7 +2161,7 @@ declare interface RecordedFile {
      * Whether the file contains the recorded audio.
      */
     containsAudio: boolean;
-    
+
     /**
      * Whether the file contains the recorded video.
      */
@@ -2183,23 +2183,23 @@ declare interface SpeakTextOptions {
     /**
      * The pitch that the text should be spoken at.
      */
-     pitch?: number;
+    pitch?: number;
 
-     /**
-      * The rate that the text should be spoken at.
-      */
-     rate?: number;
- 
-     /**
-      * The name of the voice that the text should be spoken with.
-      */
-     voice?: string;
+    /**
+     * The rate that the text should be spoken at.
+     */
+    rate?: number;
+
+    /**
+     * The name of the voice that the text should be spoken with.
+     */
+    voice?: string;
 }
 
 /**
  * An event that is used to speak some text using the builtin text to speech engine.
  */
- declare interface SpeakTextAction extends AsyncAction, SpeakTextOptions {
+declare interface SpeakTextAction extends AsyncAction, SpeakTextOptions {
     type: 'speak_text';
 
     /**
@@ -2211,14 +2211,14 @@ declare interface SpeakTextOptions {
 /**
  * An event that is used to retrieve the synthetic voices that are supported by the current system.
  */
- declare interface GetVoicesAction extends AsyncAction {
+declare interface GetVoicesAction extends AsyncAction {
     type: 'get_voices';
 }
 
 /**
  * Defines an interface that represents a synthetic voice.
  */
- declare interface SyntheticVoice {
+declare interface SyntheticVoice {
     /**
      * Whether this voice is the default synthetic voice.
      */
@@ -2239,7 +2239,7 @@ declare interface SpeakTextOptions {
 /**
  * An event that is used to retrieve the current geolocation of the device.
  */
- declare interface GetGeolocationAction extends AsyncAction {
+declare interface GetGeolocationAction extends AsyncAction {
     type: 'get_geolocation';
 }
 
@@ -2250,46 +2250,46 @@ declare interface SuccessfulGeolocation {
      * The altitude that the device is near.
      * Null if the device does not support determining the altitude.
      */
-     altitude?: number;
+    altitude?: number;
 
-     /**
-      * The accuracy of the altitude in meters.
-      * Null if the device does not support altitude.
-      */
-     altitudeAccuracy?: number;
- 
-     /**
-      * The latitude that the device is near.
-      */
-     latitude: number;
- 
-     /**
-      * The longitude that the device is near.
-      */
-     longitude: number;
- 
-     /**
-      * The accuracy of the positional location (latitude and longitude) in meters.
-      */
-     positionalAccuracy: number;
- 
-     /**
-      * The heading of the device from north in radians.
-      * 0 is true north, Math.PI/2 is east, Math.PI is south and 3/2*Math.PI is west.
-      * This value is null if the device is unable to determine the heading.
-      */
-     heading: number;
- 
-     /**
-      * The speed that the device is moving in meters per second.
-      * Null if the device does not support calculating the speed.
-      */
-     speed: number;
- 
-     /**
-      * The timestamp of the geolocation result.
-      */
-     timestamp: number;
+    /**
+     * The accuracy of the altitude in meters.
+     * Null if the device does not support altitude.
+     */
+    altitudeAccuracy?: number;
+
+    /**
+     * The latitude that the device is near.
+     */
+    latitude: number;
+
+    /**
+     * The longitude that the device is near.
+     */
+    longitude: number;
+
+    /**
+     * The accuracy of the positional location (latitude and longitude) in meters.
+     */
+    positionalAccuracy: number;
+
+    /**
+     * The heading of the device from north in radians.
+     * 0 is true north, Math.PI/2 is east, Math.PI is south and 3/2*Math.PI is west.
+     * This value is null if the device is unable to determine the heading.
+     */
+    heading: number;
+
+    /**
+     * The speed that the device is moving in meters per second.
+     * Null if the device does not support calculating the speed.
+     */
+    speed: number;
+
+    /**
+     * The timestamp of the geolocation result.
+     */
+    timestamp: number;
 }
 
 declare interface UnsuccessfulGeolocation {
@@ -2298,12 +2298,12 @@ declare interface UnsuccessfulGeolocation {
     /**
      * The code of the error that occurred.
      */
-     errorCode?: 'permission_denied' | 'position_unavailable' | 'timeout' | 'unknown';
+    errorCode?: 'permission_denied' | 'position_unavailable' | 'timeout' | 'unknown';
 
-     /**
-      * The message of the error that occurred.
-      */
-     errorMessage?: string;
+    /**
+     * The message of the error that occurred.
+     */
+    errorMessage?: string;
 }
 
 /**
@@ -2616,7 +2616,7 @@ export interface GetRecordsResult {
     /**
      * Whether there are more records available to retrieve for the query.
      */
-     hasMoreRecords: boolean;
+    hasMoreRecords: boolean;
 
     /**
      * Gets the set page of records.
@@ -2662,7 +2662,7 @@ declare interface PartialBotsState {
  * - "remoteTempShared" means that the bot is temporary and shared with this device from a remote device.
  * - "certified" means that the bot is a certificate.
  */
- export type BotSpace =
+export type BotSpace =
     | 'shared'
     | 'local'
     | 'tempLocal'
@@ -2680,7 +2680,7 @@ declare interface PartialBotsState {
  * - "permanentGlobal" means that the record is permanent and available to anyone.
  * - "permanentRestricted" means that the record is permanent and available to a specific user.
  */
-export type RecordSpace = 
+export type RecordSpace =
     | 'tempGlobal'
     | 'tempRestricted'
     | 'permanentGlobal'
@@ -2836,7 +2836,7 @@ declare interface PerformanceStats {
 /**
  * Defines an interface for a function that provides HTML VDOM capabilities to bots.
  */
- export interface HtmlFunction {
+export interface HtmlFunction {
     (...args: any[]): any;
     h: (name: string | Function, props: any, ...children: any[]) => any;
     f: any;
@@ -2856,12 +2856,12 @@ export interface DebuggerOptions {
      * If false, then all scripts will be forced to be synchronous.
      * Defaults to false.
      */
-     allowAsynchronousScripts: boolean;
+    allowAsynchronousScripts: boolean;
 
-     /**
-     * The data that the configBot should be created from.
-     * Can be a mod or another bot.
-     */
+    /**
+    * The data that the configBot should be created from.
+    * Can be a mod or another bot.
+    */
     configBot: Bot | BotTags;
 }
 
@@ -2869,9 +2869,9 @@ export interface DebuggerOptions {
 /**
  * Defines an interface that represents the result of a "create public record key" operation.
  */
- export type CreatePublicRecordKeyResult =
- | CreatePublicRecordKeySuccess
- | CreatePublicRecordKeyFailure;
+export type CreatePublicRecordKeyResult =
+    | CreatePublicRecordKeySuccess
+    | CreatePublicRecordKeyFailure;
 
 /**
  * Defines an interface that represents a successful "create public record key" result.
@@ -2940,13 +2940,13 @@ export type ServerError = 'server_error';
  */
 export type NotSupportedError = 'not_supported';
 
- /**
-  * Defines an error that occurs when the user is not logged in but they are required to be in order to perform an action.
-  */
- export type NotLoggedInError = 'not_logged_in';
+/**
+ * Defines an error that occurs when the user is not logged in but they are required to be in order to perform an action.
+ */
+export type NotLoggedInError = 'not_logged_in';
 
 export type RecordNotFoundError = 'record_not_found';
- 
+
 
 
 export type RecordDataResult = RecordDataSuccess | RecordDataFailure;
@@ -2960,13 +2960,13 @@ export interface RecordDataSuccess {
 export interface RecordDataFailure {
     success: false;
     errorCode:
-        | ServerError
-        | NotLoggedInError
-        | InvalidRecordKey
-        | RecordNotFoundError
-        | NotSupportedError
-        | 'not_authorized'
-        | 'data_too_large';
+    | ServerError
+    | NotLoggedInError
+    | InvalidRecordKey
+    | RecordNotFoundError
+    | NotSupportedError
+    | 'not_authorized'
+    | 'data_too_large';
     errorMessage: string;
 }
 
@@ -3020,8 +3020,8 @@ export interface ListDataSuccess {
 export interface ListDataFailure {
     success: false;
     errorCode:
-        | ServerError
-        | NotSupportedError;
+    | ServerError
+    | NotSupportedError;
     errorMessage: string;
 }
 
@@ -3036,13 +3036,13 @@ export interface EraseDataSuccess {
 
 export interface EraseDataFailure {
     success: false;
-    errorCode: ServerError 
-        | NotLoggedInError
-        | InvalidRecordKey
-        | RecordNotFoundError
-        | NotSupportedError
-        | 'not_authorized'
-        | 'data_not_found';
+    errorCode: ServerError
+    | NotLoggedInError
+    | InvalidRecordKey
+    | RecordNotFoundError
+    | NotSupportedError
+    | 'not_authorized'
+    | 'data_not_found';
     errorMessage: string;
 }
 
@@ -3067,32 +3067,32 @@ export interface RecordFileSuccess {
 export interface RecordFileFailure {
     success: false;
     errorCode:
-        | ServerError
-        | NotLoggedInError
-        | InvalidRecordKey
-        | RecordNotFoundError
-        | 'file_already_exists'
-        | NotSupportedError
-        | 'invalid_file_data';
+    | ServerError
+    | NotLoggedInError
+    | InvalidRecordKey
+    | RecordNotFoundError
+    | 'file_already_exists'
+    | NotSupportedError
+    | 'invalid_file_data';
     errorMessage: string;
 }
 
 
 export type EraseFileResult = EraseFileSuccess | EraseFileFailure;
 export interface EraseFileSuccess {
-    success:  true;
+    success: true;
     recordName: string;
     fileName: string;
 }
 
 export interface EraseFileFailure {
     success: false;
-    errorCode: ServerError 
-        | InvalidRecordKey
-        | RecordNotFoundError
-        | NotLoggedInError
-        | NotSupportedError
-        | 'file_not_found';
+    errorCode: ServerError
+    | InvalidRecordKey
+    | RecordNotFoundError
+    | NotLoggedInError
+    | NotSupportedError
+    | 'file_not_found';
     errorMessage: string;
 }
 
@@ -3109,11 +3109,11 @@ export interface AddCountSuccess {
 export interface AddCountFailure {
     success: false;
     errorCode:
-        | ServerError
-        | NotLoggedInError
-        | InvalidRecordKey
-        | RecordNotFoundError
-        | NotSupportedError
+    | ServerError
+    | NotLoggedInError
+    | InvalidRecordKey
+    | RecordNotFoundError
+    | NotSupportedError
     errorMessage: string;
 }
 
@@ -3144,8 +3144,8 @@ export interface GetCountSuccess {
 export interface GetCountFailure {
     success: false;
     errorCode:
-        | ServerError
-        | NotSupportedError;
+    | ServerError
+    | NotSupportedError;
     errorMessage: string;
 }
 
@@ -3157,16 +3157,16 @@ export interface AudioRecordingOptions {
      */
     stream?: boolean;
 
-     /**
-      * The MIME type that should be produced.
-      * Defaults to a containerized format (audio/mp3, audio/webm, etc.) if not specified.
-      */
+    /**
+     * The MIME type that should be produced.
+     * Defaults to a containerized format (audio/mp3, audio/webm, etc.) if not specified.
+     */
     mimeType?: string;
- 
-     /**
-      * The number of samples per second (Hz) that audio/x-raw recordings should use.
-      * Defaults to 44100 if not specified.
-      */
+
+    /**
+     * The number of samples per second (Hz) that audio/x-raw recordings should use.
+     * Defaults to 44100 if not specified.
+     */
     sampleRate?: number;
 }
 
@@ -3377,7 +3377,7 @@ declare class FixedOffsetZone extends Zone {
 /**
  * A zone that failed to parse. You should never need to instantiate this.
  */
-declare class InvalidZone extends Zone {}
+declare class InvalidZone extends Zone { }
 
 /**
  * Represents the system zone for this JavaScript environment.
@@ -4391,46 +4391,46 @@ export type EraLength = StringUnitLength;
 export type NumberingSystem = Intl.DateTimeFormatOptions extends { numberingSystem?: infer T }
     ? T
     :
-          | 'arab'
-          | 'arabext'
-          | 'bali'
-          | 'beng'
-          | 'deva'
-          | 'fullwide'
-          | 'gujr'
-          | 'guru'
-          | 'hanidec'
-          | 'khmr'
-          | 'knda'
-          | 'laoo'
-          | 'latn'
-          | 'limb'
-          | 'mlym'
-          | 'mong'
-          | 'mymr'
-          | 'orya'
-          | 'tamldec'
-          | 'telu'
-          | 'thai'
-          | 'tibt';
+    | 'arab'
+    | 'arabext'
+    | 'bali'
+    | 'beng'
+    | 'deva'
+    | 'fullwide'
+    | 'gujr'
+    | 'guru'
+    | 'hanidec'
+    | 'khmr'
+    | 'knda'
+    | 'laoo'
+    | 'latn'
+    | 'limb'
+    | 'mlym'
+    | 'mong'
+    | 'mymr'
+    | 'orya'
+    | 'tamldec'
+    | 'telu'
+    | 'thai'
+    | 'tibt';
 
 export type CalendarSystem = Intl.DateTimeFormatOptions extends { calendar?: infer T }
     ? T
     :
-          | 'buddhist'
-          | 'chinese'
-          | 'coptic'
-          | 'ethioaa'
-          | 'ethiopic'
-          | 'gregory'
-          | 'hebrew'
-          | 'indian'
-          | 'islamic'
-          | 'islamicc'
-          | 'iso8601'
-          | 'japanese'
-          | 'persian'
-          | 'roc';
+    | 'buddhist'
+    | 'chinese'
+    | 'coptic'
+    | 'ethioaa'
+    | 'ethiopic'
+    | 'gregory'
+    | 'hebrew'
+    | 'indian'
+    | 'islamic'
+    | 'islamicc'
+    | 'iso8601'
+    | 'japanese'
+    | 'persian'
+    | 'roc';
 
 export type HourCycle = 'h11' | 'h12' | 'h23' | 'h24';
 
@@ -6246,12 +6246,12 @@ declare global {
      * @param eventNames The names of the events to shout.
      * @param arg The argument to shout.
      */
-     function priorityShout(eventNames: string[], arg?: any): any;
+    function priorityShout(eventNames: string[], arg?: any): any;
 
-     /**
-     * Creates a tag value that can be used to link to the given bots.
-     * @param bots The bots that the link should point to.
-     */
+    /**
+    * Creates a tag value that can be used to link to the given bots.
+    * @param bots The bots that the link should point to.
+    */
     function createBotLink(...bots: (Bot | string | (Bot | string)[])[]): string;
 
     /**
@@ -6399,12 +6399,12 @@ declare global {
      */
     function assert(condition: boolean, message?: string): void;
 
-     /**
-      * Asserts that the given values contain the same data.
-      * Throws an error if they are not equal.
-      * @param first The first value to test.
-      * @param second The second value to test.
-      */
+    /**
+     * Asserts that the given values contain the same data.
+     * Throws an error if they are not equal.
+     * @param first The first value to test.
+     * @param second The second value to test.
+     */
     function assertEqual(first: any, second: any): void;
 
     /**
@@ -6423,7 +6423,7 @@ declare global {
      * });
      */
     const web: Web;
-    
+
     /**
     * Creates a Universally Unique IDentifier (UUID).
     */
@@ -6435,25 +6435,25 @@ declare global {
      * @param tag The tag that should be animated.
      * @param options The options for the animation. If given null, then any running animations for the given tag will be canceled.
      */
-     function animateTag(bot: Bot | (Bot | string)[] | string, tag: string, options: AnimateTagFunctionOptions): Promise<void>;
+    function animateTag(bot: Bot | (Bot | string)[] | string, tag: string, options: AnimateTagFunctionOptions): Promise<void>;
 
-     /**
-      * Animates the given tags. Returns a promise when the animation is finished.
-      * @param bot The bot or list of bots that should be animated.
-      * @param options The options for the animation. fromValue should be an object which contains the starting tag values and toValue should be an object that contains the ending tag values.
-      */
-      function animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
-     /**
-      * Animates the given tag. Returns a promise when the animation is finished.
-      * @param bot The bot or list of bots that should be animated.
-      * @param tag The tag that should be animated.
-      * @param options The options for the animation.
-      */
-     function animateTag(
-         bot: Bot | (Bot | string)[] | string,
-         tagOrOptions: string | AnimateTagFunctionOptions,
-         options?: AnimateTagFunctionOptions
-     ): Promise<void>;
+    /**
+     * Animates the given tags. Returns a promise when the animation is finished.
+     * @param bot The bot or list of bots that should be animated.
+     * @param options The options for the animation. fromValue should be an object which contains the starting tag values and toValue should be an object that contains the ending tag values.
+     */
+    function animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
+    /**
+     * Animates the given tag. Returns a promise when the animation is finished.
+     * @param bot The bot or list of bots that should be animated.
+     * @param tag The tag that should be animated.
+     * @param options The options for the animation.
+     */
+    function animateTag(
+        bot: Bot | (Bot | string)[] | string,
+        tagOrOptions: string | AnimateTagFunctionOptions,
+        options?: AnimateTagFunctionOptions
+    ): Promise<void>;
 
     /**
      * Cancels the animations that are running on the given bot(s).
@@ -6840,7 +6840,7 @@ declare global {
      * @param bot The bot or bot ID.
      * @param dimension The dimension that the bot's position should be retrieved for.
      */
-     function getBotPosition(
+    function getBotPosition(
         bot: Bot | string,
         dimension: string
     ): Point3D;
@@ -6922,10 +6922,10 @@ interface Debugger {
      */
     getCommonActions(): BotAction[];
 
-     /**
-     * Gets the list of bot actions that have been performed by bots in this debugger.
-     * Bot actions are actions that directly create/destroy/update bots or bot tags.
-     */
+    /**
+    * Gets the list of bot actions that have been performed by bots in this debugger.
+    * Bot actions are actions that directly create/destroy/update bots or bot tags.
+    */
     getBotActions(): BotAction[];
 
     /**
@@ -6951,59 +6951,59 @@ interface Debugger {
      * ]);
      *
      */
-     create(...mods: Mod[]): Bot | Bot[];
+    create(...mods: Mod[]): Bot | Bot[];
 
-     /**
-      * Destroys the given bot, bot ID, or list of bots.
-      * @param bot The bot, bot ID, or list of bots to destroy.
-      */
-     destroy(bot: Bot | string | Bot[]): void;
- 
-     /**
-      * Removes tags from the given list of bots.
-      * @param bot The bot, bot ID, or list of bots that should have their matching tags removed.
-      * @param tagSection The tag section which should be removed from the bot(s). If given a string, then all the tags
-      *                   starting with the given name will be removed. If given a RegExp, then all the tags matching the regex will be removed.
-      *
-      * @example
-      * // Remove tags named starting with "abc" from the `this` bot.
-      * removeTags(this, "abc");
-      *
-      * @example
-      * // Remove tags named "hello" using a case-insensitive regex from the `this` bot.
-      * removeTags(this, /^hello$/gi);
-      *
-      */
-     removeTags(bot: Bot | Bot[], tagSection: string | RegExp): void;
- 
-     /**
-      * Renames the given original tag to the given new tag using the given bot or list of bots.
-      * @param bot The bot or list of bots that the tag should be renamed on.
-      * @param originalTag The original tag to rename.
-      * @param newTag The new tag name.
-      * 
-      * @example
-      * // Rename the "abc" tag to "def"
-      * renameTag(this, "abc", "def")
-      */
-     renameTag(bot: Bot | Bot[], originalTag: string, newTag: string): void;
- 
-     /**
-      * Gets the ID from the given bot.
-      * @param bot The bot or string.
-      */
-     getID(bot: Bot | string): string;
- 
-     /**
-      * Gets JSON for the given data.
-      * @param data The data.
-      */
-     getJSON(data: any): string;
+    /**
+     * Destroys the given bot, bot ID, or list of bots.
+     * @param bot The bot, bot ID, or list of bots to destroy.
+     */
+    destroy(bot: Bot | string | Bot[]): void;
 
-     /**
-     * Gets nicely formatted JSON for the given data.
+    /**
+     * Removes tags from the given list of bots.
+     * @param bot The bot, bot ID, or list of bots that should have their matching tags removed.
+     * @param tagSection The tag section which should be removed from the bot(s). If given a string, then all the tags
+     *                   starting with the given name will be removed. If given a RegExp, then all the tags matching the regex will be removed.
+     *
+     * @example
+     * // Remove tags named starting with "abc" from the `this` bot.
+     * removeTags(this, "abc");
+     *
+     * @example
+     * // Remove tags named "hello" using a case-insensitive regex from the `this` bot.
+     * removeTags(this, /^hello$/gi);
+     *
+     */
+    removeTags(bot: Bot | Bot[], tagSection: string | RegExp): void;
+
+    /**
+     * Renames the given original tag to the given new tag using the given bot or list of bots.
+     * @param bot The bot or list of bots that the tag should be renamed on.
+     * @param originalTag The original tag to rename.
+     * @param newTag The new tag name.
+     * 
+     * @example
+     * // Rename the "abc" tag to "def"
+     * renameTag(this, "abc", "def")
+     */
+    renameTag(bot: Bot | Bot[], originalTag: string, newTag: string): void;
+
+    /**
+     * Gets the ID from the given bot.
+     * @param bot The bot or string.
+     */
+    getID(bot: Bot | string): string;
+
+    /**
+     * Gets JSON for the given data.
      * @param data The data.
      */
+    getJSON(data: any): string;
+
+    /**
+    * Gets nicely formatted JSON for the given data.
+    * @param data The data.
+    */
     getFormattedJSON(data: any): string;
 
     /**
@@ -7028,10 +7028,10 @@ interface Debugger {
      */
     applyDiffToSnapshot(snapshot: BotsState, diff: PartialBotsState): BotsState;
 
-     /**
-     * Creates a tag value that can be used to link to the given bots.
-     * @param bots The bots that the link should point to.
-     */
+    /**
+    * Creates a tag value that can be used to link to the given bots.
+    * @param bots The bots that the link should point to.
+    */
     createBotLink(...bots: (Bot | string | (Bot | string)[])[]): string;
 
     /**
@@ -7040,114 +7040,114 @@ interface Debugger {
      */
     getBotLinks(bot: Bot): ParsedBotLink[];
 
-     /**
-     * Updates all the links in the given bot using the given ID map.
-     * Useful if you know that the links in the given bot are outdated and you know which IDs map to the new IDs.
-     * @param bot The bot to update.
-     * @param idMap The map of old IDs to new IDs that should be used.
-     */
+    /**
+    * Updates all the links in the given bot using the given ID map.
+    * Useful if you know that the links in the given bot are outdated and you know which IDs map to the new IDs.
+    * @param bot The bot to update.
+    * @param idMap The map of old IDs to new IDs that should be used.
+    */
     updateBotLinks(bot: Bot, idMap: Map<string, string | Bot> | { [id: string]: string | Bot }): void
 
-     /**
-      * Shouts the given events in order until a bot returns a result.
-      * Returns the result that was produced or undefined if no result was produced.
-      * @param eventNames The names of the events to shout.
-      * @param arg The argument to shout.
-      */
-    priorityShout(eventNames: string[], arg?: any): any;
- 
-     /**
-      * Asks every bot in the inst to run the given action.
-      * In effect, this is like shouting to a bunch of people in a room.
-      *
-      * @param name The event name.
-      * @param arg The optional argument to include in the shout.
-      * @returns Returns a list which contains the values returned from each script that was run for the shout.
-      *
-      * @example
-      * // Tell every bot to reset themselves.
-      * shout("reset()");
-      *
-      * @example
-      * // Ask every bot for its name.
-      * const names = shout("getName()");
-      *
-      * @example
-      * // Tell every bot say "Hi" to you.
-      * shout("sayHi()", "My Name");
-      */
-     shout(name: string, arg?: any): any[];
- 
-     /**
-      * Asks the given bots to run the given action.
-      * In effect, this is like whispering to a specific set of people in a room.
-      *
-      * @param bot The bot(s) to send the event to.
-      * @param eventName The name of the event to send.
-      * @param arg The optional argument to include.
-      * @returns Returns a list which contains the values returned from each script that was run for the shout.
-      *
-      * @example
-      * // Tell all the red bots to reset themselves.
-      * whisper(getBots("#color", "red"), "reset()");
-      *
-      * @example
-      * // Ask all the tall bots for their names.
-      * const names = whisper(getBots("scaleZ", height => height >= 2), "getName()");
-      *
-      * @example
-      * // Tell every friendly bot to say "Hi" to you.
-      * whisper(getBots("friendly", true), "sayHi()", "My Name");
-      */
-     whisper(
-         bot: (Bot | string)[] | Bot | string,
-         eventName: string,
-         arg?: any
-     ): any;
- 
-     /**
-      * Shouts the given event to every bot in every loaded simulation.
-      * @param eventName The name of the event to shout.
-      * @param arg The argument to shout. This gets passed as the `that` variable to the other scripts.
-      */
-     superShout(eventName: string, arg?: any): SuperShoutAction;
- 
-     /**
-      * Watches the given bot or list of bots for changes and calls the given callback when the bot is changed or destroyed.
-      * Returns a number that can be passed to clearWatchBot() to stop watching the bot.
-      * @param bot The bot or list of bots that should be watched for changes.
-      * @param callback The function that should be called when the bot is changed or destroyed.
-      */
-     watchBot(bot: (Bot | string)[] | Bot | string, callback: () => void): number;
- 
-     /**
-      * Cancels watching a bot using the given ID number that was returned from watchBot().
-      * @param watchId The ID number that should be used to cancel the watch callbacks.
-      */
-     clearWatchBot(watchId: number): void;
- 
-     /**
-      * Watches the given portal for when bots are added and removed from it and calls the given function.
-      * Returns a number that can be passed to clearWatchPortal() to stop watching the portal.
-      * @param portalId The ID of the portal to watch.
-      * @param callback The function that should be called when the portal changes.
-      */
-     watchPortal(portalId: string, callback: () => void): number;
- 
-     /**
-      * Cancels watching a portal using the given ID number that was returned from watchPortal().
-      * @param watchId The ID number that should be used to cancel the watch callbacks.
-      */
-     clearWatchPortal(watchId: number): void;
-
-     /**
-     * Asserts that the given condition is true.
-     * Throws an error if the condition is not true.
-     * @param condition The condition to check.
-     * @param message The message to use in the error if the condition is not true.
+    /**
+     * Shouts the given events in order until a bot returns a result.
+     * Returns the result that was produced or undefined if no result was produced.
+     * @param eventNames The names of the events to shout.
+     * @param arg The argument to shout.
      */
-     assert(condition: boolean, message?: string): void;
- 
+    priorityShout(eventNames: string[], arg?: any): any;
+
+    /**
+     * Asks every bot in the inst to run the given action.
+     * In effect, this is like shouting to a bunch of people in a room.
+     *
+     * @param name The event name.
+     * @param arg The optional argument to include in the shout.
+     * @returns Returns a list which contains the values returned from each script that was run for the shout.
+     *
+     * @example
+     * // Tell every bot to reset themselves.
+     * shout("reset()");
+     *
+     * @example
+     * // Ask every bot for its name.
+     * const names = shout("getName()");
+     *
+     * @example
+     * // Tell every bot say "Hi" to you.
+     * shout("sayHi()", "My Name");
+     */
+    shout(name: string, arg?: any): any[];
+
+    /**
+     * Asks the given bots to run the given action.
+     * In effect, this is like whispering to a specific set of people in a room.
+     *
+     * @param bot The bot(s) to send the event to.
+     * @param eventName The name of the event to send.
+     * @param arg The optional argument to include.
+     * @returns Returns a list which contains the values returned from each script that was run for the shout.
+     *
+     * @example
+     * // Tell all the red bots to reset themselves.
+     * whisper(getBots("#color", "red"), "reset()");
+     *
+     * @example
+     * // Ask all the tall bots for their names.
+     * const names = whisper(getBots("scaleZ", height => height >= 2), "getName()");
+     *
+     * @example
+     * // Tell every friendly bot to say "Hi" to you.
+     * whisper(getBots("friendly", true), "sayHi()", "My Name");
+     */
+    whisper(
+        bot: (Bot | string)[] | Bot | string,
+        eventName: string,
+        arg?: any
+    ): any;
+
+    /**
+     * Shouts the given event to every bot in every loaded simulation.
+     * @param eventName The name of the event to shout.
+     * @param arg The argument to shout. This gets passed as the `that` variable to the other scripts.
+     */
+    superShout(eventName: string, arg?: any): SuperShoutAction;
+
+    /**
+     * Watches the given bot or list of bots for changes and calls the given callback when the bot is changed or destroyed.
+     * Returns a number that can be passed to clearWatchBot() to stop watching the bot.
+     * @param bot The bot or list of bots that should be watched for changes.
+     * @param callback The function that should be called when the bot is changed or destroyed.
+     */
+    watchBot(bot: (Bot | string)[] | Bot | string, callback: () => void): number;
+
+    /**
+     * Cancels watching a bot using the given ID number that was returned from watchBot().
+     * @param watchId The ID number that should be used to cancel the watch callbacks.
+     */
+    clearWatchBot(watchId: number): void;
+
+    /**
+     * Watches the given portal for when bots are added and removed from it and calls the given function.
+     * Returns a number that can be passed to clearWatchPortal() to stop watching the portal.
+     * @param portalId The ID of the portal to watch.
+     * @param callback The function that should be called when the portal changes.
+     */
+    watchPortal(portalId: string, callback: () => void): number;
+
+    /**
+     * Cancels watching a portal using the given ID number that was returned from watchPortal().
+     * @param watchId The ID number that should be used to cancel the watch callbacks.
+     */
+    clearWatchPortal(watchId: number): void;
+
+    /**
+    * Asserts that the given condition is true.
+    * Throws an error if the condition is not true.
+    * @param condition The condition to check.
+    * @param message The message to use in the error if the condition is not true.
+    */
+    assert(condition: boolean, message?: string): void;
+
     /**
      * Asserts that the given values contain the same data.
      * Throws an error if they are not equal.
@@ -7156,507 +7156,507 @@ interface Debugger {
      */
     assertEqual(received: any, expected: any): void;
 
-     /**
-      * Sends a web request based on the given options.
-      * @param options The options that specify where and what to send in the web request.
-      *
-      * @example
-      * // Send a HTTP POST request to https://www.example.com/api/createThing
-      * webhook({
-      *   method: 'POST',
-      *   url: 'https://www.example.com/api/createThing',
-      *   data: {
-      *     hello: 'world'
-      *   },
-      *   responseShout: 'requestFinished'
-      * });
-      */
-     web: Web;
-     
-     /**
-     * Creates a Universally Unique IDentifier (UUID).
+    /**
+     * Sends a web request based on the given options.
+     * @param options The options that specify where and what to send in the web request.
+     *
+     * @example
+     * // Send a HTTP POST request to https://www.example.com/api/createThing
+     * webhook({
+     *   method: 'POST',
+     *   url: 'https://www.example.com/api/createThing',
+     *   data: {
+     *     hello: 'world'
+     *   },
+     *   responseShout: 'requestFinished'
+     * });
      */
-     uuid(): string;
- 
-     /**
-      * Animates the given tag. Returns a promise when the animation is finished.
-      * @param bot The bot or list of bots that should be animated.
-      * @param tag The tag that should be animated.
-      * @param options The options for the animation. If given null, then any running animations for the given tag will be canceled.
-      */
-      animateTag(bot: Bot | (Bot | string)[] | string, tag: string, options: AnimateTagFunctionOptions): Promise<void>;
- 
-      /**
-       * Animates the given tags. Returns a promise when the animation is finished.
-       * @param bot The bot or list of bots that should be animated.
-       * @param options The options for the animation. fromValue should be an object which contains the starting tag values and toValue should be an object that contains the ending tag values.
-       */
-      animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
-      /**
-       * Animates the given tag. Returns a promise when the animation is finished.
-       * @param bot The bot or list of bots that should be animated.
-       * @param tag The tag that should be animated.
-       * @param options The options for the animation.
-       */
-      animateTag(
-          bot: Bot | (Bot | string)[] | string,
-          tagOrOptions: string | AnimateTagFunctionOptions,
-          options?: AnimateTagFunctionOptions
-      ): Promise<void>;
- 
-     /**
-      * Cancels the animations that are running on the given bot(s).
-      * @param bot The bot or list of bots that should cancel their animations.
-      * @param tag The tag that the animations should be canceld for. If omitted then all tags will be canceled.
-      */
-     clearAnimations(bot: Bot | (Bot | string)[] | string, tag?: string): void;
- 
-     /**
-      * Sends the given operation to all the devices that matches the given selector.
-      * In effect, this allows users to send each other events directly without having to edit tags.
-      *
-      * Note that currently, devices will only accept events sent from the inst.
-      *
-      * @param event The event that should be executed in the remote session(s).
-      * @param selector The selector that indicates where the event should be sent. The event will be sent to all sessions that match the selector.
-      *                 For example, specifying a username means that the event will be sent to every active session that the user has open.
-      *                 If a selector is not specified, then the event is sent to the inst.
-      * @param allowBatching Whether to allow batching this remote event with other remote events. This will preserve ordering between remote events but may not preserve ordering
-      *                      with respect to other events. Defaults to true.
-      *
-      * @example
-      * // Send a toast to all sessions for the username "bob"
-      * remote(os.toast("Hello, Bob!"), { username: "bob" });
-      */
-     remote(
-         event: BotAction,
-         selector?: SessionSelector | string | (SessionSelector | string)[],
-         allowBatching?: boolean
-     ): RemoteAction | RemoteAction[];
- 
-     /**
-      * Sends an event to the given remote or list of remotes.
-      * The other remotes will recieve an onRemoteData shout for this whisper.
-      * 
-      * In effect, this allows remotes to communicate with each other by sending arbitrary events.
-      * 
-      * @param remoteId The ID of the other remote or remotes to whisper to.
-      * @param name The name of the event.
-      * @param arg The optional argument to include in the event.
-      */
-     sendRemoteData(remoteId: string | string[], name: string, arg?: any): RemoteAction | RemoteAction[];
- 
-     /**
-      * Gets the first bot which matches all of the given filters.
-      * @param filters The filter functions that the bot needs to match.
-      * @returns The first bot that matches all the given filters.
-      *
-      * @example
-      * // Get a bot by the "name" tag.
-      * let bot = getBot(byTag("name", "The bot's name"));
-      */
-     getBot(...filters: BotFilterFunction[]): Bot;
- 
-     /**
-      * Gets the first bot ordered by ID which matches the given tag and filter.
-      * @param tag The tag the bot should match.
-      * @param filter The optional value or filter the bot should match.
-      *
-      * @example
-      * // Get a bot with the "name" tag.
-      * // Shorthand for getBot(byTag("name"))
-      * let bot = getBot("name");
-      *
-      * @example
-      * // Get a bot by the "name" tag.
-      * // Shorthand for getBot(byTag("name", "The bot's name"))
-      * let bot = getBot("name", "The bot's name");
-      *
-      * @example
-      * // Get a bot where the "name" tag starts with the letter "N".
-      * // Shorthand for getBot(byTag("name", name => name.startsWith("N")))
-      * let bot = getBot("name", name => name.startsWith("N"));
-      */
-     getBot(tag: string, filter?: any | TagFilter): Bot;
- 
-     /**
-      * Gets the first bot ordered by ID.
-      * @returns The bot with the first ID when sorted alphebetically.
-      *
-      * @example
-      * let firstBot = getBot();
-      */
-     getBot(): Bot;
- 
-     /**
-      * Gets the list of bots which match all of the given filters.
-      * @param filters The filter functions that the bots need to match.
-      * @returns A list of bots that match all the given filters. If no bots match then an empty list is returned.
-      *
-      * @example
-      * // Get all the bots that are red.
-      * let bots = getBots(byTag("color", "red"));
-      */
-     getBots(...filters: ((bot: Bot) => boolean)[]): Bot[];
- 
-     /**
-      * Gets the list of bots that have the given tag matching the given filter value.
-      * @param tag The tag the bot should match.
-      * @param filter The value or filter the bot should match.
-      *
-      * @example
-      * // Get all the bots that are red.
-      * // Shorthand for getBots(byTag("color", "red"))
-      * let bots = getBots("color", "red");
-      */
-     getBots(tag: string, filter?: any | TagFilter): Bot[];
- 
-     /**
-      * Gets a list of all the bots.
-      *
-      * @example
-      * // Gets all the bots in the inst.
-      * let bots = getBots();
-      */
-     getBots(): Bot[];
- 
-     /**
-      * Gets the list of tag values from bots that have the given tag.
-      * @param tag The tag.
-      * @param filter THe optional filter to use for the values.
-      */
-     getBotTagValues(tag: string, filter?: TagFilter): any[];
- 
-     /**
-      * Creates a filter function that checks whether bots have the given tag and value.
-      * @param tag The tag to check.
-      * @param filter The value or filter that the tag should match.
-      *
-      * @example
-      * // Find all the bots with a "name" of "bob".
-      * let bobs = getBots(byTag("name", "bob"));
-      *
-      * @example
-      * // Find all bots with a height larger than 2.
-      * let bots = getBots(byTag("height", height => height > 2));
-      *
-      * @example
-      * // Find all the bots with the "test" tag.
-      * let bots = getBots(byTag("test"));
-      */
-     byTag(tag: string, filter?: TagFilter): BotFilterFunction;
- 
-     /**
-      * Creates a filter function that checks whether bots have the given ID.
-      * @param id The ID to check for.
-      * 
-      * @example
-      * // Find all the bots with the ID "bob".
-      * let bobs = getBots(byId("bob"));
-      */
-     byID(id: string): IDRecordFilter;
- 
-     /**
-      * Creates a filter function that checks whether bots match the given mod.
-      * @param mod The mod that bots should be checked against.
-      *
-      * @example
-      * // Find all the bots with a height set to 1 and color set to "red".
-      * let bots = getBots(byMod({
-      *      "color": "red",
-      *      height: 1
-      * }));
-      */
-     byMod(mod: Mod): BotFilterFunction;
- 
-     /**
-      * Creates a filter function that checks whether bots are in the given dimension.
-      * @param dimension The dimension to check.
-      * @returns A function that returns true if the given bot is in the dimension and false if it is not.
-      *
-      * @example
-      * // Find all the bots in the "test" dimension.
-      * let bots = getBots(inDimension("test"));
-      */
-     inDimension(dimension: string): BotFilterFunction;
- 
-     /**
-      * Creates a filter function that checks whether bots are at the given position in the given dimension.
-      * @param dimension The dimension that the bots should be in.
-      * @param x The X position in the dimension that the bots should be at.
-      * @param y The Y position in the dimension that the bots should be at.
-      * @returns A function that returns true if the given bot is at the given position and false if it is not.
-      *
-      * @example
-      * // Find all the bots at (1, 2) in the "test" dimension.
-      * let bots = getBots(atPosition("test", 1, 2));
-      */
-     atPosition(
-         dimension: string,
-         x: number,
-         y: number
-     ): BotFilterFunction;
- 
-     /**
-      * Creates a filter function that checks whether bots were created by the given bot.
-      * @param bot The bot to determine weather the bots have been created by it or not.
-      * @returns A function that returns true if the bot was created by the given bot.
-      *
-      * @example
-      * // Find all the bots created by the yellow bot.
-      * let bots = getBots(byCreator(getBot('color','yellow')));
-      */
-     byCreator(bot: Bot | string): BotFilterFunction;
- 
-     /**
-      * Creates a filter function that checks whether bots are in the same stack as the given bot.
-      * @param bot The bot that other bots should be checked against.
-      * @param dimension The dimension that other bots should be checked in.
-      * @returns A function that returns true if the given bot is in the same stack as the original bot.
-      *
-      * @example
-      * // Find all bots in the same stack as `this` in the "test" dimension.
-      * let bots = getBots(inStack(this, "test"));
-      *
-      */
-     inStack(bot: Bot, dimension: string): BotFilterFunction;
- 
-     /**
-      * Creates a function that filters bots by whether they are in the given space.
-      * @param space The space that the bots should be in.
-      */
-     bySpace(space: string): BotFilterFunction;
- 
-     /**
-      * Creates a function that filters bots by whether they are neighboring the given bot.
-      * @param bot The bot that other bots should be checked against.
-      * @param dimension The dimension that other bots should be checked in.
-      * @param direction The neighboring direction to check.
-      * @returns A function that returns true if the given bot is next to the original bot.
-      *
-      * @example
-      * // Find all bots in front of `this` bot in the "test" dimension.
-      * let bots = getBots(neighboring(this, "test", "front"));
-      */
-     neighboring(
-         bot: Bot,
-         dimension: string,
-         direction: 'front' | 'left' | 'right' | 'back'
-     ): BotFilterFunction;
- 
-     /**
-      * Creates a function that filters bots by whether they match any of the given filters.
-      * @param filters The filter functions that a bot should be tested against.
-      *
-      * @example
-      * // Find all bots with the name "bob" or height 2.
-      * let bots = getBots(
-      *   either(
-      *     byTag("name", "bob"),
-      *     byTag("height", height => height === 2)
-      *   )
-      * );
-      */
-     either(...filters: BotFilterFunction[]): BotFilterFunction;
- 
-     /**
-      * Creates a function that negates the result of the given function.
-      * @param filter The function whose results should be negated.
-      *
-      * @example
-      * // Find all bots that are not in the "test" dimension.
-      * let bots = getBots(not(inDimension("test")));
-      */
-     not(filter: BotFilterFunction): BotFilterFunction;
- 
-     /**
-      * Gets the value of the given tag stored in the given bot.
-      * @param bot The bot.
-      * @param tag The tag.
-      *
-      * @example
-      * // Get the "color" tag from the `this` bot.
-      * let color = getTag(this, "color");
-      */
-     getTag(bot: Bot, ...tags: string[]): any;
- 
-     /**
-      * Sets the value of the given tag stored in the given bot.
-      * @param bot The bot.
-      * @param tag The tag to set.
-      * @param value The value to set.
-      *
-      * @example
-      * // Set a bot's color to "green".
-      * setTag(this, "color", "green");
-      */
-     setTag(bot: Bot | Bot[] | BotTags, tag: string, value: any): any;
- 
-     /**
-      * Sets the value of the given tag mask in the given bot.
-      * @param bot The bot.
-      * @param tag The tag to set.
-      * @param value The value to set.
-      * @param space The space that the tag mask should be placed in. If not specified, then the tempLocal space will be used.
-      * 
-      * @example
-      * // Set a bot's color to "green".
-      * setTagMask(this, "color", "green")
-      */
-     setTagMask(bot: Bot | Bot[], tag: string, value: any, space?: BotSpace): any;
- 
-     /**
-      * Clears the tag masks from the given bot.
-      * @param bot The bot or bots that the tag masks should be cleared from.
-      * @param space The space that the tag masks should be cleared from. If not specified, then all spaces will be cleared.
-      */
-     clearTagMasks(bot: Bot | Bot[], space?: BotSpace): void;
- 
-     /**
-      * Inserts the given text into the given tag at the given index.
-      * Returns the resulting raw tag value.
-      * @param bot The bot that should be edited.
-      * @param tag The tag that should be edited.
-      * @param index The index that the text should be inserted at.
-      * @param text The text that should be inserted.
-      */
-     insertTagText(
-         bot: Bot,
-         tag: string,
-         index: number,
-         text: string
-     ): string;
- 
-     /**
-      * Inserts the given text into the given tag and space at the given index.
-      * Returns the resulting raw tag mask value.
-      * @param bot The bot that should be edited.
-      * @param tag The tag that should be edited.
-      * @param index The index that the text should be inserted at.
-      * @param text The text that should be inserted.
-      * @param space The space that the tag exists in. If not specified then the tempLocal space will be used.
-      */
-     insertTagMaskText(
-         bot: Bot,
-         tag: string,
-         index: number,
-         text: string,
-         space?: BotSpace
-     ): string;
- 
-     /**
-      * Deletes the specified number of characters from the given tag.
-      * Returns the resulting raw tag value.
-      * @param bot The bot that should be edited.
-      * @param tag The tag that should be edited.
-      * @param index The index that the text should be deleted at.
-      * @param count The number of characters to delete.
-      */
-     deleteTagText(
-         bot: Bot,
-         tag: string,
-         index: number,
-         count: number
-     ): string;
- 
-     /**
-      * Deletes the specified number of characters from the given tag mask.
-      * Returns the resulting raw tag mask value.
-      * @param bot The bot that should be edited.
-      * @param tag The tag that should be edited.
-      * @param index The index that the text should be deleted at.
-      * @param count The number of characters to delete.
-      * @param space The space that the tag mask exists in. If not specified then the tempLocal space will be used.
-      */
-     deleteTagMaskText(
-         bot: Bot,
-         tag: string,
-         index: number,
-         count: number,
-         space?: string
-     ): string;
- 
-     /**
-      * Creates a mod from declareed mod data.
-      * @param bot The mod data that should be loaded.
-      * @param tags The tags that should be included in the output mod.
-      * @returns The mod that was loaded from the data.
-      */
-     getMod(bot: any, ...tags: (string | RegExp)[]): Mod;
- 
-     /**
-      * Gets the position that the given bot is at in the given dimension.
-      * @param bot The bot or bot ID.
-      * @param dimension The dimension that the bot's position should be retrieved for.
-      */
-      getBotPosition(
-         bot: Bot | string,
-         dimension: string
-     ): Point3D;
- 
-     /**
-      * Applies the given diff to the given bot.
-      * @param bot The bot.
-      * @param diff The diff to apply.
-      */
-     applyMod(bot: any, ...diffs: Mod[]): void;
- 
-     /**
-      * subrtacts the given diff from the given bot.
-      * @param bot The bot.
-      * @param diff The diff to apply.
-      */
-     subtractMods(bot: any, ...diffs: Mod[]): void;
- 
-     /**
-      * Produces HTML from the given HTML strings and expressions.
-      * Best used with a tagged template string.
-      */
-     html: HtmlFunction;
- 
-     /**
-      * Defines a set of functions that relate to common OS operations.
-      */
-     os: Os;
- 
-     /**
-      * Defines a set of functions that relate to common server operations.
-      * Typically, these operations are instance-independent.
-      */
-     server: Server;
- 
-     /**
-      * Defines a set of functions that handle actions.
-      */
-     action: Actions;
- 
-     /**
-      * Defines a set of functions that manage admin space.
-      */
-     adminSpace: AdminSpace;
- 
-     /**
-      * Defines a set of functions that relate to common math operations.
-      */
-     math: Math;
- 
-     /**
-      * Defines a set of functions that are used to create and transform mods.
-      */
-     mod: ModFuncs;
- 
-     // @ts-ignore: Ignore redeclaration
-     crypto: Crypto;
- 
-     /**
-      * Defines a set of experimental functions.
-      */
-     experiment: Experiment;
- 
-     /**
-      * Defines a set of performance related functions.
-      */
-     perf: Perf;
+    web: Web;
+
+    /**
+    * Creates a Universally Unique IDentifier (UUID).
+    */
+    uuid(): string;
+
+    /**
+     * Animates the given tag. Returns a promise when the animation is finished.
+     * @param bot The bot or list of bots that should be animated.
+     * @param tag The tag that should be animated.
+     * @param options The options for the animation. If given null, then any running animations for the given tag will be canceled.
+     */
+    animateTag(bot: Bot | (Bot | string)[] | string, tag: string, options: AnimateTagFunctionOptions): Promise<void>;
+
+    /**
+     * Animates the given tags. Returns a promise when the animation is finished.
+     * @param bot The bot or list of bots that should be animated.
+     * @param options The options for the animation. fromValue should be an object which contains the starting tag values and toValue should be an object that contains the ending tag values.
+     */
+    animateTag(bot: Bot | (Bot | string)[] | string, options: AnimateTagFunctionOptions): Promise<void>;
+    /**
+     * Animates the given tag. Returns a promise when the animation is finished.
+     * @param bot The bot or list of bots that should be animated.
+     * @param tag The tag that should be animated.
+     * @param options The options for the animation.
+     */
+    animateTag(
+        bot: Bot | (Bot | string)[] | string,
+        tagOrOptions: string | AnimateTagFunctionOptions,
+        options?: AnimateTagFunctionOptions
+    ): Promise<void>;
+
+    /**
+     * Cancels the animations that are running on the given bot(s).
+     * @param bot The bot or list of bots that should cancel their animations.
+     * @param tag The tag that the animations should be canceld for. If omitted then all tags will be canceled.
+     */
+    clearAnimations(bot: Bot | (Bot | string)[] | string, tag?: string): void;
+
+    /**
+     * Sends the given operation to all the devices that matches the given selector.
+     * In effect, this allows users to send each other events directly without having to edit tags.
+     *
+     * Note that currently, devices will only accept events sent from the inst.
+     *
+     * @param event The event that should be executed in the remote session(s).
+     * @param selector The selector that indicates where the event should be sent. The event will be sent to all sessions that match the selector.
+     *                 For example, specifying a username means that the event will be sent to every active session that the user has open.
+     *                 If a selector is not specified, then the event is sent to the inst.
+     * @param allowBatching Whether to allow batching this remote event with other remote events. This will preserve ordering between remote events but may not preserve ordering
+     *                      with respect to other events. Defaults to true.
+     *
+     * @example
+     * // Send a toast to all sessions for the username "bob"
+     * remote(os.toast("Hello, Bob!"), { username: "bob" });
+     */
+    remote(
+        event: BotAction,
+        selector?: SessionSelector | string | (SessionSelector | string)[],
+        allowBatching?: boolean
+    ): RemoteAction | RemoteAction[];
+
+    /**
+     * Sends an event to the given remote or list of remotes.
+     * The other remotes will recieve an onRemoteData shout for this whisper.
+     * 
+     * In effect, this allows remotes to communicate with each other by sending arbitrary events.
+     * 
+     * @param remoteId The ID of the other remote or remotes to whisper to.
+     * @param name The name of the event.
+     * @param arg The optional argument to include in the event.
+     */
+    sendRemoteData(remoteId: string | string[], name: string, arg?: any): RemoteAction | RemoteAction[];
+
+    /**
+     * Gets the first bot which matches all of the given filters.
+     * @param filters The filter functions that the bot needs to match.
+     * @returns The first bot that matches all the given filters.
+     *
+     * @example
+     * // Get a bot by the "name" tag.
+     * let bot = getBot(byTag("name", "The bot's name"));
+     */
+    getBot(...filters: BotFilterFunction[]): Bot;
+
+    /**
+     * Gets the first bot ordered by ID which matches the given tag and filter.
+     * @param tag The tag the bot should match.
+     * @param filter The optional value or filter the bot should match.
+     *
+     * @example
+     * // Get a bot with the "name" tag.
+     * // Shorthand for getBot(byTag("name"))
+     * let bot = getBot("name");
+     *
+     * @example
+     * // Get a bot by the "name" tag.
+     * // Shorthand for getBot(byTag("name", "The bot's name"))
+     * let bot = getBot("name", "The bot's name");
+     *
+     * @example
+     * // Get a bot where the "name" tag starts with the letter "N".
+     * // Shorthand for getBot(byTag("name", name => name.startsWith("N")))
+     * let bot = getBot("name", name => name.startsWith("N"));
+     */
+    getBot(tag: string, filter?: any | TagFilter): Bot;
+
+    /**
+     * Gets the first bot ordered by ID.
+     * @returns The bot with the first ID when sorted alphebetically.
+     *
+     * @example
+     * let firstBot = getBot();
+     */
+    getBot(): Bot;
+
+    /**
+     * Gets the list of bots which match all of the given filters.
+     * @param filters The filter functions that the bots need to match.
+     * @returns A list of bots that match all the given filters. If no bots match then an empty list is returned.
+     *
+     * @example
+     * // Get all the bots that are red.
+     * let bots = getBots(byTag("color", "red"));
+     */
+    getBots(...filters: ((bot: Bot) => boolean)[]): Bot[];
+
+    /**
+     * Gets the list of bots that have the given tag matching the given filter value.
+     * @param tag The tag the bot should match.
+     * @param filter The value or filter the bot should match.
+     *
+     * @example
+     * // Get all the bots that are red.
+     * // Shorthand for getBots(byTag("color", "red"))
+     * let bots = getBots("color", "red");
+     */
+    getBots(tag: string, filter?: any | TagFilter): Bot[];
+
+    /**
+     * Gets a list of all the bots.
+     *
+     * @example
+     * // Gets all the bots in the inst.
+     * let bots = getBots();
+     */
+    getBots(): Bot[];
+
+    /**
+     * Gets the list of tag values from bots that have the given tag.
+     * @param tag The tag.
+     * @param filter THe optional filter to use for the values.
+     */
+    getBotTagValues(tag: string, filter?: TagFilter): any[];
+
+    /**
+     * Creates a filter function that checks whether bots have the given tag and value.
+     * @param tag The tag to check.
+     * @param filter The value or filter that the tag should match.
+     *
+     * @example
+     * // Find all the bots with a "name" of "bob".
+     * let bobs = getBots(byTag("name", "bob"));
+     *
+     * @example
+     * // Find all bots with a height larger than 2.
+     * let bots = getBots(byTag("height", height => height > 2));
+     *
+     * @example
+     * // Find all the bots with the "test" tag.
+     * let bots = getBots(byTag("test"));
+     */
+    byTag(tag: string, filter?: TagFilter): BotFilterFunction;
+
+    /**
+     * Creates a filter function that checks whether bots have the given ID.
+     * @param id The ID to check for.
+     * 
+     * @example
+     * // Find all the bots with the ID "bob".
+     * let bobs = getBots(byId("bob"));
+     */
+    byID(id: string): IDRecordFilter;
+
+    /**
+     * Creates a filter function that checks whether bots match the given mod.
+     * @param mod The mod that bots should be checked against.
+     *
+     * @example
+     * // Find all the bots with a height set to 1 and color set to "red".
+     * let bots = getBots(byMod({
+     *      "color": "red",
+     *      height: 1
+     * }));
+     */
+    byMod(mod: Mod): BotFilterFunction;
+
+    /**
+     * Creates a filter function that checks whether bots are in the given dimension.
+     * @param dimension The dimension to check.
+     * @returns A function that returns true if the given bot is in the dimension and false if it is not.
+     *
+     * @example
+     * // Find all the bots in the "test" dimension.
+     * let bots = getBots(inDimension("test"));
+     */
+    inDimension(dimension: string): BotFilterFunction;
+
+    /**
+     * Creates a filter function that checks whether bots are at the given position in the given dimension.
+     * @param dimension The dimension that the bots should be in.
+     * @param x The X position in the dimension that the bots should be at.
+     * @param y The Y position in the dimension that the bots should be at.
+     * @returns A function that returns true if the given bot is at the given position and false if it is not.
+     *
+     * @example
+     * // Find all the bots at (1, 2) in the "test" dimension.
+     * let bots = getBots(atPosition("test", 1, 2));
+     */
+    atPosition(
+        dimension: string,
+        x: number,
+        y: number
+    ): BotFilterFunction;
+
+    /**
+     * Creates a filter function that checks whether bots were created by the given bot.
+     * @param bot The bot to determine weather the bots have been created by it or not.
+     * @returns A function that returns true if the bot was created by the given bot.
+     *
+     * @example
+     * // Find all the bots created by the yellow bot.
+     * let bots = getBots(byCreator(getBot('color','yellow')));
+     */
+    byCreator(bot: Bot | string): BotFilterFunction;
+
+    /**
+     * Creates a filter function that checks whether bots are in the same stack as the given bot.
+     * @param bot The bot that other bots should be checked against.
+     * @param dimension The dimension that other bots should be checked in.
+     * @returns A function that returns true if the given bot is in the same stack as the original bot.
+     *
+     * @example
+     * // Find all bots in the same stack as `this` in the "test" dimension.
+     * let bots = getBots(inStack(this, "test"));
+     *
+     */
+    inStack(bot: Bot, dimension: string): BotFilterFunction;
+
+    /**
+     * Creates a function that filters bots by whether they are in the given space.
+     * @param space The space that the bots should be in.
+     */
+    bySpace(space: string): BotFilterFunction;
+
+    /**
+     * Creates a function that filters bots by whether they are neighboring the given bot.
+     * @param bot The bot that other bots should be checked against.
+     * @param dimension The dimension that other bots should be checked in.
+     * @param direction The neighboring direction to check.
+     * @returns A function that returns true if the given bot is next to the original bot.
+     *
+     * @example
+     * // Find all bots in front of `this` bot in the "test" dimension.
+     * let bots = getBots(neighboring(this, "test", "front"));
+     */
+    neighboring(
+        bot: Bot,
+        dimension: string,
+        direction: 'front' | 'left' | 'right' | 'back'
+    ): BotFilterFunction;
+
+    /**
+     * Creates a function that filters bots by whether they match any of the given filters.
+     * @param filters The filter functions that a bot should be tested against.
+     *
+     * @example
+     * // Find all bots with the name "bob" or height 2.
+     * let bots = getBots(
+     *   either(
+     *     byTag("name", "bob"),
+     *     byTag("height", height => height === 2)
+     *   )
+     * );
+     */
+    either(...filters: BotFilterFunction[]): BotFilterFunction;
+
+    /**
+     * Creates a function that negates the result of the given function.
+     * @param filter The function whose results should be negated.
+     *
+     * @example
+     * // Find all bots that are not in the "test" dimension.
+     * let bots = getBots(not(inDimension("test")));
+     */
+    not(filter: BotFilterFunction): BotFilterFunction;
+
+    /**
+     * Gets the value of the given tag stored in the given bot.
+     * @param bot The bot.
+     * @param tag The tag.
+     *
+     * @example
+     * // Get the "color" tag from the `this` bot.
+     * let color = getTag(this, "color");
+     */
+    getTag(bot: Bot, ...tags: string[]): any;
+
+    /**
+     * Sets the value of the given tag stored in the given bot.
+     * @param bot The bot.
+     * @param tag The tag to set.
+     * @param value The value to set.
+     *
+     * @example
+     * // Set a bot's color to "green".
+     * setTag(this, "color", "green");
+     */
+    setTag(bot: Bot | Bot[] | BotTags, tag: string, value: any): any;
+
+    /**
+     * Sets the value of the given tag mask in the given bot.
+     * @param bot The bot.
+     * @param tag The tag to set.
+     * @param value The value to set.
+     * @param space The space that the tag mask should be placed in. If not specified, then the tempLocal space will be used.
+     * 
+     * @example
+     * // Set a bot's color to "green".
+     * setTagMask(this, "color", "green")
+     */
+    setTagMask(bot: Bot | Bot[], tag: string, value: any, space?: BotSpace): any;
+
+    /**
+     * Clears the tag masks from the given bot.
+     * @param bot The bot or bots that the tag masks should be cleared from.
+     * @param space The space that the tag masks should be cleared from. If not specified, then all spaces will be cleared.
+     */
+    clearTagMasks(bot: Bot | Bot[], space?: BotSpace): void;
+
+    /**
+     * Inserts the given text into the given tag at the given index.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     */
+    insertTagText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        text: string
+    ): string;
+
+    /**
+     * Inserts the given text into the given tag and space at the given index.
+     * Returns the resulting raw tag mask value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be inserted at.
+     * @param text The text that should be inserted.
+     * @param space The space that the tag exists in. If not specified then the tempLocal space will be used.
+     */
+    insertTagMaskText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        text: string,
+        space?: BotSpace
+    ): string;
+
+    /**
+     * Deletes the specified number of characters from the given tag.
+     * Returns the resulting raw tag value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     */
+    deleteTagText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        count: number
+    ): string;
+
+    /**
+     * Deletes the specified number of characters from the given tag mask.
+     * Returns the resulting raw tag mask value.
+     * @param bot The bot that should be edited.
+     * @param tag The tag that should be edited.
+     * @param index The index that the text should be deleted at.
+     * @param count The number of characters to delete.
+     * @param space The space that the tag mask exists in. If not specified then the tempLocal space will be used.
+     */
+    deleteTagMaskText(
+        bot: Bot,
+        tag: string,
+        index: number,
+        count: number,
+        space?: string
+    ): string;
+
+    /**
+     * Creates a mod from declareed mod data.
+     * @param bot The mod data that should be loaded.
+     * @param tags The tags that should be included in the output mod.
+     * @returns The mod that was loaded from the data.
+     */
+    getMod(bot: any, ...tags: (string | RegExp)[]): Mod;
+
+    /**
+     * Gets the position that the given bot is at in the given dimension.
+     * @param bot The bot or bot ID.
+     * @param dimension The dimension that the bot's position should be retrieved for.
+     */
+    getBotPosition(
+        bot: Bot | string,
+        dimension: string
+    ): Point3D;
+
+    /**
+     * Applies the given diff to the given bot.
+     * @param bot The bot.
+     * @param diff The diff to apply.
+     */
+    applyMod(bot: any, ...diffs: Mod[]): void;
+
+    /**
+     * subrtacts the given diff from the given bot.
+     * @param bot The bot.
+     * @param diff The diff to apply.
+     */
+    subtractMods(bot: any, ...diffs: Mod[]): void;
+
+    /**
+     * Produces HTML from the given HTML strings and expressions.
+     * Best used with a tagged template string.
+     */
+    html: HtmlFunction;
+
+    /**
+     * Defines a set of functions that relate to common OS operations.
+     */
+    os: Os;
+
+    /**
+     * Defines a set of functions that relate to common server operations.
+     * Typically, these operations are instance-independent.
+     */
+    server: Server;
+
+    /**
+     * Defines a set of functions that handle actions.
+     */
+    action: Actions;
+
+    /**
+     * Defines a set of functions that manage admin space.
+     */
+    adminSpace: AdminSpace;
+
+    /**
+     * Defines a set of functions that relate to common math operations.
+     */
+    math: Math;
+
+    /**
+     * Defines a set of functions that are used to create and transform mods.
+     */
+    mod: ModFuncs;
+
+    // @ts-ignore: Ignore redeclaration
+    crypto: Crypto;
+
+    /**
+     * Defines a set of experimental functions.
+     */
+    experiment: Experiment;
+
+    /**
+     * Defines a set of performance related functions.
+     */
+    perf: Perf;
 }
 
 /**
@@ -7680,234 +7680,234 @@ interface Os {
          * Sleeps for time in ms.
          * @param time Time in ms. 1 second is 1000ms.
          */
-     sleep(time: number): Promise<void>;
+    sleep(time: number): Promise<void>;
 
-     /**
-      * Derermines whether the player is in the given dimension.
-      * @param dimension The dimension.
-      */
-     isInDimension(dimension: string): string;
+    /**
+     * Derermines whether the player is in the given dimension.
+     * @param dimension The dimension.
+     */
+    isInDimension(dimension: string): string;
 
-     /**
-      * Redirects the user to the given dimension.
-      * @param dimension The dimension to go to.
-      *
-      * @example
-      * // Send the player to the "welcome" dimension.
-      * os.goToDimension("welcome");
-      */
-     goToDimension(dimension: string): GoToDimensionAction;
+    /**
+     * Redirects the user to the given dimension.
+     * @param dimension The dimension to go to.
+     *
+     * @example
+     * // Send the player to the "welcome" dimension.
+     * os.goToDimension("welcome");
+     */
+    goToDimension(dimension: string): GoToDimensionAction;
 
-     /**
-      * Instructs CasualOS to open the built-in developer console.
-      * The dev console provides easy access to error messages and debug logs for formulas and actions.
-      */
-     openDevConsole(): OpenConsoleAction;
+    /**
+     * Instructs CasualOS to open the built-in developer console.
+     * The dev console provides easy access to error messages and debug logs for formulas and actions.
+     */
+    openDevConsole(): OpenConsoleAction;
 
-     /**
-      * Changes the state that the given bot is in.
-      * @param bot The bot to change.
-      * @param stateName The state that the bot should move to.
-      * @param groupName The group of states that the bot's state should change in. (Defaults to "state")
-      */
-     changeState(bot: Bot, stateName: string, groupName?: string): void;
+    /**
+     * Changes the state that the given bot is in.
+     * @param bot The bot to change.
+     * @param stateName The state that the bot should move to.
+     * @param groupName The group of states that the bot's state should change in. (Defaults to "state")
+     */
+    changeState(bot: Bot, stateName: string, groupName?: string): void;
 
-     /**
-      * Enables Augmented Reality features.
-      */
-     enableAR(): EnableARAction;
+    /**
+     * Enables Augmented Reality features.
+     */
+    enableAR(): EnableARAction;
 
-     /**
-      * Enables Virtual Reality features.
-      */
-     enableVR(): EnableVRAction;
+    /**
+     * Enables Virtual Reality features.
+     */
+    enableVR(): EnableVRAction;
 
-     /**
-      * Disables Augmented Reality features.
-      */
-     disableAR(): EnableARAction;
+    /**
+     * Disables Augmented Reality features.
+     */
+    disableAR(): EnableARAction;
 
-     /**
-      * Disables Virtual Reality features.
-      */
-     disableVR(): EnableVRAction;
+    /**
+     * Disables Virtual Reality features.
+     */
+    disableVR(): EnableVRAction;
 
-     /**
-      * Promise that returns wether or not AR is supported on the device.
-      */
-     arSupported(): Promise<boolean>;
+    /**
+     * Promise that returns wether or not AR is supported on the device.
+     */
+    arSupported(): Promise<boolean>;
 
-     /**
-      * Promise that returns wether or not VR is supported on the device.
-      */
-     vrSupported(): Promise<boolean>;
+    /**
+     * Promise that returns wether or not VR is supported on the device.
+     */
+    vrSupported(): Promise<boolean>;
 
-     /**
-      * Enables Point-of-View mode.
-      * @param center The position that the camera should be placed at. Defaults to (0,0,0)
-      * @param imu Whether to use the imuPortal to control the camera rotation while in POV mode. Defaults to false.
-      */
-     enablePointOfView(center?: Point3D, imu?: boolean): EnablePOVAction;
+    /**
+     * Enables Point-of-View mode.
+     * @param center The position that the camera should be placed at. Defaults to (0,0,0)
+     * @param imu Whether to use the imuPortal to control the camera rotation while in POV mode. Defaults to false.
+     */
+    enablePointOfView(center?: Point3D, imu?: boolean): EnablePOVAction;
 
-     /**
-      * Disables Point-of-View mode.
-      */
-     disablePointOfView(): EnablePOVAction;
+    /**
+     * Disables Point-of-View mode.
+     */
+    disablePointOfView(): EnablePOVAction;
 
-     /**
-      * Gets the dimension that is loaded into the given portal for the player.
-      * If no dimension is loaded, then null is returned.
-      * @param portal The portal type.
-      */
-     getPortalDimension(portal: PortalType): string;
+    /**
+     * Gets the dimension that is loaded into the given portal for the player.
+     * If no dimension is loaded, then null is returned.
+     * @param portal The portal type.
+     */
+    getPortalDimension(portal: PortalType): string;
 
-     /**
-      * Gets information about the version of AUX that is running.
-      */
-     version(): AuxVersion;
+    /**
+     * Gets information about the version of AUX that is running.
+     */
+    version(): AuxVersion;
 
-     /**
-      * Gets information about the device that the player is using.
-      */
-     device(): AuxDevice;
+    /**
+     * Gets information about the device that the player is using.
+     */
+    device(): AuxDevice;
 
-     /**
-      * Gets whether this device has enabled collaborative features.
-      */
-     isCollaborative(): boolean;
+    /**
+     * Gets whether this device has enabled collaborative features.
+     */
+    isCollaborative(): boolean;
 
     /**
      * Gets media permission for the device.
      * Promise will resolve if permission was granted, otherwise an error will be thrown.
      */
-     getMediaPermission(options: { audio?: boolean, video?: boolean }): Promise<void>;
+    getMediaPermission(options: { audio?: boolean, video?: boolean }): Promise<void>;
 
-     /**
-      * Gets the URL that AB1 should be bootstrapped from.
-      */
-     getAB1BootstrapURL(): string;
+    /**
+     * Gets the URL that AB1 should be bootstrapped from.
+     */
+    getAB1BootstrapURL(): string;
 
-     /**
-      * Gets whether the player is in the sheet dimension.
-      */
-     inSheet(): boolean;
+    /**
+     * Gets whether the player is in the sheet dimension.
+     */
+    inSheet(): boolean;
 
-     /**
-      * Gets the 3D position of the player's camera.
-      * @param portal The portal that the camera position should be retrieved for.
-      */
-     getCameraPosition(portal?: 'grid' | 'miniGrid'): Point3D;
+    /**
+     * Gets the 3D position of the player's camera.
+     * @param portal The portal that the camera position should be retrieved for.
+     */
+    getCameraPosition(portal?: 'grid' | 'miniGrid'): Point3D;
 
-     /**
-      * Gets the 3D rotation of the player's camera.
-      * @param portal The portal that the camera rotation should be retrieved for.
-      */
-     getCameraRotation(portal?: 'grid' | 'miniGrid'): Point3D;
+    /**
+     * Gets the 3D rotation of the player's camera.
+     * @param portal The portal that the camera rotation should be retrieved for.
+     */
+    getCameraRotation(portal?: 'grid' | 'miniGrid'): Point3D;
 
-     /**
-      * Gets the 3D point that the player's camera is focusing on.
-      * @param portal The portal that the camera focus point should be retrieved for.
-      */
-     getFocusPoint(portal?: 'grid' | 'miniGrid'): Point3D;
+    /**
+     * Gets the 3D point that the player's camera is focusing on.
+     * @param portal The portal that the camera focus point should be retrieved for.
+     */
+    getFocusPoint(portal?: 'grid' | 'miniGrid'): Point3D;
 
-     /**
-      * Gets the 3D position of the player's pointer.
-      * @param pointer The position of the pointer to retrieve.
-      */
-     getPointerPosition(pointer?: 'mouse' | 'left' | 'right'): Point3D;
+    /**
+     * Gets the 3D position of the player's pointer.
+     * @param pointer The position of the pointer to retrieve.
+     */
+    getPointerPosition(pointer?: 'mouse' | 'left' | 'right'): Point3D;
 
-     /**
-      * Gets the 3D rotation of the player's pointer.
-      * @param pointer The rotation of the pointer to retrieve.
-      */
-     getPointerRotation(pointer?: 'mouse' | 'left' | 'right'): Point3D;
+    /**
+     * Gets the 3D rotation of the player's pointer.
+     * @param pointer The rotation of the pointer to retrieve.
+     */
+    getPointerRotation(pointer?: 'mouse' | 'left' | 'right'): Point3D;
 
-     /**
-      * Gets the 3D direction that the given pointer is pointing in.
-      * @param pointer The pointer to get the direction of.
-      */
-     getPointerDirection(pointer?: 'mouse' | 'left' | 'right'): Point3D;
+    /**
+     * Gets the 3D direction that the given pointer is pointing in.
+     * @param pointer The pointer to get the direction of.
+     */
+    getPointerDirection(pointer?: 'mouse' | 'left' | 'right'): Point3D;
 
-     /**
-      * Gets the input state of the given button on the mouse.
-      * @param controller The name of the controller that should be checked.
-      * @param button The name of the button on the controller.
-      */
-     getInputState(controller: 'mousePointer', button: 'left' | 'right' | 'middle'): null | 'down' | 'held';
+    /**
+     * Gets the input state of the given button on the mouse.
+     * @param controller The name of the controller that should be checked.
+     * @param button The name of the button on the controller.
+     */
+    getInputState(controller: 'mousePointer', button: 'left' | 'right' | 'middle'): null | 'down' | 'held';
 
-     /**
-      * Gets the input state of the given button on the left or right controller.
-      * @param controller The name of the controller that should be checked.
-      * @param button The name of the button on the controller.
-      */
-     getInputState(controller: 'leftPointer' | 'rightPointer', button: 'primary' | 'squeeze'): null | 'down' | 'held';
+    /**
+     * Gets the input state of the given button on the left or right controller.
+     * @param controller The name of the controller that should be checked.
+     * @param button The name of the button on the controller.
+     */
+    getInputState(controller: 'leftPointer' | 'rightPointer', button: 'primary' | 'squeeze'): null | 'down' | 'held';
 
-     /**
-      * Gets the input state of the given button on the keyboard.
-      * @param controller The name of the controller that should be checked.
-      * @param button The name of the button on the controller.
-      */
-     getInputState(controller: 'keyboard', button: string): null | 'down' | 'held';
+    /**
+     * Gets the input state of the given button on the keyboard.
+     * @param controller The name of the controller that should be checked.
+     * @param button The name of the button on the controller.
+     */
+    getInputState(controller: 'keyboard', button: string): null | 'down' | 'held';
 
-     /**
-      * Gets the input state of the given touch.
-      * @param controller The name of the controller that should be checked.
-      * @param button The index of the finger.
-      */
-     getInputState(controller: 'touch', button: '0' | '1' | '2' | '3' | '4'): null | 'down' | 'held';
+    /**
+     * Gets the input state of the given touch.
+     * @param controller The name of the controller that should be checked.
+     * @param button The index of the finger.
+     */
+    getInputState(controller: 'touch', button: '0' | '1' | '2' | '3' | '4'): null | 'down' | 'held';
 
-     /**
-      * Gets the input state of the given button on the given controller.
-      * @param controller The name of the controller that should be checked.
-      * @param button The name of the button on the controller.
-      */
-     getInputState(controller: string, button: string): null | 'down' | 'held';
+    /**
+     * Gets the input state of the given button on the given controller.
+     * @param controller The name of the controller that should be checked.
+     * @param button The name of the button on the controller.
+     */
+    getInputState(controller: string, button: string): null | 'down' | 'held';
 
-     /**
-      * Gets the list of inputs that are currently available.
-      */
-     getInputList(): string[];
+    /**
+     * Gets the list of inputs that are currently available.
+     */
+    getInputList(): string[];
 
-     /**
-      * Shows a toast message to the user.
-      * @param message The message to show.
-      * @param duration The number of seconds the message should be on the screen. (Defaults to 2)
-      */
-     toast(message: string | number | boolean | object | Array<any> | null, duration?: number): ShowToastAction;
+    /**
+     * Shows a toast message to the user.
+     * @param message The message to show.
+     * @param duration The number of seconds the message should be on the screen. (Defaults to 2)
+     */
+    toast(message: string | number | boolean | object | Array<any> | null, duration?: number): ShowToastAction;
 
-     /**
-      * Play the given url's audio.
-      * Returns a promise that resolves with the sound ID when the sound starts playing.
-      * @param url The URL to play.
-      * 
-      * @example
-      * // Play a cow "moo"
-      * os.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
-      */
-     playSound(url: string): Promise<string>;
+    /**
+     * Play the given url's audio.
+     * Returns a promise that resolves with the sound ID when the sound starts playing.
+     * @param url The URL to play.
+     * 
+     * @example
+     * // Play a cow "moo"
+     * os.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+     */
+    playSound(url: string): Promise<string>;
 
-     /**
-      * Preloads the audio for the given URL.
-      * Returns a promise that resolves when the audio has finished loading.
-      * @param url The URl to preload.
-      * 
-      * @example
-      * // Preload a cow "moo"
-      * os.bufferSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
-      */
-     bufferSound(url: string): Promise<void>;
+    /**
+     * Preloads the audio for the given URL.
+     * Returns a promise that resolves when the audio has finished loading.
+     * @param url The URl to preload.
+     * 
+     * @example
+     * // Preload a cow "moo"
+     * os.bufferSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+     */
+    bufferSound(url: string): Promise<void>;
 
-     /**
-      * Cancels the sound with the given ID.
-      * Returns a promise that resolves when the audio has been canceled.
-      * @param soundID The ID of the sound that is being canceled.
-      *
-      * @example
-      * // Play and cancel a sound
-      * const id = await os.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
-      * os.cancelSound(id);
-      */
-     cancelSound(soundID: number): Promise<void>;
+    /**
+     * Cancels the sound with the given ID.
+     * Returns a promise that resolves when the audio has been canceled.
+     * @param soundID The ID of the sound that is being canceled.
+     *
+     * @example
+     * // Play and cancel a sound
+     * const id = await os.playSound("https://freesound.org/data/previews/58/58277_634166-lq.mp3");
+     * os.cancelSound(id);
+     */
+    cancelSound(soundID: number): Promise<void>;
 
     /**
      * Starts a new audio recording.
@@ -7929,143 +7929,143 @@ interface Os {
      */
     meetCommand(command: string, ...args: any[]): MeetCommandAction;
 
-     /**
-      * Shows a QR Code that contains a link to a inst and dimension.
-      * @param inst The inst that should be joined. Defaults to the current inst.
-      * @param dimension The dimension that should be joined. Defaults to the current dimension.
-      */
-     showJoinCode(
-         inst?: string,
-         dimension?: string
-     ): ShowJoinCodeAction;
+    /**
+     * Shows a QR Code that contains a link to a inst and dimension.
+     * @param inst The inst that should be joined. Defaults to the current inst.
+     * @param dimension The dimension that should be joined. Defaults to the current dimension.
+     */
+    showJoinCode(
+        inst?: string,
+        dimension?: string
+    ): ShowJoinCodeAction;
 
-     /**
-      * Requests that AUX enters fullscreen mode.
-      * Depending on the web browser, this may ask the player for permission.
-      */
-     requestFullscreenMode(): RequestFullscreenAction;
+    /**
+     * Requests that AUX enters fullscreen mode.
+     * Depending on the web browser, this may ask the player for permission.
+     */
+    requestFullscreenMode(): RequestFullscreenAction;
 
-     /**
-      * Exits fullscreen mode.
-      */
-     exitFullscreenMode(): ExitFullscreenAction;
+    /**
+     * Exits fullscreen mode.
+     */
+    exitFullscreenMode(): ExitFullscreenAction;
 
-     /**
-      * Shares some information via the device's social sharing functionality.
-      * @param options The options.
-      */
-     share(options: ShareOptions): ShareAction;
+    /**
+     * Shares some information via the device's social sharing functionality.
+     * @param options The options.
+     */
+    share(options: ShareOptions): ShareAction;
 
-     /**
-      * Closes the circle wipe transition effect.
-      * @param options The options that should be used for the effect.
-      */
-     closeCircleWipe(options?: Partial<OpenCircleWipeOptions>): Promise<void>;
+    /**
+     * Closes the circle wipe transition effect.
+     * @param options The options that should be used for the effect.
+     */
+    closeCircleWipe(options?: Partial<OpenCircleWipeOptions>): Promise<void>;
 
-     /**
-      * Opens the circle wipe transition effect.
-      * @param options The options that should be used for the effect.
-      */
-     openCircleWipe(options?: Partial<OpenCircleWipeOptions>): Promise<void>;
+    /**
+     * Opens the circle wipe transition effect.
+     * @param options The options that should be used for the effect.
+     */
+    openCircleWipe(options?: Partial<OpenCircleWipeOptions>): Promise<void>;
 
-     /**
-      * Adds the given list of snap targets to the current drag operation.
-      * @param targets The list of targets to add.
-      */
-     addDropSnap(...targets: SnapTarget[]): AddDropSnapTargetsAction;
+    /**
+     * Adds the given list of snap targets to the current drag operation.
+     * @param targets The list of targets to add.
+     */
+    addDropSnap(...targets: SnapTarget[]): AddDropSnapTargetsAction;
 
-     /**
-      * Adds the given list of snap targets for when the specified bot is being dropped on.
-      * @param bot The bot.
-      * @param targets The targets that should be enabled when the bot is being dropped on.
-      */
-     addBotDropSnap(bot: Bot | string, ...targets: SnapTarget[]): AddDropSnapTargetsAction;
+    /**
+     * Adds the given list of snap targets for when the specified bot is being dropped on.
+     * @param bot The bot.
+     * @param targets The targets that should be enabled when the bot is being dropped on.
+     */
+    addBotDropSnap(bot: Bot | string, ...targets: SnapTarget[]): AddDropSnapTargetsAction;
 
-     /**
-      * Enables custom dragging for the current drag operation.
-      * This will disable the built-in logic that moves the bot(s) and
-      * enables the "onDragging" and "onAnyBotDragging" listen tags.
-      */
-     enableCustomDragging(): EnableCustomDraggingAction;
+    /**
+     * Enables custom dragging for the current drag operation.
+     * This will disable the built-in logic that moves the bot(s) and
+     * enables the "onDragging" and "onAnyBotDragging" listen tags.
+     */
+    enableCustomDragging(): EnableCustomDraggingAction;
 
-     /**
-      * Logs the given data to the developer console.
-      * @param args The data to log.
-      */
-     log(...args: any[]): void;
+    /**
+     * Logs the given data to the developer console.
+     * @param args The data to log.
+     */
+    log(...args: any[]): void;
 
-     /**
-      * Gets the geolocation of the device.
-      * Returns a promise that resolves with the location.
-      */
-     getGeolocation(): Promise<GeoLocation>;
+    /**
+     * Gets the geolocation of the device.
+     * Returns a promise that resolves with the location.
+     */
+    getGeolocation(): Promise<GeoLocation>;
 
-     /**
-      * Shows some HTML to the user.
-      * @param html The HTML to show.
-      */
-     showHtml(html: string): ShowHtmlAction;
+    /**
+     * Shows some HTML to the user.
+     * @param html The HTML to show.
+     */
+    showHtml(html: string): ShowHtmlAction;
 
-     /**
-      * Hides the HTML from the user.
-      */
-     hideHtml(): HideHtmlAction;
+    /**
+     * Hides the HTML from the user.
+     */
+    hideHtml(): HideHtmlAction;
 
-     /**
-      * Moves the camera to view the given bot.
-      * Returns a promise that resolves when the bot is focused.
-      * @param botOrPosition The bot, bot ID, or position to view.
-      * @param options The options to use for moving the camera.
-      */
-     focusOn(
-         botOrPosition: Bot | string | { x: number, y: number },
-         options: FocusOnOptions
-     ): Promise<void>;
+    /**
+     * Moves the camera to view the given bot.
+     * Returns a promise that resolves when the bot is focused.
+     * @param botOrPosition The bot, bot ID, or position to view.
+     * @param options The options to use for moving the camera.
+     */
+    focusOn(
+        botOrPosition: Bot | string | { x: number, y: number },
+        options: FocusOnOptions
+    ): Promise<void>;
 
-     /**
-      * Opens the QR Code Scanner.
-      * @param camera The camera that should be used.
-      */
-     openQRCodeScanner(camera?: CameraType): OpenQRCodeScannerAction;
+    /**
+     * Opens the QR Code Scanner.
+     * @param camera The camera that should be used.
+     */
+    openQRCodeScanner(camera?: CameraType): OpenQRCodeScannerAction;
 
-     /**
-      * Closes the QR Code Scanner.
-      */
-     closeQRCodeScanner(): OpenQRCodeScannerAction;
+    /**
+     * Closes the QR Code Scanner.
+     */
+    closeQRCodeScanner(): OpenQRCodeScannerAction;
 
-     /**
-      * Shows the given QR Code.
-      * @param code The code to show.
-      */
-     showQRCode(code: string): ShowQRCodeAction;
+    /**
+     * Shows the given QR Code.
+     * @param code The code to show.
+     */
+    showQRCode(code: string): ShowQRCodeAction;
 
-     /**
-      * Hides the QR Code.
-      */
-     hideQRCode(): ShowQRCodeAction;
+    /**
+     * Hides the QR Code.
+     */
+    hideQRCode(): ShowQRCodeAction;
 
-     /**
-      * Opens the barcode scanner.
-      * @param camera The camera that should be used.
-      */
-     openBarcodeScanner(camera?: CameraType): OpenBarcodeScannerAction;
+    /**
+     * Opens the barcode scanner.
+     * @param camera The camera that should be used.
+     */
+    openBarcodeScanner(camera?: CameraType): OpenBarcodeScannerAction;
 
-     /**
-      * Closes the barcode scanner.
-      */
-     closeBarcodeScanner(): OpenBarcodeScannerAction;
+    /**
+     * Closes the barcode scanner.
+     */
+    closeBarcodeScanner(): OpenBarcodeScannerAction;
 
-     /**
-      * Shows the given barcode.
-      * @param code The code that should be shown.
-      * @param format The format that the barcode should be shown in.
-      */
-     showBarcode(code: string, format?: BarcodeFormat): ShowBarcodeAction;
+    /**
+     * Shows the given barcode.
+     * @param code The code that should be shown.
+     * @param format The format that the barcode should be shown in.
+     */
+    showBarcode(code: string, format?: BarcodeFormat): ShowBarcodeAction;
 
-     /**
-      * Hides the barcode.
-      */
-     hideBarcode(): ShowBarcodeAction;
+    /**
+     * Hides the barcode.
+     */
+    hideBarcode(): ShowBarcodeAction;
 
     /**
      * Shows an image classifier for the given ML Model.
@@ -8080,271 +8080,271 @@ interface Os {
      */
     closeImageClassifier(): Promise<void>;
 
-     /**
-      * Shows the chat bar.
-      */
-     showChat(): ShowChatBarAction;
+    /**
+     * Shows the chat bar.
+     */
+    showChat(): ShowChatBarAction;
 
-     /**
-      * Shows the chat bar with the given placeholder.
-      * @param placeholder The placeholder text that should be in the chat bar.
-      */
-     showChat(placeholder: string): ShowChatBarAction;
+    /**
+     * Shows the chat bar with the given placeholder.
+     * @param placeholder The placeholder text that should be in the chat bar.
+     */
+    showChat(placeholder: string): ShowChatBarAction;
 
-     /**
-      * Shows the chat bar with the given options.
-      * @param options The options that should be used to show the chat bar.
-      */
-     showChat(options: ShowChatOptions): ShowChatBarAction;
+    /**
+     * Shows the chat bar with the given options.
+     * @param options The options that should be used to show the chat bar.
+     */
+    showChat(options: ShowChatOptions): ShowChatBarAction;
 
-     /**
-      * Shows the run bar.
-      * @param placeholderOrOptions The placeholder text or options. (optional)
-      */
-     showChat(
-         placeholderOrOptions?: string | ShowChatOptions
-     ): ShowChatBarAction;
+    /**
+     * Shows the run bar.
+     * @param placeholderOrOptions The placeholder text or options. (optional)
+     */
+    showChat(
+        placeholderOrOptions?: string | ShowChatOptions
+    ): ShowChatBarAction;
 
-     /**
-      * Hides the run bar.
-      */
-     hideChat(): ShowChatBarAction;
+    /**
+     * Hides the run bar.
+     */
+    hideChat(): ShowChatBarAction;
 
-     /**
-      * Enqueues the given script to execute after this script is done running.
-      * @param script The script that should be executed.
-      */
-     run(script: string): Promise<any>;
+    /**
+     * Enqueues the given script to execute after this script is done running.
+     * @param script The script that should be executed.
+     */
+    run(script: string): Promise<any>;
 
-     /**
-      * Downloads the given data.
-      * @param data The data to download. Objects will be formatted as JSON before downloading.
-      * @param filename The name of the file that the data should be downloaded as.
-      * @param mimeType The MIME type that should be used. If not specified then it will be inferred from the filename.
-      */
-     download(
-         data: string | object | ArrayBuffer | Blob,
-         filename: string,
-         mimeType?: string
-     ): DownloadAction;
+    /**
+     * Downloads the given data.
+     * @param data The data to download. Objects will be formatted as JSON before downloading.
+     * @param filename The name of the file that the data should be downloaded as.
+     * @param mimeType The MIME type that should be used. If not specified then it will be inferred from the filename.
+     */
+    download(
+        data: string | object | ArrayBuffer | Blob,
+        filename: string,
+        mimeType?: string
+    ): DownloadAction;
 
-     /**
-      * Downloads the given list of bots.
-      * @param bots The bots that should be downloaded.
-      * @param filename The name of the file that the bots should be downloaded as.
-      */
-     downloadBots(bots: Bot[], filename: string): DownloadAction;
+    /**
+     * Downloads the given list of bots.
+     * @param bots The bots that should be downloaded.
+     * @param filename The name of the file that the bots should be downloaded as.
+     */
+    downloadBots(bots: Bot[], filename: string): DownloadAction;
 
-     /**
-      * Downloads all the shared bots in the inst.
-      */
-     downloadInst(): DownloadAction;
+    /**
+     * Downloads all the shared bots in the inst.
+     */
+    downloadInst(): DownloadAction;
 
-     /**
-      * Shows the "Upload AUX File" dialog.
-      */
-     showUploadAuxFile(): ShowUploadAuxFileAction;
+    /**
+     * Shows the "Upload AUX File" dialog.
+     */
+    showUploadAuxFile(): ShowUploadAuxFileAction;
 
-     /**
-      * Shows the "Upload Files" dialog.
-      */
-     showUploadFiles(): Promise<UploadedFile[]>;
+    /**
+     * Shows the "Upload Files" dialog.
+     */
+    showUploadFiles(): Promise<UploadedFile[]>;
 
-     /**
-      * Loads the inst with the given ID.
-      * @param id The ID of the inst to load.
-      */
-     loadInst(id: string): LoadServerAction;
+    /**
+     * Loads the inst with the given ID.
+     * @param id The ID of the inst to load.
+     */
+    loadInst(id: string): LoadServerAction;
 
-     /**
-      * Unloads the inst with the given ID.
-      * @param id The ID of the inst to unload.
-      */
-     unloadInst(id: string): UnloadServerAction;
+    /**
+     * Unloads the inst with the given ID.
+     * @param id The ID of the inst to unload.
+     */
+    unloadInst(id: string): UnloadServerAction;
 
-     /**
-      * Imports the AUX from the given URL or JSON
-      * @param urlOrJSON The URL or JSON to load.
-      *                  If given JSON, then it will be imported as if it was a .aux file.
-      *                  If given a URL, then it will be downloaded and then imported.
-      */
-     importAUX(urlOrJSON: string): ImportAUXAction | ApplyStateAction;
+    /**
+     * Imports the AUX from the given URL or JSON
+     * @param urlOrJSON The URL or JSON to load.
+     *                  If given JSON, then it will be imported as if it was a .aux file.
+     *                  If given a URL, then it will be downloaded and then imported.
+     */
+    importAUX(urlOrJSON: string): ImportAUXAction | ApplyStateAction;
 
-     /**
-      * Parses the given JSON or PDF data and returns the list of bots that were contained in it.
-      * @param jsonOrPdf The JSON or PDF data to parse.
-      */
-     parseBotsFromData(jsonOrPdf: string): Bot[];
+    /**
+     * Parses the given JSON or PDF data and returns the list of bots that were contained in it.
+     * @param jsonOrPdf The JSON or PDF data to parse.
+     */
+    parseBotsFromData(jsonOrPdf: string): Bot[];
 
-     /**
-      * Replaces the bot that the user is beginning to drag.
-      * Only works from inside a onDrag() or onAnyBotDrag() listen tag.
-      * @param bot The bot or mod that should be dragged instead of the original.
-      */
-     replaceDragBot(bot: Mod): ReplaceDragBotAction;
+    /**
+     * Replaces the bot that the user is beginning to drag.
+     * Only works from inside a onDrag() or onAnyBotDrag() listen tag.
+     * @param bot The bot or mod that should be dragged instead of the original.
+     */
+    replaceDragBot(bot: Mod): ReplaceDragBotAction;
 
-     /**
-      * Sets the text stored in the player's clipboard.
-      * @param text The text to set to the clipboard.
-      */
-     setClipboard(text: string): SetClipboardAction;
+    /**
+     * Sets the text stored in the player's clipboard.
+     * @param text The text to set to the clipboard.
+     */
+    setClipboard(text: string): SetClipboardAction;
 
-     /**
-      * Redirects the user to the given URL.
-      * @param url The URL to go to.
-      *
-      * @example
-      * // Send the player to wikipedia.
-      * os.goToURL("https://wikipedia.org");
-      */
-     goToURL(url: string): GoToURLAction;
+    /**
+     * Redirects the user to the given URL.
+     * @param url The URL to go to.
+     *
+     * @example
+     * // Send the player to wikipedia.
+     * os.goToURL("https://wikipedia.org");
+     */
+    goToURL(url: string): GoToURLAction;
 
-     /**
-      * Redirects the user to the given URL.
-      * @param url The URL to go to.
-      *
-      * @example
-      * // Open wikipedia in a new tab.
-      * os.openURL("https://wikipedia.org");
-      */
-     openURL(url: string): OpenURLAction;
+    /**
+     * Redirects the user to the given URL.
+     * @param url The URL to go to.
+     *
+     * @example
+     * // Open wikipedia in a new tab.
+     * os.openURL("https://wikipedia.org");
+     */
+    openURL(url: string): OpenURLAction;
 
-     /**
-      * Shows an input box to edit the given bot and tag.
-      *
-      * @param bot The bot or bot ID that should be edited.
-      * @param tag The tag which should be edited on the bot.
-      * @param options The options that indicate how the input box should be customized.
-      *
-      * @example
-      * // Show an input box for `this` bot's label.
-      * os.showInputForTag(this, "label", {
-      *            title: "Change the label",
-      *            type: "text"
-      * });
-      *
-      * @example
-      * // Show a color picker for the bot's color.
-      * os.showInputForTag(this, "color", {
-      *            title: "Change the color",
-      *            type: "color",
-      *            subtype: "advanced"
-      * });
-      */
-     showInputForTag(
-         bot: Bot | string,
-         tag: string,
-         options?: Partial<ShowInputOptions>
-     ): ShowInputForTagAction;
+    /**
+     * Shows an input box to edit the given bot and tag.
+     *
+     * @param bot The bot or bot ID that should be edited.
+     * @param tag The tag which should be edited on the bot.
+     * @param options The options that indicate how the input box should be customized.
+     *
+     * @example
+     * // Show an input box for `this` bot's label.
+     * os.showInputForTag(this, "label", {
+     *            title: "Change the label",
+     *            type: "text"
+     * });
+     *
+     * @example
+     * // Show a color picker for the bot's color.
+     * os.showInputForTag(this, "color", {
+     *            title: "Change the color",
+     *            type: "color",
+     *            subtype: "advanced"
+     * });
+     */
+    showInputForTag(
+        bot: Bot | string,
+        tag: string,
+        options?: Partial<ShowInputOptions>
+    ): ShowInputForTagAction;
 
-     /**
-      * Shows an input box. Returns a promise that resolves with the new value.
-      *
-      * @param currentValue The value that the input box should be prefilled with.
-      * @param options The options that indicate how the input box should be customized.
-      *
-      * @example
-      * // Show an input box.
-      * const result = await os.showInput({
-      *    title: "Change the label",
-      *    type: "text"
-      * });
-      */
-     showInput: MaskFunc<(
-         currentValue?: any,
-         options?: Partial<ShowInputOptions>
-     ) => Promise<string>>;
+    /**
+     * Shows an input box. Returns a promise that resolves with the new value.
+     *
+     * @param currentValue The value that the input box should be prefilled with.
+     * @param options The options that indicate how the input box should be customized.
+     *
+     * @example
+     * // Show an input box.
+     * const result = await os.showInput({
+     *    title: "Change the label",
+     *    type: "text"
+     * });
+     */
+    showInput: MaskFunc<(
+        currentValue?: any,
+        options?: Partial<ShowInputOptions>
+    ) => Promise<string>>;
 
-     /**
-      * Shows a checkout screen that lets the user purchase something.
-      *
-      * @param options The options for the payment box.
-      *
-      * @example
-      * // Show a checkout box for 10 cookies
-      * os.checkout({
-      *   productId: '10_cookies',
-      *   title: '10 Cookies',
-      *   description: '$5.00',
-      *   processingServer: 'cookies_checkout'
-      * });
-      *
-      */
-     checkout(options: CheckoutOptions): StartCheckoutAction;
+    /**
+     * Shows a checkout screen that lets the user purchase something.
+     *
+     * @param options The options for the payment box.
+     *
+     * @example
+     * // Show a checkout box for 10 cookies
+     * os.checkout({
+     *   productId: '10_cookies',
+     *   title: '10 Cookies',
+     *   description: '$5.00',
+     *   processingServer: 'cookies_checkout'
+     * });
+     *
+     */
+    checkout(options: CheckoutOptions): StartCheckoutAction;
 
-     /**
-      * Gets the dimension that the player is currently viewing.
-      */
-     getCurrentDimension(): string;
+    /**
+     * Gets the dimension that the player is currently viewing.
+     */
+    getCurrentDimension(): string;
 
-     /**
-      * Gets the inst that the player is currently in.
-      */
-     getCurrentInst(): string;
+    /**
+     * Gets the inst that the player is currently in.
+     */
+    getCurrentInst(): string;
 
-     /**
-      * Gets the distance that the player bot is from the given dimension.
-      *
-      * Returns 0 if the player bot is in the dimension, 1 if the dimension is in a portal, and -1 if neither are true.
-      *
-      * @param dimension The dimension to check for.
-      */
-     getDimensionalDepth(dimension: string): number;
+    /**
+     * Gets the distance that the player bot is from the given dimension.
+     *
+     * Returns 0 if the player bot is in the dimension, 1 if the dimension is in a portal, and -1 if neither are true.
+     *
+     * @param dimension The dimension to check for.
+     */
+    getDimensionalDepth(dimension: string): number;
 
-     /**
-      * Determines whether the player has the given bot in their miniGridPortal.
-      * @param bots The bot or bots to check.
-      */
-     hasBotInMiniPortal(bots: Bot | Bot[]): boolean;
+    /**
+     * Determines whether the player has the given bot in their miniGridPortal.
+     * @param bots The bot or bots to check.
+     */
+    hasBotInMiniPortal(bots: Bot | Bot[]): boolean;
 
-     /**
-      * Gets the current user's bot.
-      */
-     getBot(): Bot;
+    /**
+     * Gets the current user's bot.
+     */
+    getBot(): Bot;
 
-     /**
-      * Gets the name of the dimension that is used for the current user's menu.
-      */
-     getMenuDimension(): string;
+    /**
+     * Gets the name of the dimension that is used for the current user's menu.
+     */
+    getMenuDimension(): string;
 
-     /**
-      * Gets the name of the dimension that is used for the current user's miniGridPortal.
-      */
-     getMiniPortalDimension(): string;
+    /**
+     * Gets the name of the dimension that is used for the current user's miniGridPortal.
+     */
+    getMiniPortalDimension(): string;
 
-     /**
-      * Registers a custom app for the given bot with the given options.
-      * Apps allow you add custom functionality to the CasualOS frontend and are deeply integrated into the CasualOS platform.
-      * 
-      * @param id The ID of the app.
-      * @param bot The bot that should be used to control the app.
-      */
-      registerApp(
-         id: string,
-         bot: Bot | string
-     ): Promise<void>;
+    /**
+     * Registers a custom app for the given bot with the given options.
+     * Apps allow you add custom functionality to the CasualOS frontend and are deeply integrated into the CasualOS platform.
+     * 
+     * @param id The ID of the app.
+     * @param bot The bot that should be used to control the app.
+     */
+    registerApp(
+        id: string,
+        bot: Bot | string
+    ): Promise<void>;
 
-     /**
-      * Removes a custom app from the session.
-      * 
-      * @param id The ID of the app.
-      */
-     unregisterApp(
-         id: string
-     ): Promise<void>;
+    /**
+     * Removes a custom app from the session.
+     * 
+     * @param id The ID of the app.
+     */
+    unregisterApp(
+        id: string
+    ): Promise<void>;
 
-     /**
-      * Sets the output of the given app.
-      * @param id The ID of the app.
-      * @param output The output that the app should display.
-      */
-     compileApp(id: string, output: any): SetAppOutputAction;
+    /**
+     * Sets the output of the given app.
+     * @param id The ID of the app.
+     * @param output The output that the app should display.
+     */
+    compileApp(id: string, output: any): SetAppOutputAction;
 
-     /**
-      * Requests that the current session be authorized and for a global bot to be created
-      * to contain information about the authorized user. Resovles with a null bot if unable to login.
-      */
-     requestAuthBot(): Promise<Bot>;
+    /**
+     * Requests that the current session be authorized and for a global bot to be created
+     * to contain information about the authorized user. Resovles with a null bot if unable to login.
+     */
+    requestAuthBot(): Promise<Bot>;
 
     /**
      * Gets an access key for the given public record.
@@ -8427,7 +8427,7 @@ interface Os {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
      */
-     eraseManualApprovalData(recordKey: string, address: string): Promise<EraseDataResult>;
+    eraseManualApprovalData(recordKey: string, address: string): Promise<EraseDataResult>;
 
     /**
      * Records the given data as a file.
@@ -8435,7 +8435,7 @@ interface Os {
      * @param data The data that should be recorded.
      * @param options The options that should be used to record the file.
      */
-     recordFile(
+    recordFile(
         recordKey: string,
         data: any,
         options?: RecordFileOptions
@@ -8446,15 +8446,15 @@ interface Os {
      * @param result The successful result of a os.recordFile() call.
      */
     getFile(result: RecordFileSuccess): Promise<any>;
-     /**
-      * Gets the data stored in the given file.
-      * @param url The URL that the file is stored at.
-      */
+    /**
+     * Gets the data stored in the given file.
+     * @param url The URL that the file is stored at.
+     */
     getFile(url: string): Promise<any>;
-     /**
-      * Gets the data stored in the given file.
-      * @param urlOrRecordFileResult The URL or the successful result of the record file operation.
-      */
+    /**
+     * Gets the data stored in the given file.
+     * @param urlOrRecordFileResult The URL or the successful result of the record file operation.
+     */
     getFile(urlOrRecordFileResult: string | RecordFileSuccess): Promise<any>;
 
     /**
@@ -8463,11 +8463,11 @@ interface Os {
      * @param result The successful result of a os.recordFile() call.
      */
     eraseFile(recordKey: string, result: RecordFileSuccess): Promise<EraseFileResult>;
-     /**
-      * Deletes the specified file using the given record key.
-      * @param recordKey The key that should be used to delete the file.
-      * @param url The URL that the file is stored at.
-      */
+    /**
+     * Deletes the specified file using the given record key.
+     * @param recordKey The key that should be used to delete the file.
+     * @param url The URL that the file is stored at.
+     */
     eraseFile(recordKey: string, url: string): Promise<EraseFileResult>;
     /**
      * Deletes the specified file using the given record key.
@@ -8496,64 +8496,64 @@ interface Os {
      */
     convertGeolocationToWhat3Words(location: ConvertGeolocationToWhat3WordsOptions): Promise<string>;
 
-     /**
-      * Specifies that the given prefix should be interpreted as code.
-      * @param prefix The prefix that code tags should start with.
-      * @param options The options that should be used for the prefix.
-      */
+    /**
+     * Specifies that the given prefix should be interpreted as code.
+     * @param prefix The prefix that code tags should start with.
+     * @param options The options that should be used for the prefix.
+     */
     registerTagPrefix(prefix: string, options?: RegisterPrefixOptions): Promise<void>;
 
-     /**
-      * Gets the number of devices that are viewing the current inst.
-      * @param inst The inst to get the statistics for. If omitted, then the current inst is used.
-      */
-     remoteCount(inst?: string): Promise<number>;
+    /**
+     * Gets the number of devices that are viewing the current inst.
+     * @param inst The inst to get the statistics for. If omitted, then the current inst is used.
+     */
+    remoteCount(inst?: string): Promise<number>;
 
-      /**
-      * Gets the list of remote IDs that are connected to the inst.
-      */
-     remotes(): Promise<string[]>;
+    /**
+    * Gets the list of remote IDs that are connected to the inst.
+    */
+    remotes(): Promise<string[]>;
 
-     /**
-      * Sends an event to the server to setup a new inst if it does not exist.
-      * @param inst The inst.
-      * @param botOrMod The bot or mod that should be cloned into the new inst.
-      */
-     setupInst(inst: string, botOrMod?: Mod): Promise<void>;
+    /**
+     * Sends an event to the server to setup a new inst if it does not exist.
+     * @param inst The inst.
+     * @param botOrMod The bot or mod that should be cloned into the new inst.
+     */
+    setupInst(inst: string, botOrMod?: Mod): Promise<void>;
 
-      /**
-      * Gets the total number of devices that are connected to the server.
-      */
-     totalRemoteCount(): Promise<number>;
+    /**
+    * Gets the total number of devices that are connected to the server.
+    */
+    totalRemoteCount(): Promise<number>;
 
-     /**
-      * Gets the list of instances that are on the server.
-      */
-     instances(): Promise<string[]>;
+    /**
+     * Gets the list of instances that are on the server.
+     */
+    instances(): Promise<string[]>;
 
-     /**
-      * Gets the list of instances that are on the server.
-      */
-     instStatuses(): Promise<{
-         inst: string,
-         lastUpdateTime: Date
-     }[]>;
+    /**
+     * Gets the list of instances that are on the server.
+     */
+    instStatuses(): Promise<{
+        inst: string,
+        lastUpdateTime: Date
+    }[]>;
 
-     /**
-      * Creates a new debugger that can be used to test and simulate bots.
-      * @param options The options that should be used for the debugger.
-      */
-     createDebugger(options?: DebuggerOptions): Debugger;
+    /**
+     * Creates a new debugger that can be used to test and simulate bots.
+     * @param options The options that should be used for the debugger.
+     */
+    createDebugger(options?: DebuggerOptions): Debugger;
 
-     /**
-      * Gets the debugger that this script is currently running in.
-      */
-     getExecutingDebugger(): Debugger;
+    /**
+     * Gets the debugger that this script is currently running in.
+     */
+    getExecutingDebugger(): Debugger;
 
-     /**
-      * The global variables that are stored in the OS.
-      */
-     vars: typeof globalThis;
+    /**
+     * The global variables that are stored in the OS.
+     */
+    vars: typeof globalThis;
 }
 
 interface Server {
@@ -8708,81 +8708,81 @@ interface Server {
      * Initializes i2c for use.
      */
     rpioI2CBegin(): Promise<void>;
-    
+
     /**
      * Configure the slave address.
      * @param address The slave address to set.
      */
     rpioI2CSetSlaveAddress(address: number): Promise<void>;
-    
+
     /**
      * Set the baud rate. Directly set the speed in hertz.
      * @param rate The i2c refresh rate in hertz.
      */
     rpioI2CSetBaudRate(rate: number): Promise<void>;
-    
+
     /**
      * Set the baud rate. Set it based on a divisor of the base 250MHz rate.
      * @param rate The i2c refresh rate based on a divisor of the base 250MHz rate.
      */
     rpioI2CSetClockDivider(rate: number): Promise<void>;
-    
+
     /**
      * Read from the i2c slave.
      * @param rx Buffer to read.
      * @param length Optional. Length of the buffer to read.
      */
     rpioI2CRead(rx: number[], length?: number): Promise<void>;
-    
+
     /**
      * Write to the i2c slave.
      * @param tx Buffer to write.
      * @param length Optional. Length of the buffer to write.
      */
     rpioI2CWrite(tx: number[], length?: number): Promise<void>;
-    
+
     /**
      * 
      */
     // rpioI2CReadRegisterRestart(): Promise<void>;
-    
+
     /**
      * 
      */
     // rpioI2CWriteReadRestart(): Promise<void>;
-    
+
     /**
      * Turn off the i²c interface and return the pins to GPIO.
      */
     rpioI2CEnd(): Promise<void>;
-    
-    
+
+
     /**
      * This is a power-of-two divisor of the base 19.2MHz rate, with a maximum value of 4096 (4.6875kHz).
      * @param rate The PWM refresh rate.
      */
     rpioPWMSetClockDivider(rate: number): Promise<void>;
-    
+
     /**
      * This determines the maximum pulse width.
      * @param pin The physical pin number.
      * @param range The PWM range for a pin.
      */
     rpioPWMSetRange(pin: number, range: number): Promise<void>;
-    
-    
+
+
     /**
      * Set the width for a given pin.
      * @param pin The physical pin number.
      * @param width The PWM width for a pin.
      */
     rpioPWMSetData(pin: number, width: number): Promise<void>;
-    
+
     /**
      * Initiate SPI mode.
      */
     rpioSPIBegin(): Promise<void>;
-    
+
     /**
      * Choose which of the chip select / chip enable pins to control.
      *  Value | Pin
@@ -8793,7 +8793,7 @@ interface Server {
      * @param value The value correlating to pin(s) to control.
      */
     rpioSPIChipSelect(value: 0 | 1 | 2): Promise<void>;
-    
+
     /**
      * If your device's CE pin is active high, use this to change the polarity.
      * *  Value | Pin
@@ -8805,13 +8805,13 @@ interface Server {
      * @param polarity Set the polarity it activates on. HIGH or LOW
      */
     rpioSPISetCSPolarity(value: 0 | 1 | 2, polarity: 'HIGH' | 'LOW'): Promise<void>;
-    
+
     /**
      * Set the SPI clock speed.
      * @param rate It is an even divisor of the base 250MHz rate ranging between 0 and 65536.
      */
     rpioSPISetClockDivider(rate: number): Promise<void>;
-    
+
     /**
      * Set the SPI Data Mode.
      *  Mode | CPOL | CPHA
@@ -8823,22 +8823,22 @@ interface Server {
      * @param mode The SPI Data Mode.
      */
     rpioSPISetDataMode(mode: 0 | 1 | 2 | 3): Promise<void>;
-    
+
     /**
      * 
      */
     rpioSPITransfer(tx: number[]): Promise<void>;
-    
+
     /**
      * 
      */
     rpioSPIWrite(tx: number[]): Promise<void>;
-    
+
     /**
      * Release the pins back to general purpose use.
      */
     rpioSPIEnd(): Promise<void>;
-    
+
     /**
      * Establish the connection to the bluetooth serial device
      * @param name A friendly device name. Example: Brush01
@@ -8877,7 +8877,7 @@ interface Server {
      * {number} [bindingOptions.vtime=0] see [`man termios`](http://linux.die.net/man/3/termios) LinuxBinding and DarwinBinding
      */
     serialConnect(name: string, device: string, mac: string, channel: number, options?: object, cb?: any): Promise<void>;
-    
+
     /**
      * Parses and returns the serial stream to the event tag 'onSerialData'.
      * @param bot The id of the bot you want data streamed to. The bot needs the 'onSerialData' tag.
@@ -8898,7 +8898,7 @@ interface Server {
      * @param cb
      */
     serialUpdate(name: string, options: object, cb?: any): Promise<void>;
-    
+
     /**
      * Writes the provided data/command to the device
      * @param name A friendly device name. Example: Brush01
@@ -8907,8 +8907,8 @@ interface Server {
      * @param cb
      * @param taskId The ID of the async task.
      */
-    serialWrite(name: string, data: string|number[], encoding?: string, cb?: any): Promise<void>;
-    
+    serialWrite(name: string, data: string | number[], encoding?: string, cb?: any): Promise<void>;
+
     /**
      * Request a number of bytes from the SerialPort.
      * @param name A friendly device name. Example: Brush01
@@ -8916,7 +8916,7 @@ interface Server {
      * @param taskId The ID of the async task.
      */
     serialRead(name: string, size?: number): Promise<void>;
-    
+
     /**
      * Closes an open connection. 
      * @param name A friendly device name. Example: Brush01
@@ -8925,33 +8925,33 @@ interface Server {
      * @param taskId The ID of the async task.
      */
     serialClose(name: string, device: string, cb?: any): Promise<void>;
-    
+
     /**
      * Flush discards data that has been received but not read, or written but not transmitted by the operating system. 
      * @param name A friendly device name. Example: Brush01
      * @param taskId The ID of the async task.
      */
     serialFlush(name: string): Promise<void>;
-    
+
     /**
      * Waits until all output data is transmitted to the serial port. After any pending write has completed, it calls `tcdrain()` or `FlushFileBuffers()` to ensure it has been written to the device. 
      * @param name A friendly device name. Example: Brush01
      * @param taskId The ID of the async task.
      */
     serialDrain(name: string): Promise<void>;
-    
+
     /**
      * Causes a stream in flowing mode to stop emitting 'data' events, switching out of flowing mode. Any data that becomes available remains in the internal buffer.
      * @param name A friendly device name. Example: Brush01
      */
     serialPause(name: string): Promise<void>;
-    
+
     /**
      * Causes an explicitly paused, Readable stream to resume emitting 'data' events, switching the stream into flowing mode.
      * @param name A friendly device name. Example: Brush01
      */
     serialResume(name: string): Promise<void>;
-    
+
     /**
      * Executes the given shell script on the server.
      * @param script The shell script that should be executed.
@@ -9278,7 +9278,7 @@ interface ModFuncs {
     };
 };
 
-interface Crypto{
+interface Crypto {
     /**
      * Calculates the SHA-256 hash of the given data.
      * Returns the hexadecimal string of the hash.
@@ -9344,7 +9344,7 @@ interface Crypto{
      * Determines if the given value has been encrypted with symmetric encryption.
      * @param cyphertext The value to test to see if it is encrypted.
      */
-     isEncrypted(cyphertext: string): boolean;
+    isEncrypted(cyphertext: string): boolean;
 
     /**
      * Contains functions useful for asymmetric encryption.
@@ -9375,7 +9375,7 @@ interface Crypto{
          * asymmetric encryption.
          * @param keypair The value to test to see if it is a keypair that can be used for asymmetric encryption.
          */
-         isKeypair(keypair: string): boolean;
+        isKeypair(keypair: string): boolean;
 
         /**
          * Encrypts the given data with the given keypair and returns the result.
@@ -9412,7 +9412,7 @@ interface Crypto{
          * Determines if the given value is encrypted using asymmetric encryption.
          * @param cyphertext The value to test to see if it is encrypted.
          */
-         isEncrypted(cyphertext: string): boolean;
+        isEncrypted(cyphertext: string): boolean;
     };
 
     /**
@@ -9558,7 +9558,7 @@ interface Experiment {
         bot: Bot,
         dimension: string,
         anchorPoint: BotAnchorPoint
-    ): {x: number, y: number, z: number};
+    ): { x: number, y: number, z: number };
 
     /**
      * Starts a new recording.

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -55,6 +55,8 @@ import {
     defineGlobalBot,
     isBotLink,
     parseBotLink,
+    isBotDate,
+    parseBotDate,
 } from '../bots';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -1643,6 +1645,11 @@ export class AuxRuntime
             value = true;
         } else if (value === 'false') {
             value = false;
+        } else if (isBotDate(value)) {
+            const result = parseBotDate(value);
+            if (result) {
+                value = result;
+            }
         }
 
         return { value, listener };

--- a/src/aux-common/runtime/RuntimeBot.spec.ts
+++ b/src/aux-common/runtime/RuntimeBot.spec.ts
@@ -23,6 +23,7 @@ import {
     RuntimeBotInterface,
     RealtimeEditMode,
     flattenTagMasks,
+    RealtimeEditConfig,
 } from './RuntimeBot';
 import { TestScriptBotFactory } from './test/TestScriptBotFactory';
 import { createCompiledBot, CompiledBot } from './CompiledBot';
@@ -39,7 +40,7 @@ import {
     remoteEdit,
     remoteEdits,
 } from '../aux-format-2';
-import { types } from 'util';
+import { DateTime } from 'luxon';
 
 describe('RuntimeBot', () => {
     let precalc: CompiledBot;
@@ -48,14 +49,22 @@ describe('RuntimeBot', () => {
     let version: AuxVersion;
     let device: AuxDevice;
     let manager: RuntimeBotInterface;
-    let updateTagMock: jest.Mock;
+    let updateTagMock: jest.Mock<
+        RealtimeEditConfig,
+        [CompiledBot, string, any]
+    >;
     let getListenerMock: jest.Mock;
     let getRawValueMock: jest.Mock;
     let getSignatureMock: jest.Mock;
     let notifyChangeMock: jest.Mock;
-    let updateTagMaskMock: jest.Mock;
+    let updateTagMaskMock: jest.Mock<
+        RealtimeEditConfig,
+        [CompiledBot, string, string[], any]
+    >;
     let getTagMaskMock: jest.Mock;
     let getTagLinkMock: jest.Mock;
+    let realtimeEditMode: RealtimeEditMode;
+    let changedValue: any;
 
     beforeEach(() => {
         version = {
@@ -71,6 +80,8 @@ describe('RuntimeBot', () => {
             isCollaborative: true,
             ab1BootstrapUrl: 'ab1Bootstrap',
         };
+        realtimeEditMode = RealtimeEditMode.Immediate;
+        changedValue = null;
         updateTagMock = jest.fn();
         updateTagMock.mockImplementation((bot, tag, value) => {
             if (isTagEdit(value)) {
@@ -87,7 +98,10 @@ describe('RuntimeBot', () => {
                     delete bot.tags[tag];
                 }
             }
-            return RealtimeEditMode.Immediate;
+            return {
+                mode: realtimeEditMode,
+                changedValue: changedValue ?? value,
+            };
         });
 
         updateTagMaskMock = jest.fn();
@@ -112,7 +126,10 @@ describe('RuntimeBot', () => {
                     }
                 }
             }
-            return RealtimeEditMode.Immediate;
+            return {
+                mode: realtimeEditMode,
+                changedValue: changedValue ?? value,
+            };
         });
 
         getTagMaskMock = jest.fn();
@@ -247,11 +264,28 @@ describe('RuntimeBot', () => {
 
         it('should update the raw tags with the new value', () => {
             script.tags.fun = 'hello';
+            expect(script.tags.fun).toEqual('hello');
             expect(script.raw.fun).toEqual('hello');
         });
 
+        it('should use the returned changedValue for changes', () => {
+            realtimeEditMode = RealtimeEditMode.Immediate;
+            changedValue = 'mycustomvalue';
+            script.tags.fun = DateTime.utc(2021, 11, 13, 7, 14, 41, 13);
+            expect(script.tags.fun).toEqual(
+                DateTime.utc(2021, 11, 13, 7, 14, 41, 13)
+            );
+            expect(script.raw.fun).toEqual(
+                DateTime.utc(2021, 11, 13, 7, 14, 41, 13)
+            );
+            expect(script.changes.fun).toBe('mycustomvalue');
+        });
+
         it('should prevent setting the tag when updateTag() returns RealtimeEditMode.None', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.None);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.None,
+                changedValue: 'hello',
+            });
             script.tags.fun = 'hello';
             expect(script.tags.fun).not.toEqual('hello');
             expect(script.raw.fun).not.toEqual('hello');
@@ -273,14 +307,20 @@ describe('RuntimeBot', () => {
         });
 
         it('should prevent deleting the tag when updateTag() returns RealtimeEditMode.None', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.None);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.None,
+                changedValue: null,
+            });
             delete script.tags.abc;
             expect(script.tags.abc).not.toEqual(null);
             expect(script.raw.abc).not.toEqual(null);
         });
 
         it('should delay setting the tag when updateTag() returns RealtimeEditMode.Delayed', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.Delayed);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.Delayed,
+                changedValue: 'fun',
+            });
             script.tags.abc = 'fun';
             expect(script.tags.abc).not.toEqual('fun');
             expect(script.raw.abc).not.toEqual('fun');
@@ -288,7 +328,10 @@ describe('RuntimeBot', () => {
         });
 
         it('should delay deleting the tag when updateTag() returns RealtimeEditMode.Delayed', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.Delayed);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.Delayed,
+                changedValue: null,
+            });
             delete script.tags.abc;
             expect(script.tags.abc).not.toEqual(null);
             expect(script.raw.abc).not.toEqual(null);
@@ -583,10 +626,26 @@ describe('RuntimeBot', () => {
         });
 
         it('should prevent setting the tag when updateTag() returns RealtimeEditMode.None', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.None);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.None,
+                changedValue: 'hello',
+            });
             script.raw.fun = 'hello';
             expect(script.tags.fun).not.toEqual('hello');
             expect(script.raw.fun).not.toEqual('hello');
+        });
+
+        it('should use the returned changedValue for changes', () => {
+            realtimeEditMode = RealtimeEditMode.Immediate;
+            changedValue = 'mycustomvalue';
+            script.raw.fun = DateTime.utc(2021, 11, 13, 7, 14, 41, 13);
+            expect(script.tags.fun).toEqual(
+                DateTime.utc(2021, 11, 13, 7, 14, 41, 13)
+            );
+            expect(script.raw.fun).toEqual(
+                DateTime.utc(2021, 11, 13, 7, 14, 41, 13)
+            );
+            expect(script.changes.fun).toBe('mycustomvalue');
         });
 
         it('should support the delete keyword', () => {
@@ -600,14 +659,20 @@ describe('RuntimeBot', () => {
         });
 
         it('should prevent deleting the tag when updateTag() returns RealtimeEditMode.None', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.None);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.None,
+                changedValue: null,
+            });
             delete script.raw.abc;
             expect(script.tags.abc).not.toEqual(null);
             expect(script.raw.abc).not.toEqual(null);
         });
 
         it('should delay setting the tag when updateTag() returns RealtimeEditMode.Delayed', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.Delayed);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.Delayed,
+                changedValue: 'fun',
+            });
             script.raw.abc = 'fun';
             expect(script.tags.abc).not.toEqual('fun');
             expect(script.raw.abc).not.toEqual('fun');
@@ -615,7 +680,10 @@ describe('RuntimeBot', () => {
         });
 
         it('should delay deleting the tag when updateTag() returns RealtimeEditMode.Delayed', () => {
-            updateTagMock.mockReturnValueOnce(RealtimeEditMode.Delayed);
+            updateTagMock.mockReturnValueOnce({
+                mode: RealtimeEditMode.Delayed,
+                changedValue: null,
+            });
             delete script.raw.abc;
             expect(script.tags.abc).not.toEqual(null);
             expect(script.raw.abc).not.toEqual(null);
@@ -950,6 +1018,20 @@ describe('RuntimeBot', () => {
             expect(script.maskChanges).toEqual({
                 tempLocal: {
                     abc: true,
+                },
+            });
+        });
+
+        it('should use the returned changedValue for changes', () => {
+            realtimeEditMode = RealtimeEditMode.Immediate;
+            changedValue = 'mycustomvalue';
+            script.masks.fun = DateTime.utc(2021, 11, 13, 7, 14, 41, 13);
+            expect(script.masks.fun).toEqual(
+                DateTime.utc(2021, 11, 13, 7, 14, 41, 13)
+            );
+            expect(script.maskChanges).toEqual({
+                tempLocal: {
+                    fun: 'mycustomvalue',
                 },
             });
         });

--- a/src/aux-common/runtime/Utils.spec.ts
+++ b/src/aux-common/runtime/Utils.spec.ts
@@ -8,6 +8,7 @@ import {
 } from './Utils';
 import './BlobPolyfill';
 import { createDummyRuntimeBot } from './test/TestScriptBotFactory';
+import { DateTime } from 'luxon';
 
 describe('convertErrorToCopiableValue()', () => {
     it('should convert error objects into an object with message and name', () => {
@@ -192,6 +193,12 @@ describe('convertToCopiableValue()', () => {
         const result = convertToCopiableValue(test);
 
         expect(result).toBe('[Function test]');
+    });
+
+    it('should format DateTime objects', () => {
+        const value = DateTime.utc(2012, 11, 13, 14, 15, 16);
+        const result = convertToCopiableValue(value);
+        expect(result).toBe('📅2012-11-13T14:15:16Z');
     });
 
     const errorCases = [

--- a/src/aux-common/runtime/Utils.ts
+++ b/src/aux-common/runtime/Utils.ts
@@ -1,10 +1,16 @@
 import { RealtimeEditMode } from './RuntimeBot';
-import { hasValue, isBot, isRuntimeBot } from '../bots/BotCalculations';
+import {
+    formatBotDate,
+    hasValue,
+    isBot,
+    isRuntimeBot,
+} from '../bots/BotCalculations';
 import { AuxPartitionRealtimeStrategy } from '../partitions/AuxPartition';
 import { forOwn } from 'lodash';
 import { Easing, EaseMode, EaseType, Bot } from '../bots';
 import TWEEN, { Easing as TweenEasing } from '@tweenjs/tween.js';
 import './BlobPolyfill';
+import { DateTime } from 'luxon';
 
 /**
  * Converts the given error to a copiable value.
@@ -104,6 +110,8 @@ function _convertToCopiableValue(
             return value;
         } else if (ArrayBuffer.isView(value)) {
             return value;
+        } else if (value instanceof DateTime) {
+            return formatBotDate(value);
         } else {
             let result = {} as any;
             map.set(value, result);

--- a/src/aux-common/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-common/runtime/test/TestScriptBotFactory.ts
@@ -70,7 +70,10 @@ export const testScriptBotInterface: RuntimeBotInterface = {
                 delete bot.values[tag];
             }
         }
-        return RealtimeEditMode.Immediate;
+        return {
+            mode: RealtimeEditMode.Immediate,
+            changedValue: newValue,
+        };
     },
     getValue(bot: PrecalculatedBot, tag: string) {
         return bot.values[tag];
@@ -120,7 +123,10 @@ export const testScriptBotInterface: RuntimeBotInterface = {
                 bot.masks[space][tag] = value;
             }
         }
-        return RealtimeEditMode.Immediate;
+        return {
+            mode: RealtimeEditMode.Immediate,
+            changedValue: value,
+        };
     },
     getTagLink(bot: CompiledBot, tag: string) {
         return null;

--- a/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotTable/BotTable.ts
@@ -32,6 +32,7 @@ import {
     BotSpace,
     getScriptPrefix,
     isBotLink,
+    KNOWN_TAG_PREFIXES,
 } from '@casual-simulation/aux-common';
 import { EventBus } from '@casual-simulation/aux-components';
 
@@ -199,9 +200,7 @@ export default class BotTable extends Vue {
     }
 
     getTagPrefix(tag: string, space: string) {
-        const prefixes = this._simulation.portals.scriptPrefixes.map(
-            (p) => p.prefix
-        );
+        const prefixes = KNOWN_TAG_PREFIXES;
         let allSamePrefix = true;
         let currentPrefix = null;
         for (let bot of this.bots) {

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.css
@@ -11,10 +11,6 @@
     color: #fe6a2f;
 }
 
-.custom-prefix {
-    color: #7b64ff;
-}
-
 .bot-tag.light .tag-name {
     font-weight: 400;
 }

--- a/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
+++ b/src/aux-server/aux-web/shared/vue-components/BotTag/BotTag.vue
@@ -1,7 +1,7 @@
 <template>
     <span class="tag bot-tag" :class="{ clonable: allowCloning, light: light }">
         <span v-if="prefix">
-            <span :class="{ 'at-symbol': isScript, 'custom-prefix': !isScript }">{{ prefix }}</span
+            <span :class="{ 'at-symbol': isScript }">{{ prefix }}</span
             ><span class="tag-name">{{ tag }}</span>
         </span>
         <span v-else>


### PR DESCRIPTION
-   Added the ability to store dates in tags by prefixing them with `📅`.
    -   Dates must be formatted similarly to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
        -   `2012-02-06` (year-month-day in UTC-0 time zone)
        -   `2015-08-16T08:45:00` (year-month-day + hour:minute:second in UTC-0 time zone)
        -   `2015-08-16T08:45:00 America/New_York` (year-month-day + hour:minute:second in specified time zone)
        -   `2015-08-16T08:45:00 local` (year-month-day + hour:minute:second + in local time zone)
    -   In scripts, date tags are automatically parsed and converted to DateTime objects.
        -   DateTime objects are easy-to-use representations of date and time with respect to a specific time zone.
        -   They work better than the built-in [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) class because DateTime supports time zones whereas Date does not.
        -   You can learn more about them by checking out the [documentation](https://docs.casualos.com/docs/actions#datetime).
-   Added the `getDateTime(value)` function to make parsing strings into DateTime objects easy.
    -   Parses the given value and returns a new DateTime that represents the date that was contained in the value.
    -   Returns null if the value could not be parsed.