### PR TITLE
Add the ability to login to the Auth site with SMS

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,6 +28,12 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Fix node-gyp (Windows Only)
+              if: matrix.os == 'windows-latest'
+              shell: pwsh
+              run: |
+                  npm install -g node-gyp
+                  npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
             - name: npm install and test
               run: |
                   npm ci
@@ -48,6 +54,12 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Fix node-gyp (Windows Only)
+              if: matrix.os == 'windows-latest'
+              shell: pwsh
+              run: |
+                  npm install -g node-gyp
+                  npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
             - name: npm install and build
               run: |
                   npm ci
@@ -68,6 +80,12 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: Fix node-gyp (Windows Only)
+              if: matrix.os == 'windows-latest'
+              shell: pwsh
+              run: |
+                  npm install -g node-gyp
+                  npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
             - name: yarn install and build docs
               run: |
                   cd docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
               with:
                   node-version: 14.x
                   registry-url: 'https://registry.npmjs.org'
+            - name: Fix node-gyp (Windows Only)
+              if: matrix.os == 'windows-latest'
+              shell: pwsh
+              run: |
+                  npm install -g node-gyp
+                  npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
             - name: NPM Install
               run: |
                   npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### :rocket: Improvements
 
 -   Improved performance for lower end devices by making CasualOS more efficient when automatically updating bots with user input.
+-   Added the ability to login with a phone number instead of an email address.
 
 ## V3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 -   Improved performance for lower end devices by making CasualOS more efficient when automatically updating bots with user input.
 -   Added the ability to login with a phone number instead of an email address.
+    -   This feature is enabled by the `ENABLE_SMS_AUTHENTICATION` environment variable during builds.
 
 ## V3.0.1
 

--- a/src/aux-auth/README.md
+++ b/src/aux-auth/README.md
@@ -24,6 +24,7 @@ To deploy this project to AWS Lambda, follow these steps:
     - `REDIS_USE_TLS` - Whether TLS should be used to connect to redis.
     - `REDIS_PASSWORD` - The password that should be used to connect to redis.
     - `REDIS_RECORDS_NAMESPACE` - The key prefix that records should be stored under in redis.
+    - `ENABLE_SMS_AUTHENTICATION` - Whether SMS authentication is should be enabled for logins.
 3. Run a build.
 4. After the build, go to CloudFormation and find the stack update.
     - Review the changes to ensure that they are correct and then execute the stack update.

--- a/src/aux-auth/shared/AuthMetadata.ts
+++ b/src/aux-auth/shared/AuthMetadata.ts
@@ -1,6 +1,7 @@
 export interface UserMetadata {
     email: string;
     name: string;
+    phone: string;
     avatarUrl: string;
     avatarPortraitUrl: string;
 }

--- a/src/aux-auth/web/iframe/AuthHandler.ts
+++ b/src/aux-auth/web/iframe/AuthHandler.ts
@@ -222,6 +222,20 @@ export class AuthHandler implements AuxAuth {
             return;
         }
 
+        sms = sms.trim();
+        if (!sms.startsWith('+')) {
+            this._loginUIStatus.next({
+                page: 'enter_email',
+                siteName: this.siteName,
+                termsOfServiceUrl: this.termsOfServiceUrl,
+                showInvalidSmsError: true,
+                errorCode: 'invalid_sms',
+                errorMessage: 'The phone number must include the country code.',
+                supportsSms: this._supportsSms
+            });
+            return;
+        }
+
         console.log('[AuthHandler] Got SMS number.');
         this._providedSms.next(sms);
     }
@@ -356,13 +370,13 @@ export class AuthHandler implements AuxAuth {
                         phoneNumber: sms
                     });
                     this._loginUIStatus.next({
-                        page: 'check_sms'
+                        page: 'show_iframe'
                     });
 
-                    await promiEvent;
+                    const result = await promiEvent;
 
                     sub.unsubscribe();
