### PR TITLE
Add subjectless record keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
     -   This makes bot strokes that are scaled appear correct.
     -   This change also makes lines and strokes appear the same size on screen no matter the zoom level of the camera. This can make it easier to identify bots when zoomed out a lot.
 -   Added the ability to allow/deny login with phone numbers based on regex rules defined in a DynamoDB table.
+-   Added the `os.getSubjectlessPublicRecordKey(recordName)` function to make it possible to create a record key that allow publishing record data without being logged in.
+    -   All record keys are now split into two categories: subjectfull keys and subjectless keys.
+    -   subjectfull keys require login in order to publish data are are the default type of key.
+    -   subjectless keys do not require login in order to publish data.
+    -   When publishing data with a subjectless key, all users are treated as anonymous. In effect, this makes the owner of the record fully responsible for the content that they publish.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-auth/scripts/bootstrap.js
+++ b/src/aux-auth/scripts/bootstrap.js
@@ -31,6 +31,7 @@ const EMAIL_TABLE = 'EmailRules';
 const SMS_TABLE = 'SmsRules';
 const RECORDS_BUCKET = 'records-bucket';
 const PUBLIC_RECORDS_TABLE = 'PublicRecords';
+const PUBLIC_RECORDS_KEYS_TABLE = 'PublicRecordsKeys';
 const DATA_TABLE = 'Data';
 const MANUAL_DATA_TABLE = 'ManualData';
 const FILES_TABLE = 'Files';
@@ -236,6 +237,31 @@ async function start() {
             .promise();
     } else {
         console.log('Public Records Table already exists');
+    }
+
+    const hasPublicRecordsKeysTable =
+        tablesResult.TableNames.includes(PUBLIC_RECORDS_KEYS_TABLE);
+    if (!hasPublicRecordsKeysTable || reset) {
+        if (hasPublicRecordsKeysTable) {
+            console.log('Deleting Public Records Keys Table');
+            await ddb
+                .deleteTable({
+                    TableName: PUBLIC_RECORDS_KEYS_TABLE,
+                })
+                .promise();
+        }
+
+        console.log('Creating Public Records Keys Table');
+
+        const params = template.Resources.PublicRecordsKeysTable.Properties;
+        await ddb
+            .createTable({
+                TableName: PUBLIC_RECORDS_KEYS_TABLE,
+                ...params,
+            })
+            .promise();
+    } else {
+        console.log('Public Records Keys Table already exists');
     }
 
     const hasDataTable = tablesResult.TableNames.includes(DATA_TABLE);

