### PR TITLE
Use Three.js Line2 for lines and strokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
         -   `os.countEvents(recordName, eventName, endpoint?)`
 -   Improved the sheetPortal and and multi-line editor to support editing tags that contain object values.
 -   Updated the Terms of Service, Acceptable Use Policy, and Privacy Policy to make it clearer which websites they apply to.
+-   Improved how lines are rendered to use an implementation built into three.js.
+    -   This makes bot strokes that are scaled appear correct.
+    -   This change also makes lines and strokes appear the same size on screen no matter the zoom level of the camera. This can make it easier to identify bots when zoomed out a lot.
 
 ### :bug: Bug Fixes
 

--- a/__mocks__/@casual-simulation/three/examples/jsm/lines/Line2.js
+++ b/__mocks__/@casual-simulation/three/examples/jsm/lines/Line2.js
@@ -1,0 +1,7 @@
+'use strict';
+
+class Line2 {}
+
+module.exports = {
+    Line2: Line2,
+};

--- a/__mocks__/@casual-simulation/three/examples/jsm/lines/LineGeometry.js
+++ b/__mocks__/@casual-simulation/three/examples/jsm/lines/LineGeometry.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class LineGeometry {
+    setPositions() {}
+}
+
+module.exports = {
+    LineGeometry: LineGeometry,
+};

--- a/__mocks__/@casual-simulation/three/examples/jsm/lines/LineMaterial.js
+++ b/__mocks__/@casual-simulation/three/examples/jsm/lines/LineMaterial.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class LineMaterial {
+    
+}
+
+module.exports = {
+    LineMaterial: LineMaterial,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,4 +22,9 @@ module.exports = {
             '<rootDir>/__mocks__/esbuild.wasm.js',
         '^aux-jest-matchers$': '<rootDir>/jest/jest-matchers.ts',
     },
+    globals: {
+        'ts-jest': {
+            tsconfig: 'tsconfig.test.json'
+        }
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,9 +1544,9 @@
 			}
 		},
 		"@casual-simulation/three": {
-			"version": "0.125.4",
-			"resolved": "https://registry.npmjs.org/@casual-simulation/three/-/three-0.125.4.tgz",
-			"integrity": "sha512-/n11aXazVg1oonCLEdE3w54SuAXEG/1h52F6VrIZ2KdA+oEfrn0FhWyWBRl/T/iv6sg13o3SDzbPXH74uU3oXw=="
+			"version": "0.139.3",
+			"resolved": "https://registry.npmjs.org/@casual-simulation/three/-/three-0.139.3.tgz",
+			"integrity": "sha512-CXTBaUvGmXG4Q+jzkPsLT6PqIcRLHQ+MJxzoW7Gz0diC5Vud4RuWU58ntJFtJIq3LtwSKFLMl8PCzGYCVhZjgg=="
 		},
 		"@chenfengyuan/vue-qrcode": {
 			"version": "1.0.2",
@@ -6681,6 +6681,12 @@
 			"requires": {
 				"@types/jest": "*"
 			}
+		},
+		"@types/three": {
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+			"integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
+			"dev": true
 		},
 		"@types/through": {
 			"version": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "@types/bson": "4.0.5",
         "@types/offscreencanvas": "^2019.6.4",
         "@types/luxon": "2.0.9",
+        "@types/three": "^0.139.0",
         "braces": "^2.3.2",
         "chai": "^4.2.0",
         "concurrently": "^4.0.1",

--- a/src/aux-common/package.json
+++ b/src/aux-common/package.json
@@ -40,7 +40,7 @@
         "@casual-simulation/expect": "^3.0.0",
         "@casual-simulation/fast-json-stable-stringify": "^3.0.0",
         "@casual-simulation/stacktrace": "^3.0.0",
-        "@casual-simulation/three": "^0.125.4",
+        "@casual-simulation/three": "^0.139.3",
         "@tweenjs/tween.js": "18.6.0",
         "@types/acorn": "^4.0.6",
         "@types/estraverse": "^5.1.1",

--- a/src/aux-common/tsconfig.json
+++ b/src/aux-common/tsconfig.json
@@ -8,7 +8,10 @@
         "composite": true,
         "incremental": true
     },