-                    resolve(null);
+                    resolve(result);
                 } catch(err) {
                     console.log('[AuthHandler] Unable to send SMS.', err);
                     this._loginUIStatus.next({

--- a/src/aux-auth/web/iframe/AuthHandler.ts
+++ b/src/aux-auth/web/iframe/AuthHandler.ts
@@ -19,6 +19,8 @@ const REFRESH_BUFFER_SECONDS = 5;
 
 const NULL_SERVICE = '(null)';
 
+declare let ENABLE_SMS_AUTHENTICATION: boolean;
+
 /**
  * Defines a class that implements the backend for an AuxAuth instance.
  */
@@ -503,6 +505,6 @@ export class AuthHandler implements AuxAuth {
     }
 
     private get _supportsSms() {
-        return true;
+        return ENABLE_SMS_AUTHENTICATION === true;
     }
 }

--- a/src/aux-auth/web/shared/AuthManager.ts
+++ b/src/aux-auth/web/shared/AuthManager.ts
@@ -17,6 +17,7 @@ export class AuthManager {
     private _magic: Magic;
 
     private _email: string;
+    private _phone: string;
     private _userId: string;
     private _idToken: string;
     private _appMetadata: AppMetadata;
@@ -41,6 +42,10 @@ export class AuthManager {
 
     get email() {
         return this._email;
+    }
+
+    get phone() {
+        return this._phone;
     }
 
     get idToken() {
@@ -80,10 +85,11 @@ export class AuthManager {
     }
 
     async loadUserInfo() {
-        const { email, issuer, publicAddress } =
+        const { email, issuer, publicAddress, phoneNumber } =
             await this.magic.user.getMetadata();
         this._idToken = await this.magic.user.getIdToken();
         this._email = email;
+        this._phone = phoneNumber;
         this._userId = issuer;
 
         this._saveAcceptedTerms(true);

--- a/src/aux-auth/web/site/AuthHome/AuthHome.ts
+++ b/src/aux-auth/web/site/AuthHome/AuthHome.ts
@@ -16,6 +16,7 @@ export default class AuthHome extends Vue {
     metadata: UserMetadata = null;
     originalEmail: string = null;
     originalName: string = null;
+    originalPhone: string = null;
     originalAvatarUrl: string = null;
     originalAvatarPortraitUrl: string = null;
 
@@ -39,11 +40,13 @@ export default class AuthHome extends Vue {
             this.originalName = authManager.name;
             this.originalAvatarUrl = authManager.avatarUrl;
             this.originalAvatarPortraitUrl = authManager.avatarPortraitUrl;
+            this.originalPhone = authManager.phone;
             this.metadata = {
                 email: authManager.email,
                 avatarUrl: authManager.avatarUrl,
                 avatarPortraitUrl: authManager.avatarPortraitUrl,
                 name: authManager.name,
+                phone: authManager.phone,
             };
         });
     }

--- a/src/aux-auth/web/site/AuthHome/AuthHome.vue
+++ b/src/aux-auth/web/site/AuthHome/AuthHome.vue
@@ -23,6 +23,17 @@
                         >Save Email</md-button
                     >
                 </div>
+                <div class="button-field">
+                    <md-field class="md-disabled">
+                        <label for="email">Phone</label>
+                        <md-input
+                            v-model="metadata.phone"
+                            type="text"
+                            placeholder="Phone"
+                            disabled
+                        ></md-input>
+                    </md-field>
+                </div>
                 <div>
                     <avatar
                         :avatarUrl="metadata.avatarUrl"

--- a/src/aux-auth/web/vite.config.ts
+++ b/src/aux-auth/web/vite.config.ts
@@ -77,6 +77,9 @@ export default defineConfig(({ command, mode }) => {
             MAGIC_API_KEY: JSON.stringify(
                 process.env.MAGIC_API_KEY ?? 'pk_live_3CE2D56694071EC1'
             ),
+            ENABLE_SMS_AUTHENTICATION: JSON.stringify(
+                process.env.ENABLE_SMS_AUTHENTICATION ?? (command !== 'build')
+            ),
         },
         publicDir,
         resolve: {

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.css
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.css
@@ -6,3 +6,7 @@
 .terms-of-service-error {
     color: #c93131;
 }
+
+.md-overlay {
+    transition: opacity 0.4s;
+}

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
@@ -143,6 +143,8 @@
                 <md-button @click="hideCheckEmail()">Close</md-button>
             </md-dialog-actions>
         </md-dialog>
+
+        <div v-show="showIframe" class="md-overlay md-fixed md-dialog-overlay"></div>
     </div>
 </template>
 <script src="./RecordsUI.ts"></script>

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
@@ -143,28 +143,8 @@
                 <md-button @click="hideCheckEmail()">Close</md-button>
             </md-dialog-actions>
         </md-dialog>
-
-        <md-dialog
-            :md-active.sync="showCheckSms"
-            :md-close-on-esc="false"
-            :md-click-outside-to-close="true"
-            :md-fullscreen="true"
-            @md-closed="hideCheckSms()"
-            class="input-dialog"
-        >
-            <md-dialog-title>Check your phone</md-dialog-title>
-            <md-dialog-content>
-                <p>
-                    We sent a text message to <strong>{{ email }}</strong
-                    >.
-                </p>
-                <p>Click the link to login or sign up.</p>
-            </md-dialog-content>
-            <md-dialog-actions>
-                <md-button @click="hideCheckSms()">Close</md-button>
-            </md-dialog-actions>
-        </md-dialog>
     </div>
 </template>
 <script src="./RecordsUI.ts"></script>
 <style src="./RecordsUI.css" scoped></style>
+<style src="./RecordsUIGlobal.css"></style>

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
@@ -86,7 +86,7 @@
                 <div class="md-layout md-gutter">
                     <div class="md-layout-item">
                         <md-field :class="emailFieldClass">
-                            <label for="email">Email</label>
+                            <label for="email">{{ emailFieldHint }}</label>
                             <md-input
                                 name="email"
                                 id="email"
@@ -96,6 +96,9 @@
                             />
                             <span v-show="showEmailError" class="md-error"
                                 >This email is not allowed</span
+                            >
+                            <span v-show="showSmsError" class="md-error"
+                                >This phone number is not allowed</span
                             >
                         </md-field>
                     </div>
@@ -138,6 +141,27 @@
             </md-dialog-content>
             <md-dialog-actions>
                 <md-button @click="hideCheckEmail()">Close</md-button>
+            </md-dialog-actions>
+        </md-dialog>
+
+        <md-dialog
+            :md-active.sync="showCheckSms"
+            :md-close-on-esc="false"
+            :md-click-outside-to-close="true"
+            :md-fullscreen="true"
+            @md-closed="hideCheckSms()"
+            class="input-dialog"
+        >
+            <md-dialog-title>Check your phone</md-dialog-title>
+            <md-dialog-content>
+                <p>
+                    We sent a text message to <strong>{{ email }}</strong
+                    >.
+                </p>
+                <p>Click the link to login or sign up.</p>
+            </md-dialog-content>
+            <md-dialog-actions>
+                <md-button @click="hideCheckSms()">Close</md-button>
             </md-dialog-actions>
         </md-dialog>
     </div>

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUIGlobal.css
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUIGlobal.css
@@ -9,4 +9,5 @@ iframe.auth-helper-iframe {
     left: calc(50% - 200px);
 
     border-radius: 16px;
+    border: none;
 }

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUIGlobal.css
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUIGlobal.css
@@ -1,0 +1,12 @@
+iframe.auth-helper-iframe {
+    position: absolute;
+    z-index: 999;
+
+    width: 400px;
+    height: 500px;
+
+    top: calc(50% - 250px);
+    left: calc(50% - 200px);
+
+    border-radius: 16px;
+}

--- a/src/aux-vm-browser/managers/AuthHelper.ts
+++ b/src/aux-vm-browser/managers/AuthHelper.ts
@@ -257,6 +257,22 @@ export class AuthHelper implements AuthHelperInterface {
         );
     }
 
+    async provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void> {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 3) {
+            return;
+        }
+        return await this._proxy.provideSmsNumber(
+            sms,
+            acceptedTermsOfService
+        );
+    }
+
     async cancelLogin() {
         if (!hasValue(this._origin)) {
             return;

--- a/src/aux-vm-browser/managers/AuthHelper.ts
+++ b/src/aux-vm-browser/managers/AuthHelper.ts
@@ -98,6 +98,7 @@ export class AuthHelper implements AuthHelperInterface {
         });
         this._iframe.src = iframeUrl;
         this._iframe.style.display = 'none';
+        this._iframe.className = 'auth-helper-iframe';
 
         let promise = waitForLoad(this._iframe);
         document.body.insertBefore(this._iframe, document.body.firstChild);
@@ -129,6 +130,17 @@ export class AuthHelper implements AuthHelperInterface {
                 })
             );
         }
+
+        this._loginUIStatus.subscribe(status => {
+            if (!this._iframe) {
+                return;
+            }
+            if (status.page === 'show_iframe') {
+                this._iframe.style.display = null;
+            } else {
+                this._iframe.style.display = 'none';
+            }
+        });
 
         this._initialized = true;
     }

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -24,7 +24,8 @@ export interface LoginStatus {
 export type LoginUIStatus =
     | LoginUINoStatus
     | LoginUIEmailStatus
-    | LoginUICheckEmailStatus;
+    | LoginUICheckEmailStatus
+    | LoginUICheckSmsStatus;
 
 export interface LoginUINoStatus {
     page: false;
@@ -46,12 +47,23 @@ export interface LoginUIEmailStatus {
     showAcceptTermsOfServiceError?: boolean;
     showEnterEmailError?: boolean;
     showInvalidEmailError?: boolean;
+    showEnterSmsError?: boolean;
+    showInvalidSmsError?: boolean;
     errorCode?: string;
     errorMessage?: string;
+
+    /**
+     * Whether SMS phone numbers are supported for login.
+     */
+    supportsSms?: boolean;
 }
 
 export interface LoginUICheckEmailStatus {
     page: 'check_email';
+}
+
+export interface LoginUICheckSmsStatus {
+    page: 'check_sms';
 }
 
 /**
@@ -131,6 +143,15 @@ export interface AuxAuth {
         email: string,
         acceptedTermsOfService: boolean
     ): Promise<void>;
+
+    /**
+     * Specifies the SMS phone number and whether the user accepted the terms of service during the login process.
+     * Resolves with a validation result that indicates whether an error ocurred and what should be shown to the user.
+     * Only supported on protocol version 3 or more.
+     * @param sms The SMS phone number that should be used to login.
+     * @param acceptedTermsOfService Whether the user accepted the terms of service.
+     */
+    provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void>;
 
     /**
      * Cancels the in-progress login attempt.

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -25,7 +25,7 @@ export type LoginUIStatus =
     | LoginUINoStatus
     | LoginUIEmailStatus
     | LoginUICheckEmailStatus
-    | LoginUICheckSmsStatus;
+    | LoginUIShowIframe;
 
 export interface LoginUINoStatus {
     page: false;
@@ -62,8 +62,8 @@ export interface LoginUICheckEmailStatus {
     page: 'check_email';
 }
 
-export interface LoginUICheckSmsStatus {
-    page: 'check_sms';
+export interface LoginUIShowIframe {
+    page: 'show_iframe';
 }
 
 /**

--- a/src/aux-vm/managers/AuthHelperInterface.ts
+++ b/src/aux-vm/managers/AuthHelperInterface.ts
@@ -68,6 +68,13 @@ export interface AuthHelperInterface extends SubscriptionLike {
     ): Promise<void>;
 
     /**
+     * Provides the given email address and whether the user accepted the terms of service for the login flow.
+     * @param sms The email address that the user provided.
+     * @param acceptedTermsOfService Whether the user accepted the terms of service.
+     */
+    provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void>
+
+    /**
      * Cancels the current login if it is using the custom UI flow.
      */
     cancelLogin(): Promise<void>;

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -45,6 +45,7 @@ describe('RecordsManager', () => {
         authenticate: jest.fn(),
         getAuthToken: jest.fn(),
         createPublicRecordKey: jest.fn(),
+        provideSmsNumber: jest.fn(),
     };
     let sub: Subscription;
 
@@ -64,6 +65,7 @@ describe('RecordsManager', () => {
             loginUIStatus: null,
             provideEmailAddress: jest.fn(),
             setUseCustomUI: jest.fn(),
+            provideSmsNumber: jest.fn(),
             get supportsAuthentication() {
                 return true;
             },


### PR DESCRIPTION
### :rocket: Improvements
-   Added the ability to login with a phone number instead of an email address.
    -   This feature is enabled by the `ENABLE_SMS_AUTHENTICATION` environment variable during builds.