### PR TITLE
Add the string tag prefix for tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CasualOS Changelog
 
+## V3.0.4
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Added the ability to force AUX to intepret values as strings by prefixing the tag value with the 📝 emoji.
+    -   This can be useful for when you want to ensure that a tag value is interpreted a string.
+    -   For example, the string `"01"` will be interpreted as the number `1` by default but `"📝01"` will preserve the leading 0.
+
 ## V3.0.3
 
 #### Date: 3/22/2022

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1739,6 +1739,11 @@ export const BOT_LINK_TAG_PREFIX: string = '🔗';
 export const DATE_TAG_PREFIX: string = '📅';
 
 /**
+ * The prefix for string tags.
+ */
+ export const STRING_TAG_PREFIX: string = '📝';
+
+/**
  * The default script prefixes for custom portals.
  */
 export const DEFAULT_CUSTOM_PORTAL_SCRIPT_PREFIXES: string[] = ['📖'];
@@ -1751,6 +1756,7 @@ export const KNOWN_TAG_PREFIXES: string[] = [
     DNA_TAG_PREFIX,
     BOT_LINK_TAG_PREFIX,
     DATE_TAG_PREFIX,
+    STRING_TAG_PREFIX,
 ];
 
 /**

--- a/src/aux-common/bots/BotCalculations.spec.ts
+++ b/src/aux-common/bots/BotCalculations.spec.ts
@@ -1,6 +1,7 @@
 import {
     isFormula,
     isNumber,
+    isTaggedString,
     createBot,
     calculateBotValue,
     validateTag,
@@ -46,6 +47,7 @@ import {
     isBotDate,
     parseBotDate,
     formatBotDate,
+    parseTaggedString,
 } from './BotCalculations';
 import { Bot, BotsState, DNA_TAG_PREFIX } from './Bot';
 import { v4 as uuid } from 'uuid';
@@ -577,6 +579,34 @@ describe('BotCalculations', () => {
             'be %s when given %s',
             (expected: boolean, value: string) => {
                 expect(isNumber(value)).toBe(expected);
+            }
+        );
+    });
+
+    describe('isTaggedString()', () => {
+        const cases = [
+            [true, '📝123'] as const,
+            [false, '123'] as const,
+        ];
+
+        it.each(cases)(
+            'be %s when given %s',
+            (expected: boolean, value: string) => {
+                expect(isTaggedString(value)).toBe(expected);
+            }
+        );
+    });
+
+    describe('parseTaggedString()', () => {
+        const cases = [
+            ['📝123', '123'] as const,
+            ['123', '123'] as const,
+        ];
+
+        it.each(cases)(
+            'map %s to %s',
+            (value: string, expected: string) => {
+                expect(parseTaggedString(value)).toBe(expected);
             }
         );
     });

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -58,6 +58,7 @@ import {
     BotLabelPadding,
     BOT_LINK_TAG_PREFIX,
     DATE_TAG_PREFIX,
+    STRING_TAG_PREFIX,
 } from './Bot';
 
 import { BotCalculationContext, cacheFunction } from './BotCalculationContext';
@@ -717,6 +718,25 @@ export function isNumber(value: string): boolean {
         ((/^-?\d*(?:\.?\d+)?$/.test(value) && value !== '-') ||
             (typeof value === 'string' && 'infinity' === value.toLowerCase()))
     );
+}
+
+/**
+ * Determines if the given value is a string that is tagged with the 📝 emoji.
+ * @param value The value to check.
+ */
+export function isTaggedString(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith(STRING_TAG_PREFIX);
+}
+
+/**
+ * Parses the given tagged string into a regular string value.
+ * @param value The value that should be parsed as a string.
+ */
+export function parseTaggedString(value: string): string {
+    if (isTaggedString(value)) {
+        return value.substring(STRING_TAG_PREFIX.length);
+    }
+    return value;
 }
 
 /**

--- a/src/aux-common/runtime/AuxRuntime.spec.ts
+++ b/src/aux-common/runtime/AuxRuntime.spec.ts
@@ -497,6 +497,62 @@ describe('AuxRuntime', () => {
                 });
             });
 
+            describe('string', () => {
+                it('should support the 📝 emoji to indicate a string', () => {
+                    const update = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                num: '📝123.145',
+                            }),
+                        })
+                    );
+
+                    expect(update).toEqual({
+                        state: {
+                            test: createPrecalculatedBot(
+                                'test',
+                                {
+                                    num: '123.145',
+                                },
+                                {
+                                    num: '📝123.145',
+                                }
+                            ),
+                        },
+                        addedBots: ['test'],
+                        removedBots: [],
+                        updatedBots: [],
+                    });
+                });
+
+                it('should treat values as a string by default', () => {
+                    const update = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                num: 'my string',
+                            }),
+                        })
+                    );
+
+                    expect(update).toEqual({
+                        state: {
+                            test: createPrecalculatedBot(
+                                'test',
+                                {
+                                    num: 'my string',
+                                },
+                                {
+                                    num: 'my string',
+                                }
+                            ),
+                        },
+                        addedBots: ['test'],
+                        removedBots: [],
+                        updatedBots: [],
+                    });
+                });
+            });
+
             describe('numbers', () => {
                 it('should calculate number values', () => {
                     const update = runtime.stateUpdated(

--- a/src/aux-common/runtime/AuxRuntime.ts
+++ b/src/aux-common/runtime/AuxRuntime.ts
@@ -58,6 +58,8 @@ import {
     isBotDate,
     parseBotDate,
     formatBotDate,
+    isTaggedString,
+    parseTaggedString,
 } from '../bots';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
 import { AuxCompiler, AuxCompiledScript } from './AuxCompiler';
@@ -1665,6 +1667,8 @@ export class AuxRuntime
             } catch (ex) {
                 value = ex;
             }
+        } else if (isTaggedString(value)) {
+            value = parseTaggedString(value);
         } else if (isNumber(value)) {
             value = parseFloat(value);
         } else if (value === 'true') {

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.ts
@@ -292,6 +292,7 @@ export default class MonacoTagEditor extends Vue {
         const rawTagValue = getTagValueForSpace(bot, tag, space);
 
         this.hasError =
+            (isScript(rawTagValue) || isFormula(rawTagValue)) &&
             typeof rawTagValue === 'string' &&
             typeof calculatedTagValue === 'string' &&
             rawTagValue !== calculatedTagValue;


### PR DESCRIPTION
### :rocket: Improvements

-   Added the ability to force AUX to intepret values as strings by prefixing the tag value with the 📝 emoji.
    -   This can be useful for when you want to ensure that a tag value is interpreted a string.
    -   For example, the string `"01"` will be interpreted as the number `1` by default but `"📝01"` will preserve the leading 0.