-    "include": ["**/*.ts"],
+    "include": [
+        "**/*.ts",
+        "../aux-server/typings/**/*"
+    ],
     "exclude": ["node_modules", "lib", "**/*.spec.ts"],
     "references": [
         { "path": "../aux-records" },

--- a/src/aux-components/package.json
+++ b/src/aux-components/package.json
@@ -47,7 +47,7 @@
         "@casual-simulation/crypto": "^3.0.0",
         "@casual-simulation/crypto-browser": "^3.0.0",
         "@casual-simulation/crypto-node": "^3.0.0",
-        "@casual-simulation/three": "^0.125.4",
+        "@casual-simulation/three": "^0.139.3",
         "@casual-simulation/tunnel": "^3.0.0",
         "@chenfengyuan/vue-qrcode": "^1.0.0",
         "@hapi/joi": "15.1.1",

--- a/src/aux-server/aux-web/shared/scene/Arrow3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Arrow3D.ts
@@ -14,7 +14,7 @@ export class Arrow3D extends Object3D {
     public static DefaultColor: Color = buildSRGBColor(1, 1, 1);
     public static DefaultHeadWidth = 0.15;
     public static DefaultHeadLength = 0.3;
-    public static DefaultLineWidth = 0.015;
+    public static DefaultLineWidth = 0.0015;
 
     /**
      * Three JS helper that draws arrows.

--- a/src/aux-server/aux-web/shared/scene/Arrow3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Arrow3D.ts
@@ -14,7 +14,7 @@ export class Arrow3D extends Object3D {
     public static DefaultColor: Color = buildSRGBColor(1, 1, 1);
     public static DefaultHeadWidth = 0.15;
     public static DefaultHeadLength = 0.3;
-    public static DefaultLineWidth = 0.0015;
+    public static DefaultLineWidth = 0.001;
 
     /**
      * Three JS helper that draws arrows.

--- a/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
@@ -150,7 +150,7 @@ export class ArrowHelper extends Object3D {
 
         // Convert to SRGB manually because the MeshLineMaterial
         // does not convert the colors to the renderer output encoding.
-        this.lineMaterial.color.convertLinearToSRGB();
+        // this.lineMaterial.color.convertLinearToSRGB();
 
         this.coneMaterial.color.set(color);
     }

--- a/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Modified to utilize three.meshline (https://github.com/spite/THREE.MeshLine/tree/v1.3.0)
+// Modified to utilize Line2
 
 import {
     Float32BufferAttribute,
@@ -39,11 +39,7 @@ import { Line2 } from '@casual-simulation/three/examples/jsm/lines/Line2';
 import { LineGeometry } from '@casual-simulation/three/examples/jsm/lines/LineGeometry';
 import { LineMaterial } from '@casual-simulation/three/examples/jsm/lines/LineMaterial';
 
-// @ts-ignore
-// import { MeshLine, MeshLineMaterial } from 'three.meshline';
-
 const _axis = /*@__PURE__*/ new Vector3();
-// let _lineGeometry: BufferGeometry;
 let _coneGeometry: CylinderGeometry;
 
 export class ArrowHelper extends Object3D {
@@ -83,17 +79,13 @@ export class ArrowHelper extends Object3D {
         this.position.copy(origin);
 
         this.meshLine = new LineGeometry();
-        // this.meshLine = new MeshLine();
         this.lineMaterial = new LineMaterial();
-        // this.lineMaterial.
         this.lineMaterial.color = new Color(color);
         this.lineMaterial.toneMapped = false;
-        // this.lineMaterial.sizeAttenuation = true;
         this.lineMaterial.linewidth = 1;
         this.lineMaterial.fog = false;
 
         this.line = new Line2(this.meshLine, this.lineMaterial);
-        // this.line = new Line( _lineGeometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
         this.line.matrixAutoUpdate = false;
         this.add(this.line);
 
@@ -132,8 +124,6 @@ export class ArrowHelper extends Object3D {
         let points = [0, 0, 0, 0, Math.max(0.0001, length - headLength), 0];
 
         this.meshLine.setPositions(points);
-        // this.meshLine.setPoints(points);
-        // this.line.scale.set( 1, , 1 ); // see #17458
         this.line.updateMatrix();
 
         this.cone.scale.set(headWidth, headLength, headWidth);
@@ -147,11 +137,6 @@ export class ArrowHelper extends Object3D {
 
     setColor(color: number | Color) {
         this.lineMaterial.color.set(color);
-
-        // Convert to SRGB manually because the MeshLineMaterial
-        // does not convert the colors to the renderer output encoding.
-        // this.lineMaterial.color.convertLinearToSRGB();
-
         this.coneMaterial.color.set(color);
     }
 

--- a/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/ArrowHelper.ts
@@ -35,20 +35,24 @@ import {
     Color,
 } from '@casual-simulation/three';
 
+import { Line2 } from '@casual-simulation/three/examples/jsm/lines/Line2';
+import { LineGeometry } from '@casual-simulation/three/examples/jsm/lines/LineGeometry';
+import { LineMaterial } from '@casual-simulation/three/examples/jsm/lines/LineMaterial';
+
 // @ts-ignore
-import { MeshLine, MeshLineMaterial } from 'three.meshline';
+// import { MeshLine, MeshLineMaterial } from 'three.meshline';
 
 const _axis = /*@__PURE__*/ new Vector3();
 // let _lineGeometry: BufferGeometry;
 let _coneGeometry: CylinderGeometry;
 
 export class ArrowHelper extends Object3D {
-    line: Mesh;
-    lineMaterial: MeshLineMaterial;
+    line: Line2;
+    lineMaterial: LineMaterial;
     cone: Mesh;
     coneMaterial: MeshBasicMaterial;
 
-    meshLine: MeshLine;
+    meshLine: LineGeometry;
 
     constructor(
         dir?: Vector3,
@@ -78,16 +82,17 @@ export class ArrowHelper extends Object3D {
 
         this.position.copy(origin);
 
-        this.meshLine = new MeshLine();
-        this.lineMaterial = new MeshLineMaterial();
+        this.meshLine = new LineGeometry();
+        // this.meshLine = new MeshLine();
+        this.lineMaterial = new LineMaterial();
         // this.lineMaterial.
         this.lineMaterial.color = new Color(color);
         this.lineMaterial.toneMapped = false;
-        this.lineMaterial.sizeAttenuation = true;
-        this.lineMaterial.lineWidth = 1;
+        // this.lineMaterial.sizeAttenuation = true;
+        this.lineMaterial.linewidth = 1;
         this.lineMaterial.fog = false;
 
-        this.line = new Mesh(this.meshLine, this.lineMaterial);
+        this.line = new Line2(this.meshLine, this.lineMaterial);
         // this.line = new Line( _lineGeometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
         this.line.matrixAutoUpdate = false;
         this.add(this.line);
@@ -126,7 +131,8 @@ export class ArrowHelper extends Object3D {
 
         let points = [0, 0, 0, 0, Math.max(0.0001, length - headLength), 0];
 
-        this.meshLine.setPoints(points);
+        this.meshLine.setPositions(points);
+        // this.meshLine.setPoints(points);
         // this.line.scale.set( 1, , 1 ); // see #17458
         this.line.updateMatrix();
 
@@ -136,7 +142,7 @@ export class ArrowHelper extends Object3D {
     }
 
     setLineWidth(width: number) {
-        this.lineMaterial.lineWidth = width;
+        this.lineMaterial.linewidth = width;
     }
 
     setColor(color: number | Color) {

--- a/src/aux-server/aux-web/shared/scene/LineSegments.ts
+++ b/src/aux-server/aux-web/shared/scene/LineSegments.ts
@@ -7,14 +7,19 @@ import {
 } from '@casual-simulation/three';
 
 // @ts-ignore This import is not picked up by Jest
-import { MeshLineMaterial, MeshLine } from 'three.meshline';
+// import { MeshLineMaterial, MeshLine } from 'three.meshline';
+
+import { Line2 } from '@casual-simulation/three/examples/jsm/lines/Line2';
+import { LineGeometry } from '@casual-simulation/three/examples/jsm/lines/LineGeometry';
+import { LineMaterial } from '@casual-simulation/three/examples/jsm/lines/LineMaterial';
+
 import { disposeMaterial, buildSRGBColor } from './SceneUtils';
 import { Arrow3D } from './Arrow3D';
 
 export class LineSegments extends Object3D {
-    private _meshes: Mesh[] = [];
-    private _meshLines: MeshLine[] = [];
-    private _lineMaterial: MeshLineMaterial;
+    private _meshes: Line2[] = [];
+    private _meshLines: LineGeometry[] = [];
+    private _lineMaterial: LineMaterial;
     private _lines: number[] = [];
 
     get material() {
@@ -24,12 +29,17 @@ export class LineSegments extends Object3D {
     constructor(lines: number[]) {
         super();
 
-        this._lineMaterial = new MeshLineMaterial();
+        this._lineMaterial = new LineMaterial();
         this._lineMaterial.color = Arrow3D.DefaultColor.clone();
         this._lineMaterial.toneMapped = false;
-        this._lineMaterial.sizeAttenuation = true;
-        this._lineMaterial.lineWidth = Arrow3D.DefaultLineWidth;
+        // this._lineMaterial.sizeAttenuation = true;
+        this._lineMaterial.linewidth = Arrow3D.DefaultLineWidth;
         this._lines = lines;
+
+        let meshLine = new LineGeometry();
+        
+        // meshLine.setPositions(lines);
+
 
         for (let i = 0; i + 5 < lines.length; i += 6) {
             let [x1, y1, z1, x2, y2, z2] = lines.slice(i, i + 6);
@@ -39,27 +49,26 @@ export class LineSegments extends Object3D {
             let dir = vec2.clone().sub(vec1);
 
             dir.normalize();
-            dir.multiplyScalar(this._lineMaterial.lineWidth);
+            dir.multiplyScalar(this._lineMaterial.linewidth);
 
-            let meshLine = new MeshLine();
-            meshLine.setPoints(
+            let meshLine = new LineGeometry();
+            meshLine.setPositions(
                 [
-                    x1 - dir.x,
-                    y1 - dir.y,
-                    z1 - dir.z,
+                    // x1 - dir.x,
+                    // y1 - dir.y,
+                    // z1 - dir.z,
                     x1,
                     y1,
                     z1,
                     x2,
                     y2,
                     z2,
-                    x2 + dir.x,
-                    y2 + dir.y,
-                    z2 + dir.z,
+                    // x2 + dir.x,
+                    // y2 + dir.y,
+                    // z2 + dir.z,
                 ],
-                (p: number) => this._calculatePointWidth(p)
             );
-            let mesh = new Mesh(meshLine, this._lineMaterial);
+            let mesh = new Line2(meshLine, this._lineMaterial);
             mesh.matrixAutoUpdate = false;
             this._meshLines.push(meshLine);
             this._meshes.push(mesh);
@@ -68,7 +77,7 @@ export class LineSegments extends Object3D {
     }
 
     public setLineWidth(width: number) {
-        this._lineMaterial.lineWidth = width * Arrow3D.DefaultLineWidth;
+        this._lineMaterial.linewidth = width * Arrow3D.DefaultLineWidth;
         this._updateLines();
     }
 
@@ -101,9 +110,9 @@ export class LineSegments extends Object3D {
             let dir = vec2.clone().sub(vec1);
 
             dir.normalize();
-            dir.multiplyScalar(this._lineMaterial.lineWidth);
+            dir.multiplyScalar(this._lineMaterial.linewidth);
 
-            meshLine.setPoints(
+            meshLine.setPositions(
                 [
                     x1 - dir.x,
                     y1 - dir.y,
@@ -118,16 +127,16 @@ export class LineSegments extends Object3D {
                     y2 + dir.y,
                     z2 + dir.z,
                 ],
-                (p: number) => this._calculatePointWidth(p)
+                // (p: number) => this._calculatePointWidth(p)
             );
         }
         this.updateMatrix();
     }
 
-    private _calculatePointWidth(percent: number): number {
-        if (percent === 0 || percent === 1) {
-            return 0.25;
-        }
-        return 1;
-    }
+    // private _calculatePointWidth(percent: number): number {
+    //     if (percent === 0 || percent === 1) {
+    //         return 0.25;
+    //     }
+    //     return 1;
+    // }
 }

--- a/src/aux-server/aux-web/shared/scene/LineSegments.ts
+++ b/src/aux-server/aux-web/shared/scene/LineSegments.ts
@@ -83,7 +83,7 @@ export class LineSegments extends Object3D {
 
     public setColor(color: number | Color) {
         this._lineMaterial.color = new Color(color);
-        this._lineMaterial.color.convertLinearToSRGB();
+        // this._lineMaterial.color.convertLinearToSRGB();
     }
 
     public dispose() {

--- a/src/aux-server/aux-web/shared/scene/LineSegments.ts
+++ b/src/aux-server/aux-web/shared/scene/LineSegments.ts
@@ -6,9 +6,6 @@ import {
     Mesh,
 } from '@casual-simulation/three';
 
-// @ts-ignore This import is not picked up by Jest
-// import { MeshLineMaterial, MeshLine } from 'three.meshline';
-
 import { Line2 } from '@casual-simulation/three/examples/jsm/lines/Line2';
 import { LineGeometry } from '@casual-simulation/three/examples/jsm/lines/LineGeometry';
 import { LineMaterial } from '@casual-simulation/three/examples/jsm/lines/LineMaterial';
@@ -32,14 +29,10 @@ export class LineSegments extends Object3D {
         this._lineMaterial = new LineMaterial();
         this._lineMaterial.color = Arrow3D.DefaultColor.clone();
         this._lineMaterial.toneMapped = false;
-        // this._lineMaterial.sizeAttenuation = true;
         this._lineMaterial.linewidth = Arrow3D.DefaultLineWidth;
         this._lines = lines;
 
         let meshLine = new LineGeometry();
-        
-        // meshLine.setPositions(lines);
-
 
         for (let i = 0; i + 5 < lines.length; i += 6) {
             let [x1, y1, z1, x2, y2, z2] = lines.slice(i, i + 6);
@@ -54,18 +47,12 @@ export class LineSegments extends Object3D {
             let meshLine = new LineGeometry();
             meshLine.setPositions(
                 [
-                    // x1 - dir.x,
-                    // y1 - dir.y,
-                    // z1 - dir.z,
                     x1,
                     y1,
                     z1,
                     x2,
                     y2,
                     z2,
-                    // x2 + dir.x,
-                    // y2 + dir.y,
-                    // z2 + dir.z,
                 ],
             );
             let mesh = new Line2(meshLine, this._lineMaterial);
@@ -83,7 +70,6 @@ export class LineSegments extends Object3D {
 
     public setColor(color: number | Color) {
         this._lineMaterial.color = new Color(color);
-        // this._lineMaterial.color.convertLinearToSRGB();
     }
 
     public dispose() {
@@ -114,29 +100,15 @@ export class LineSegments extends Object3D {
 
             meshLine.setPositions(
                 [
-                    x1 - dir.x,
-                    y1 - dir.y,
-                    z1 - dir.z,
                     x1,
                     y1,
                     z1,
                     x2,
                     y2,
                     z2,
-                    x2 + dir.x,
-                    y2 + dir.y,
-                    z2 + dir.z,
                 ],
-                // (p: number) => this._calculatePointWidth(p)
             );
         }
         this.updateMatrix();
     }
-
-    // private _calculatePointWidth(percent: number): number {
-    //     if (percent === 0 || percent === 1) {
-    //         return 0.25;
-    //     }
-    //     return 1;
-    // }
 }

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -126,7 +126,7 @@ export function createUserCone(
     let material = baseAuxMeshMaterial();
     material.color.set(new Color(color || 0x00d000));
     material.side = DoubleSide;
-    material.flatShading = true;
+    // material.flatShading = true;
     material.transparent = true;
     material.opacity = 0.4;
     const mesh = new Mesh(geometry, material);

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -56,7 +56,8 @@ import EggUrl from '../../public/meshes/egg.glb';
 import { Axial, HexMesh } from '../hex';
 import { sortBy } from 'lodash';
 import { SubscriptionLike } from 'rxjs';
-import { MeshLineMaterial } from 'three.meshline';
+// import { MeshLineMaterial } from 'three.meshline';
+import { LineMaterial } from '@casual-simulation/three/examples/jsm/lines/LineMaterial';
 import { Arrow3D } from '../Arrow3D';
 
 const gltfPool = getGLTFPool('main');
@@ -245,7 +246,7 @@ export class BotShapeDecorator
         }
 
         this.stroke.visible = true;
-        const strokeMat = <MeshLineMaterial>this.stroke.material;
+        const strokeMat = <LineMaterial>this.stroke.material;
         if (typeof strokeColorValue !== 'undefined') {
             strokeMat.visible = !isTransparent(strokeColorValue);
             if (strokeMat.visible) {
@@ -255,9 +256,9 @@ export class BotShapeDecorator
             strokeMat.visible = false;
         }
         if (typeof strokeWidth !== 'undefined') {
-            strokeMat.lineWidth = Arrow3D.DefaultLineWidth * strokeWidth;
+            strokeMat.linewidth = Arrow3D.DefaultLineWidth * strokeWidth;
         } else {
-            strokeMat.lineWidth = Arrow3D.DefaultLineWidth;
+            strokeMat.linewidth = Arrow3D.DefaultLineWidth;
         }
     }
 

--- a/src/aux-server/package.json
+++ b/src/aux-server/package.json
@@ -57,7 +57,7 @@
         "@casual-simulation/crypto": "^3.0.0",
         "@casual-simulation/crypto-browser": "^3.0.0",
         "@casual-simulation/crypto-node": "^3.0.0",
-        "@casual-simulation/three": "^0.125.4",
+        "@casual-simulation/three": "^0.139.3",
         "@casual-simulation/tunnel": "^3.0.0",
         "@casual-simulation/websocket": "^3.0.0",
         "@chenfengyuan/vue-qrcode": "^1.0.0",

--- a/src/aux-server/typings/casual-simulation.three.d.ts
+++ b/src/aux-server/typings/casual-simulation.three.d.ts
@@ -1,0 +1,209 @@
+declare module '@casual-simulation/three' {
+    export * from 'three';
+    import { MaterialParameters, Color, Texture, Material, NormalMapTypes, Vector2 } from 'three';
+
+    
+    export interface MeshToonMaterialParameters extends MaterialParameters {
+        /** geometry color in hexadecimal. Default is 0xffffff. */
+        color?: Color | string | number;
+        specular?: Color | string | number;
+        shininess?: number;
+        opacity?: number;
+        gradientMap?: Texture | null;
+        map?: Texture | null;
+        lightMap?: Texture | null;
+        lightMapIntensity?: number;
+        aoMap?: Texture | null;
+        aoMapIntensity?: number;
+        emissive?: Color | string | number;
+        emissiveIntensity?: number;
+        emissiveMap?: Texture | null;
+        bumpMap?: Texture | null;
+        bumpScale?: number;
+        normalMap?: Texture | null;
+        normalMapType?: NormalMapTypes;
+        normalScale?: Vector2;
+        displacementMap?: Texture | null;
+        displacementScale?: number;
+        displacementBias?: number;
+        specularMap?: Texture | null;
+        alphaMap?: Texture | null;
+        wireframe?: boolean;
+        wireframeLinewidth?: number;
+        wireframeLinecap?: string;
+        wireframeLinejoin?: string;
+        skinning?: boolean;
+        morphTargets?: boolean;
+        morphNormals?: boolean;
+    }
+
+    export class MeshToonMaterial extends Material {
+
+        constructor( parameters?: MeshToonMaterialParameters );
+
+        /**
+         * @default 'MeshToonMaterial'
+         */
+        type: string;
+
+        /**
+         * @default { 'TOON': '' }
+         */
+        defines: { [key: string]: any };
+
+        /**
+         * @default new THREE.Color( 0xffffff )
+         */
+        color: Color;
+        specular: Color;
+        shininess: number;
+        gradientMap: Texture | null;
+
+        /**
+         * @default null
+         */
+        map: Texture | null;
+
+        /**
+         * @default null
+         */
+        lightMap: Texture | null;
+
+        /**
+         * @default 1
+         */
+        lightMapIntensity: number;
+
+        /**
+         * @default null
+         */
+        aoMap: Texture | null;
+
+        /**
+         * @default 1
+         */
+        aoMapIntensity: number;
+
+        /**
+         * @default new THREE.Color( 0x000000 )
+         */
+        emissive: Color;
+
+        /**
+         * @default 1
+         */
+        emissiveIntensity: number;
+
+        /**
+         * @default null
+         */
+        emissiveMap: Texture | null;
+
+        /**
+         * @default null
+         */
+        bumpMap: Texture | null;
+
+        /**
+         * @default 1
+         */
+        bumpScale: number;
+
+        /**
+         * @default null
+         */
+        normalMap: Texture | null;
+
+        /**
+         * @default THREE.TangentSpaceNormalMap
+         */
+        normalMapType: NormalMapTypes;
+
+        /**
+         * @default new THREE.Vector2( 1, 1 )
+         */
+        normalScale: Vector2;
+
+        /**
+         * @default null
+         */
+        displacementMap: Texture | null;
+
+        /**
+         * @default 1
+         */
+        displacementScale: number;
+
+        /**
+         * @default 0
+         */
+        displacementBias: number;
+        specularMap: Texture | null;
+        /**
+         * @default null
+         */
+        alphaMap: Texture | null;
+
+        /**
+         * @default false
+         */
+        wireframe: boolean;
+
+        /**
+         * @default 1
+         */
+        wireframeLinewidth: number;
+
+        /**
+         * @default 'round'
+         */
+        wireframeLinecap: string;
+
+        /**
+         * @default 'round'
+         */
+        wireframeLinejoin: string;
+
+        /**
+         * @default false
+         */
+        skinning: boolean;
+
+        /**
+         * @default false
+         */
+        morphTargets: boolean;
+
+        /**
+         * @default false
+         */
+        morphNormals: boolean;
+
+        setValues( parameters: MeshToonMaterialParameters ): void;
+
+    }
+}
+
+declare module '@casual-simulation/three/examples/jsm/lines/Line2' {
+    export * from 'three/examples/jsm/lines/Line2';
+}
+
+declare module '@casual-simulation/three/examples/jsm/lines/LineGeometry' {
+    export * from 'three/examples/jsm/lines/LineGeometry';
+}
+
+declare module '@casual-simulation/three/examples/jsm/lines/LineMaterial' {
+    export * from 'three/examples/jsm/lines/LineMaterial';
+}
+
+declare module '@casual-simulation/three/examples/jsm/loaders/GLTFLoader' {
+    export * from 'three/examples/jsm/loaders/GLTFLoader';
+}
+
+declare module '@casual-simulation/three/examples/jsm/loaders/DRACOLoader' {
+    export * from 'three/examples/jsm/loaders/DRACOLoader';
+}
+
+declare module '@casual-simulation/three/examples/jsm/renderers/CSS3DRenderer' {
+    export * from 'three/examples/jsm/renderers/CSS3DRenderer';
+}

--- a/src/causal-tree-cli/debug/index.ts
+++ b/src/causal-tree-cli/debug/index.ts
@@ -1,10 +1,10 @@
 import { prompt } from 'inquirer';
 
 import {
-    SocketManager,
     ApiaryConnectionClient,
     AwsSocket,
 } from '@casual-simulation/causal-tree-client-apiary';
+import { SocketManager } from '@casual-simulation/websocket';
 import { filter, first, skip } from 'rxjs/operators';
 import { indexOf } from 'benchmark';
 import { option } from 'commander';

--- a/src/causal-tree-cli/package.json
+++ b/src/causal-tree-cli/package.json
@@ -42,6 +42,7 @@
         "@casual-simulation/causal-tree-store-cassandradb": "^3.0.2",
         "@casual-simulation/causal-tree-store-mongodb": "^3.0.2",
         "@casual-simulation/causal-trees": "^3.0.2",
+        "@casual-simulation/websocket": "^3.0.0",
         "cassandra-driver": "4.5.1",
         "cli-progress": "3.8.1",
         "colors": "1.4.0",

--- a/src/causal-tree-cli/tsconfig.json
+++ b/src/causal-tree-cli/tsconfig.json
@@ -14,6 +14,7 @@
         { "path": "../causal-trees" },
         { "path": "../causal-tree-store-cassandradb" },
         { "path": "../causal-tree-store-mongodb" },
-        { "path": "../causal-tree-client-apiary" }
+        { "path": "../causal-tree-client-apiary" },
+        { "path": "../websocket" }
     ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,50 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "typeRoots": [
+            "node_modules/@types",
+            "src/aux-server/typings",
+            "src/aux-vm/typings",
+            "src/crypto-node/typings",
+            "./typings"
+        ],
+        "paths": {
+            "three-legacy-gltf-loader": [
+                "src/aux-server/aux-web/shared/public/three-legacy-gltf-loader/index.d.ts"
+            ],
+            "aux-jest-matchers": ["jest/jest-matchers.ts"]
+        }
+    },
+    "files": [
+        "src/aux-server/typings/casual-simulation.three.d.ts"
+    ],
+    "references": [
+        { "path": "./src/crypto" },
+        { "path": "./src/aux-server" },
+        { "path": "./src/aux-auth" },
+        { "path": "./src/aux-common" },
+        { "path": "./src/aux-components" },
+        { "path": "./src/aux-vm" },
+        { "path": "./src/aux-vm-client" },
+        { "path": "./src/aux-vm-node" },
+        { "path": "./src/aux-vm-browser" },
+        { "path": "./src/aux-vm-deno" },
+        { "path": "./src/aux-records" },
+        { "path": "./src/aux-records-aws" },
+        { "path": "./src/causal-trees" },
+        { "path": "./src/causal-tree-client-apiary" },
+        { "path": "./src/causal-tree-store-mongodb" },
+        { "path": "./src/causal-tree-store-cassandradb" },
+        { "path": "./src/causal-tree-server-websocket" },
+        { "path": "./src/causal-tree-client-websocket" },
+        { "path": "./src/crypto-browser" },
+        { "path": "./src/crypto-node" },
+        { "path": "./src/stacktrace" },
+        { "path": "./src/tunnel" },
+        { "path": "./src/undom" },
+        { "path": "./src/fast-json-stable-stringify" },
+        { "path": "./src/expect" },
+        { "path": "./src/chalk" },
+        { "path": "./src/websocket" }
+    ]
+}


### PR DESCRIPTION
### :rocket: Improvements
-   Improved how lines are rendered to use an implementation built into three.js.
    -   This makes bot strokes that are scaled appear correct.
    -   This change also makes lines and strokes appear the same size on screen no matter the zoom level of the camera. This can make it easier to identify bots when zoomed out a lot.