### PR TITLE
Add the os.addDropGrid() and os.addBotDropGrid() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
     -   This allows moving the camera focus point to any position in 3D space.
     -   The Z coordinate defaults to 0 if not specified.
 -   Added the `menuItemShowSubmitWhenEmpty` tag to allow showing the submit button on input menu items even if the input box does not have any value.
+-   Added the `os.addDropGrid(...grids)` and `os.addBotDropGrid(botId, ...grids)` functions to make it easy to snap bots to a custom grid.
+    -   These functions are useful if you want to snap bots to a grid with a custom position or rotation.
+    -   Additionally, they can be used to move bots in a grid that is attached to a portal bot.
+    -   See the documentation for detailed usage information.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3166,6 +3166,107 @@ os.addBotDropSnap(thisBot, {
 }, "face");
 ```
 
+### `os.addDropGrid(...targets)`
+
+Specifies a list of grids that can be used to position the currently dragged bot.
+
+If called when the user is not dragging anything, then this function does nothing.
+
+**Each parameter** is an object with the following properties:
+
+```typescript
+let grid: {
+    /**
+     * The 3D position that the grid should appear at.
+     */
+    position?: { x: number, y: number, z: number };
+
+    /**
+     * The 3D rotation that the grid should appear at.
+     */
+    rotation?: { x: number, y: number, z: number, w?: number };
+
+    /**
+     * The bot that defines the portal that the grid should exist in.
+     * 
+     * If null, then this defaults to the bot that is showing the portal that the dragged bot exists in.
+     * For common cases this will be the configBot, but it could also be a bot that has a portal form.
+     */
+    portalBot?: Bot | string;
+
+    /**
+     * The tag that the portal uses to determine which dimension to show.
+     * Defaults to formAddress if the specified portalBot is not the configBot and gridPortal if the specified portalBot is the configBot.
+     */
+    portalTag?: string;
+
+    /**
+     * The 2D bounds of the grid.
+     * Defaults to 10 x 10.
+     */
+    bounds?: { x: number, y: number };
+
+    /**
+     * The priority that this grid should be evaluated in over other grids.
+     * Higher priorities will be evaluated before lower priorities.
+     */
+    priority?: number;
+
+    /**
+     * Whether to visualize the grid while a bot is being dragged.
+     * Defaults to false.
+     */
+    showGrid?: boolean;
+};
+```
+
+#### Examples:
+
+```typescript title='Add a grid for the portal that the bot currently exists in.'
+os.addDropGrid({});
+```
+
+```typescript title='Add a grid with a 60 degree X rotation.'
+os.addDropGrid({
+    position: { x: 0, y: 0, z: 0 },
+    rotation: { x: 60 * (Math.PI / 180), y: 0, z: 0 },
+});
+```
+
+```typescript title='Add a grid for a specific portal bot.'
+os.addDropGrid({
+    portalBot: getBot(byTag('form', 'portal'), byTag('formAddress', 'myDimension')),
+});
+```
+
+```typescript title='Add a grid with a custom size.'
+os.addDropGrid({
+    position: { x: 0, y: 0, z: 3 },
+    bounds: { x: 20, y: 10 }
+});
+```
+
+```typescript title='Add a grid that the user can see.'
+os.addDropGrid({
+    position: { x: 0, y: 0, z: 3 },
+    showGrid: true
+});
+```
+
+```typescript title='Add multiple grids with custom priorities'
+os.addDropGrid({
+    position: { x: 0, y: 0, z: 3 },
+    bounds: { x: 10, y: 10 },
+    showGrid: true,
+    priority: 10
+}, {
+    position: { x: 0, y: 0, z: 0 },
+    bounds: { x: 20, y: 20 },
+    showGrid: true,
+    priority: 20
+});
+```
+
 ### `os.showChat(placeholder?)`
 
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -3267,6 +3267,110 @@ os.addDropGrid({
 });
 ```
 
+### `os.addBotDropGrid(bot, ...targets)`
+
+Specifies a list of grids that can be used to position the currently dragged bot when it is being dropped on the given bot.
+
+If called when the user is not dragging anything, then this function does nothing.
+
+The **first parameter** is the bot which, when the dragged bot is being dropped onto it (as indicated by <TagLink tag='@onDropEnter'/>/<TagLink tag='@onDropExit'/>),
+the specified snap targets will take effect.
+
+The **other parameters** are objects with the following properties:
+
+```typescript
+let grid: {
+    /**
+     * The 3D position that the grid should appear at.
+     */
+    position?: { x: number, y: number, z: number };
+
+    /**
+     * The 3D rotation that the grid should appear at.
+     */
+    rotation?: { x: number, y: number, z: number, w?: number };
+
+    /**
+     * The bot that defines the portal that the grid should exist in.
+     * 
+     * If null, then this defaults to the bot that is showing the portal that the dragged bot exists in.
+     * For common cases this will be the configBot, but it could also be a bot that has a portal form.
+     */
+    portalBot?: Bot | string;
+
+    /**
+     * The tag that the portal uses to determine which dimension to show.
+     * Defaults to formAddress if the specified portalBot is not the configBot and gridPortal if the specified portalBot is the configBot.
+     */
+    portalTag?: string;
+
+    /**
+     * The 2D bounds of the grid.
+     * Defaults to 10 x 10.
+     */
+    bounds?: { x: number, y: number };
+
+    /**
+     * The priority that this grid should be evaluated in over other grids.
+     * Higher priorities will be evaluated before lower priorities.
+     */
+    priority?: number;
+
+    /**
+     * Whether to visualize the grid while a bot is being dragged.
+     * Defaults to false.
+     */
+    showGrid?: boolean;
+};
+```
+
+#### Examples:
+
+```typescript title='Add a grid for the portal that the bot currently exists in when it is being dropped on this bot.'
+os.addDropGrid(thisBot, {});
+```
+
+```typescript title='Add a grid with a 60 degree X rotation when it is being dropped on this bot.'
+os.addBotDropGrid(thisBot, {
+    position: { x: 0, y: 0, z: 0 },
+    rotation: { x: 60 * (Math.PI / 180), y: 0, z: 0 },
+});
+```
+
+```typescript title='Add a grid for a specific portal bot when it is being dropped on this bot.'
+os.addBotDropGrid(thisBot, {
+    portalBot: getBot(byTag('form', 'portal'), byTag('formAddress', 'myDimension')),
+});
+```
+
+```typescript title='Add a grid with a custom size when it is being dropped on this bot.'
+os.addBotDropGrid(thisBot, {
+    position: { x: 0, y: 0, z: 3 },
+    bounds: { x: 20, y: 10 }
+});
+```
+
+```typescript title='Add a grid that the user can see when it is being dropped on this bot.'
+os.addBotDropGrid(thisBot, {
+    position: { x: 0, y: 0, z: 3 },
+    showGrid: true
+});
+```
+
+```typescript title='Add multiple grids with custom priorities when it is being dropped on this bot.'
+os.addBotDropGrid(thisBot, {
+    position: { x: 0, y: 0, z: 3 },
+    bounds: { x: 10, y: 10 },
+    showGrid: true,
+    priority: 10
+}, {
+    position: { x: 0, y: 0, z: 0 },
+    bounds: { x: 20, y: 20 },
+    showGrid: true,
+    priority: 20
+});
+```
+
 ### `os.showChat(placeholder?)`
 
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -108,7 +108,8 @@ export type ExtraActions =
     | HtmlAppEventAction
     | SetAppOutputAction
     | UnregisterHtmlAppAction
