### PR TITLE
Add the ability to support querying separate records instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CasualOS Changelog
 
+## V3.0.5
+
+#### Date: TBD
+
+### :rocket: Improvements
+
+-   Added the ability to specify which auth site records should be loaded/retrieved from.
+    -   This is useful for saving or getting records from another CasualOS instance.
+    -   The following functions have been updated to support an optional `endpoint` parameter:
+        -   `os.recordData(key, address, data, endpoint?)`
+        -   `os.getData(recordName, address, endpoint?)`
+        -   `os.listData(recordName, startingAddress?, endpoint?)`
+        -   `os.eraseData(key, address, endpoint?)`
+        -   `os.recordManualApprovalData(key, address, data, endpoint?)`
+        -   `os.getManualApprovalData(recordName, address, endpoint?)`
+        -   `os.listManualApprovalData(recordName, startingAddress?, endpoint?)`
+        -   `os.eraseManualApprovalData(key, address, endpoint?)`
+        -   `os.recordFile(key, data, options?, endpoint?)`
+        -   `os.eraseFile(key, url, endpoint?)`
+        -   `os.recordEvent(key, eventName, endpoint?)`
+        -   `os.countEvents(recordName, eventName, endpoint?)`
+
 ## V3.0.4
 
 #### Date: 3/31/2022

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1982,7 +1982,7 @@ const isRecordKey = os.isRecordKey(tags.myRecordKey);
 os.toast(tags.myRecordKey ' is ' + (isRecordKey ? 'a' : 'not a') + ' record key.');
 ```
 
-### `os.recordData(recordKey, address, data)`
+### `os.recordData(recordKey, address, data, endpoint?)`
 
 Stores the given <GlossaryRef term='data-record'>data</GlossaryRef> in the given <GlossaryRef term='record'>record</GlossaryRef> at the given address.
 If data already exists at the given address, it will be overwritten.
@@ -1994,7 +1994,10 @@ The **first parameter** is the key that should be used to access the record. You
 The **second parameter** is the address that the data should be stored at.
 
 The **third parameter** is the data that should be stored. This can be any value that can be serialized to JSON.
-Must be less than 300KB in size. If you need to store data larger than 300KB, you can use <ActionLink action='os.recordFile(recordKey, fileData, options?)' /> instead.
+Must be less than 300KB in size. If you need to store data larger than 300KB, you can use <ActionLink action='os.recordFile(recordKey, fileData, options?, endpoint?)' /> instead.
+
+The **fourth parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2046,7 +2049,7 @@ if (result.success) {
 }
 ```
 
-### `os.eraseData(recordKey, address)`
+### `os.eraseData(recordKey, address, endpoint?)`
 
 Erases the <GlossaryRef term='data-record'>data</GlossaryRef> stored at the given address in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Returns a promise that resolves with an object that contains the data (if successful) or information about the error that occurred.
@@ -2055,6 +2058,8 @@ The **first parameter** is the key that should be used to access the record. You
 
 The **second parameter** is the address that the data is stored at.
 
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2106,7 +2111,7 @@ if (result.success) {
 }
 ```
 
-### `os.getData(recordKeyOrName, address)`
+### `os.getData(recordKeyOrName, address, endpoint?)`
 
 Gets the <GlossaryRef term='data-record'>data</GlossaryRef> stored at the given address in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Returns a promise that resolves with an object that contains the data (if successful) or information about the error that occurred.
@@ -2115,6 +2120,9 @@ The **first parameter** is the record name or a record key. This indicates the r
 Note that you don't need a record key in order to retrieve data from a public record. Using a record name will work just fine.
 
 The **second parameter** is the address that the data should be retrieved from.
+
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2182,7 +2190,7 @@ if (result.success) {
 ```
 
 
-### `os.listData(recordNameOrKey, startingAddress?)`
+### `os.listData(recordNameOrKey, startingAddress?, endpoint?)`
 
 Gets a partial list of <GlossaryRef term='data-record'>data</GlossaryRef> that is stored in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Optionally accepts the address before the first item that should be included in the list.
@@ -2196,6 +2204,9 @@ Note that you don't need a record key in order to retrieve data from a public re
 The **second parameter** is optional and is the address after which items will be included in the list.
 Since items are ordered within the record by address, this can be used as way to iterate through all the data items in a record.
 If omitted, then the list will start with the first item.
+
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2270,29 +2281,29 @@ while(true) {
 }
 ```
 
-### `os.recordManualApprovalData(recordKey, address, data)`
+### `os.recordManualApprovalData(recordKey, address, data, endpoint?)`
 
 Stores the given <GlossaryRef term='manual-approval-data-record'>manual approval data</GlossaryRef> in the given <GlossaryRef term='record'>record</GlossaryRef> at the given address.
 If data already exists at the given address, it will be overwritten.
 
 Returns a promise that resolves with an object that indicates if the request was successful.
 
-Works the same as <ActionLink action='os.recordData(recordKey, address, data)'/> except that manual approval data records require the user to allow the operation manually.
+Works the same as <ActionLink action='os.recordData(recordKey, address, data, endpoint?)'/> except that manual approval data records require the user to allow the operation manually.
 
-### `os.eraseManualApprovalData(recordKey, address)`
+### `os.eraseManualApprovalData(recordKey, address,  endpoint?)`
 
 Erases the <GlossaryRef term='manual-approval-data-record'>manual approval data</GlossaryRef> stored at the given address in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Returns a promise that resolves with an object that contains the data (if successful) or information about the error that occurred.
 
-Works the same as <ActionLink action='os.eraseData(recordKeyOrName, address)'/> except that manual approval data records require the user to allow the operation manually.
+Works the same as <ActionLink action='os.eraseData(recordKeyOrName, address, endpoint?)'/> except that manual approval data records require the user to allow the operation manually.
 
-### `os.getManualApprovalData(recordKeyOrName, address)`
+### `os.getManualApprovalData(recordKeyOrName, address, endpoint?)`
 
 Gets the <GlossaryRef term='manual-approval-data-record'>manual approval data</GlossaryRef> stored at the given address in the given <GlossaryRef term='record'>record</GlossaryRef>.
 
-Works the same as <ActionLink action='os.getData(recordKeyOrName, address)'/> except that manual approval data records require the user to allow the operation manually.
+Works the same as <ActionLink action='os.getData(recordKeyOrName, address, endpoint?)'/> except that manual approval data records require the user to allow the operation manually.
 
-### `os.recordFile(recordKey, fileData, options?)`
+### `os.recordFile(recordKey, fileData, options?, endpoint?)`
 
 Stores the given <GlossaryRef term='file-record'>file data</GlossaryRef> in the given <GlossaryRef term='record'>record</GlossaryRef> using the given options for the file.
 The file can later be retrieved by using <ActionLink action='os.getFile(urlOrRecordFileResult)' />.
@@ -2326,6 +2337,9 @@ let options: {
     mimeType?: string;
 };
 ```
+
+The **fourth parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2416,7 +2430,25 @@ if (result.success) {
 }
 ```
 
-### `os.eraseFile(recordKey, urlOrRecordFileResult)`
+```typescript title='Upload a file to a custom endpoint'
+const files = await os.showUploadFiles();
+
+if (files.length <= 0) {
+    return;
+}
+
+const file = files[0];
+const result = await os.recordFile(tags.recordKey, file, undefined, 'https://myendpoint.com');
+
+if (result.success) {
+    tags.uploadUrl = result.url;
+    os.toast("Success! Uploaded to " + result.url);
+} else {
+    os.toast("Failed " + result.errorMessage);
+}
+```
+
+### `os.eraseFile(recordKey, urlOrRecordFileResult, endpoint?)`
 
 Erases the <GlossaryRef term='file-record'>file</GlossaryRef> at the given URL or at the URL that was specified in the given <ActionLink action='os.recordFile(recordKey, fileData, options?)' /> result.
 
@@ -2426,6 +2458,8 @@ The **first parameter** is the key that should be used to access the record. You
 
 The **second parameter** is the URL that the file is stored at. It can also be the result of a <ActionLink action='os.recordFile(recordKey, fileData, options?)' /> call.
 
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2500,7 +2534,7 @@ if (result.success) {
 const fileData = await os.getFile(tags.uploadUrl);
 ```
 
-### `os.recordEvent(recordKey, eventName)`
+### `os.recordEvent(recordKey, eventName, endpoint?)`
 
 Records that the given <GlossaryRef term='event-record'>event</GlossaryRef> occurred in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Returns a promise that resolves with an object that indicates whether the operation was successful or unsuccessful.
@@ -2508,6 +2542,9 @@ Returns a promise that resolves with an object that indicates whether the operat
 The **first parameter** is the key that should be used to access the record. You can request a record key by using <ActionLink action='os.getPublicRecordKey(name)' />.
 
 The **second parameter** is the name of the event whose count should be incremented.
