### PR TITLE
Add the number emoji prefix for tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CasualOS Changelog
 
+## V3.0.4
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Added the ability to force a tag to interpret values as numbers by prefixing the tag value with the 🔢 emoji.
+    -   This can be useful when you want to ensure that a tag is interpreted as a number.
+-   Added support for scientific notation in numbers.
+    -   `1.23e3` will now be interpreted as `1230`.
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where `infinity` and `-infinity` would always be calculated as `NaN` instead of their corresponding numerical values.
+
 ## V3.0.3
 
 #### Date: 3/22/2022

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1739,6 +1739,11 @@ export const BOT_LINK_TAG_PREFIX: string = '🔗';
 export const DATE_TAG_PREFIX: string = '📅';
 
 /**
+ * The prefix for number tags.
+ */
+export const NUMBER_TAG_PREFIX: string = '🔢';
+
+/**
  * The default script prefixes for custom portals.
  */
 export const DEFAULT_CUSTOM_PORTAL_SCRIPT_PREFIXES: string[] = ['📖'];
@@ -1751,6 +1756,7 @@ export const KNOWN_TAG_PREFIXES: string[] = [
     DNA_TAG_PREFIX,
     BOT_LINK_TAG_PREFIX,
     DATE_TAG_PREFIX,
+    NUMBER_TAG_PREFIX,
 ];
 
 /**

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -46,6 +46,8 @@ import {
     isBotDate,
     parseBotDate,
     formatBotDate,
+    parseNumber,
+    parseTaggedNumber,
 } from './BotCalculations';
 import { Bot, BotsState, DNA_TAG_PREFIX } from './Bot';
 import { v4 as uuid } from 'uuid';
@@ -561,16 +563,58 @@ describe('BotCalculations', () => {
             [true, '19.325'] as const,
             [true, '-27.981'] as const,
             [true, '27.0'] as const,
+            [true, '2.70E10'] as const,
             [false, '1.'] as const,
             [true, '.01'] as const,
             [true, '.567'] as const,
             [true, 'infinity'] as const,
             [true, 'Infinity'] as const,
             [true, 'InFIniTy'] as const,
+            [true, '-InFIniTy'] as const,
             [false, '$123'] as const,
             [false, 'abc'] as const,
             [false, '.'] as const,
             [false, '-'] as const,
+        ];
+
+        const prefixCases = [
+            [true, '🔢123'] as const,
+            [true, '🔢0'] as const,
+            [true, '🔢-12'] as const,
+            [true, '🔢19.325'] as const,
+            [true, '🔢-27.981'] as const,
+            [true, '🔢27.0'] as const,
+            [false, '🔢1.'] as const,
+            [true, '🔢.01'] as const,
+            [true, '🔢.567'] as const,
+            [true, '🔢infinity'] as const,
+            [true, '🔢Infinity'] as const,
+            [true, '🔢InFIniTy'] as const,
+            [true, '🔢-InFIniTy'] as const,
+            [false, '🔢$123'] as const,
+            [false, '🔢abc'] as const,
+            [false, '🔢.'] as const,
+            [false, '🔢-'] as const,
+
+            // Scientific notation
+            [true, '🔢1.02E10'] as const,
+            [true, '🔢1.02e10'] as const,
+            [true, '🔢1.02E-10'] as const,
+            [true, '🔢1.02e-10'] as const,
+            [true, '🔢-1.02E10'] as const,
+            [true, '🔢-1.02e10'] as const,
+            [true, '🔢-1.02E-10'] as const,
+            [true, '🔢-1.02e-10'] as const,
+            [false, '🔢-1.02e-10.23'] as const,
+            [true, '1.02E10'] as const,
+            [true, '1.02e10'] as const,
+            [false, '1.02e10.23'] as const,
+            [true, '1.02E-10'] as const,
+            [true, '1.02e-10'] as const,
+            [true, '-1.02E10'] as const,
+            [true, '-1.02E-10'] as const,
+            [true, '-1.02e10'] as const,
+            [true, '-1.02e-10'] as const,
         ];
 
         it.each(cases)(
@@ -579,6 +623,72 @@ describe('BotCalculations', () => {
                 expect(isNumber(value)).toBe(expected);
             }
         );
+
+        it.each(prefixCases)('be %s when given %s', (expected: boolean, value: string) => {
+            expect(isNumber(value)).toBe(expected);
+        });
+    });
+
+    describe('parseNumber()', () => {
+        const parseCases = [
+            [123, '123'] as const,
+            [0, '0'] as const,
+            [-12, '-12'] as const,
+            [19.325, '19.325'] as const,
+            [-27.981, '-27.981'] as const,
+            [27, '27.0'] as const,
+            [.01, '.01'] as const,
+            [.567, '.567'] as const,
+            [Infinity, 'infinity'] as const,
+            [Infinity, 'Infinity'] as const,
+            [Infinity, 'InFIniTy'] as const,
+            [-Infinity, '-InFIniTy'] as const,
+
+            [123, '🔢123'] as const,
+            [0, '🔢0'] as const,
+            [-12, '🔢-12'] as const,
+            [19.325, '🔢19.325'] as const,
+            [-27.981, '🔢-27.981'] as const,
+            [27, '🔢27.0'] as const,
+            [.01, '🔢.01'] as const,
+            [.567, '🔢.567'] as const,
+            [Infinity, '🔢infinity'] as const,
+            [Infinity, '🔢Infinity'] as const,
+            [Infinity, '🔢InFIniTy'] as const,
+            [-Infinity, '🔢-InFIniTy'] as const,
+
+            // Scientific notation
+            [1.02E10, '🔢1.02E10'] as const,
+            [1.02E10, '🔢1.02e10'] as const,
+            [1.02E-10, '🔢1.02E-10'] as const,
+            [1.02E-10, '🔢1.02e-10'] as const,
+            [-1.02E10, '🔢-1.02E10'] as const,
+            [-1.02E10, '🔢-1.02e10'] as const,
+            [-1.02E-10, '🔢-1.02E-10'] as const,
+            [-1.02E-10, '🔢-1.02e-10'] as const,
+            [-123.02E-10, '🔢-123.02e-10'] as const,
+
+            [NaN, 'NaN'] as const,
+            [NaN, 'abc'] as const,
+            [NaN, '🔢abc'] as const,
+            [NaN, '🔢NaN'] as const,
+        ];
+
+        it.each(parseCases)('parse %s from %s', (expected: number, given: string) => {
+            expect(parseNumber(given)).toBe(expected);
+        });
+    });
+
+    describe('parseTaggedNumber()', () => {
+        const cases = [
+            ['🔢123', '123'],
+            ['123', '123'],
+            ['🔢abc', 'abc'],
+        ];
+
+        it.each(cases)('it should map %s to %s', (given, expected) => {
+            expect(parseTaggedNumber(given)).toBe(expected);
+        });
     });
 
     describe('isBot()', () => {

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -58,6 +58,7 @@ import {
     BotLabelPadding,
     BOT_LINK_TAG_PREFIX,
     DATE_TAG_PREFIX,
+    NUMBER_TAG_PREFIX,
 } from './Bot';
 
 import { BotCalculationContext, cacheFunction } from './BotCalculationContext';
@@ -707,16 +708,58 @@ export function getScriptPrefix(prefixes: string[], value: unknown): string {
     return null;
 }
 
+const INFINITIES = new Set([
+    'infinity', '-infinity'
+]);
+
 /**
  * Determines if the given value represents a number.
  */
 export function isNumber(value: string): boolean {
+    value = parseTaggedNumber(value);
     return (
         typeof value === 'string' &&
         value.length > 0 &&
-        ((/^-?\d*(?:\.?\d+)?$/.test(value) && value !== '-') ||
-            (typeof value === 'string' && 'infinity' === value.toLowerCase()))
+        ((/^-?\d*(?:\.?\d+)?(?:[eE]-?\d+)?$/.test(value) && value !== '-') ||
+            (typeof value === 'string' && INFINITIES.has(value.toLowerCase())))
     );
+}
+
+/**
+ * Determines if the given value starts with the 🔢 emoji tag.
+ * @param value The value to test.
+ */
+export function isTaggedNumber(value: string): boolean {
+    return typeof value === 'string' && value.startsWith(NUMBER_TAG_PREFIX);
+}
+
+/**
+ * Parses the given tagged number into a regular number value.
+ * @param value The value to parse.
+ */
+export function parseTaggedNumber(value: string): string {
+    if (isTaggedNumber(value)) {
+        return value.substring(NUMBER_TAG_PREFIX.length);
+    }
+    return value;
+}
+
+/**
+ * Parses the given value into a number.
+ * @param value The value to parse.
+ */
+export function parseNumber(value: string): number {
+    value = parseTaggedNumber(value);
+    if (isNumber(value)) {
+        const valueLowerCase = value.toLowerCase();
+        if (valueLowerCase === 'infinity') {
+            return Infinity;
+        } else if (valueLowerCase === '-infinity') {
+            return -Infinity;
+        }
+        return parseFloat(value);
+    }
+    return NaN;
 }
 
 /**
@@ -2933,7 +2976,7 @@ export function calculateValue(
     formula: string
 ): any {
     if (isNumber(formula)) {
-        return parseFloat(formula);
+        return parseNumber(formula);
     } else if (formula === 'true') {
         return true;
     } else if (formula === 'false') {

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -551,6 +551,66 @@ describe('AuxRuntime', () => {
                         updatedBots: [],
                     });
                 });
+
+                it('should support tagged numbers', () => {
+                    const update = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                num: '🔢123.145',
+                                num2: '🔢abc',
+                            }),
+                        })
+                    );
+
+                    expect(update).toEqual({
+                        state: {
+                            test: createPrecalculatedBot(
+                                'test',
+                                {
+                                    num: 123.145,
+                                    num2: NaN,
+                                },
+                                {
+                                    num: '🔢123.145',
+                                    num2: '🔢abc',
+                                }
+                            ),
+                        },
+                        addedBots: ['test'],
+                        removedBots: [],
+                        updatedBots: [],
+                    });
+                });
+
+                it('should support infinity', () => {
+                    const update = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                num: 'infinity',
+                                num2: '-infinity',
+                            }),
+                        })
+                    );
+
+                    expect(update).toEqual({
+                        state: {
+                            test: createPrecalculatedBot(
+                                'test',
+                                {
+                                    num: Infinity,
+                                    num2: -Infinity,
+                                },
+                                {
+                                    num: 'infinity',
+                                    num2: '-infinity',
+                                }
+                            ),
+                        },
+                        addedBots: ['test'],
+                        removedBots: [],
+                        updatedBots: [],
+                    });
+                });
             });
 
             describe('booleans', () => {

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -58,6 +58,8 @@ import {
     isBotDate,
     parseBotDate,
     formatBotDate,
+    parseNumber,
+    isTaggedNumber,
 } from '../bots';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -1666,7 +1668,11 @@ export class AuxRuntime
                 value = ex;
             }
         } else if (isNumber(value)) {
-            value = parseFloat(value);
+            value = parseNumber(value);
+        } else if (isTaggedNumber(value)) {
+            // Tagged numbers that are not valid numbers
+            // should always be NaN.
+            value = NaN;
         } else if (value === 'true') {
             value = true;
         } else if (value === 'false') {


### PR DESCRIPTION
### :rocket: Improvements

-   Added the ability to force a tag to interpret values as numbers by prefixing the tag value with the 🔢 emoji.
    -   This can be useful when you want to ensure that a tag is interpreted as a number.
-   Added support for scientific notation in numbers.
    -   `1.23e3` will now be interpreted as `1230`.

### :bug: Bug Fixes

-   Fixed an issue where `infinity` and `-infinity` would always be calculated as `NaN` instead of their corresponding numerical values.