-    | MeetCommandAction;
+    | MeetCommandAction
+    | AddDropGridTargetsAction;
 
 /**
  * Defines a set of possible async action types.
@@ -2761,16 +2762,21 @@ export interface OpenCircleWipeOptions {
 }
 
 /**
- * An event that is used to add some snap points for a drag operation.
+ * Defines a base interface for actions that can add drop snap points.
  */
-export interface AddDropSnapTargetsAction extends Action {
-    type: 'add_drop_snap_targets';
-
+export interface AddDropSnapAction extends Action {
     /**
      * The ID of the bot that, when it is a drop target, the snap points should be enabled.
      * If null, then the targets apply globally during the drag operation.
      */
-    botId?: string;
+     botId?: string;
+}
+
+/**
+ * An event that is used to add some snap points for a drag operation.
+ */
+export interface AddDropSnapTargetsAction extends AddDropSnapAction {
+    type: 'add_drop_snap_targets';
 
     /**
      * The list of snap targets that should be used.
@@ -2829,6 +2835,67 @@ export type SnapTarget =
     | 'bots'
     | SnapPoint
     | SnapAxis;
+
+/**
+ * An event that is used to add grids as possible drop locations for a drag operation.
+ */
+export interface AddDropGridTargetsAction extends AddDropSnapAction {
+    type: 'add_drop_grid_targets';
+
+    /**
+     * The list of grids that bots should be snapped to.
+     */
+    targets: SnapGrid[];
+}
+
+/**
+ * Defines an interface that represents a snap grid.
+ * That is, a 2D plane that is segmented into discrete sections.
+ */
+export interface SnapGrid {
+    /**
+     * The 3D position of the grid.
+     * If not specified, then 0,0,0 is used.
+     */
+    position?: { x: number, y: number, z: number };
+
+    /**
+     * The 3D rotation of the grid.
+     * If not specified, then the identity rotation is used.
+     */
+    rotation?: { x: number, y: number, z: number, w?: number };
+
+    /**
+     * The ID of the bot that defines the portal that this grid should use.
+     * If not specifed, then the config bot is used.
+     */
+    portalBotId?: string;
+
+    /**
+     * The tag that contains the portal dimension.
+     * If a portalBotId is specified, then this defaults to formAddress.
+     * If a portalBotId is not specified, then this defaults to gridPortal.
+     */
+    portalTag?: string;
+
+    /**
+     * The priority that the snap grid has.
+     * Higher numbers mean higher priority.
+     */
+    priority?: number;
+
+    /**
+     * The bounds that the snap grid has.
+     * If not specified, then default bounds are used.
+     */
+    bounds?: { x: number, y: number };
+
+    /**
+     * Whether to visualize the grid when dragging bots around.
+     * Defaults to false.
+     */
+    showGrid?: boolean;
+}
 
 /**
  * An event that is used to disable the default dragging logic (moving the bot) and enable
@@ -5662,6 +5729,22 @@ export function addDropSnap(
 ): AddDropSnapTargetsAction {
     return {
         type: 'add_drop_snap_targets',
+        botId,
+        targets,
+    };
+}
+
+/**
+ * Creates a AddDropGridTargetsAction.
+ * @param botId The ID of the bot.
+ * @param targets The list of snap targets to add.
+ */
+export function addDropGrid(
+    botId: string,
+    targets: SnapGrid[]
+): AddDropGridTargetsAction {
+    return {
+        type: 'add_drop_grid_targets',
         botId,
         targets,
     };

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4096,6 +4096,51 @@ describe('AuxLibrary', () => {
             });
         });
 
+        describe('os.addBotDropGrid()', () => {
+            it('should return a AddDropSnapGridTargetsAction', () => {
+                const action = library.api.os.addBotDropGrid(bot1, {
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1,
+                    bounds: { x: 5, y: 2 },
+                    showGrid: true
+                });
+                const expected = addDropGrid(bot1.id, [{
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1,
+                    bounds: { x: 5, y: 2 },
+                    showGrid: true
+                }]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept a list of targets', () => {
+                const action = library.api.os.addBotDropGrid(bot1, {
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1
+                }, {
+                    portalBot: bot1,
+                    bounds: { x: 10, y: 15 }
+                });
+                const expected = addDropGrid(bot1.id, [
+                    {
+                        position: { x: 0, y: 0, z: 0 },
+                        rotation: { x: 0, y: 0, z: 0 },
+                        priority: 1
+                    },
+                    {
+                        portalBotId: bot1.id,
+                        bounds: { x: 10, y: 15 }
+                    }
+                ]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
         describe('os.enableCustomDragging()', () => {
             it('should return a EnableCustomDraggingAction', () => {
                 const action = library.api.os.enableCustomDragging();

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -178,6 +178,7 @@ import {
     openImageClassifier,
     DATE_TAG_PREFIX,
     getAverageFrameRate,
+    addDropGrid,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -4044,6 +4045,51 @@ describe('AuxLibrary', () => {
                         },
                         distance: 1,
                     },
+                ]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.addDropGrid()', () => {
+            it('should return a AddDropSnapGridTargetsAction', () => {
+                const action = library.api.os.addDropGrid({
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1,
+                    bounds: { x: 5, y: 2 },
+                    showGrid: true
+                });
+                const expected = addDropGrid(null, [{
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1,
+                    bounds: { x: 5, y: 2 },
+                    showGrid: true
+                }]);
+                expect(action).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept a list of targets', () => {
+                const action = library.api.os.addDropGrid({
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    priority: 1
+                }, {
+                    portalBot: bot1,
+                    bounds: { x: 10, y: 15 }
+                });
+                const expected = addDropGrid(null, [
+                    {
+                        position: { x: 0, y: 0, z: 0 },
+                        rotation: { x: 0, y: 0, z: 0 },
+                        priority: 1
+                    },
+                    {
+                        portalBotId: bot1.id,
+                        bounds: { x: 10, y: 15 }
+                    }
                 ]);
                 expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1217,6 +1217,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 addDropSnap,
                 addBotDropSnap,
                 addDropGrid,
+                addBotDropGrid,
                 enableCustomDragging,
                 log,
                 getGeolocation,
@@ -3170,7 +3171,20 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param targets The list of grids to add.
      */
     function addDropGrid(...targets: SnapGridTarget[]): AddDropGridTargetsAction {
-        return addAction(calcAddDropGrid(null, targets.map(t => ({
+        return addAction(calcAddDropGrid(null, mapSnapGridTargets(targets)));
+    }
+
+    /**
+     * Adds the given list of grids to the current drag operation for when the specified bot is being dropped on.
+     * @param bot The bot.
+     * @param targets The list of grids to add.
+     */
+    function addBotDropGrid(bot: Bot | string, ...targets: SnapGridTarget[]): AddDropGridTargetsAction {
+        return addAction(calcAddDropGrid(getID(bot), mapSnapGridTargets(targets)));
+    }
+
+    function mapSnapGridTargets(targets: SnapGridTarget[]): SnapGrid[] {
+        return targets.map(t => ({
             position: t.position,
             rotation: t.rotation,
             bounds: t.bounds,
@@ -3178,7 +3192,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             portalTag: t.portalTag,
             priority: t.priority,
             showGrid: t.showGrid,
-        }))));
+        }));
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -246,7 +246,8 @@ declare type ExtraActions =
     | EnableCustomDraggingAction
     | EnablePOVAction
     | SetAppOutputAction
-    | MeetCommandAction;
+    | MeetCommandAction
+    | AddDropGridTargetsAction;
 
 /**
  * Defines a set of possible async action types.
@@ -1960,16 +1961,21 @@ declare interface OpenCircleWipeOptions {
 }
 
 /**
- * An event that is used to add some snap points for a drag operation.
+ * Defines a base interface for actions that can add drop snap points.
  */
-declare interface AddDropSnapTargetsAction extends Action {
-    type: 'add_drop_snap_targets';
-
+export interface AddDropSnapAction extends Action {
     /**
      * The ID of the bot that, when it is a drop target, the snap points should be enabled.
      * If null, then the targets apply globally during the drag operation.
      */
-    botId?: string;
+     botId?: string;
+}
+
+/**
+ * An event that is used to add some snap points for a drag operation.
+ */
+export interface AddDropSnapTargetsAction extends AddDropSnapAction {
+    type: 'add_drop_snap_targets';
 
     /**
      * The list of snap targets that should be used.
@@ -2022,6 +2028,109 @@ export interface SnapAxis {
  * - "bots" means that the dragged bot will snap to other bots.
  */
 declare type SnapTarget = 'ground' | 'grid' | 'face' | 'bots' | SnapPoint | SnapAxis;
+
+
+/**
+ * An event that is used to add grids as possible drop locations for a drag operation.
+ */
+export interface AddDropGridTargetsAction extends AddDropSnapAction {
+    type: 'add_drop_grid_targets';
+
+    /**
+     * The list of grids that bots should be snapped to.
+     */
+    targets: SnapGrid[];
+}
+
+/**
+ * Defines an interface that represents a snap grid.
+ * That is, a 2D plane that is segmented into discrete sections.
+ */
+export interface SnapGrid {
+    /**
+     * The 3D position of the grid.
+     * If not specified, then 0,0,0 is used.
+     */
+    position?: { x: number, y: number, z: number };
+
+    /**
+     * The 3D rotation of the grid.
+     * If not specified, then the identity rotation is used.
+     */
+    rotation?: { x: number, y: number, z: number, w?: number };
+
+    /**
+     * The ID of the bot that defines the portal that this grid should use.
+     * If not specifed, then the config bot is used.
+     */
+    portalBotId?: string;
+
+    /**
+     * The tag that contains the portal dimension.
+     * If a portalBotId is specified, then this defaults to formAddress.
+     * If a portalBotId is not specified, then this defaults to gridPortal.
+     */
+    portalTag?: string;
+
+    /**
+     * The priority that the snap grid has.
+     * Higher numbers mean higher priority.
+     */
+    priority?: number;
+
+    /**
+     * The bounds that the snap grid has.
+     * If not specified, then default bounds are used.
+     */
+    bounds?: { x: number, y: number };
+
+    /**
+     * Whether to visualize the grid when dragging bots around.
+     * Defaults to false.
+     */
+    showGrid?: boolean;
+}
+
+export interface SnapGridTarget {
+    /**
+     * The 3D position that the grid should appear at.
+     */
+    position?: { x: number, y: number, z: number };
+
+    /**
+     * The 3D rotation that the grid should appear at.
+     */
+    rotation?: { x: number, y: number, z: number, w?: number };
+
+    /**
+     * The bot that defines the portal that the grid should exist in.
+     * If null, then this defaults to the configBot.
+     */
+    portalBot?: Bot | string;
+
+    /**
+     * The tag that the portal uses to determine which dimension to show. Defaults to formAddress.
+     */
+    portalTag?: string;
+
+    /**
+     * The bounds of the grid.
+     * Defaults to 10 x 10.
+     */
+    bounds?: { x: number, y: number };
+
+    /**
+     * The priority that this grid should be evaluated in over other grids.
+     * Higher priorities will be evaluated before lower priorities.
+     */
+    priority?: number;
+
+    /**
+     * Whether to visualize the grid while a bot is being dragged.
+     * Defaults to false.
+     */
+    showGrid?: boolean;
+}
 
 /**
  * An event that is used to disable the default dragging logic (moving the bot) and enable
@@ -8009,6 +8118,12 @@ interface Os {
      * @param targets The targets that should be enabled when the bot is being dropped on.
      */
     addBotDropSnap(bot: Bot | string, ...targets: SnapTarget[]): AddDropSnapTargetsAction;
+
+    /**
+     * Adds the given list of grids to the current drag operation.
+     * @param targets The list of grids to add.
+     */
+    addDropGrid(...targets: SnapGridTarget[]): AddDropGridTargetsAction;
 
     /**
      * Enables custom dragging for the current drag operation.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8126,6 +8126,13 @@ interface Os {
     addDropGrid(...targets: SnapGridTarget[]): AddDropGridTargetsAction;
 
     /**
+     * Adds the given list of grids to the current drag operation for when the specified bot is being dropped on.
+     * @param bot The bot.
+     * @param targets The list of grids to add.
+     */
+    addBotDropGrid(bot: Bot | string, ...targets: SnapGridTarget[]): AddDropGridTargetsAction;
+
+    /**
      * Enables custom dragging for the current drag operation.
      * This will disable the built-in logic that moves the bot(s) and
      * enables the "onDragging" and "onAnyBotDragging" listen tags.

--- a/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
@@ -214,9 +214,9 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
         this._updateCurrentViewport();
 
         // Get input ray for grid ray cast.
-        let inputRay: Ray = this._getInputRay();
+        const inputRay: Ray = this._getInputRay();
 
-        let grid3D = this._inMiniPortal
+        const grid3D = this._inMiniPortal
             ? this._miniSimulation3D.grid3D
             : this._inMapPortal
             ? this._mapSimulation3D.grid3D
@@ -1274,13 +1274,6 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
                     .multiply(auxPosition)
                     .multiply(auxRotation)
                     .multiply(auxScale);
-
-                // Convert the three.js position back to a CasualOS position
-                // The function is symmetrical so it works both ways.
-                // position.multiplyScalar();
-                // position.set(position.x, -position.z, position.y);
-
-                // const m = new Matrix4().compose(position, matrixRotation, scale);
 
                 result.applyMatrix4(m);
 

--- a/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
@@ -20,6 +20,8 @@ import {
     getBotRotation,
     SnapAxis,
     calculateGridScale,
+    SnapGrid,
+    realNumberOrDefault,
 } from '@casual-simulation/aux-common';
 import { PlayerInteractionManager } from '../PlayerInteractionManager';
 import {
@@ -40,7 +42,7 @@ import { Input, InputMethod } from '../../../shared/scene/Input';
 import { PlayerPageSimulation3D } from '../../scene/PlayerPageSimulation3D';
 import { MiniSimulation3D } from '../../scene/MiniSimulation3D';
 import { PlayerGame } from '../../scene/PlayerGame';
-import { take, drop } from 'lodash';
+import { take, drop, flatMap } from 'lodash';
 import { IOperation } from '../../../shared/interaction/IOperation';
 import { PlayerModDragOperation } from './PlayerModDragOperation';
 import {
@@ -60,6 +62,18 @@ import { MapSimulation3D } from '../../scene/MapSimulation3D';
 import { ExternalRenderers, SpatialReference } from '../../MapUtils';
 import { PriorityGrid3D } from '../../../shared/scene/PriorityGrid3D';
 import { BoundedGrid3D } from '../../../shared/scene/BoundedGrid3D';
+import { DimensionGroup3D } from '../../../shared/scene/DimensionGroup3D';
+import { first } from '@casual-simulation/causal-trees';
+import { convertCasualOSPositionToThreePosition } from '../../../shared/scene/grid/Grid';
+
+const INTERNAL_GRID_FLAG = Symbol('internal_grid');
+const INTERNAL_GRID_DIMENSION = Symbol('internal_grid_dimension');
+
+interface InternalGrid {
+    [INTERNAL_GRID_FLAG]: boolean;
+    [INTERNAL_GRID_DIMENSION]: string;
+}
+
 
 export class PlayerBotDragOperation extends BaseBotDragOperation {
     // This overrides the base class BaseInteractionManager
@@ -105,7 +119,11 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
 
     private _hasGridOffset: boolean = false;
     private _targetBot: Bot = undefined;
-    private _internalGrid: Grid3D & Object3D;
+
+    /**
+     * The map of SnapGrid objects to Grid3D objects.
+     */
+    private _internalGrids: Map<SnapGrid, Grid3D & Object3D & InternalGrid>;
 
     protected get game(): PlayerGame {
         return <PlayerGame>this._simulation3D.game;
@@ -153,6 +171,7 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
             dimension && this._mapSimulation3D.mapDimension === dimension;
         this._originallyInMiniMapPortal = this._inMiniMapPortal =
             dimension && this._miniMapSimulation3D.mapDimension === dimension;
+        this._internalGrids = new Map();
 
         if (this._hit) {
             const obj = this._interaction.findGameObjectForHit(this._hit);
@@ -204,30 +223,6 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
             : this._inMiniMapPortal
             ? this._miniMapSimulation3D.grid3D
             : this._simulation3D.grid3D;
-
-        const group = this._hitBot?.dimensionGroup;
-
-        if (group.boundBot) {
-            let newGrid3D = new PriorityGrid3D();
-
-            if (!this._internalGrid) {
-                let grid = this._internalGrid = new BoundedGrid3D();
-                grid.useAuxCoordinates = true;
-                grid.tileScale = calculateGridScale(null, null);
-                grid.showGrid(true);
-                this._sub.add(() => {
-                    if (this._internalGrid) {
-                        safeSetParent(this._internalGrid, null);
-                        this._internalGrid = null;
-                    }
-                });
-            }
-            safeSetParent(this._internalGrid, group);
-            newGrid3D.grids.push(this._internalGrid);
-            newGrid3D.grids.push(grid3D);
-
-            grid3D = newGrid3D;
-        }
 
         const canDrag = this._canDrag(calc);
 
@@ -424,6 +419,12 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
                     new Euler(rotation.x, rotation.y, rotation.z, 'XYZ')
                 );
 
+                return true;
+            }
+        }
+
+        if (options.snapGrids.length > 0) {
+            if (this._dragOnGrids(calc, snapPointGrid ?? grid3D, inputRay, options.snapGrids)) {
                 return true;
             }
         }
@@ -905,6 +906,110 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
         return false;
     }
 
+    private _dragOnGrids(calc: BotCalculationContext, grid3D: Grid3D, inputRay: Ray, grids: SnapGrid[]): boolean {
+        const currentSim = this._inMiniPortal
+            ? this._miniSimulation3D
+            : this._inMapPortal
+            ? this._mapSimulation3D
+            : this._inMiniMapPortal
+            ? this._miniMapSimulation3D
+            : this._simulation3D;
+
+        // TODO: Maybe filter grids based on which portal
+
+        let _3dGrids = grids.map(g => {
+            let grid = this._internalGrids.get(g);
+            if (!grid) {
+                let bounded = new BoundedGrid3D();
+                grid = bounded as any;
+                grid[INTERNAL_GRID_FLAG] = true;
+                bounded.useAuxCoordinates =  true;
+                if (hasValue(g.rotation)) {
+                    if (hasValue(g.rotation.w)) {
+                        bounded.quaternion.set(
+                            realNumberOrDefault(g.rotation.x, 0),
+                            realNumberOrDefault(g.rotation.z, 0),
+                            realNumberOrDefault(g.rotation.y, 0),
+                            realNumberOrDefault(g.rotation.w, 1),
+                        );
+                    } else {
+                        bounded.rotation.set(
+                            realNumberOrDefault(g.rotation.x, 0),
+                            realNumberOrDefault(g.rotation.z, 0),
+                            realNumberOrDefault(g.rotation.y, 0),
+                        );
+                    }
+                }
+                if (hasValue(g.bounds)) {
+                    bounded.maxX = Math.floor(realNumberOrDefault(g.bounds.x, 5) / 2);
+                    bounded.minX = Math.floor(realNumberOrDefault(-g.bounds.x, -5) / 2);
+                    bounded.maxY = Math.floor(realNumberOrDefault(g.bounds.y, 5) / 2);
+                    bounded.minY = Math.floor(realNumberOrDefault(-g.bounds.y, -5) / 2);
+                } else {
+                    bounded.maxX = 5;
+                    bounded.minX = -5;
+                    bounded.maxY = 5;
+                    bounded.minY = -5;
+                }
+
+                if (!hasValue(g.portalBotId)) {
+                    safeSetParent(bounded, this._hitBot.dimensionGroup);
+                    grid[INTERNAL_GRID_DIMENSION] = this._originalDimension;
+                    bounded.tileScale = this._hitBot.dimensionGroup.simulation3D.getGridScale(this._hitBot);
+                } else {
+                    let hasParent = false;
+                    for (let sim of [currentSim, ...this.game.getSimulations()]) {
+                        let group = sim.dimensionGroupForBotAndTag(g.portalBotId, g.portalTag ?? (g.portalBotId === sim.simulation.helper.userId ? 'gridPortal' : 'formAddress'));
+                        if (group && group instanceof DimensionGroup3D) {
+                            grid[INTERNAL_GRID_DIMENSION] = first(group.dimensions.values());
+                            safeSetParent(bounded, group);
+                            hasParent = true;
+                            bounded.tileScale = group.simulation3D.getGridScale(group);
+
+                            break;
+                        }
+                    }
+
+                    if (!hasParent) {
+                        // No portal could be found so we should skip this grid.
+                        return null;
+                    }
+                }
+
+                if (hasValue(g.position)) {
+                    // Use a three.js position for the grid because
+                    // the grid needs to be positioned like a bot would be.
+                    bounded.position.copy(
+                        convertCasualOSPositionToThreePosition(
+                            realNumberOrDefault(g.position.x, 0),
+                            realNumberOrDefault(g.position.y, 0),
+                            realNumberOrDefault(g.position.z, 0),
+                            bounded.tileScale
+                        ));
+                }
+
+                if (g.showGrid) {
+                    bounded.showGrid(true);
+                }
+
+                bounded.updateMatrixWorld(true);
+
+                this._internalGrids.set(g, grid);
+
+                this._sub.add(() => {
+                    safeSetParent(bounded, null);
+                });
+            }
+            return grid;
+        }).filter(g => !!g);
+
+        let priorityGrid = new PriorityGrid3D();
+        priorityGrid.grids.push(..._3dGrids);
+        priorityGrid.grids.push(grid3D);
+
+        return this._dragOnGrid(calc, priorityGrid, inputRay);
+    }
+
     private _dragOnGrid(
         calc: BotCalculationContext,
         grid3D: Grid3D,
@@ -1009,8 +1114,8 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
     }
 
     private _calculateNextDimension(grid: Grid3D) {
-        if (grid === this._internalGrid) {
-            return this._originalDimension;
+        if ((grid as unknown as InternalGrid)[INTERNAL_GRID_FLAG]) {
+            return (grid as unknown as InternalGrid)[INTERNAL_GRID_DIMENSION] as string;
         }
         const dimension =
             this._simulation3D.getDimensionForGrid(grid) ||
@@ -1136,9 +1241,58 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
                 gridTile.tileCoordinate.y,
                 0
             );
+            let rotation: Euler;
+
+            const grid = gridTile.grid;
+            if ((grid as unknown as InternalGrid)[INTERNAL_GRID_FLAG]) {
+                const obj = (grid as unknown as Object3D);
+
+                const position = new Vector3();
+                const matrixRotation = new Quaternion();
+                const scale = new Vector3();
+                obj.matrix.decompose(position, matrixRotation, scale);
+
+                const scaleAdjustment = 1/(grid as BoundedGrid3D).tileScale;
+                const auxPosition = new Matrix4().makeTranslation(
+                    position.x * scaleAdjustment,
+                    -position.z * scaleAdjustment,
+                    position.y * scaleAdjustment
+                );
+
+                const auxRotation = new Matrix4().makeRotationFromQuaternion(
+                    matrixRotation
+                );
+                convertRotationToAuxCoordinates(auxRotation);
+
+                const auxScale = new Matrix4().makeScale(
+                    scale.x,
+                    scale.z,
+                    scale.y
+                );
+
+                const m = new Matrix4()
+                    .multiply(auxPosition)
+                    .multiply(auxRotation)
+                    .multiply(auxScale);
+
+                // Convert the three.js position back to a CasualOS position
+                // The function is symmetrical so it works both ways.
+                // position.multiplyScalar();
+                // position.set(position.x, -position.z, position.y);
+
+                // const m = new Matrix4().compose(position, matrixRotation, scale);
+
+                result.applyMatrix4(m);
+
+                rotation = new Euler(
+                    obj.rotation.x,
+                    obj.rotation.z,
+                    obj.rotation.y
+                );
+            }
             result.applyMatrix4(this._gridOffset);
             this._toCoord = new Vector2(result.x, result.y);
-            this._updateBotsPositions(this._bots, result);
+            this._updateBotsPositions(this._bots, result, rotation);
         }
     }
 

--- a/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/DragOperation/PlayerBotDragOperation.ts
@@ -741,7 +741,7 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
             const targetDistance = point.distance * point.distance;
 
             // use world space for comparing the snap point to the ray
-            const convertedPoint = grid.getWorldPosition(snapPoint);
+            const convertedPoint = grid.getGridWorldPosition(snapPoint);
             inputRay.closestPointToPoint(convertedPoint, targetPoint);
 
             // convert back to grid space for comparing distances
@@ -802,9 +802,9 @@ export class PlayerBotDragOperation extends BaseBotDragOperation {
             const targetDistance = axis.distance * axis.distance;
 
             // use world space for comparing the snap point to the ray
-            const convertedOrigin = grid.getWorldPosition(snapRay.origin);
+            const convertedOrigin = grid.getGridWorldPosition(snapRay.origin);
             const convertedDirection = grid
-                .getWorldPosition(snapRay.direction)
+                .getGridWorldPosition(snapRay.direction)
                 .normalize();
 
             // https://stackoverflow.com/questions/58151978/threejs-how-to-calculate-the-closest-point-on-a-three-ray-to-another-three-ray

--- a/src/aux-server/aux-web/aux-player/scene/MapPortalGrid3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/MapPortalGrid3D.ts
@@ -123,7 +123,7 @@ export class MapPortalGrid3D implements Grid3D {
         return new Vector3(x, y, z);
     }
 
-    getWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
+    getGridWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
         const [x, y, z] = ExternalRenderers.toRenderCoordinates(
             this.mapView,
             [position.x, position.y, position.z],

--- a/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerSimulation3D.ts
@@ -253,8 +253,9 @@ export abstract class PlayerSimulation3D extends Simulation3D {
         );
     }
 
-    getGridScale(bot: AuxBot3D): number {
-        const portal = bot.dimensionGroup.portalTag;
+    getGridScale(bot: AuxBot3D | DimensionGroup3D): number {
+        const group = bot instanceof DimensionGroup3D ? bot : bot.dimensionGroup;
+        const portal = group.portalTag;
         const config = this._portalConfigs.get(portal);
         return config ? config.gridScale : calculateGridScale(null, null);
     }

--- a/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/DragOperation/BaseBotDragOperation.ts
@@ -156,6 +156,8 @@ export abstract class BaseBotDragOperation implements IOperation {
                             action.botId,
                             action.targets
                         );
+                    } else if(action.type === 'add_drop_grid_targets') {
+                        this._snapInterface.addSnapGrids(action.botId, action.targets);
                     }
                 }
             );

--- a/src/aux-server/aux-web/shared/interaction/DragOperation/SnapInterface.ts
+++ b/src/aux-server/aux-web/shared/interaction/DragOperation/SnapInterface.ts
@@ -1,10 +1,12 @@
-import { SnapAxis, SnapPoint, SnapTarget } from '@casual-simulation/aux-common';
+import { SnapAxis, SnapPoint, SnapTarget, SnapGrid } from '@casual-simulation/aux-common';
+import { sortBy } from 'lodash';
 
 export interface SnapOptions {
     snapGround: boolean;
     snapGrid: boolean;
     snapFace: boolean;
     snapBots: boolean;
+    snapGrids: SnapGrid[];
     snapPoints: SnapPoint[];
     snapAxes: SnapAxis[];
     botId: string;
@@ -17,6 +19,13 @@ export interface SnapBotsInterface {
      * @param targets The targets.
      */
     addSnapTargets(botId: string, targets: SnapTarget[]): void;
+
+    /**
+     * Adds snap grids for the given bot.
+     * @param botId The ID of the bot that the targets should be in effect for. If null, then the targets will be used globally.
+     * @param grids The grids.
+     */
+    addSnapGrids(botId: string, grids: SnapGrid[]): void;
 
     /**
      * Gets the global snap options.
@@ -52,6 +61,7 @@ export class SnapBotsHelper implements SnapBotsInterface {
                         'origin' in t
                 ) as SnapOptions['snapAxes'],
                 botId: botId,
+                snapGrids: [],
             };
             this._snapOptions.set(botId ?? null, options);
         } else {
@@ -72,6 +82,27 @@ export class SnapBotsHelper implements SnapBotsInterface {
                     }
                 }
             }
+        }
+    }
+
+    addSnapGrids(botId: string, grids: SnapGrid[]) {
+        let options = this._snapOptions.get(botId ?? null);
+        if (!options) {
+            options = {
+                snapGround: false,
+                snapGrid: false,
+                snapFace: false,
+                snapBots: false,
+                snapPoints: [],
+                snapAxes: [],
+                botId: botId,
+                snapGrids: sortBy(grids, g => -(g.priority ?? 0))
+            };
+
+            this._snapOptions.set(botId ?? null, options);
+        } else {
+            options.snapGrids.push(...grids);
+            options.snapGrids = sortBy(options.snapGrids, g => -(g.priority ?? 0));
         }
     }
 

--- a/src/aux-server/aux-web/shared/scene/BoundedGrid3D.ts
+++ b/src/aux-server/aux-web/shared/scene/BoundedGrid3D.ts
@@ -118,7 +118,7 @@ export class BoundedGrid3D extends Object3D implements Grid3D {
         );
     }
 
-    getWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
+    getGridWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
         const result = new Vector3(
             position.x,
             position.z,

--- a/src/aux-server/aux-web/shared/scene/CompoundGrid3D.ts
+++ b/src/aux-server/aux-web/shared/scene/CompoundGrid3D.ts
@@ -74,7 +74,7 @@ export class CompoundGrid3D implements Grid3D {
      * Scales the given position by the tile scale and returns the result.
      * @param position The input position.
      */
-    getWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
+    getGridWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
         const grid = this.primaryGrid;
         if (!grid) {
             throw new Error(
@@ -82,6 +82,6 @@ export class CompoundGrid3D implements Grid3D {
             );
         }
 
-        return grid.getWorldPosition(position);
+        return grid.getGridWorldPosition(position);
     }
 }

--- a/src/aux-server/aux-web/shared/scene/Grid3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Grid3D.ts
@@ -35,7 +35,7 @@ export interface Grid3D {
      * Gets the world position for the given grid-local position.
      * @param gridPosition The grid position.
      */
-    getWorldPosition(gridPosition: {
+    getGridWorldPosition(gridPosition: {
         x: number;
         y: number;
         z: number;

--- a/src/aux-server/aux-web/shared/scene/PriorityGrid3D.spec.ts
+++ b/src/aux-server/aux-web/shared/scene/PriorityGrid3D.spec.ts
@@ -1,0 +1,113 @@
+import { PriorityGrid3D } from './PriorityGrid3D';
+import { BoundedGrid3D } from './BoundedGrid3D';
+import { Ray, Vector3 } from '@casual-simulation/three';
+
+describe('PriorityGrid3D', () => {
+    describe('getTileFromRay()', () => {
+        it('should return the tile from first closest grid', () => {
+            const priorityGrid = new PriorityGrid3D();
+
+            const grid1 = new BoundedGrid3D();
+            grid1.position.set(0, 0, 0);
+            grid1.updateMatrixWorld(true);
+
+            const grid2 = new BoundedGrid3D();
+            grid2.position.set(0, 1, 0);
+            grid2.updateMatrixWorld(true);
+
+            priorityGrid.grids.push(grid1, grid2);
+
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getTileFromRay(ray, true);
+            const expected = grid1.getTileFromRay(ray, true);
+
+            expect(actual.tileCoordinate).toEqual(expected.tileCoordinate);
+            expect(actual.center).toEqual(expected.center);
+            expect(actual.corners).toEqual(expected.corners);
+            expect(actual.grid).toBe(expected.grid);
+        });
+
+        it('should ignore grids that are not enabled', () => {
+            const priorityGrid = new PriorityGrid3D();
+
+            const grid1 = new BoundedGrid3D();
+            grid1.position.set(0, 0, 0);
+            grid1.enabled = false;
+            grid1.updateMatrixWorld(true);
+
+            const grid2 = new BoundedGrid3D();
+            grid2.position.set(0, 1, 0);
+            grid2.updateMatrixWorld(true);
+
+            priorityGrid.grids.push(grid1, grid2);
+
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getTileFromRay(ray, true);
+            const expected = grid2.getTileFromRay(ray, true);
+
+            expect(actual.tileCoordinate).toEqual(expected.tileCoordinate);
+            expect(actual.center).toEqual(expected.center);
+            expect(actual.corners).toEqual(expected.corners);
+            expect(actual.grid).toBe(expected.grid);
+        });
+
+        it('should return null if there is no grid', () => {
+            const priorityGrid = new PriorityGrid3D();
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getTileFromRay(ray, true);
+
+            expect(actual).toBe(null);
+        });
+    });
+
+    describe('getPointFromRay()', () => {
+        it('should return the point from the first grid', () => {
+            const priorityGrid = new PriorityGrid3D();
+
+            const grid1 = new BoundedGrid3D();
+            grid1.position.set(0, 0, 0);
+            grid1.updateMatrixWorld(true);
+
+            const grid2 = new BoundedGrid3D();
+            grid2.position.set(0, 1, 0);
+            grid2.updateMatrixWorld(true);
+
+            priorityGrid.grids.push(grid1, grid2);
+
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getPointFromRay(ray);
+            const expected = grid1.getPointFromRay(ray);
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should ignore grids that are not enabled', () => {
+            const priorityGrid = new PriorityGrid3D();
+
+            const grid1 = new BoundedGrid3D();
+            grid1.position.set(0, 0, 0);
+            grid1.enabled = false;
+            grid1.updateMatrixWorld(true);
+
+            const grid2 = new BoundedGrid3D();
+            grid2.position.set(0, 1, 0);
+            grid2.updateMatrixWorld(true);
+
+            priorityGrid.grids.push(grid1, grid2);
+
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getPointFromRay(ray);
+            const expected = grid2.getPointFromRay(ray);
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should return null if there is no grid', () => {
+            const priorityGrid = new PriorityGrid3D();
+            const ray = new Ray(new Vector3(0, 10, 0), new Vector3(0, -1, 0));
+            const actual = priorityGrid.getPointFromRay(ray);
+
+            expect(actual).toBe(null);
+        });
+    });
+});

--- a/src/aux-server/aux-web/shared/scene/PriorityGrid3D.ts
+++ b/src/aux-server/aux-web/shared/scene/PriorityGrid3D.ts
@@ -1,0 +1,80 @@
+import { Ray, Vector3 } from '@casual-simulation/three';
+import { Grid3D, GridTile } from './Grid3D';
+
+/**
+ * Defines a class that provides an implementation of Grid3D that is able to represent multiple grids based on their given priority.
+ */
+export class PriorityGrid3D implements Grid3D {
+
+    /**
+     * The list of grids that this priority grid represents.
+     */
+    grids: Grid3D[] = [];
+
+    get enabled() {
+        return true;
+    }
+
+    get primaryGrid() {
+        return this.grids[0];
+    }
+
+    getPointFromRay(ray: Ray): Vector3 {
+        for (let grid of this.grids) {
+            if (!grid.enabled) {
+                continue;
+            }
+            const point = grid.getPointFromRay(ray);
+            if (point) {
+                return point;
+            }
+        }
+
+        return null;
+    }
+
+    getTileFromRay(ray: Ray, roundToWholeNumber: boolean): GridTile {
+        for (let grid of this.grids) {
+            if (!grid.enabled) {
+                continue;
+            }
+            const tile = grid.getTileFromRay(ray, roundToWholeNumber);
+            if (tile) {
+                return tile;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Scales the given position by the tile scale and returns the result.
+     * @param position The input position.
+     */
+    getGridPosition(position: { x: number; y: number; z: number }): Vector3 {
+        const grid = this.primaryGrid;
+        if (!grid) {
+            throw new Error(
+                'Cannot scale the position because no primrary grid exists!'
+            );
+        }
+
+        return grid.getGridPosition(position);
+    }
+
+    /**
+     * Scales the given position by the tile scale and returns the result.
+     * @param position The input position.
+     */
+    getWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
+        const grid = this.primaryGrid;
+        if (!grid) {
+            throw new Error(
+                'Cannot scale the position because no primrary grid exists!'
+            );
+        }
+
+        return grid.getWorldPosition(position);
+    }
+
+}

--- a/src/aux-server/aux-web/shared/scene/PriorityGrid3D.ts
+++ b/src/aux-server/aux-web/shared/scene/PriorityGrid3D.ts
@@ -66,7 +66,7 @@ export class PriorityGrid3D implements Grid3D {
      * Scales the given position by the tile scale and returns the result.
      * @param position The input position.
      */
-    getWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
+    getGridWorldPosition(position: { x: number; y: number; z: number }): Vector3 {
         const grid = this.primaryGrid;
         if (!grid) {
             throw new Error(
@@ -74,7 +74,7 @@ export class PriorityGrid3D implements Grid3D {
             );
         }
 
-        return grid.getWorldPosition(position);
+        return grid.getGridWorldPosition(position);
     }
 
 }

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -711,7 +711,7 @@ export function safeSetParent(obj: Object3D, parent: Object3D): boolean {
     if (obj.parent) {
         obj.parent.remove(obj);
     }
-    parent.add(obj);
+    parent?.add(obj);
     return true;
 }
 

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -549,6 +549,10 @@ export abstract class Simulation3D
 
     _onLoaded() {}
 
+    /**
+     * Gets the list of bot visualizers for the given Bot ID.
+     * @param id The ID of the bot.
+     */
     findBotsById(id: string): AuxBotVisualizer[] {
         let list = this._botMap.get(id);
         if (!list) {

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -856,7 +856,7 @@ export abstract class Simulation3D
      * Gets the grid scale that should be used for the given bot.
      * @param bot The bot.
      */
-    abstract getGridScale(bot: AuxBot3D): number;
+    abstract getGridScale(bot: AuxBot3D | DimensionGroup3D): number;
 
     /**
      * Gets the default grid scale that should be used for converting units.


### PR DESCRIPTION
### :rocket: Improvements

-   Added the `os.addDropGrid(...grids)` and `os.addBotDropGrid(botId, ...grids)` functions to make it easy to snap bots to a custom grid.
    -   These functions are useful if you want to snap bots to a grid with a custom position or rotation.
    -   Additionally, they can be used to move bots in a grid that is attached to a portal bot.
    -   See the documentation for detailed usage information.