+
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 
@@ -2556,7 +2593,7 @@ let result: {
 await os.recordEvent(myRecordKey, 'click');
 ```
 
-### `os.countEvents(recordNameOrKey, eventName)`
+### `os.countEvents(recordNameOrKey, eventName, endpoint?)`
 
 Gets the number of times that the given <GlossaryRef term='event-record'>event</GlossaryRef> has been recorded in the given <GlossaryRef term='record'>record</GlossaryRef>.
 Returns a promise that resolves with an object that indicates whether the operation was successful or unsuccessful.
@@ -2564,6 +2601,9 @@ Returns a promise that resolves with an object that indicates whether the operat
 The **first parameter** is the name of the record that the event count should be retrieved from. It can also be a record key.
 
 The **second parameter** is the name of the event whose count should be retrieved.
+
+The **third parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
 

--- a/docs/docs/glossary/DataRecord.mdx
+++ b/docs/docs/glossary/DataRecord.mdx
@@ -9,5 +9,5 @@ Data records are most useful for storing relatively lightweight information that
 #### See Also
 
 -   <GlossaryRef term='record'>Record</GlossaryRef>
--   <ActionLink action='os.recordData(recordKey, address, data)' />
--   <ActionLink action='os.getData(recordKeyOrName, address)' />
+-   <ActionLink action='os.recordData(recordKey, address, data, endpoint?)' />
+-   <ActionLink action='os.getData(recordKeyOrName, address, endpoint?)' />

--- a/docs/docs/glossary/FileRecord.mdx
+++ b/docs/docs/glossary/FileRecord.mdx
@@ -9,5 +9,5 @@ File records are most useful for storing heavy data (images, MP3s, etc.) that do
 #### See Also
 
 -   <GlossaryRef term='record'>Record</GlossaryRef>
--   <ActionLink action='os.recordFile(recordKey, fileData, options?)' />
+-   <ActionLink action='os.recordFile(recordKey, fileData, options?, endpoint?)' />
 -   <ActionLink action='os.getFile(urlOrRecordFileResult)' />

--- a/docs/docs/glossary/ManualApprovalDataRecord.mdx
+++ b/docs/docs/glossary/ManualApprovalDataRecord.mdx
@@ -7,5 +7,5 @@ A Manual Approval Data Record is a <GlossaryRef term='data-record'>data record</
 
 -   <GlossaryRef term='data-record'>Data Record</GlossaryRef>
 -   <GlossaryRef term='record'>Record</GlossaryRef>
--   <ActionLink action='os.recordData(recordKey, address, data)' />
--   <ActionLink action='os.getData(recordKeyOrName, address)' />
+-   <ActionLink action='os.recordManualApprovalData(recordKey, address, data, endpoint?)' />
+-   <ActionLink action='os.getManualApprovalData(recordKeyOrName, address, endpoint?)' />

--- a/src/aux-auth/web/iframe/AuthHandler.ts
+++ b/src/aux-auth/web/iframe/AuthHandler.ts
@@ -129,7 +129,7 @@ export class AuthHandler implements AuxAuth {
     }
 
     async getProtocolVersion() {
-        return 3;
+        return 4;
     }
 
     async getRecordsOrigin(): Promise<string> {

--- a/src/aux-auth/web/iframe/AuthHandler.ts
+++ b/src/aux-auth/web/iframe/AuthHandler.ts
@@ -132,6 +132,10 @@ export class AuthHandler implements AuxAuth {
         return 3;
     }
 
+    async getRecordsOrigin(): Promise<string> {
+        return Promise.resolve(authManager.apiEndpoint);
+    }
+
     async openAccountPage(): Promise<void> {
         const url = new URL('/', location.origin);
         window.open(url.href, '_blank');

--- a/src/aux-auth/web/shared/AuthManager.ts
+++ b/src/aux-auth/web/shared/AuthManager.ts
@@ -215,6 +215,10 @@ export class AuthManager {
         const response = await axios.get(`${API_ENDPOINT}/api/emailRules`);
         return response.data;
     }
+
+    get apiEndpoint(): string {
+        return API_ENDPOINT;
+    }
 }
 
 declare var MAGIC_API_KEY: string;

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -3233,9 +3233,19 @@ export interface DefineGlobalBotAction extends AsyncAction {
 export const APPROVED_SYMBOL = Symbol('approved');
 
 /**
- * Defines an interface that represents tbe base for actions that deal with data records.
+ * Defines an interface that represents the base for actions that deal with records.
  */
-export interface DataRecordAction extends AsyncAction {
+export interface RecordsAction extends AsyncAction {
+    /**
+     * The HTTP endpoint that the request should interface with.
+     */
+    endpoint?: string;
+}
+
+/**
+ * Defines an interface that represents the base for actions that deal with data records.
+ */
+export interface DataRecordAction extends RecordsAction {
     /**
      * Whether this action is trying to publish data that requires manual approval.
      */
@@ -3323,7 +3333,7 @@ export interface EraseRecordDataAction extends DataRecordAction {
 /**
  * Defines an event that publishes a file to a record.
  */
-export interface RecordFileAction extends AsyncAction {
+export interface RecordFileAction extends RecordsAction {
     type: 'record_file';
 
     /**
@@ -3350,7 +3360,7 @@ export interface RecordFileAction extends AsyncAction {
 /**
  * Defines an event that erases a file from a record.
  */
-export interface EraseFileAction extends AsyncAction {
+export interface EraseFileAction extends RecordsAction {
     type: 'erase_file';
 
     /**
@@ -3381,7 +3391,7 @@ export interface FileRecordedFailure {
 /**
  * Defines an action that records that an event happened.
  */
-export interface RecordEventAction extends AsyncAction {
+export interface RecordEventAction extends RecordsAction {
     type: 'record_event';
 
     /**
@@ -3403,7 +3413,7 @@ export interface RecordEventAction extends AsyncAction {
 /**
  * Defines an action that retrieves the number of times an event has happened.
  */
-export interface GetEventCountAction extends AsyncAction {
+export interface GetEventCountAction extends RecordsAction {
     type: 'get_event_count';
 
     /**
@@ -6157,6 +6167,7 @@ export function getPublicRecordKey(
  * @param address The address that the data should be stored at in the record.
  * @param data The data to store.
  * @param requiresApproval Whether to try to record data that requires approval.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID of the task.
  */
 export function recordData(
@@ -6164,6 +6175,7 @@ export function recordData(
     address: string,
     data: any,
     requiresApproval: boolean,
+    endpoint: string,
     taskId: number | string
 ): RecordDataAction {
     return {
@@ -6172,6 +6184,7 @@ export function recordData(
         address,
         data,
         requiresApproval,
+        endpoint,
         taskId,
     };
 }
@@ -6181,12 +6194,14 @@ export function recordData(
  * @param recordName The name of the record to retrieve.
  * @param address The address of the data to retrieve.
  * @param requiresApproval Whether to try to get a record that requires manual approval.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID of the task.
  */
 export function getRecordData(
     recordName: string,
     address: string,
     requiresApproval: boolean,
+    endpoint: string,
     taskId?: number | string
 ): GetRecordDataAction {
     return {
@@ -6194,6 +6209,7 @@ export function getRecordData(
         recordName,
         address,
         requiresApproval,
+        endpoint,
         taskId,
     };
 }
@@ -6202,11 +6218,13 @@ export function getRecordData(
  * Creates a ListRecordDataAction.
  * @param recordName The name of the record.
  * @param startingAddress The address that the list should start with.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID of the task.
  */
 export function listDataRecord(
     recordName: string,
     startingAddress: string,
+    endpoint: string,
     taskId?: number | string
 ): ListRecordDataAction {
     return {
@@ -6214,6 +6232,7 @@ export function listDataRecord(
         recordName,
         startingAddress,
         requiresApproval: false,
+        endpoint,
         taskId,
     };
 }
@@ -6223,12 +6242,14 @@ export function listDataRecord(
  * @param recordKey The key that should be used to access the record.
  * @param address The address of the data to erase.
  * @param requiresApproval Whether to try to erase a record that requires manual approval.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID of the task.
  */
 export function eraseRecordData(
     recordKey: string,
     address: string,
     requiresApproval: boolean,
+    endpoint: string,
     taskId?: number | string
 ): EraseRecordDataAction {
     return {
@@ -6236,6 +6257,7 @@ export function eraseRecordData(
         recordKey,
         address,
         requiresApproval,
+        endpoint,
         taskId,
     };
 }
@@ -6257,12 +6279,14 @@ export function approveDataRecord<T extends DataRecordAction>(action: T): T {
  * @param data The data to store.
  * @param description The description of the file.
  * @param mimeType The MIME type of the file.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  */
 export function recordFile(
     recordKey: string,
     data: any,
     description: string,
     mimeType: string,
+    endpoint: string,
     taskId?: number | string
 ): RecordFileAction {
     return {
@@ -6271,6 +6295,7 @@ export function recordFile(
         data,
         description,
         mimeType,
+        endpoint,
         taskId,
     };
 }
@@ -6279,17 +6304,20 @@ export function recordFile(
  * Creates a EraseFileAction.
  * @param recordKey The key that should be used to access the record.
  * @param fileUrl The URL that the file was stored at.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID of the task.
  */
 export function eraseFile(
     recordKey: string,
     fileUrl: string,
+    endpoint: string,
     taskId?: number | string
 ): EraseFileAction {
     return {
         type: 'erase_file',
         recordKey,
         fileUrl,
+        endpoint,
         taskId,
     };
 }
@@ -6299,12 +6327,14 @@ export function eraseFile(
  * @param recordKey The key that should be used to access the record.
  * @param eventName The name of the event.
  * @param count The number of times that the event occurred.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The Id of the task.
  */
 export function recordEvent(
     recordKey: string,
     eventName: string,
     count: number,
+    endpoint: string,
     taskId?: number | string
 ): RecordEventAction {
     return {
@@ -6312,6 +6342,7 @@ export function recordEvent(
         recordKey,
         eventName,
         count,
+        endpoint,
         taskId,
     };
 }
@@ -6320,17 +6351,20 @@ export function recordEvent(
  * Creates a GetEventCountAction.
  * @param recordName The name of the record.
  * @param eventName The name of the events.
+ * @param endpoint The HTTP Origin that should be used for the records request.
  * @param taskId The ID.
  */
 export function getEventCount(
     recordName: string,
     eventName: string,
+    endpoint: string,
     taskId?: number | string
 ): GetEventCountAction {
     return {
         type: 'get_event_count',
         recordName,
         eventName,
+        endpoint,
         taskId,
     };
 }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4488,6 +4488,26 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     false,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    'myEndpoint'
+                );
+                const expected = recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    false,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4510,6 +4530,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     false,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4534,6 +4555,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     false,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4553,6 +4575,26 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     true,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.recordManualApprovalData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    'myEndpoint',
+                );
+                const expected = recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    true,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4575,6 +4617,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     true,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4599,6 +4642,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     true,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4616,6 +4660,24 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.getData(
+                    'recordKey',
+                    'address',
+                    'myEndpoint',
+                );
+                const expected = getRecordData(
+                    'recordKey',
+                    'address',
+                    false,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4631,6 +4693,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     false,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4648,6 +4711,24 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.getManualApprovalData(
+                    'recordKey',
+                    'address',
+                    'myEndpoint'
+                );
+                const expected = getRecordData(
+                    'recordKey',
+                    'address',
+                    true,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4663,6 +4744,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     true,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4676,6 +4758,19 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     null,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.listData('recordName', undefined, 'myEndpoint');
+                const expected = listDataRecord(
+                    'recordName',
+                    null,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4690,6 +4785,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     'address',
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4704,6 +4800,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     'address',
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4721,6 +4818,24 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.eraseData(
+                    'recordKey',
+                    'address',
+                    'myEndpoint',
+                );
+                const expected = eraseRecordData(
+                    'recordKey',
+                    'address',
+                    false,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4762,6 +4877,24 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.eraseManualApprovalData(
+                    'recordKey',
+                    'address',
+                    'myEndpoint'
+                );
+                const expected = eraseRecordData(
+                    'recordKey',
+                    'address',
+                    true,
+                    'myEndpoint',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4810,6 +4943,28 @@ describe('AuxLibrary', () => {
                     'data',
                     'description',
                     undefined,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.recordFile(
+                    'recordKey',
+                    'data',
+                    {
+                        description: 'description',
+                    },
+                    'https://localhost:5000'
+                );
+                const expected = recordFile(
+                    'recordKey',
+                    'data',
+                    'description',
+                    undefined,
+                    'https://localhost:5000',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4826,6 +4981,7 @@ describe('AuxLibrary', () => {
                     'data',
                     undefined,
                     undefined,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4845,6 +5001,7 @@ describe('AuxLibrary', () => {
                     'data',
                     undefined,
                     'image/png',
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4885,6 +5042,7 @@ describe('AuxLibrary', () => {
                     },
                     undefined,
                     undefined,
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4961,6 +5119,23 @@ describe('AuxLibrary', () => {
                 const expected = eraseFile(
                     'recordKey',
                     'fileUrl',
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.eraseFile(
+                    'recordKey',
+                    'fileUrl',
+                    'http://localhost:5000'
+                );
+                const expected = eraseFile(
+                    'recordKey',
+                    'fileUrl',
+                    'http://localhost:5000',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4998,6 +5173,24 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'eventName',
                     1,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.recordEvent(
+                    'recordKey',
+                    'eventName',
+                    'http://localhost:5000'
+                );
+                const expected = recordEvent(
+                    'recordKey',
+                    'eventName',
+                    1,
+                    'http://localhost:5000',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5038,6 +5231,23 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordKey',
                     'eventName',
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom endpoints', async () => {
+                const action: any = library.api.os.countEvents(
+                    'recordKey',
+                    'eventName',
+                    'http://localhost:5000'
+                );
+                const expected = getEventCount(
+                    'recordKey',
+                    'eventName',
+                    'http://localhost:5000',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5052,6 +5262,7 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordName',
                     'eventName',
+                    null,
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -3344,9 +3344,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    function recordData(recordKey: string, address: string, data: any) {
-        return baseRecordData(recordKey, address, data, false);
+    function recordData(recordKey: string, address: string, data: any, endpoint: string = null) {
+        return baseRecordData(recordKey, address, data, false, endpoint);
     }
 
     /**
@@ -3356,13 +3357,15 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function recordManualApprovalData(
         recordKey: string,
         address: string,
-        data: any
+        data: any,
+        endpoint: string = null
     ) {
-        return baseRecordData(recordKey, address, data, true);
+        return baseRecordData(recordKey, address, data, true, endpoint);
     }
 
     /**
@@ -3370,12 +3373,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function baseRecordData(
         recordKey: string,
         address: string,
         data: any,
-        requiresApproval: boolean
+        requiresApproval: boolean,
+        endpoint: string = null
     ): Promise<RecordDataResult> {
         const task = context.createTask();
         const event = calcRecordData(
@@ -3383,6 +3388,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             address,
             convertToCopiableValue(data),
             requiresApproval,
+            endpoint,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3392,35 +3398,41 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Gets the data stored in the given record at the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param address The address that the data is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function getData(
         recordKeyOrName: string,
-        address: string
+        address: string,
+        endpoint: string = null
     ): Promise<GetDataResult> {
-        return baseGetData(recordKeyOrName, address, false);
+        return baseGetData(recordKeyOrName, address, false, endpoint);
     }
 
     /**
      * Gets the data stored in the given record at the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param address The address that the data is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function getManualApprovalData(
         recordKeyOrName: string,
-        address: string
+        address: string,
+        endpoint: string = null
     ): Promise<GetDataResult> {
-        return baseGetData(recordKeyOrName, address, true);
+        return baseGetData(recordKeyOrName, address, true, endpoint);
     }
 
     /**
      * Gets the data stored in the given record at the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param address The address that the data is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function baseGetData(
         recordKeyOrName: string,
         address: string,
-        requiresApproval: boolean
+        requiresApproval: boolean,
+        endpoint: string,
     ): Promise<GetDataResult> {
         let recordName = isRecordKey(recordKeyOrName)
             ? parseRecordKey(recordKeyOrName)[0]
@@ -3430,6 +3442,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             recordName,
             address,
             requiresApproval,
+            endpoint,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3439,16 +3452,18 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Lists the data stored in the given record starting with the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param startingAddress The address that the list should start with.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function listData(
         recordKeyOrName: string,
-        startingAddress: string = null
+        startingAddress: string = null,
+        endpoint: string = null
     ): Promise<ListDataResult> {
         let recordName = isRecordKey(recordKeyOrName)
             ? parseRecordKey(recordKeyOrName)[0]
             : recordKeyOrName;
         const task = context.createTask();
-        const event = listDataRecord(recordName, startingAddress, task.taskId);
+        const event = listDataRecord(recordName, startingAddress, endpoint, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3456,12 +3471,14 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Erases the data stored in the given record at the given address.
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function eraseData(
         recordKey: string,
-        address: string
+        address: string,
+        endpoint: string = null,
     ): Promise<EraseDataResult> {
-        return baseEraseData(recordKey, address, false);
+        return baseEraseData(recordKey, address, false, endpoint);
     }
 
     /**
@@ -3469,23 +3486,27 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      *
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function eraseManualApprovalData(
         recordKey: string,
-        address: string
+        address: string,
+        endpoint: string = null
     ): Promise<EraseDataResult> {
-        return baseEraseData(recordKey, address, true);
+        return baseEraseData(recordKey, address, true, endpoint);
     }
 
     /**
      * Erases the data stored in the given record at the given address.
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function baseEraseData(
         recordKey: string,
         address: string,
-        requiresApproval: boolean
+        requiresApproval: boolean,
+        endpoint: string = null
     ): Promise<EraseDataResult> {
         if (!hasValue(recordKey)) {
             throw new Error('A recordKey must be provided.');
@@ -3504,6 +3525,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             recordKey,
             address,
             requiresApproval,
+            endpoint,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3514,11 +3536,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The record that the file should be recorded in.
      * @param data The data that should be recorded.
      * @param options The options that should be used to record the file.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function recordFile(
         recordKey: string,
         data: any,
-        options?: RecordFileOptions
+        options?: RecordFileOptions,
+        endpoint: string = null
     ): Promise<RecordFileApiResult> {
         if (!hasValue(recordKey)) {
             throw new Error('A recordKey must be provided.');
@@ -3536,6 +3560,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             convertToCopiableValue(data),
             options?.description,
             options?.mimeType,
+            endpoint,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3590,28 +3615,34 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param result The successful result of a os.recordFile() call.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function eraseFile(
         recordKey: string,
-        result: RecordFileApiSuccess
+        result: RecordFileApiSuccess,
+        endpoint?: string
     ): Promise<EraseFileResult>;
     /**
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param url The URL that the file is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function eraseFile(
         recordKey: string,
-        url: string
+        url: string,
+        endpoint?: string
     ): Promise<EraseFileResult>;
     /**
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param urlOrRecordFileResult The URL or the successful result of the record file operation.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function eraseFile(
         recordKey: string,
-        fileUrlOrRecordFileResult: string | RecordFileApiSuccess
+        fileUrlOrRecordFileResult: string | RecordFileApiSuccess,
+        endpoint: string = null
     ): Promise<EraseFileResult> {
         if (!hasValue(recordKey)) {
             throw new Error('A recordKey must be provided.');
@@ -3638,7 +3669,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         }
 
         const task = context.createTask();
-        const event = calcEraseFile(recordKey, url, task.taskId);
+        const event = calcEraseFile(recordKey, url, endpoint, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3646,10 +3677,12 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Records that the given event occurred.
      * @param recordKey The key that should be used to record the event.
      * @param eventName The name of the event.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function recordEvent(
         recordKey: string,
-        eventName: string
+        eventName: string,
+        endpoint: string = null
     ): Promise<AddCountResult> {
         if (!hasValue(recordKey)) {
             throw new Error('A recordKey must be provided.');
@@ -3664,7 +3697,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         }
 
         const task = context.createTask();
-        const event = calcRecordEvent(recordKey, eventName, 1, task.taskId);
+        const event = calcRecordEvent(recordKey, eventName, 1, endpoint, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3672,10 +3705,12 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Gets the number of times that the given event has been recorded.
      * @param recordNameOrKey The name of the record.
      * @param eventName The name of the event.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     function countEvents(
         recordNameOrKey: string,
-        eventName: string
+        eventName: string,
+        endpoint: string = null
     ): Promise<GetCountResult> {
         if (!hasValue(recordNameOrKey)) {
             throw new Error('A recordNameOrKey must be provided.');
@@ -3694,7 +3729,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             : recordNameOrKey;
 
         const task = context.createTask();
-        const event = calcGetEventCount(recordName, eventName, task.taskId);
+        const event = calcGetEventCount(recordName, eventName, endpoint, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8546,36 +8546,42 @@ interface Os {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     recordData(
         recordKey: string,
         address: string,
-        data: any
+        data: any,
+        endpoint?: string
     ): Promise<RecordDataResult>;
 
     /**
      * Gets the data stored in the given record at the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param address The address that the data is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     getData(
         recordKeyOrName: string,
-        address: string
+        address: string,
+        endpoint?: string
     ): Promise<GetDataResult>;
 
     /**
      * Lists the data stored in the given record starting with the given address.
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param startingAddress The address that the list should start with.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    listData(recordKeyOrName: string, startingAddress?: string): Promise<ListDataResult>;
+    listData(recordKeyOrName: string, startingAddress?: string, endpoint?: string): Promise<ListDataResult>;
 
     /**
      * Erases the data stored in the given record at the given address.
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    eraseData(recordKey: string, address: string): Promise<EraseDataResult>;
+    eraseData(recordKey: string, address: string, endpoint?: string): Promise<EraseDataResult>;
 
     /**
      * Records the given data to the given address inside the record for the given record key.
@@ -8584,11 +8590,13 @@ interface Os {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     recordManualApprovalData(
         recordKey: string,
         address: string,
-        data: any
+        data: any,
+        endpoint?: string
     ): Promise<RecordDataResult>;
 
     /**
@@ -8597,10 +8605,12 @@ interface Os {
      * 
      * @param recordKeyOrName The record that the data should be retrieved from.
      * @param address The address that the data is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     getManualApprovalData(
         recordKeyOrName: string,
-        address: string
+        address: string,
+        endpoint?: string
     ): Promise<GetDataResult>;
 
     /**
@@ -8609,19 +8619,22 @@ interface Os {
      * 
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be erased from.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    eraseManualApprovalData(recordKey: string, address: string): Promise<EraseDataResult>;
+    eraseManualApprovalData(recordKey: string, address: string, endpoint?: string): Promise<EraseDataResult>;
 
     /**
      * Records the given data as a file.
      * @param recordKey The record that the file should be recorded in.
      * @param data The data that should be recorded.
      * @param options The options that should be used to record the file.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
     recordFile(
         recordKey: string,
         data: any,
-        options?: RecordFileOptions
+        options?: RecordFileOptions,
+        endpoint?: string
     ): Promise<RecordFileResult>;
 
     /**
@@ -8644,34 +8657,39 @@ interface Os {
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param result The successful result of a os.recordFile() call.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    eraseFile(recordKey: string, result: RecordFileSuccess): Promise<EraseFileResult>;
+    eraseFile(recordKey: string, result: RecordFileSuccess, endpoint?: string): Promise<EraseFileResult>;
     /**
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param url The URL that the file is stored at.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    eraseFile(recordKey: string, url: string): Promise<EraseFileResult>;
+    eraseFile(recordKey: string, url: string, endpoint?: string): Promise<EraseFileResult>;
     /**
      * Deletes the specified file using the given record key.
      * @param recordKey The key that should be used to delete the file.
      * @param urlOrRecordFileResult The URL or the successful result of the record file operation.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    eraseFile(recordKey: string, fileUrlOrRecordFileResult: string | RecordFileSuccess): Promise<EraseFileResult>;
+    eraseFile(recordKey: string, fileUrlOrRecordFileResult: string | RecordFileSuccess, endpoint?: string): Promise<EraseFileResult>;
 
     /**
      * Records that the given event occurred.
      * @param recordKey The key that should be used to record the event.
      * @param eventName The name of the event.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    recordEvent(recordKey: string, eventName: string): Promise<AddCountResult>;
+    recordEvent(recordKey: string, eventName: string, endpoint?: string): Promise<AddCountResult>;
 
     /**
      * Gets the number of times that the given event has been recorded.
      * @param recordNameOrKey The record that the event count should be retrieved from.
      * @param eventName The name of the event.
+     * @param endpoint The records endpoint that should be queried. Optional.
      */
-    countEvents(recordNameOrKey: string, eventName: string): Promise<GetCountResult>;
+    countEvents(recordNameOrKey: string, eventName: string, endpoint?: string): Promise<GetCountResult>;
 
     /**
      * Converts the given geolocation to a what3words (https://what3words.com/) address.

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -1040,7 +1040,7 @@ export default class PlayerApp extends Vue {
                     }
                 } else if (e.type === 'request_auth_data') {
                     try {
-                        const id = await simulation.auth.authenticate();
+                        const id = await simulation.auth.primary.authenticate();
 
                         simulation.helper.transaction(
                             asyncResult(e.taskId, id, false)
@@ -1178,6 +1178,7 @@ export default class PlayerApp extends Vue {
                                 '[PlayerApp] Authenticating user in background...'
                             );
                             simulation.auth
+                                .primary
                                 .authenticateInBackground()
                                 .then((data) => {
                                     if (data) {

--- a/src/aux-server/aux-web/shared/vue-components/BotChat/BotChat.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotChat/BotChat.ts
@@ -97,7 +97,7 @@ export default class BotChat extends Vue {
         this.avatarUrl = null;
         this._sub = appManager.whileLoggedIn((user, sim) => {
             return [
-                sim.auth.loginStatus.subscribe((status) => {
+                sim.auth.primary.loginStatus.subscribe((status) => {
                     if (status.isLoggingIn || status.isLoading) {
                         this.isLoggingIn = true;
                         this.isLoggedIn = false;
@@ -136,9 +136,9 @@ export default class BotChat extends Vue {
 
     login() {
         if (!this.isLoggedIn) {
-            appManager.simulationManager.primary.auth.authenticate();
+            appManager.simulationManager.primary.auth.primary.authenticate();
         } else {
-            appManager.simulationManager.primary.auth.openAccountPage();
+            appManager.simulationManager.primary.auth.primary.openAccountPage();
         }
     }
 

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -1,0 +1,316 @@
+import { wrap, proxy, Remote, expose, transfer, createEndpoint } from 'comlink';
+import {
+    AuthHelperInterface,
+    AuxAuth,
+    LoginStatus,
+    LoginUIStatus,
+} from '@casual-simulation/aux-vm';
+import { setupChannel, waitForLoad } from '../html/IFrameHelpers';
+import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
+import { AuthData, hasValue } from '@casual-simulation/aux-common';
+import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+
+// Save the query string that was used when the site loaded
+const query = typeof location !== 'undefined' ? location.search : null;
+
+interface StaticAuxAuth {
+    new (): AuxAuth;
+}
+
+/**
+ * Defines a class that helps handle authentication/authorization for a particular endpoint.
+ */
+export class AuthEndpointHelper implements AuthHelperInterface {
+    private _origin: string;
+    private _defaultRecordsOrigin: string;
+    private _iframe: HTMLIFrameElement;
+    private _channel: MessageChannel;
+    private _proxy: Remote<AuxAuth>;
+    private _initialized: boolean = false;
+    private _protocolVersion: number = 1;
+    private _sub: Subscription = new Subscription();
+    private _loginStatus: BehaviorSubject<LoginStatus> =
+        new BehaviorSubject<LoginStatus>({});
+    private _loginUIStatus: BehaviorSubject<LoginUIStatus> =
+        new BehaviorSubject<LoginUIStatus>({
+            page: false,
+        });
+    private _initPromise: Promise<void>;
+    private _recordsOrigin: string;
+
+    /**
+     * Creates a new instance of the AuthHelper class.
+     * @param iframeOrigin The URL that the auth iframe should be loaded from.
+     * @param defaultRecordsOrigin The HTTP Origin that should be used for the records origin if the auth site does not support protocol version 4.
+     */
+    constructor(iframeOrigin?: string, defaultRecordsOrigin?: string) {
+        this._origin = iframeOrigin;
+        this._defaultRecordsOrigin = defaultRecordsOrigin;
+    }
+
+    get origin(): string {
+        return this._origin;
+    }
+
+    get recordsOrigin(): string {
+        return this._recordsOrigin ?? this._defaultRecordsOrigin ?? this._origin;
+    }
+
+    get loginStatus() {
+        return this._loginStatus;
+    }
+
+    get loginUIStatus() {
+        return this._loginUIStatus;
+    }
+
+    /**
+     * Gets whether authentication is supported by this inst.
+     */
+    get supportsAuthentication() {
+        return hasValue(this._origin);
+    }
+
+    get closed() {
+        return this._sub?.closed;
+    }
+
+    unsubscribe() {
+        return this.dispose();
+    }
+
+    dispose() {
+        if (this._sub) {
+            this._sub.unsubscribe();
+            this._sub = null;
+        }
+    }
+
+    private async _init() {
+        if (!this._initPromise) {
+            this._initPromise = this._initCore();
+        }
+        return this._initPromise;
+    }
+
+    private async _initCore() {
+        if (!hasValue(this._origin)) {
+            throw new Error(
+                'Cannot initialize AuthHelper because no iframe origin is set.'
+            );
+        }
+        this._loginStatus.next({
+            isLoading: true,
+        });
+        const iframeUrl = new URL(`/iframe.html${query}`, this._origin).href;
+
+        const iframe = (this._iframe = document.createElement('iframe'));
+        this._sub.add(() => {
+            iframe.remove();
+        });
+        this._iframe.src = iframeUrl;
+        this._iframe.style.display = 'none';
+        this._iframe.className = 'auth-helper-iframe';
+
+        let promise = waitForLoad(this._iframe);
+        document.body.insertBefore(this._iframe, document.body.firstChild);
+
+        await promise;
+
+        this._channel = setupChannel(this._iframe.contentWindow);
+
+        const wrapper = wrap<StaticAuxAuth>(this._channel.port1);
+        this._proxy = await new wrapper();
+        try {
+            this._protocolVersion = await this._proxy.getProtocolVersion();
+        } catch (err) {
+            console.log(
+                '[AuthHelper] Could not get protocol version. Defaulting to version 1.'
+            );
+            this._protocolVersion = 1;
+        }
+
+        if (this._protocolVersion >= 2) {
+            await this._proxy.addLoginUICallback(
+                proxy((status) => {
+                    this._loginUIStatus.next(status);
+                })
+            );
+            await this._proxy.addLoginStatusCallback(
+                proxy((status) => {
+                    this._loginStatus.next(status);
+                })
+            );
+        }
+
+        if (this._protocolVersion >= 4) {
+            this._recordsOrigin = await this._proxy.getRecordsOrigin();
+        }
+
+        this._loginUIStatus.subscribe(status => {
+            if (!this._iframe) {
+                return;
+            }
+            if (status.page === 'show_iframe') {
+                this._iframe.style.display = null;
+            } else {
+                this._iframe.style.display = 'none';
+            }
+        });
+
+        this._initialized = true;
+    }
+
+    /**
+     * Determines if the user is authenticated.
+     */
+    async isAuthenticated() {
+        if (!hasValue(this._origin)) {
+            return false;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        return await this._proxy.isLoggedIn();
+    }
+
+    /**
+     * Requests that the user become authenticated if they are not already.
+     */
+    async authenticate() {
+        if (!hasValue(this._origin)) {
+            return null;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        const result = await this._proxy.login();
+
+        if (this._protocolVersion < 2) {
+            this._loginStatus.next({
+                authData: result,
+            });
+        }
+        return result;
+    }
+
+    /**
+     * Requests that the user become authenticated entirely in the background.
+     * This will not show any UI to the user but may also mean that the user will not be able to be authenticated.
+     */
+    async authenticateInBackground() {
+        if (!hasValue(this._origin)) {
+            return null;
+        }
+        this._loginStatus.next({
+            isLoggingIn: true,
+        });
+        if (!this._initialized) {
+            await this._init();
+        }
+        const result = await this._proxy.login(true);
+        if (this._protocolVersion < 2) {
+            this._loginStatus.next({
+                authData: result,
+            });
+        }
+        return result;
+    }
+
+    async createPublicRecordKey(
+        recordName: string
+    ): Promise<CreatePublicRecordKeyResult> {
+        if (!hasValue(this._origin)) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage: 'Records are not supported on this inst.',
+            };
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        return await this._proxy.createPublicRecordKey(recordName);
+    }
+
+    async getAuthToken(): Promise<string> {
+        if (!hasValue(this._origin)) {
+            return null;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        return await this._proxy.getAuthToken();
+    }
+
+    async openAccountPage(): Promise<void> {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 2) {
+            return;
+        }
+        return await this._proxy.openAccountPage();
+    }
+
+    async setUseCustomUI(useCustomUI: boolean) {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 2) {
+            return;
+        }
+        return await this._proxy.setUseCustomUI(useCustomUI);
+    }
+
+    async provideEmailAddress(email: string, acceptedTermsOfService: boolean) {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 2) {
+            return;
+        }
+        return await this._proxy.provideEmailAddress(
+            email,
+            acceptedTermsOfService
+        );
+    }
+
+    async provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void> {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 3) {
+            return;
+        }
+        return await this._proxy.provideSmsNumber(
+            sms,
+            acceptedTermsOfService
+        );
+    }
+
+    async cancelLogin() {
+        if (!hasValue(this._origin)) {
+            return;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        if (this._protocolVersion < 2) {
+            return;
+        }
+        return await this._proxy.cancelLogin();
+    }
+}

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -198,7 +198,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
      * Requests that the user become authenticated entirely in the background.
      * This will not show any UI to the user but may also mean that the user will not be able to be authenticated.
      */
-    async authenticateInBackground() {
+     async authenticateInBackground() {
         if (!hasValue(this._origin)) {
             return null;
         }

--- a/src/aux-vm-browser/managers/AuthHelper.ts
+++ b/src/aux-vm-browser/managers/AuthHelper.ts
@@ -1,300 +1,32 @@
-import { wrap, proxy, Remote, expose, transfer, createEndpoint } from 'comlink';
-import {
-    AuthHelperInterface,
-    AuxAuth,
-    LoginStatus,
-    LoginUIStatus,
-} from '@casual-simulation/aux-vm';
-import { setupChannel, waitForLoad } from '../html/IFrameHelpers';
-import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
-import { AuthData, hasValue } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { LoginUIStatus } from '@casual-simulation/aux-vm/auth';
+import { AuthHelperInterface } from '@casual-simulation/aux-vm/managers';
+import { Observable, Subject } from 'rxjs';
+import { AuthEndpointHelper } from './AuthEndpointHelper';
 
-// Save the query string that was used when the site loaded
-const query = typeof location !== 'undefined' ? location.search : null;
+export class AuthHelper {
 
-interface StaticAuxAuth {
-    new (): AuxAuth;
-}
+    private _primary: AuthHelperInterface;
+    private _loginUIStatus: Subject<LoginUIStatus>;
 
-/**
- * Defines a class that helps handle authentication/authorization for the aux VM.
- */
-export class AuthHelper implements AuthHelperInterface {
-    private _origin: string;
-    private _iframe: HTMLIFrameElement;
-    private _channel: MessageChannel;
-    private _proxy: Remote<AuxAuth>;
-    private _initialized: boolean = false;
-    private _protocolVersion: number = 1;
-    private _sub: Subscription = new Subscription();
-    private _loginStatus: BehaviorSubject<LoginStatus> =
-        new BehaviorSubject<LoginStatus>({});
-    private _loginUIStatus: BehaviorSubject<LoginUIStatus> =
-        new BehaviorSubject<LoginUIStatus>({
-            page: false,
-        });
-    private _initPromise: Promise<void>;
+    constructor(primaryAuthOrigin: string, primaryRecordsOrigin: string) {
+        this._primary = new AuthEndpointHelper(primaryAuthOrigin, primaryRecordsOrigin);
+        this._loginUIStatus = new Subject();
 
-    /**
-     * Creates a new instance of the AuthHelper class.
-     * @param iframeOrigin The URL that the auth iframe should be loaded from.
-     */
-    constructor(iframeOrigin?: string) {
-        this._origin = iframeOrigin;
+        this._primary.loginUIStatus.subscribe(this._loginUIStatus);
     }
 
-    get loginStatus() {
-        return this._loginStatus;
+    get primary(): AuthHelperInterface {
+        return this._primary;
     }
 
-    get loginUIStatus() {
+    get loginUIStatus(): Observable<LoginUIStatus> {
         return this._loginUIStatus;
     }
 
-    /**
-     * Gets whether authentication is supported by this inst.
-     */
-    get supportsAuthentication() {
-        return hasValue(this._origin);
+    createEndpoint(endpoint: string): AuthHelperInterface {
+        const helper = new AuthEndpointHelper(endpoint);
+        helper.loginUIStatus.subscribe(this._loginUIStatus);
+        return helper;
     }
 
-    get closed() {
-        return this._sub?.closed;
-    }
-
-    unsubscribe() {
-        return this.dispose();
-    }
-
-    dispose() {
-        if (this._sub) {
-            this._sub.unsubscribe();
-            this._sub = null;
-        }
-    }
-
-    private async _init() {
-        if (!this._initPromise) {
-            this._initPromise = this._initCore();
-        }
-        return this._initPromise;
-    }
-
-    private async _initCore() {
-        if (!hasValue(this._origin)) {
-            throw new Error(
-                'Cannot initialize AuthHelper because no iframe origin is set.'
-            );
-        }
-        this._loginStatus.next({
-            isLoading: true,
-        });
-        const iframeUrl = new URL(`/iframe.html${query}`, this._origin).href;
-
-        const iframe = (this._iframe = document.createElement('iframe'));
-        this._sub.add(() => {
-            iframe.remove();
-        });
-        this._iframe.src = iframeUrl;
-        this._iframe.style.display = 'none';
-        this._iframe.className = 'auth-helper-iframe';
-
-        let promise = waitForLoad(this._iframe);
-        document.body.insertBefore(this._iframe, document.body.firstChild);
-
-        await promise;
-
-        this._channel = setupChannel(this._iframe.contentWindow);
-
-        const wrapper = wrap<StaticAuxAuth>(this._channel.port1);
-        this._proxy = await new wrapper();
-        try {
-            this._protocolVersion = await this._proxy.getProtocolVersion();
-        } catch (err) {
-            console.log(
-                '[AuthHelper] Could not get protocol version. Defaulting to version 1.'
-            );
-            this._protocolVersion = 1;
-        }
-
-        if (this._protocolVersion >= 2) {
-            await this._proxy.addLoginUICallback(
-                proxy((status) => {
-                    this._loginUIStatus.next(status);
-                })
-            );
-            await this._proxy.addLoginStatusCallback(
-                proxy((status) => {
-                    this._loginStatus.next(status);
-                })
-            );
-        }
-
-        this._loginUIStatus.subscribe(status => {
-            if (!this._iframe) {
-                return;
-            }
-            if (status.page === 'show_iframe') {
-                this._iframe.style.display = null;
-            } else {
-                this._iframe.style.display = 'none';
-            }
-        });
-
-        this._initialized = true;
-    }
-
-    /**
-     * Determines if the user is authenticated.
-     */
-    async isAuthenticated() {
-        if (!hasValue(this._origin)) {
-            return false;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        return await this._proxy.isLoggedIn();
-    }
-
-    /**
-     * Requests that the user become authenticated if they are not already.
-     */
-    async authenticate() {
-        if (!hasValue(this._origin)) {
-            return null;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        const result = await this._proxy.login();
-
-        if (this._protocolVersion < 2) {
-            this._loginStatus.next({
-                authData: result,
-            });
-        }
-        return result;
-    }
-
-    /**
-     * Requests that the user become authenticated entirely in the background.
-     * This will not show any UI to the user but may also mean that the user will not be able to be authenticated.
-     */
-    async authenticateInBackground() {
-        if (!hasValue(this._origin)) {
-            return null;
-        }
-        this._loginStatus.next({
-            isLoggingIn: true,
-        });
-        if (!this._initialized) {
-            await this._init();
-        }
-        const result = await this._proxy.login(true);
-        if (this._protocolVersion < 2) {
-            this._loginStatus.next({
-                authData: result,
-            });
-        }
-        return result;
-    }
-
-    async createPublicRecordKey(
-        recordName: string
-    ): Promise<CreatePublicRecordKeyResult> {
-        if (!hasValue(this._origin)) {
-            return {
-                success: false,
-                errorCode: 'not_supported',
-                errorMessage: 'Records are not supported on this inst.',
-            };
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        return await this._proxy.createPublicRecordKey(recordName);
-    }
-
-    async getAuthToken(): Promise<string> {
-        if (!hasValue(this._origin)) {
-            return null;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        return await this._proxy.getAuthToken();
-    }
-
-    async openAccountPage(): Promise<void> {
-        if (!hasValue(this._origin)) {
-            return;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        if (this._protocolVersion < 2) {
-            return;
-        }
-        return await this._proxy.openAccountPage();
-    }
-
-    async setUseCustomUI(useCustomUI: boolean) {
-        if (!hasValue(this._origin)) {
-            return;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        if (this._protocolVersion < 2) {
-            return;
-        }
-        return await this._proxy.setUseCustomUI(useCustomUI);
-    }
-
-    async provideEmailAddress(email: string, acceptedTermsOfService: boolean) {
-        if (!hasValue(this._origin)) {
-            return;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        if (this._protocolVersion < 2) {
-            return;
-        }
-        return await this._proxy.provideEmailAddress(
-            email,
-            acceptedTermsOfService
-        );
-    }
-
-    async provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void> {
-        if (!hasValue(this._origin)) {
-            return;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        if (this._protocolVersion < 3) {
-            return;
-        }
-        return await this._proxy.provideSmsNumber(
-            sms,
-            acceptedTermsOfService
-        );
-    }
-
-    async cancelLogin() {
-        if (!hasValue(this._origin)) {
-            return;
-        }
-        if (!this._initialized) {
-            await this._init();
-        }
-        if (this._protocolVersion < 2) {
-            return;
-        }
-        return await this._proxy.cancelLogin();
-    }
 }

--- a/src/aux-vm-browser/managers/AuthHelper.ts
+++ b/src/aux-vm-browser/managers/AuthHelper.ts
@@ -1,32 +1,55 @@
 import { LoginUIStatus } from '@casual-simulation/aux-vm/auth';
 import { AuthHelperInterface } from '@casual-simulation/aux-vm/managers';
 import { Observable, Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { AuthEndpointHelper } from './AuthEndpointHelper';
 
 export class AuthHelper {
-
     private _primary: AuthHelperInterface;
-    private _loginUIStatus: Subject<LoginUIStatus>;
+    private _loginUIStatus: Subject<LoginUIStatus & { endpoint: string }>;
+    private _auths: Map<string, AuthHelperInterface>;
+    private _useCustomUI: boolean = false;
 
     constructor(primaryAuthOrigin: string, primaryRecordsOrigin: string) {
         this._primary = new AuthEndpointHelper(primaryAuthOrigin, primaryRecordsOrigin);
+        this._auths = new Map();
         this._loginUIStatus = new Subject();
-
-        this._primary.loginUIStatus.subscribe(this._loginUIStatus);
+        this._primary.loginUIStatus
+            .pipe(map(s => ({ ...s, endpoint: primaryAuthOrigin })))
+            .subscribe(this._loginUIStatus);
+        this._auths.set(primaryAuthOrigin, this._primary);
     }
 
     get primary(): AuthHelperInterface {
         return this._primary;
     }
 
-    get loginUIStatus(): Observable<LoginUIStatus> {
+    get loginUIStatus(): Observable<LoginUIStatus & { endpoint: string }> {
         return this._loginUIStatus;
+    }
+
+    getEndpoint(endpoint: string): AuthHelperInterface {
+        return this._auths.get(endpoint);
     }
 
     createEndpoint(endpoint: string): AuthHelperInterface {
         const helper = new AuthEndpointHelper(endpoint);
-        helper.loginUIStatus.subscribe(this._loginUIStatus);
+        helper.loginUIStatus
+            .pipe(map(s => ({ ...s, endpoint })))
+            .subscribe(
+                this._loginUIStatus
+            );
+        this._auths.set(endpoint, helper);
+        helper.setUseCustomUI(this._useCustomUI);
         return helper;
+    }
+
+    setUseCustomUI(useCustomUI: boolean) {
+        this._useCustomUI = useCustomUI;
+
+        for (let auth of this._auths.values()) {
+            auth.setUseCustomUI(useCustomUI);
+        }
     }
 
 }

--- a/src/aux-vm-browser/managers/index.ts
+++ b/src/aux-vm-browser/managers/index.ts
@@ -4,4 +4,5 @@ export * from './BrowserSimulation';
 export * from './BrowserSimulationCalculations';
 export * from './IdePortalManager';
 export * from './AuthHelper';
+export * from './AuthEndpointHelper';
 export * from './SystemPortalManager';

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -157,4 +157,10 @@ export interface AuxAuth {
      * Cancels the in-progress login attempt.
      */
     cancelLogin(): Promise<void>;
+
+    /**
+     * Gets the HTTP Origin that the records API is hosted at for this authentication service.
+     * Only supported on protocol version 4 or more.
+     */
+    getRecordsOrigin(): Promise<string>;
 }

--- a/src/aux-vm/managers/AuthHelperInterface.ts
+++ b/src/aux-vm/managers/AuthHelperInterface.ts
@@ -8,6 +8,16 @@ import { LoginStatus, LoginUIStatus } from '../auth/AuxAuth';
  */
 export interface AuthHelperInterface extends SubscriptionLike {
     /**
+     * The HTTP Origin that this helper interface loaded.
+     */
+    origin: string;
+
+    /**
+     * The HTTP Origin that hosts the records API for this authentication service.
+     */
+    recordsOrigin: string;
+
+    /**
      * Gets whether this inst supports authentication.
      */
     supportsAuthentication: boolean;

--- a/src/aux-vm/managers/AuthHelperInterface.ts
+++ b/src/aux-vm/managers/AuthHelperInterface.ts
@@ -44,6 +44,12 @@ export interface AuthHelperInterface extends SubscriptionLike {
     authenticate(): Promise<AuthData>;
 
     /**
+     * Requests that the user become authenticated entirely in the background.
+     * This will not show any UI to the user but may also mean that the user will not be able to be authenticated.
+     */
+    authenticateInBackground(): Promise<AuthData>;
+
+    /**
      * Gets the auth token for the user.
      */
     getAuthToken(): Promise<string>;

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -75,6 +75,7 @@ describe('RecordsManager', () => {
             provideEmailAddress: jest.fn(),
             setUseCustomUI: jest.fn(),
             provideSmsNumber: jest.fn(),
+            authenticateInBackground: jest.fn(),
             get supportsAuthentication() {
                 return true;
             },
@@ -102,6 +103,7 @@ describe('RecordsManager', () => {
             provideEmailAddress: jest.fn(),
             setUseCustomUI: jest.fn(),
             provideSmsNumber: jest.fn(),
+            authenticateInBackground: jest.fn(),
             get supportsAuthentication() {
                 return true;
             },

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -47,6 +47,15 @@ describe('RecordsManager', () => {
         createPublicRecordKey: jest.fn(),
         provideSmsNumber: jest.fn(),
     };
+    let customAuth: AuthHelperInterface;
+    let customAuthMock = {
+        isAuthenticated: jest.fn(),
+        authenticate: jest.fn(),
+        getAuthToken: jest.fn(),
+        createPublicRecordKey: jest.fn(),
+        provideSmsNumber: jest.fn(),
+    };
+    let authFactory: (endpoint: string) => AuthHelperInterface;
     let sub: Subscription;
 
     beforeEach(async () => {
@@ -72,16 +81,52 @@ describe('RecordsManager', () => {
             get closed() {
                 return false;
             },
+            get origin() {
+                return 'http://localhost:3002';
+            },
+            get recordsOrigin() {
+                return 'http://localhost:3002';
+            }
         };
+
+        customAuthMock = customAuth = {
+            isAuthenticated: jest.fn(),
+            authenticate: jest.fn(),
+            getAuthToken: jest.fn(),
+            createPublicRecordKey: jest.fn(),
+            unsubscribe: jest.fn(),
+            openAccountPage: jest.fn(),
+            cancelLogin: jest.fn(),
+            loginStatus: null,
+            loginUIStatus: null,
+            provideEmailAddress: jest.fn(),
+            setUseCustomUI: jest.fn(),
+            provideSmsNumber: jest.fn(),
+            get supportsAuthentication() {
+                return true;
+            },
+            get closed() {
+                return false;
+            },
+            get origin() {
+                return 'http://localhost:9999';
+            },
+            get recordsOrigin() {
+                return 'http://localhost:9999';
+            }
+        };
+
+        authFactory = (endpoint: string) => endpoint === 'http://localhost:9999' ? customAuth : auth;
 
         records = new RecordsManager(
             {
                 version: '1.0.0',
                 versionHash: '1234567890abcdef',
                 recordsOrigin: 'http://localhost:3002',
+                authOrigin: 'http://localhost:3002'
             },
             helper,
-            auth
+            authFactory
         );
     });
 
@@ -138,6 +183,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
+                        null,
                         1
                     ),
                 ]);
@@ -174,6 +220,63 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    recordData(
+                        'myToken',
+                        'myAddress',
+                        {
+                            myRecord: true,
+                        },
+                        false,
+                        'http://localhost:9999',
+                        1
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastPost()).toEqual([
+                    'http://localhost:9999/api/v2/records/data',
+                    {
+                        recordKey: 'myToken',
+                        address: 'myAddress',
+                        data: {
+                            myRecord: true,
+                        },
+                    },
+                    {
+                        headers: {
+                            Authorization: 'Bearer authToken',
+                        },
+                    },
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
+
             it('should make a POST request to /api/v2/records/manual/data for manual records', async () => {
                 setResponse({
                     data: {
@@ -195,6 +298,7 @@ describe('RecordsManager', () => {
                                 myRecord: true,
                             },
                             true,
+                            null,
                             1
                         )
                     ),
@@ -232,6 +336,65 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
+            it('should support custom endpoints for manual records', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    approveDataRecord(
+                        recordData(
+                            'myToken',
+                            'myAddress',
+                            {
+                                myRecord: true,
+                            },
+                            true,
+                            'http://localhost:9999',
+                            1
+                        )
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastPost()).toEqual([
+                    'http://localhost:9999/api/v2/records/manual/data',
+                    {
+                        recordKey: 'myToken',
+                        address: 'myAddress',
+                        data: {
+                            myRecord: true,
+                        },
+                    },
+                    {
+                        headers: {
+                            Authorization: 'Bearer authToken',
+                        },
+                    },
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
+
             it('should attempt to login if not authenticated', async () => {
                 setResponse({
                     data: {
@@ -253,6 +416,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
+                        null,
                         1
                     ),
                 ]);
@@ -284,6 +448,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
+                        null,
                         1
                     ),
                 ]);
@@ -302,42 +467,6 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
-            it('should fail if no recordsOrigin is set', async () => {
-                records = new RecordsManager(
-                    {
-                        version: '1.0.0',
-                        versionHash: '1234567890abcdef',
-                        recordsOrigin: null,
-                    },
-                    helper,
-                    auth
-                );
-
-                records.handleEvents([
-                    recordData(
-                        'myToken',
-                        'myAddress',
-                        {
-                            myRecord: true,
-                        },
-                        false,
-                        1
-                    ),
-                ]);
-
-                await waitAsync();
-
-                expect(vm.events).toEqual([
-                    asyncResult(1, {
-                        success: false,
-                        errorCode: 'not_supported',
-                        errorMessage: 'Records are not supported on this inst.',
-                    }),
-                ]);
-                expect(authMock.isAuthenticated).not.toBeCalled();
-                expect(authMock.authenticate).not.toBeCalled();
-                expect(authMock.getAuthToken).not.toBeCalled();
-            });
 
             it('should ignore actions that require manual approval but are not approved', async () => {
                 setResponse({
@@ -359,6 +488,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         true,
+                        null,
                         1
                     ),
                 ]);
@@ -396,13 +526,51 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, 1),
+                    getRecordData('testRecord', 'myAddress', false, null, 1),
                 ]);
 
                 await waitAsync();
 
                 expect(getLastGet()).toEqual([
                     'http://localhost:3002/api/v2/records/data?recordName=testRecord&address=myAddress',
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                        data: {
+                            abc: 'def',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                        data: {
+                            abc: 'def',
+                        },
+                    },
+                });
+
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    getRecordData('testRecord', 'myAddress', false, 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastGet()).toEqual([
+                    'http://localhost:9999/api/v2/records/data?recordName=testRecord&address=myAddress',
                 ]);
 
                 await waitAsync();
@@ -435,7 +603,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        getRecordData('testRecord', 'myAddress', true, 1)
+                        getRecordData('testRecord', 'myAddress', true, null, 1)
                     ),
                 ]);
 
@@ -443,6 +611,46 @@ describe('RecordsManager', () => {
 
                 expect(getLastGet()).toEqual([
                     'http://localhost:3002/api/v2/records/manual/data?recordName=testRecord&address=myAddress',
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                        data: {
+                            abc: 'def',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should support custom endpoints for manual record data', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                        data: {
+                            abc: 'def',
+                        },
+                    },
+                });
+
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    approveDataRecord(
+                        getRecordData('testRecord', 'myAddress', true, 'http://localhost:9999', 1)
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastGet()).toEqual([
+                    'http://localhost:9999/api/v2/records/manual/data?recordName=testRecord&address=myAddress',
                 ]);
 
                 await waitAsync();
@@ -467,11 +675,11 @@ describe('RecordsManager', () => {
                         recordsOrigin: null,
                     },
                     helper,
-                    auth
+                    () => null
                 );
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, 1),
+                    getRecordData('testRecord', 'myAddress', false, null, 1),
                 ]);
 
                 await waitAsync();
@@ -500,7 +708,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', true, 1),
+                    getRecordData('testRecord', 'myAddress', true, null, 1),
                 ]);
 
                 await waitAsync();
@@ -535,13 +743,55 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    listDataRecord('testRecord', 'myAddress', 1),
+                    listDataRecord('testRecord', 'myAddress', null, 1),
                 ]);
 
                 await waitAsync();
 
                 expect(getLastGet()).toEqual([
                     'http://localhost:3002/api/v2/records/data/list?recordName=testRecord&address=myAddress',
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        items: {
+                            address: 'myAddress',
+                            data: {
+                                abc: 'def',
+                            },
+                        },
+                    }),
+                ]);
+            });
+
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        items: {
+                            address: 'myAddress',
+                            data: {
+                                abc: 'def',
+                            },
+                        },
+                    },
+                });
+
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    listDataRecord('testRecord', 'myAddress', 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastGet()).toEqual([
+                    'http://localhost:9999/api/v2/records/data/list?recordName=testRecord&address=myAddress',
                 ]);
 
                 await waitAsync();
@@ -576,7 +826,7 @@ describe('RecordsManager', () => {
 
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([listDataRecord('testRecord', null, 1)]);
+                records.handleEvents([listDataRecord('testRecord', null, null, 1)]);
 
                 await waitAsync();
 
@@ -619,7 +869,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, 1),
+                    eraseRecordData('myToken', 'myAddress', false, null, 1),
                 ]);
 
                 await waitAsync();
@@ -651,6 +901,51 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    eraseRecordData('myToken', 'myAddress', false, 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getRequests()).toEqual([
+                    [
+                        'DELETE',
+                        'http://localhost:9999/api/v2/records/data',
+                        { recordKey: 'myToken', address: 'myAddress' },
+                        {
+                            headers: {
+                                Authorization: 'Bearer authToken',
+                            },
+                        },
+                    ],
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
+
             it('should make a DELETE request to /api/v2/records/manual/data for manual record data', async () => {
                 setResponse({
                     data: {
@@ -665,7 +960,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        eraseRecordData('myToken', 'myAddress', true, 1)
+                        eraseRecordData('myToken', 'myAddress', true, null, 1)
                     ),
                 ]);
 
@@ -698,6 +993,53 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
+            it('should support custom endpoints for manual record data', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    approveDataRecord(
+                        eraseRecordData('myToken', 'myAddress', true, 'http://localhost:9999', 1)
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(getRequests()).toEqual([
+                    [
+                        'DELETE',
+                        'http://localhost:9999/api/v2/records/manual/data',
+                        { recordKey: 'myToken', address: 'myAddress' },
+                        {
+                            headers: {
+                                Authorization: 'Bearer authToken',
+                            },
+                        },
+                    ],
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
+
             it('should fail if no recordsOrigin is set', async () => {
                 records = new RecordsManager(
                     {
@@ -706,11 +1048,11 @@ describe('RecordsManager', () => {
                         recordsOrigin: null,
                     },
                     helper,
-                    auth
+                    () => null
                 );
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, 1),
+                    eraseRecordData('myToken', 'myAddress', false, null, 1),
                 ]);
 
                 await waitAsync();
@@ -737,7 +1079,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', true, 1),
+                    eraseRecordData('myToken', 'myAddress', true, null, 1),
                 ]);
 
                 await waitAsync();
@@ -778,7 +1120,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', undefined, 1),
+                    recordFile('myToken', 'myFile', 'test.txt', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -842,7 +1184,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', 'text/xml', 1),
+                    recordFile('myToken', 'myFile', 'test.txt', 'text/xml', null, 1),
                 ]);
 
                 await waitAsync();
@@ -907,7 +1249,7 @@ describe('RecordsManager', () => {
                 const json = stringify(obj);
 
                 records.handleEvents([
-                    recordFile('myToken', obj, 'test.json', undefined, 1),
+                    recordFile('myToken', obj, 'test.json', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -972,7 +1314,7 @@ describe('RecordsManager', () => {
                 const json = stringify(obj);
 
                 records.handleEvents([
-                    recordFile('myToken', obj, 'test.json', 'text/plain', 1),
+                    recordFile('myToken', obj, 'test.json', 'text/plain', null, 1),
                 ]);
 
                 await waitAsync();
@@ -1031,7 +1373,7 @@ describe('RecordsManager', () => {
                 const blob = new Blob([html], { type: 'text/html' });
 
                 records.handleEvents([
-                    recordFile('myToken', blob, 'test.html', undefined, 1),
+                    recordFile('myToken', blob, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1090,7 +1432,7 @@ describe('RecordsManager', () => {
                 const blob = new Blob([html], { type: 'text/html' });
 
                 records.handleEvents([
-                    recordFile('myToken', blob, 'test.html', 'text/plain', 1),
+                    recordFile('myToken', blob, 'test.html', 'text/plain', null, 1),
                 ]);
 
                 await waitAsync();
@@ -1159,7 +1501,7 @@ describe('RecordsManager', () => {
                 };
 
                 records.handleEvents([
-                    recordFile('myToken', file, 'test.html', undefined, 1),
+                    recordFile('myToken', file, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1222,7 +1564,7 @@ describe('RecordsManager', () => {
                 };
 
                 records.handleEvents([
-                    recordFile('myToken', file, 'test.html', undefined, 1),
+                    recordFile('myToken', file, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1296,6 +1638,7 @@ describe('RecordsManager', () => {
                         file,
                         'test.html',
                         'application/octet-stream',
+                        null,
                         1
                     ),
                 ]);
@@ -1359,7 +1702,7 @@ describe('RecordsManager', () => {
                 }
 
                 records.handleEvents([
-                    recordFile('myToken', buffer, 'test.html', undefined, 1),
+                    recordFile('myToken', buffer, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1426,6 +1769,7 @@ describe('RecordsManager', () => {
                         buffer,
                         'test.html',
                         'application/zip',
+                        null,
                         1
                     ),
                 ]);
@@ -1490,7 +1834,7 @@ describe('RecordsManager', () => {
                 const doubles = new Float64Array(buffer);
 
                 records.handleEvents([
-                    recordFile('myToken', doubles, 'test.html', undefined, 1),
+                    recordFile('myToken', doubles, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1546,7 +1890,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 10, 'test.html', undefined, 1),
+                    recordFile('myToken', 10, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1602,7 +1946,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, 1),
+                    recordFile('myToken', true, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1611,6 +1955,62 @@ describe('RecordsManager', () => {
                     [
                         'post',
                         'http://localhost:3002/api/v2/records/file',
+                        {
+                            recordKey: 'myToken',
+                            fileSha256Hex:
+                                'b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b',
+                            fileByteLength: 4,
+                            fileMimeType: 'text/plain',
+                            fileDescription: 'test.html',
+                        },
+                        {
+                            headers: {
+                                Authorization: 'Bearer authToken',
+                            },
+                        },
+                    ],
+                    [
+                        'post',
+                        'https://example.com/upload',
+                        expect.expect('toBeUtf8EncodedText', 'true'),
+                        {
+                            headers: {
+                                test: 'abc',
+                            },
+                        },
+                    ],
+                ]);
+            });
+
+            it('should support custom endpoints', async () => {
+                setNextResponse({
+                    data: {
+                        success: true,
+                        uploadUrl: 'https://example.com/upload',
+                        uploadMethod: 'POST',
+                        uploadHeaders: {
+                            test: 'abc',
+                        },
+                        fileName: 'test.html',
+                    },
+                });
+                setNextResponse({
+                    status: 200,
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    recordFile('myToken', true, 'test.html', undefined, 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getRequests()).toEqual([
+                    [
+                        'post',
+                        'http://localhost:9999/api/v2/records/file',
                         {
                             recordKey: 'myToken',
                             fileSha256Hex:
@@ -1678,7 +2078,7 @@ describe('RecordsManager', () => {
                     authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                     records.handleEvents([
-                        recordFile('myToken', value, 'test.html', undefined, 1),
+                        recordFile('myToken', value, 'test.html', undefined, null, 1),
                     ]);
 
                     await waitAsync();
@@ -1708,7 +2108,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, 1),
+                    recordFile('myToken', true, 'test.html', undefined, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1789,6 +2189,7 @@ describe('RecordsManager', () => {
                                 true,
                                 'test.html',
                                 undefined,
+                                null,
                                 1
                             ),
                         ]);
@@ -1825,32 +2226,6 @@ describe('RecordsManager', () => {
                     }
                 );
             });
-
-            it('should fail if no recordsOrigin is set', async () => {
-                records = new RecordsManager(
-                    {
-                        version: '1.0.0',
-                        versionHash: '1234567890abcdef',
-                        recordsOrigin: null,
-                    },
-                    helper,
-                    auth
-                );
-
-                records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', undefined, 1),
-                ]);
-
-                await waitAsync();
-
-                expect(vm.events).toEqual([
-                    asyncResult(1, {
-                        success: false,
-                        errorCode: 'not_supported',
-                        errorMessage: 'Records are not supported on this inst.',
-                    }),
-                ]);
-            });
         });
 
         describe('erase_file', () => {
@@ -1870,7 +2245,7 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(true);
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', null, 1)]);
 
                 await waitAsync();
 
@@ -1900,6 +2275,49 @@ describe('RecordsManager', () => {
                 expect(authMock.authenticate).not.toBeCalled();
                 expect(authMock.getAuthToken).toBeCalled();
             });
+
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        fileName: 'myFile',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', 'http://localhost:9999', 1)]);
+
+                await waitAsync();
+
+                expect(getRequests()).toEqual([
+                    [
+                        'DELETE',
+                        'http://localhost:9999/api/v2/records/file',
+                        { recordKey: 'myToken', fileUrl: 'myFileUrl' },
+                        {
+                            headers: {
+                                Authorization: 'Bearer authToken',
+                            },
+                        },
+                    ],
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        fileName: 'myFile',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
         });
 
         describe('record_event', () => {
@@ -1920,7 +2338,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, 1),
+                    recordEvent('recordKey', 'eventName', 10, null, 1),
                 ]);
 
                 await waitAsync();
@@ -1952,6 +2370,52 @@ describe('RecordsManager', () => {
                 expect(authMock.authenticate).not.toBeCalled();
                 expect(authMock.getAuthToken).toBeCalled();
             });
+
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        eventName: 'testEvent',
+                    },
+                });
+
+                customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
+                customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    recordEvent('recordKey', 'eventName', 10, 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastPost()).toEqual([
+                    'http://localhost:9999/api/v2/records/events/count',
+                    {
+                        recordKey: 'recordKey',
+                        eventName: 'eventName',
+                        count: 10,
+                    },
+                    {
+                        headers: {
+                            Authorization: 'Bearer authToken',
+                        },
+                    },
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        eventName: 'testEvent',
+                    }),
+                ]);
+                expect(customAuthMock.isAuthenticated).toBeCalled();
+                expect(customAuthMock.authenticate).not.toBeCalled();
+                expect(customAuthMock.getAuthToken).toBeCalled();
+            });
         });
 
         describe('get_event_count', () => {
@@ -1972,7 +2436,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', 1),
+                    getEventCount('testRecord', 'myAddress', null, 1),
                 ]);
 
                 await waitAsync();
@@ -1998,14 +2462,13 @@ describe('RecordsManager', () => {
                     {
                         version: '1.0.0',
                         versionHash: '1234567890abcdef',
-                        recordsOrigin: null,
                     },
                     helper,
-                    auth
+                    () => null
                 );
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', 1),
+                    getEventCount('testRecord', 'myAddress', null, 1),
                 ]);
 
                 await waitAsync();
@@ -2017,6 +2480,163 @@ describe('RecordsManager', () => {
                         errorMessage: 'Records are not supported on this inst.',
                     }),
                 ]);
+            });
+
+            it('should support custom endpoints', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        eventName: 'testEvent',
+                        count: 10,
+                    },
+                });
+
+                authMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    getEventCount('testRecord', 'myAddress', 'http://localhost:9999', 1),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastGet()).toEqual([
+                    'http://localhost:9999/api/v2/records/events/count?recordName=testRecord&eventName=myAddress',
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        eventName: 'testEvent',
+                        count: 10,
+                    }),
+                ]);
+            });
+        });
+
+        describe('Common Errors', () => {
+            const events = [
+                ['record_data', recordData(
+                    'myToken',
+                    'myAddress',
+                    {
+                        myRecord: true,
+                    },
+                    false,
+                    null,
+                    1
+                )] as const,
+                ['get_record_data', getRecordData('testRecord', 'myAddress', false, null, 1)] as const,
+                ['list_record_data', listDataRecord('testRecord', null, null, 1)] as const,
+                ['erase_record_data', eraseRecordData('myToken', 'myAddress', false, null, 1)] as const,
+                ['record_file', recordFile('myToken', 'myFile', 'test.txt', undefined, null, 1)] as const,
+                ['erase_file', eraseFile('myToken', 'myFileUrl', null, 1)] as const,
+                ['record_event', recordEvent('recordKey', 'eventName', 10, null, 1)] as const,
+                ['get_event_count', getEventCount('testRecord', 'myAddress', null, 1)] as const
+            ];
+
+            describe.each(events)('%s', (desc, event) => {
+                it('should fail if the authFactory returns null', async () => {
+                    let factory = jest.fn();
+                    records = new RecordsManager(
+                        {
+                            version: '1.0.0',
+                            versionHash: '1234567890abcdef',
+                            authOrigin: 'https://localhost:321',
+                            recordsOrigin: 'https://localhost:145'
+                        },
+                        helper,
+                        factory
+                    );
+
+                    factory.mockReturnValueOnce(null);
+
+                    records.handleEvents([
+                        event,
+                    ]);
+
+                    await waitAsync();
+
+                    expect(vm.events).toEqual([
+                        asyncResult(1, {
+                            success: false,
+                            errorCode: 'not_supported',
+                            errorMessage: 'Records are not supported on this inst.',
+                        }),
+                    ]);
+
+                    expect(factory).toBeCalledWith('https://localhost:321');
+                });
+
+                it('should fail if authOrigin is null and no endpoint is provided', async () => {
+                    let factory = jest.fn();
+                    records = new RecordsManager(
+                        {
+                            version: '1.0.0',
+                            versionHash: '1234567890abcdef',
+                            authOrigin: null
+                        },
+                        helper,
+                        factory
+                    );
+
+                    factory.mockReturnValueOnce(null);
+
+                    records.handleEvents([
+                        event,
+                    ]);
+
+                    await waitAsync();
+
+                    expect(vm.events).toEqual([
+                        asyncResult(1, {
+                            success: false,
+                            errorCode: 'not_supported',
+                            errorMessage: 'Records are not supported on this inst.',
+                        }),
+                    ]);
+
+                    expect(factory).not.toBeCalled();
+                });
+
+                it('should attempt to use the endpoint provided in the event', async () => {
+                    let factory = jest.fn();
+                    records = new RecordsManager(
+                        {
+                            version: '1.0.0',
+                            versionHash: '1234567890abcdef',
+                            authOrigin: null
+                        },
+                        helper,
+                        factory
+                    );
+
+                    let e = {
+                        ...event,
+                        endpoint: 'http://localhost:999'
+                    };
+
+                    factory.mockReturnValueOnce(null);
+
+                    records.handleEvents([
+                        e,
+                    ]);
+
+                    await waitAsync();
+
+                    expect(vm.events).toEqual([
+                        asyncResult(1, {
+                            success: false,
+                            errorCode: 'not_supported',
+                            errorMessage: 'Records are not supported on this inst.',
+                        }),
+                    ]);
+
+                    expect(factory).toBeCalledWith('http://localhost:999');
+                });
             });
         });
     });


### PR DESCRIPTION
### :rocket: Improvements

-   Added the ability to specify which auth site records should be loaded/retrieved from.
    -   This is useful for saving or getting records from another CasualOS instance.
    -   The following functions have been updated to support an optional `endpoint` parameter:
        -   `os.recordData(key, address, data, endpoint?)`
        -   `os.getData(recordName, address, endpoint?)`
        -   `os.listData(recordName, startingAddress?, endpoint?)`
        -   `os.eraseData(key, address, endpoint?)`
        -   `os.recordManualApprovalData(key, address, data, endpoint?)`
        -   `os.getManualApprovalData(recordName, address, endpoint?)`
        -   `os.listManualApprovalData(recordName, startingAddress?, endpoint?)`
        -   `os.eraseManualApprovalData(key, address, endpoint?)`
        -   `os.recordFile(key, data, options?, endpoint?)`
        -   `os.eraseFile(key, url, endpoint?)`
        -   `os.recordEvent(key, eventName, endpoint?)`
        -   `os.countEvents(recordName, eventName, endpoint?)`