--- a/src/aux-auth/server/MongoDBRecordsStore.ts
+++ b/src/aux-auth/server/MongoDBRecordsStore.ts
@@ -1,11 +1,13 @@
-import { Record, RecordsStore } from '@casual-simulation/aux-records';
+import { Record, RecordsStore, RecordKey } from '@casual-simulation/aux-records';
 import { Collection } from 'mongodb';
 
 export class MongoDBRecordsStore implements RecordsStore {
     private _collection: Collection<Record>;
+    private _keyCollection: Collection<RecordKey>;
 
-    constructor(collection: Collection<Record>) {
+    constructor(collection: Collection<Record>, keys: Collection<RecordKey>) {
         this._collection = collection;
+        this._keyCollection = keys;
     }
 
     async updateRecord(record: Record): Promise<void> {
@@ -31,4 +33,26 @@ export class MongoDBRecordsStore implements RecordsStore {
 
         return record;
     }
+
+    /**
+     * Adds the given record key to the store.
+     * @param key The key to add.
+     */
+     async addRecordKey(key: RecordKey): Promise<void> {
+        await this._keyCollection.insertOne(key);
+     }
+
+     /**
+      * Gets the record key for the given record name that has the given hash.
+      * @param recordName The name of the record.
+      * @param hash The scrypt hash of the key that should be retrieved.
+      */
+     async getRecordKeyByRecordAndHash(recordName: string, hash: string): Promise<RecordKey> {
+         const key = await this._keyCollection.findOne({
+             recordName: recordName,
+             secretHash: hash
+         });
+
+         return key;
+     }
 }

--- a/src/aux-auth/serverless/aws/src/utils.ts
+++ b/src/aux-auth/serverless/aws/src/utils.ts
@@ -26,6 +26,13 @@ export function validateOrigin(
     return origins.has(origin);
 }
 
+export function formatStatusCode(response: { success: false, errorCode: string } | { success: true }) {
+    if (response.success === false && response.errorCode === 'not_logged_in') {
+        return 401;
+    }
+    return 200;
+}
+
 export function formatResponse(
     request: APIGatewayProxyEvent,
     response: any,

--- a/src/aux-auth/serverless/aws/template.yml
+++ b/src/aux-auth/serverless/aws/template.yml
@@ -252,6 +252,7 @@ Resources:
                     # Make table name accessible as environment variable from function code during execution
                     MAGIC_SECRET_KEY: !Ref MagicSecretKeyParameter
                     PUBLIC_RECORDS_TABLE: !Ref PublicRecordsTable
+                    PUBLIC_RECORDS_KEYS_TABLE: !Ref PublicRecordsKeysTable
                     DATA_TABLE: !Ref DataTable
                     MANUAL_DATA_TABLE: !Ref ManualDataTable
                     EVENTS_TABLE: !Ref EventsTable
@@ -464,6 +465,23 @@ Resources:
                   KeyType: HASH
             AttributeDefinitions:
                 - AttributeName: recordName
+                  AttributeType: S
+            ProvisionedThroughput:
+                ReadCapacityUnits: 2
+                WriteCapacityUnits: 2
+
+    PublicRecordsKeysTable:
+        Type: AWS::DynamoDB::Table
+        Properties:
+            KeySchema:
+                - AttributeName: recordName
+                  KeyType: HASH
+                - AttributeName: secretHash
+                  KeyType: RANGE
+            AttributeDefinitions:
+                - AttributeName: recordName
+                  AttributeType: S
+                - AttributeName: secretHash
                   AttributeType: S
             ProvisionedThroughput:
                 ReadCapacityUnits: 2

--- a/src/aux-auth/web/iframe/AuthHandler.ts
+++ b/src/aux-auth/web/iframe/AuthHandler.ts
@@ -7,7 +7,7 @@ import {
     waitForLoad,
 } from '../../../aux-vm-browser/html/IFrameHelpers';
 import { authManager } from '../shared/AuthManager';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { CreatePublicRecordKeyResult, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 import { RPCError, RPCErrorCode } from 'magic-sdk';
@@ -98,7 +98,8 @@ export class AuthHandler implements AuxAuth {
     }
 
     async createPublicRecordKey(
-        recordName: string
+        recordName: string,
+        policy?: PublicRecordKeyPolicy,
     ): Promise<CreatePublicRecordKeyResult> {
         console.log('[AuthHandler] Creating public record key:', recordName);
         if (!(await this.isLoggedIn())) {
@@ -116,8 +117,9 @@ export class AuthHandler implements AuxAuth {
             };
         }
 
+        const key = await authManager.createPublicRecordKey(recordName, policy);
         console.log('[AuthHandler] Record key created.');
-        return await authManager.createPublicRecordKey(recordName);
+        return key;
     }
 
     async getAuthToken(): Promise<string> {
@@ -129,7 +131,7 @@ export class AuthHandler implements AuxAuth {
     }
 
     async getProtocolVersion() {
-        return 4;
+        return 5;
     }
 
     async getRecordsOrigin(): Promise<string> {

--- a/src/aux-auth/web/shared/AuthManager.ts
+++ b/src/aux-auth/web/shared/AuthManager.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Magic } from 'magic-sdk';
 import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import { AppMetadata } from '../../shared/AuthMetadata';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { CreatePublicRecordKeyResult, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
 import { isStringValid, RegexRule } from './Utils';
 
 const EMAIL_KEY = 'userEmail';
@@ -116,7 +116,8 @@ export class AuthManager {
     }
 
     async createPublicRecordKey(
-        recordName: string
+        recordName: string,
+        policy: PublicRecordKeyPolicy
     ): Promise<CreatePublicRecordKeyResult> {
         if (!this.userInfoLoaded) {
             await this.loadUserInfo();
@@ -127,6 +128,7 @@ export class AuthManager {
             `${API_ENDPOINT}/api/v2/records/key`,
             {
                 recordName: recordName,
+                policy: policy
             },
             {
                 headers: {

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -3464,6 +3464,14 @@ export interface ConvertGeolocationToWhat3WordsAction
 }
 
 /**
+ * Defines a type that represents the different kinds of policies that a record key can have.
+ * 
+ * - null and "subjectfull" indicate that actions performed with this key must require a subject to provide their access token in order for operations to succeed.
+ * - "subjectless" indicates that actions may be performed with key despite not having an access key from a subject.
+ */
+export type PublicRecordKeyPolicy = null | 'subjectfull' | 'subjectless';
+
+/**
  * Defines an interface that represents an action that requests a key to a public record.
  */
 export interface GetPublicRecordKeyAction extends AsyncAction {
@@ -3473,6 +3481,11 @@ export interface GetPublicRecordKeyAction extends AsyncAction {
      * The name of the record.
      */
     recordName: string;
+
+    /**
+     * The policy that the record key should have.
+     */
+    policy?: PublicRecordKeyPolicy;
 }
 
 export interface MediaPermssionOptions {
@@ -6148,15 +6161,18 @@ export function convertGeolocationToWhat3Words(
 /**
  * Creates a GetPublicRecordKeyAction.
  * @param recordName The name of the record.
+ * @param policy The policy that the requested record key should have.
  * @param taskId The ID of the task.
  */
 export function getPublicRecordKey(
     recordName: string,
+    policy: PublicRecordKeyPolicy,
     taskId: number | string
 ): GetPublicRecordKeyAction {
     return {
         type: 'get_public_record_key',
         recordName,
+        policy,
         taskId,
     };
 }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -222,7 +222,7 @@ import {
 import { fromByteArray, toByteArray } from 'base64-js';
 import { Fragment } from 'preact';
 import fastJsonStableStringify from '@casual-simulation/fast-json-stable-stringify';
-import { formatRecordKey } from '@casual-simulation/aux-records';
+import { formatV1RecordKey, formatV2RecordKey } from '@casual-simulation/aux-records';
 import { DateTime, FixedOffsetZone } from 'luxon';
 
 const uuidMock: jest.Mock = <any>uuid;
@@ -4446,17 +4446,34 @@ describe('AuxLibrary', () => {
         describe('os.getPublicRecordKey()', () => {
             it('should emit a GetPublicRecordAction', async () => {
                 const action: any = library.api.os.getPublicRecordKey('name');
-                const expected = getPublicRecordKey('name', context.tasks.size);
+                const expected = getPublicRecordKey('name', 'subjectfull', context.tasks.size);
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.getSubjectlessPublicRecordKey()', () => {
+            it('should emit a GetPublicRecordAction', async () => {
+                const action: any = library.api.os.getSubjectlessPublicRecordKey('name');
+                const expected = getPublicRecordKey('name', 'subjectless', context.tasks.size);
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });
 
         describe('os.isRecordKey()', () => {
-            it('should return true if the value is a record key', () => {
+            it('should return true if the value is a v1 record key', () => {
                 expect(
                     library.api.os.isRecordKey(
-                        formatRecordKey('myRecord', 'mySecret')
+                        formatV1RecordKey('myRecord', 'mySecret')
+                    )
+                ).toBe(true);
+            });
+
+            it('should return true if the value is a v2 record key', () => {
+                expect(
+                    library.api.os.isRecordKey(
+                        formatV2RecordKey('myRecord', 'mySecret', 'subjectfull')
                     )
                 ).toBe(true);
             });
@@ -4684,9 +4701,25 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
-            it('should parse record keys into a record name', async () => {
+            it('should parse v1 record keys into a record name', async () => {
                 const action: any = library.api.os.getData(
-                    formatRecordKey('recordName', 'test'),
+                    formatV1RecordKey('recordName', 'test'),
+                    'address'
+                );
+                const expected = getRecordData(
+                    'recordName',
+                    'address',
+                    false,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should parse v2 record keys into a record name', async () => {
+                const action: any = library.api.os.getData(
+                    formatV2RecordKey('recordName', 'test', 'subjectfull'),
                     'address'
                 );
                 const expected = getRecordData(
@@ -4735,9 +4768,25 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
-            it('should parse record keys into a record name', async () => {
+            it('should parse v1 record keys into a record name', async () => {
                 const action: any = library.api.os.getManualApprovalData(
-                    formatRecordKey('recordName', 'test'),
+                    formatV1RecordKey('recordName', 'test'),
+                    'address'
+                );
+                const expected = getRecordData(
+                    'recordName',
+                    'address',
+                    true,
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should parse v2 record keys into a record name', async () => {
+                const action: any = library.api.os.getManualApprovalData(
+                    formatV2RecordKey('recordName', 'test', 'subjectfull'),
                     'address'
                 );
                 const expected = getRecordData(
@@ -4792,9 +4841,24 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
-            it('should parse record keys into a record name', async () => {
+            it('should parse v1 record keys into a record name', async () => {
                 const action: any = library.api.os.listData(
-                    formatRecordKey('recordName', 'test'),
+                    formatV1RecordKey('recordName', 'test'),
+                    'address'
+                );
+                const expected = listDataRecord(
+                    'recordName',
+                    'address',
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should parse v2 record keys into a record name', async () => {
+                const action: any = library.api.os.listData(
+                    formatV2RecordKey('recordName', 'test', 'subjectfull'),
                     'address'
                 );
                 const expected = listDataRecord(
@@ -5254,9 +5318,24 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
-            it('should parse record keys into a record name', async () => {
+            it('should parse v1 record keys into a record name', async () => {
                 const action: any = library.api.os.countEvents(
-                    formatRecordKey('recordName', 'test'),
+                    formatV1RecordKey('recordName', 'test'),
+                    'eventName'
+                );
+                const expected = getEventCount(
+                    'recordName',
+                    'eventName',
+                    null,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should parse v2 record keys into a record name', async () => {
+                const action: any = library.api.os.countEvents(
+                    formatV2RecordKey('recordName', 'test', 'subjectfull'),
                     'eventName'
                 );
                 const expected = getEventCount(

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -1240,6 +1240,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 requestAuthBot,
 
                 getPublicRecordKey,
+                getSubjectlessPublicRecordKey,
                 isRecordKey,
                 recordData,
                 recordManualApprovalData,
@@ -3327,7 +3328,19 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         name: string
     ): Promise<CreatePublicRecordKeyResult> {
         const task = context.createTask();
-        const event = calcGetPublicRecordKey(name, task.taskId);
+        const event = calcGetPublicRecordKey(name, 'subjectfull', task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets a subjectless access key for the given public record.
+     * @param name The name of the record.
+     */
+     function getSubjectlessPublicRecordKey(
+        name: string
+    ): Promise<CreatePublicRecordKeyResult> {
+        const task = context.createTask();
+        const event = calcGetPublicRecordKey(name, 'subjectless', task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8536,6 +8536,14 @@ interface Os {
     getPublicRecordKey(recordName: string): Promise<CreatePublicRecordKeyResult>;
 
     /**
+     * Gets a subjectless access key for the given public record.
+     * @param name The name of the record.
+     */
+    getSubjectlessPublicRecordKey(
+        recordName: string
+    ): Promise<CreatePublicRecordKeyResult>;
+
+    /**
      * Determines if the given value is a record key.
      * @param key The value to check.
      */

--- a/src/aux-records/DataRecordsController.spec.ts
+++ b/src/aux-records/DataRecordsController.spec.ts
@@ -3,10 +3,12 @@ import { MemoryRecordsStore } from './MemoryRecordsStore';
 import { RecordsController } from './RecordsController';
 import {
     DataRecordsController,
+    EraseDataFailure,
     EraseDataSuccess,
     GetDataFailure,
     GetDataResult,
     GetDataSuccess,
+    RecordDataFailure,
     RecordDataSuccess,
 } from './DataRecordsController';
 import { DataRecordsStore } from './DataRecordsStore';
@@ -18,6 +20,7 @@ describe('DataRecordsController', () => {
     let store: DataRecordsStore;
     let manager: DataRecordsController;
     let key: string;
+    let subjectlessKey: string;
 
     beforeEach(async () => {
         recordsStore = new MemoryRecordsStore();
@@ -27,10 +30,20 @@ describe('DataRecordsController', () => {
 
         const result = await records.createPublicRecordKey(
             'testRecord',
+            'subjectfull',
             'testUser'
         );
         if (result.success) {
             key = result.recordKey;
+        }
+
+        const result2 = await records.createPublicRecordKey(
+            'testRecord',
+            'subjectless',
+            'testUser'
+        );
+        if (result2.success) {
+            subjectlessKey = result2.recordKey;
         }
     });
 
@@ -54,6 +67,74 @@ describe('DataRecordsController', () => {
                 data: 'data',
                 publisherId: 'testUser',
                 subjectId: 'subjectId',
+            });
+        });
+
+        it('should reject the request if given an invalid key', async () => {
+            const result = (await manager.recordData(
+                'not_a_key',
+                'address',
+                'data',
+                'subjectId'
+            )) as RecordDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('invalid_record_key');
+        });
+
+        it('should reject the request if given a null subject ID', async () => {
+            const result = (await manager.recordData(
+                key,
+                'address',
+                'data',
+                null
+            )) as RecordDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('not_logged_in');
+        });
+
+        it('should allow the request if given a null subject ID with a subjectless key', async () => {
+            const result = (await manager.recordData(
+                subjectlessKey,
+                'address',
+                'data',
+                null
+            )) as RecordDataSuccess;
+
+            expect(result.success).toBe(true);
+            expect(result.recordName).toBe('testRecord');
+            expect(result.address).toBe('address');
+            
+            await expect(
+                store.getData('testRecord', 'address')
+            ).resolves.toEqual({
+                success: true,
+                data: 'data',
+                publisherId: 'testUser',
+                subjectId: null,
+            });
+        });
+
+        it('should clear the subject if using a subjectless key', async () => {
+            const result = (await manager.recordData(
+                subjectlessKey,
+                'address',
+                'data',
+                'subjectId'
+            )) as RecordDataSuccess;
+
+            expect(result.success).toBe(true);
+            expect(result.recordName).toBe('testRecord');
+            expect(result.address).toBe('address');
+            
+            await expect(
+                store.getData('testRecord', 'address')
+            ).resolves.toEqual({
+                success: true,
+                data: 'data',
+                publisherId: 'testUser',
+                subjectId: null,
             });
         });
     });
@@ -134,7 +215,8 @@ describe('DataRecordsController', () => {
 
             const result = (await manager.eraseData(
                 key,
-                'address'
+                'address',
+                'userId'
             )) as EraseDataSuccess;
 
             expect(result.success).toBe(true);
@@ -146,5 +228,100 @@ describe('DataRecordsController', () => {
             expect(storeResult.success).toBe(false);
             expect(storeResult.errorCode).toBe('data_not_found');
         });
+
+        it('should reject the request if given an invalid key', async () => {
+            await store.setData(
+                'testRecord',
+                'address',
+                'data',
+                'testUser',
+                'subjectId'
+            );
+
+            const result = (await manager.eraseData(
+                'wrongkey',
+                'address',
+                'userId'
+            )) as EraseDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('invalid_record_key');
+
+            const storeResult = await store.getData('testRecord', 'address');
+
+            expect(storeResult.success).toBe(true);
+            expect(storeResult.data).toBe('data');
+            expect(storeResult.publisherId).toBe('testUser');
+            expect(storeResult.subjectId).toBe('subjectId');
+        });
+
+        it('should reject the request if given a null subjectId', async () => {
+            await store.setData(
+                'testRecord',
+                'address',
+                'data',
+                'testUser',
+                'subjectId'
+            );
+
+            const result = (await manager.eraseData(
+                key,
+                'address',
+                null
+            )) as EraseDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('not_logged_in');
+
+            const storeResult = await store.getData('testRecord', 'address');
+
+            expect(storeResult.success).toBe(true);
+            expect(storeResult.data).toBe('data');
+        });
+
+        it('should be able to delete items with a subjectless key', async () => {
+            await store.setData(
+                'testRecord',
+                'address',
+                'data',
+                'testUser',
+                'subjectId'
+            );
+
+            const result = (await manager.eraseData(
+                subjectlessKey,
+                'address',
+                null
+            )) as EraseDataSuccess;
+
+            expect(result.success).toBe(true);
+            expect(result.recordName).toBe('testRecord');
+            expect(result.address).toBe('address');
+
+            const storeResult = await store.getData('testRecord', 'address');
+
+            expect(storeResult.success).toBe(false);
+            expect(storeResult.errorCode).toBe('data_not_found');
+        });
+
+        it('should do nothing if trying to delete some data that doesnt exist', async () => {
+            await store.setData(
+                'testRecord',
+                'address',
+                'data',
+                'testUser',
+                'subjectId'
+            );
+
+            const result = (await manager.eraseData(
+                subjectlessKey,
+                'missing',
+                'userId'
+            )) as EraseDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('data_not_found');
+        });
+        
     });
 });

--- a/src/aux-records/DataRecordsController.ts
+++ b/src/aux-records/DataRecordsController.ts
@@ -55,6 +55,18 @@ export class DataRecordsController {
                 };
             }
 
+            if (!subjectId && result.policy !== 'subjectless') {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage: 'The user must be logged in in order to record data.',
+                };
+            }
+
+            if (result.policy === 'subjectless') {
+                subjectId = null;
+            }
+
             const recordName = result.recordName;
             const result2 = await this._store.setData(
                 recordName,
@@ -134,9 +146,17 @@ export class DataRecordsController {
         }
     }
 
+    /**
+     * Erases the data in the given record and address.
+     * Uses the given record key to access the record and the given subject ID to determine if the user is allowed to access the record.
+     * @param recordKey The key that should be used to access the record.
+     * @param address The address that the record should be deleted from.
+     * @param subjectId THe ID of the user that this request came from.
+     */
     async eraseData(
         recordKey: string,
-        address: string
+        address: string,
+        subjectId: string
     ): Promise<EraseDataResult> {
         try {
             const result = await this._manager.validatePublicRecordKey(
@@ -147,6 +167,14 @@ export class DataRecordsController {
                     success: false,
                     errorCode: result.errorCode,
                     errorMessage: result.errorMessage,
+                };
+            }
+
+            if (!subjectId && result.policy !== 'subjectless') {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage: 'The user must be logged in in order to record data.',
                 };
             }
 
@@ -242,6 +270,7 @@ export interface EraseDataFailure {
     success: false;
     errorCode:
         | ServerError
+        | NotLoggedInError
         | EraseDataStoreResult['errorCode']
         | ValidatePublicRecordKeyFailure['errorCode'];
     errorMessage: string;

--- a/src/aux-records/EventRecordsController.spec.ts
+++ b/src/aux-records/EventRecordsController.spec.ts
@@ -2,6 +2,7 @@ import { RecordsStore } from './RecordsStore';
 import { MemoryRecordsStore } from './MemoryRecordsStore';
 import { RecordsController } from './RecordsController';
 import {
+    AddCountFailure,
     AddCountSuccess,
     EventRecordsController,
     GetCountSuccess,
@@ -24,6 +25,7 @@ describe('EventRecordsController', () => {
 
         const result = await records.createPublicRecordKey(
             'testRecord',
+            'subjectfull',
             'testUser'
         );
         if (result.success) {
@@ -36,7 +38,8 @@ describe('EventRecordsController', () => {
             const result = (await manager.addCount(
                 key,
                 'address',
-                5
+                5,
+                'userId'
             )) as AddCountSuccess;
 
             expect(result.success).toBe(true);
@@ -48,6 +51,26 @@ describe('EventRecordsController', () => {
             ).resolves.toEqual({
                 success: true,
                 count: 5,
+            });
+        });
+
+        it('should return a not_logged_in error if a null user ID is given for a subjectfull key', async () => {
+            const result = (await manager.addCount(
+                key,
+                'address',
+                5,
+                null
+            )) as AddCountFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('not_logged_in');
+            expect(result.errorMessage).toBe('The user must be logged in in order to record events.');
+
+            await expect(
+                store.getEventCount('testRecord', 'address')
+            ).resolves.toEqual({
+                success: true,
+                count: 0,
             });
         });
     });

--- a/src/aux-records/EventRecordsController.ts
+++ b/src/aux-records/EventRecordsController.ts
@@ -31,11 +31,13 @@ export class EventRecordsController {
      * @param recordKey The record key that should be used to add the events.
      * @param eventName The name of the events to record.
      * @param count The number of events to add/subtract.
+     * @param subjectId The ID of the user that is adding the count.
      */
     async addCount(
         recordKey: string,
         eventName: string,
-        count: number
+        count: number,
+        subjectId: string,
     ): Promise<AddCountResult> {
         try {
             const result = await this._manager.validatePublicRecordKey(
@@ -46,6 +48,14 @@ export class EventRecordsController {
                     success: false,
                     errorCode: result.errorCode,
                     errorMessage: result.errorMessage,
+                };
+            }
+
+            if (!subjectId && result.policy !== 'subjectless') {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage: 'The user must be logged in in order to record events.',
                 };
             }
 

--- a/src/aux-records/FileRecordsController.ts
+++ b/src/aux-records/FileRecordsController.ts
@@ -37,6 +37,18 @@ export class FileRecordsController {
                 return keyResult;
             }
 
+            if (!userId && keyResult.policy !== 'subjectless') {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage: 'The user must be logged in in order to record files.',
+                };
+            }
+
+            if (keyResult.policy === 'subjectless') {
+                userId = null;
+            }
+
             const publisherId = keyResult.ownerId;
             const recordName = keyResult.recordName;
             const subjectId = userId;
@@ -125,9 +137,16 @@ export class FileRecordsController {
         }
     }
 
+    /**
+     * Attempts to erase the given file using the given record key and subject.
+     * @param recordKey The key that should be used to erase the file.
+     * @param fileName The name of the file.
+     * @param subjectId The ID of the user that is making this request.
+     */
     async eraseFile(
         recordKey: string,
-        fileName: string
+        fileName: string,
+        subjectId: string
     ): Promise<EraseFileResult> {
         try {
             const keyResult = await this._controller.validatePublicRecordKey(
@@ -136,6 +155,14 @@ export class FileRecordsController {
 
             if (keyResult.success === false) {
                 return keyResult;
+            }
+
+            if (!subjectId && keyResult.policy !== 'subjectless') {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage: 'The user must be logged in in order to erase files.',
+                };
             }
 
             const publisherId = keyResult.ownerId;

--- a/src/aux-records/MemoryRecordsStore.ts
+++ b/src/aux-records/MemoryRecordsStore.ts
@@ -1,7 +1,12 @@
-import { Record, RecordsStore } from './RecordsStore';
+import { Record, RecordKey, RecordsStore } from './RecordsStore';
 
 export class MemoryRecordsStore implements RecordsStore {
     private _records: Record[] = [];
+    private _recordKeys: RecordKey[] = [];
+
+    get recordKeys() {
+        return this._recordKeys;
+    }
 
     async getRecordByName(name: string): Promise<Record> {
         const record = this._records.find((r) => r.name === name);
@@ -24,5 +29,19 @@ export class MemoryRecordsStore implements RecordsStore {
         if (existingRecordIndex < 0) {
             this._records.push(record);
         }
+    }
+
+    async addRecordKey(key: RecordKey): Promise<void> {
+        const existingKeyIndex = this._recordKeys.findIndex(
+            (k) => k.recordName === key.recordName && k.secretHash === key.secretHash
+        );
+        if (existingKeyIndex < 0) {
+            this._recordKeys.push(key);
+        }
+    }
+
+    async getRecordKeyByRecordAndHash(recordName: string, hash: string): Promise<RecordKey> {
+        const key = this._recordKeys.find(k => k.recordName === recordName && k.secretHash == hash);
+        return key;
     }
 }

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -2,7 +2,9 @@ import { fromBase64String, toBase64String } from './Utils';
 import {
     CreatePublicRecordKeyFailure,
     CreatePublicRecordKeySuccess,
-    formatRecordKey,
+    DEFAULT_RECORD_KEY_POLICY,
+    formatV1RecordKey,
+    formatV2RecordKey,
     isRecordKey,
     parseRecordKey,
     RecordsController,
@@ -29,6 +31,7 @@ describe('RecordsController', () => {
         it('should return a value that contains the formatted record name and a random password', async () => {
             const result = (await manager.createPublicRecordKey(
                 'name',
+                'subjectfull',
                 'userId'
             )) as CreatePublicRecordKeySuccess;
 
@@ -37,9 +40,17 @@ describe('RecordsController', () => {
             expect(await store.getRecordByName('name')).toEqual({
                 name: 'name',
                 ownerId: 'userId',
-                secretHashes: [expect.any(String)],
+                secretHashes: [],
                 secretSalt: expect.any(String),
             });
+            expect(store.recordKeys).toEqual([
+                {
+                    recordName: 'name',
+                    secretHash: expect.any(String),
+                    policy: 'subjectfull',
+                    creatorId: 'userId'
+                }
+            ]);
         });
 
         it('should be able to add a key to an existing record', async () => {
@@ -51,6 +62,7 @@ describe('RecordsController', () => {
             });
             const result = (await manager.createPublicRecordKey(
                 'name',
+                'subjectless',
                 'userId'
             )) as CreatePublicRecordKeySuccess;
 
@@ -59,9 +71,48 @@ describe('RecordsController', () => {
             expect(await store.getRecordByName('name')).toEqual({
                 name: 'name',
                 ownerId: 'userId',
-                secretHashes: ['test', expect.any(String)],
+                secretHashes: ['test'],
                 secretSalt: 'salt',
             });
+            expect(store.recordKeys).toEqual([
+                {
+                    recordName: 'name',
+                    secretHash: expect.any(String),
+                    policy: 'subjectless',
+                    creatorId: 'userId'
+                }
+            ]);
+        });
+
+        it('should default to subjectfull records if a null policy is given', async () => {
+            await store.addRecord({
+                name: 'name',
+                ownerId: 'userId',
+                secretHashes: ['test'],
+                secretSalt: 'salt',
+            });
+            const result = (await manager.createPublicRecordKey(
+                'name',
+                null,
+                'userId'
+            )) as CreatePublicRecordKeySuccess;
+
+            expect(result.success).toBe(true);
+            expect(isRecordKey(result.recordKey)).toBe(true);
+            expect(await store.getRecordByName('name')).toEqual({
+                name: 'name',
+                ownerId: 'userId',
+                secretHashes: ['test'],
+                secretSalt: 'salt',
+            });
+            expect(store.recordKeys).toEqual([
+                {
+                    recordName: 'name',
+                    secretHash: expect.any(String),
+                    policy: 'subjectfull',
+                    creatorId: 'userId'
+                }
+            ]);
         });
 
         it('should return an error if the user id is different from the creator of the record', async () => {
@@ -73,6 +124,7 @@ describe('RecordsController', () => {
             });
             const result = (await manager.createPublicRecordKey(
                 'name',
+                'subjectfull',
                 'differentId'
             )) as CreatePublicRecordKeyFailure;
 
@@ -89,6 +141,7 @@ describe('RecordsController', () => {
             });
             const result = (await manager.createPublicRecordKey(
                 'name',
+                'subjectless',
                 'differentId'
             )) as CreatePublicRecordKeyFailure;
 
@@ -98,63 +151,304 @@ describe('RecordsController', () => {
                 expect.stringContaining('Test Error')
             );
         });
+        
+        it('should return an invalid_policy error if the given policy is not supported', async () => {
+            await store.addRecord({
+                name: 'name',
+                ownerId: 'userId',
+                secretHashes: ['test'],
+                secretSalt: 'salt',
+            });
+            const result = (await manager.createPublicRecordKey(
+                'name',
+                'wrongpolicy' as any,
+                'userId'
+            )) as CreatePublicRecordKeyFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('invalid_policy');
+            expect(result.errorMessage).toBe('The record key policy must be either "subjectfull" or "subjectless".');
+            expect(await store.getRecordByName('name')).toEqual({
+                name: 'name',
+                ownerId: 'userId',
+                secretHashes: ['test'],
+                secretSalt: 'salt',
+            });
+            expect(store.recordKeys).toEqual([]);
+        });
+
+        it('should return an not_logged_in error if the user id is null', async () => {
+            const result = (await manager.createPublicRecordKey(
+                'name',
+                'subjectfull',
+                null
+            )) as CreatePublicRecordKeyFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('not_logged_in');
+            expect(result.errorMessage).toBe(
+                'The user must be logged in in order to create a record key.'
+            );
+        });
     });
 
     describe('validatePublicRecordKey()', () => {
-        it('should return true if the given key is valid and is contained in the secret hashes of the record', async () => {
-            const salt = fromByteArray(randomBytes(16));
-            const hash1 = hashPasswordWithSalt('password1', salt);
-            const hash2 = hashPasswordWithSalt('password2', salt);
-            const hash3 = hashPasswordWithSalt('password3', salt);
-            store.addRecord({
-                name: 'name',
-                ownerId: 'userId',
-                secretHashes: [hash3, hash2, hash1],
-                secretSalt: salt,
-            });
-            const result = (await manager.validatePublicRecordKey(
-                formatRecordKey('name', 'password1')
-            )) as ValidatePublicRecordKeySuccess;
+        describe('v1 keys', () => {
+            it('should return true if the given key is valid and is contained in the secret hashes of the record', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [hash3, hash2, hash1],
+                    secretSalt: salt,
+                });
+                const result = (await manager.validatePublicRecordKey(
+                    formatV1RecordKey('name', 'password1')
+                )) as ValidatePublicRecordKeySuccess;
 
-            expect(result).toEqual({
-                success: true,
-                recordName: 'name',
-                ownerId: 'userId',
+                expect(result).toEqual({
+                    success: true,
+                    recordName: 'name',
+                    ownerId: 'userId',
+                    policy: 'subjectfull',
+                });
+            });
+
+            it('should return true if the given key is valid and is contained in the key store', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [],
+                    secretSalt: salt,
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash1,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash2,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash3,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                
+                const result = (await manager.validatePublicRecordKey(
+                    formatV1RecordKey('name', 'password1')
+                )) as ValidatePublicRecordKeySuccess;
+
+                expect(result).toEqual({
+                    success: true,
+                    recordName: 'name',
+                    ownerId: 'userId',
+                    policy: 'subjectfull',
+                });
+            });
+
+            it('should return false if given null', async () => {
+                const result = (await manager.validatePublicRecordKey(
+                    null
+                )) as ValidatePublicRecordKeyFailure;
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'invalid_record_key',
+                    errorMessage: 'Invalid record key.',
+                });
+            });
+
+            it('should return a general error if the store throws while getting a record', async () => {
+                store.getRecordByName = jest.fn(() => {
+                    throw new Error('Test Error');
+                });
+                const result = (await manager.validatePublicRecordKey(
+                    formatV1RecordKey('name', 'password1')
+                )) as ValidatePublicRecordKeyFailure;
+
+                expect(result.success).toBe(false);
+                expect(result.errorCode).toBe('server_error');
+                expect(result.errorMessage).toEqual(
+                    expect.stringContaining('Test Error')
+                );
             });
         });
 
-        it('should return false if given null', async () => {
-            const result = (await manager.validatePublicRecordKey(
-                null
-            )) as ValidatePublicRecordKeyFailure;
+        describe('v2 keys', () => {
+            it('should return true if the given key is valid and is contained in the secret hashes of the record', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [hash3, hash2, hash1],
+                    secretSalt: salt,
+                });
+                const result = (await manager.validatePublicRecordKey(
+                    formatV2RecordKey('name', 'password1', 'subjectfull')
+                )) as ValidatePublicRecordKeySuccess;
 
-            expect(result).toEqual({
-                success: false,
-                errorCode: 'invalid_record_key',
-                errorMessage: 'Invalid record key.',
+                expect(result).toEqual({
+                    success: true,
+                    recordName: 'name',
+                    ownerId: 'userId',
+                    policy: 'subjectfull',
+                });
             });
-        });
 
-        it('should return a general error if the store throws while getting a record', async () => {
-            store.getRecordByName = jest.fn(() => {
-                throw new Error('Test Error');
+            it('should return false if the given key is valid but has a non-default policy when it is contained in the secret hashes of the record', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [hash3, hash2, hash1],
+                    secretSalt: salt,
+                });
+                const result = (await manager.validatePublicRecordKey(
+                    formatV2RecordKey('name', 'password1', 'subjectless')
+                )) as ValidatePublicRecordKeySuccess;
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'invalid_record_key',
+                    errorMessage: 'Invalid record key.',
+                });
             });
-            const result = (await manager.validatePublicRecordKey(
-                formatRecordKey('name', 'password1')
-            )) as ValidatePublicRecordKeyFailure;
 
-            expect(result.success).toBe(false);
-            expect(result.errorCode).toBe('server_error');
-            expect(result.errorMessage).toEqual(
-                expect.stringContaining('Test Error')
-            );
+            it('should return true if the given key is valid and is contained in the key store', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [],
+                    secretSalt: salt,
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash1,
+                    policy: 'subjectless',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash2,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash3,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                
+                const result = (await manager.validatePublicRecordKey(
+                    formatV2RecordKey('name', 'password1', 'subjectless')
+                )) as ValidatePublicRecordKeySuccess;
+
+                expect(result).toEqual({
+                    success: true,
+                    recordName: 'name',
+                    ownerId: 'userId',
+                    policy: 'subjectless',
+                });
+            });
+
+            it('should return false if the given key is valid but does not have the correct policy', async () => {
+                const salt = fromByteArray(randomBytes(16));
+                const hash1 = hashPasswordWithSalt('password1', salt);
+                const hash2 = hashPasswordWithSalt('password2', salt);
+                const hash3 = hashPasswordWithSalt('password3', salt);
+                store.addRecord({
+                    name: 'name',
+                    ownerId: 'userId',
+                    secretHashes: [],
+                    secretSalt: salt,
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash1,
+                    policy: 'subjectless',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash2,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                store.addRecordKey({
+                    recordName: 'name',
+                    secretHash: hash3,
+                    policy: 'subjectfull',
+                    creatorId: 'userId',
+                });
+                
+                const result = (await manager.validatePublicRecordKey(
+                    formatV2RecordKey('name', 'password1', 'subjectfull')
+                )) as ValidatePublicRecordKeySuccess;
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'invalid_record_key',
+                    errorMessage: 'Invalid record key.',
+                });
+            });
+
+            it('should return false if given null', async () => {
+                const result = (await manager.validatePublicRecordKey(
+                    null
+                )) as ValidatePublicRecordKeyFailure;
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'invalid_record_key',
+                    errorMessage: 'Invalid record key.',
+                });
+            });
+
+            it('should return a general error if the store throws while getting a record', async () => {
+                store.getRecordByName = jest.fn(() => {
+                    throw new Error('Test Error');
+                });
+                const result = (await manager.validatePublicRecordKey(
+                    formatV2RecordKey('name', 'password1', 'subjectfull')
+                )) as ValidatePublicRecordKeyFailure;
+
+                expect(result.success).toBe(false);
+                expect(result.errorCode).toBe('server_error');
+                expect(result.errorMessage).toEqual(
+                    expect.stringContaining('Test Error')
+                );
+            });
         });
     });
 });
 
-describe('formatRecordKey()', () => {
+describe('formatV1RecordKey()', () => {
     it('should combine the given record name and password', () => {
-        const result = formatRecordKey('name', 'password');
+        const result = formatV1RecordKey('name', 'password');
 
         const [version, name, password] = result.split('.');
 
@@ -164,46 +458,120 @@ describe('formatRecordKey()', () => {
     });
 });
 
-describe('parseRecordKey()', () => {
-    it('should parse the given key into the name and password', () => {
-        const key = formatRecordKey('name', 'password');
-        const [name, password] = parseRecordKey(key);
+describe('formatV2RecordKey()', () => {
+    it('should combine the given record name and password and policy', () => {
+        const result = formatV2RecordKey('name', 'password', 'subjectless');
 
-        expect(name).toBe('name');
-        expect(password).toBe('password');
+        const split = result.split('.');
+
+        expect(split).toEqual(['vRK2', toBase64String('name'), toBase64String('password'), 'subjectless']);
     });
 
-    it('should return null if given an empty string', () => {
-        const result = parseRecordKey('');
+    it('should default to subjectfull policies', () => {
+        const result = formatV2RecordKey('name', 'password', null);
 
-        expect(result).toBe(null);
-    });
+        const split = result.split('.');
 
-    it('should return null if given a string with the wrong version', () => {
-        const result = parseRecordKey('vK1');
-
-        expect(result).toBe(null);
-    });
-
-    it('should return null if given a string with no data', () => {
-        const result = parseRecordKey('vRK1.');
-
-        expect(result).toBe(null);
-    });
-
-    it('should return null if given a string with no password', () => {
-        const result = parseRecordKey(`vRK1.${toBase64String('name')}`);
-
-        expect(result).toBe(null);
-    });
-
-    it('should return null if given a null key', () => {
-        const result = parseRecordKey(null);
-
-        expect(result).toBe(null);
+        expect(split).toEqual(['vRK2', toBase64String('name'), toBase64String('password'), 'subjectfull']);
     });
 });
 
-// describe('isRecordKey()', () => {
-//     it('should return true if ')
-// });
+describe('parseRecordKey()', () => {
+
+    describe('v1', () => {
+        it('should parse the given key into the name and password', () => {
+            const key = formatV1RecordKey('name', 'password');
+            const [name, password, policy] = parseRecordKey(key);
+    
+            expect(name).toBe('name');
+            expect(password).toBe('password');
+            expect(policy).toBe(DEFAULT_RECORD_KEY_POLICY); // Should always be the default policy
+        });
+
+        it('should return null if given an empty string', () => {
+            const result = parseRecordKey('');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with the wrong version', () => {
+            const result = parseRecordKey('vK1');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with no data', () => {
+            const result = parseRecordKey('vRK1.');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with no password', () => {
+            const result = parseRecordKey(`vRK1.${toBase64String('name')}`);
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a null key', () => {
+            const result = parseRecordKey(null);
+    
+            expect(result).toBe(null);
+        });
+    });
+
+    describe('v2', () => {
+        it('should parse the given key into the name and password', () => {
+            const key = formatV2RecordKey('name', 'password', 'subjectless');
+            const [name, password, policy] = parseRecordKey(key);
+    
+            expect(name).toBe('name');
+            expect(password).toBe('password');
+            expect(policy).toBe('subjectless');
+        });
+
+        it('should return null if given an empty string', () => {
+            const result = parseRecordKey('');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with the wrong version', () => {
+            const result = parseRecordKey('vK2');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with no data', () => {
+            const result = parseRecordKey('vRK2.');
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a string with no password', () => {
+            const result = parseRecordKey(`vRK2.${toBase64String('name')}`);
+    
+            expect(result).toBe(null);
+        });
+
+        it('should return null if given a string with no policy', () => {
+            const result = parseRecordKey(`vRK2.${toBase64String('name')}.${toBase64String('password')}`);
+    
+            expect(result).toBe(null);
+        });
+
+        it('should return null if given a string with an unknown policy', () => {
+            const result = parseRecordKey(`vRK2.${toBase64String('name')}.${toBase64String('password')}.wrong`);
+    
+            expect(result).toBe(null);
+        });
+    
+        it('should return null if given a null key', () => {
+            const result = parseRecordKey(null);
+    
+            expect(result).toBe(null);
+        });
+    });
+
+    
+});
+

--- a/src/aux-records/RecordsStore.ts
+++ b/src/aux-records/RecordsStore.ts
@@ -19,6 +19,19 @@ export interface RecordsStore {
      * @param name The name of the record.
      */
     getRecordByName(name: string): Promise<Record>;
+
+    /**
+     * Adds the given record key to the store.
+     * @param key The key to add.
+     */
+    addRecordKey(key: RecordKey): Promise<void>;
+
+    /**
+     * Gets the record key for the given record name that has the given hash.
+     * @param recordName The name of the record.
+     * @param hash The scrypt hash of the key that should be retrieved.
+     */
+    getRecordKeyByRecordAndHash(recordName: string, hash: string): Promise<RecordKey>;
 }
 
 /**
@@ -47,4 +60,38 @@ export interface Record {
      * it is fine because there are very few secrets per salt (i.e. not 1 salt per million users but 1 salt per couple record keys) and the secrets are randomly generated.
      */
     secretSalt: string;
+}
+
+
+/**
+ * Defines a type that represents the different kinds of policies that a record key can have.
+ * 
+ * - null and "subjectfull" indicate that actions performed with this key must require a subject to provide their access token in order for operations to succeed.
+ * - "subjectless" indicates that actions may be performed with key despite not having an access key from a subject.
+ */
+export type PublicRecordKeyPolicy = null | 'subjectfull' | 'subjectless';
+
+/**
+ * Defines an interface for record key objects.
+ */
+export interface RecordKey {
+    /**
+     * The name of the record that the key is for.
+     */
+    recordName: string;
+
+    /**
+     * The scrypt hash of the secret that this key is for.
+     */
+    secretHash: string;
+
+    /**
+     * The policy that the key uses.
+     */
+    policy: PublicRecordKeyPolicy;
+
+    /**
+     * The ID of the user that created this key.
+     */
+    creatorId: string;
 }

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.ts
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.ts
@@ -19,6 +19,7 @@ import {
 import {
     CreatePublicRecordKeyResult,
     parseRecordKey,
+    PublicRecordKeyPolicy,
 } from '@casual-simulation/aux-records';
 
 @Component({
@@ -30,6 +31,7 @@ export default class RecordsUI extends Vue {
 
     showRequestPublicRecord: boolean = false;
     requestRecordName: string = '';
+    requestRecordPolicy: PublicRecordKeyPolicy = null;
 
     showAllowRecordData: boolean = false;
     allowRecordName: string = '';
@@ -179,6 +181,7 @@ export default class RecordsUI extends Vue {
                 if (e.type === 'get_public_record_key') {
                     this.showRequestPublicRecord = true;
                     this.requestRecordName = e.recordName;
+                    this.requestRecordPolicy = e.policy;
                     this._requestRecordTaskId = e.taskId;
                     this._requestRecordSimulation = sim;
                     this.$emit('visible');
@@ -272,7 +275,7 @@ export default class RecordsUI extends Vue {
         this._hideCreateRecordKey();
 
         if (taskId && sim) {
-            const result = await sim.auth.primary.createPublicRecordKey(recordName);
+            const result = await sim.auth.primary.createPublicRecordKey(recordName, this.requestRecordPolicy);
             sim.helper.transaction(asyncResult(taskId, result));
         }
     }

--- a/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/RecordsUI/RecordsUI.vue
@@ -7,7 +7,7 @@
             class="input-dialog"
         >
             <md-dialog-content class="input-dialog-content">
-                <p>Do you want to create a record key for "{{ requestRecordName }}"?</p>
+                <p>Do you want to create a {{ requestRecordPolicy }} record key for "{{ requestRecordName }}"?</p>
             </md-dialog-content>
             <md-dialog-actions>
                 <md-button class="md-primary" @click="createRecordKey(requestRecordName)"

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -8,7 +8,7 @@ import {
 import { setupChannel, waitForLoad } from '../html/IFrameHelpers';
 import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { AuthData, hasValue } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { CreatePublicRecordKeyResult, parseRecordKey, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
 
 // Save the query string that was used when the site loaded
 const query = typeof location !== 'undefined' ? location.search : null;
@@ -218,7 +218,8 @@ export class AuthEndpointHelper implements AuthHelperInterface {
     }
 
     async createPublicRecordKey(
-        recordName: string
+        recordName: string,
+        policy: PublicRecordKeyPolicy
     ): Promise<CreatePublicRecordKeyResult> {
         if (!hasValue(this._origin)) {
             return {
@@ -230,7 +231,16 @@ export class AuthEndpointHelper implements AuthHelperInterface {
         if (!this._initialized) {
             await this._init();
         }
-        return await this._proxy.createPublicRecordKey(recordName);
+        return await this._proxy.createPublicRecordKey(recordName, policy);
+    }
+
+    async getRecordKeyPolicy(recordKey: string): Promise<PublicRecordKeyPolicy> {
+        const keyInfo = parseRecordKey(recordKey);
+        if (!keyInfo) {
+            return null;
+        }
+        const [name, secret, policy] = keyInfo;
+        return policy;
     }
 
     async getAuthToken(): Promise<string> {

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -1,5 +1,5 @@
 import { AuthData } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { CreatePublicRecordKeyResult, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
 
 /**
  * Defines an interface that represents the login state of the user.
@@ -85,9 +85,11 @@ export interface AuxAuth {
     /**
      * Gets a record key for the given record.
      * @param recordName The name of the record.
+     * @param policy The policy that the record should have. Only supported on protocol version 5 or more.
      */
     createPublicRecordKey(
-        recordName: string
+        recordName: string,
+        policy?: PublicRecordKeyPolicy
     ): Promise<CreatePublicRecordKeyResult>;
 
     /**

--- a/src/aux-vm/managers/AuthHelperInterface.ts
+++ b/src/aux-vm/managers/AuthHelperInterface.ts
@@ -1,5 +1,5 @@
 import { AuthData } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult } from '@casual-simulation/aux-records';
+import { CreatePublicRecordKeyResult, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
 import { Observable, SubscriptionLike } from 'rxjs';
 import { LoginStatus, LoginUIStatus } from '../auth/AuxAuth';
 
@@ -59,7 +59,8 @@ export interface AuthHelperInterface extends SubscriptionLike {
      * @param recordName The name of the record that the key should be created for.
      */
     createPublicRecordKey(
-        recordName: string
+        recordName: string,
+        policy: PublicRecordKeyPolicy,
     ): Promise<CreatePublicRecordKeyResult>;
 
     /**
@@ -94,4 +95,10 @@ export interface AuthHelperInterface extends SubscriptionLike {
      * Cancels the current login if it is using the custom UI flow.
      */
     cancelLogin(): Promise<void>;
+
+    /**
+     * Gets the policy for the given record key.
+     * @param recordKey The record key.
+     */
+    getRecordKeyPolicy(recordKey: string): Promise<PublicRecordKeyPolicy>;
 }


### PR DESCRIPTION
### :rocket: Improvements
-   Added the `os.getSubjectlessPublicRecordKey(recordName)` function to make it possible to create a record key that allow publishing record data without being logged in.
    -   All record keys are now split into two categories: subjectfull keys and subjectless keys.
    -   subjectfull keys require login in order to publish data are are the default type of key.
    -   subjectless keys do not require login in order to publish data.
    -   When publishing data with a subjectless key, all users are treated as anonymous. In effect, this makes the owner of the record fully responsible for the content that they publish.