### PR TITLE
Added os.meetFunction(), @onMeetEntered, @onMeetExited, and meetPortalJWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
     -   subjectfull keys require login in order to publish data are are the default type of key.
     -   subjectless keys do not require login in order to publish data.
     -   When publishing data with a subjectless key, all users are treated as anonymous. In effect, this makes the owner of the record fully responsible for the content that they publish.
+-   Added the `os.meetFunction(functionName, ...args)` function to allow querying the current meet portal meeting state.
+    -   `functionName` is the name of the function that should be triggered from the [Jitsi Meet API](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#functions).
+    -   `args` is the list of arguments that should be provided to the function.
+    -   Returns a promise that resolves with the result of the function call.
+-   Added the `@onMeetEntered` and `@onMeetExited` shouts which are triggered whenever the current user starts/stops participating in a meet.
+    -   Unlike `@onMeetLoaded`, `@onMeetEntered` is only triggered after the user clicks the "Join" button from the meeting waiting room.
+    -   See the documentation for more detailed information.
+-   Added the `meetPortalJWT` tag to the meetPortalBot to allow using JSON Web Tokens for authenticating moderators in meetings.
+    -   See the Jitsi FAQ for more information on how to setup a moderator for a meeting: https://developer.8x8.com/jaas/docs/faq#how-can-i-set-a-user-as-moderator-for-a-meeting
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -5489,6 +5489,23 @@ os.meetCommand('displayName', 'ABC123');
 os.meetCommand('hangup')
 ```
 
+### `os.meetFunction(functionName, ...args)`
+
+Executes the given function on the Jitsi Meet API and returns a promise that resolves with the result.
+The functions are only valid if the meet portal is fully loaded (see <TagLink tag='@onMeetLoaded'/>).
+
+A full list of functions can be found here in the [Jitsi Meet Handbook](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#functions).
+
+#### Examples:
+
+```typescript title='Get a list of all the participants.'
+const participants = await os.meetFunction('getParticipantsInfo')
+```
+
+```typescript title='Get a list of available breakout rooms.'
+const rooms = await os.meetFunction('listBreakoutRooms');
+```
+
 ## Debug Actions
 
 

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -1316,7 +1316,10 @@ let that: {
 
 ### `@onMeetLoaded`
 
-A shout that is sent when the user finishes loading the meet portal.  
+A shout that is sent when the meet portal finishes loading.
+Note that when this shout is sent, the user may not actually be in the meeting. They simply be in the meeting waiting area and not actually in the meeting.
+If you want notification when the user has become a participant in a meeting, use <TagLink tag='@onMeetEntered'/>.
+
 It is safe to run <ActionLink action='os.meetCommand(command, ...args)'/> after this shout has been received.
 
 #### Arguments:
@@ -1331,7 +1334,7 @@ let that: {
 
 ### `@onMeetLeave`
 
-A shout that is sent when the user leaves the meet portal.
+A shout that is sent when the meet portal is closed.
 
 #### Arguments:
 ```typescript
@@ -1341,6 +1344,47 @@ let that: {
      */
     roomName: string;
 }
+```
+
+### `@onMeetEntered`
+
+A shout that is sent when the user enters a meet portal meeting.
+Unlike <TagLink tag='@onMeetLoaded'/>, this listener is triggered only when the user becomes an active participant in a meeting. That is, after they've clicked the "join" button to enter the meeting.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The name of the room that the user joined.
+     * Note that this may be different from the meetPortal since a meeting can contain several breakout rooms.
+     */
+    roomName: string;
+
+    /**
+     * The ID of the participant that was created for the user.
+     */
+    participantId: string;
+
+    /**
+     * Whether the room that the user has joined is a breakout room.
+     */
+    isBreakoutRoom: boolean;
+};
+```
+
+### `@onMeetExited`
+
+A shout that is sent when the user exits a meet portal meeting.
+Unlike <TagLink tag='@onMeetLeave'/>, this listener may be triggered if the user exits a breakout room and re-enters the main meeting room.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The name of the room that the user exited.
+     */
+    roomName: string;
+};
 ```
 
 ### `@onRemoteData`

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -1933,6 +1933,25 @@ Whether the meet portal should require the user define a display name.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `meetPortalJWT`
+<Badges>
+    <MeetPortalBadge/>
+</Badges>
+
+The JSON Web Token (JWT) that should be used to join the meeting.
+Used to give the current user moderator permissions.
+
+#### Possible Values are:
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    The user will be a normal user in the meet portal. (Default)
+  </PossibleValueCode>
+  <PossibleValue value='Any String'>
+    The user will use the JWT for authentication in the meet portal.
+    Depending on the settings used to create the JWT, this may make the user a moderator.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `tagPortalAnchorPoint`
 <Badges>
     <TagPortalBadge/>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1626,6 +1626,16 @@ export const ON_MEET_LOADED: string = 'onMeetLoaded';
 export const ON_MEET_LEAVE: string = 'onMeetLeave';
 
 /**
+ * The name of the event that is triggered when the user has entered a meet.
+ */
+export const ON_MEET_ENTERED: string = 'onMeetEntered';
+
+/**
+ * The name of the event that is triggered when the user has exited a meet.
+ */
+export const ON_MEET_EXITED: string = 'onMeetExited';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -2153,6 +2163,8 @@ export const KNOWN_TAGS: string[] = [
     ON_EXIT_AR,
     ON_MEET_LOADED,
     ON_MEET_LEAVE,
+    ON_MEET_ENTERED,
+    ON_MEET_EXITED,
 ];
 
 export function onClickArg(face: string, dimension: string) {

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1967,6 +1967,7 @@ export const KNOWN_TAGS: string[] = [
     'meetPortalStartWithVideoMuted',
     'meetPortalStartWithAudioMuted',
     'meetPortalRequireDisplayName',
+    'meetPortalJWT',
     'mapPortalBasemap',
 
     'tagPortalAnchorPoint',

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -220,7 +220,8 @@ export type AsyncActions =
     | VRSupportedAction
     | MediaPermissionAction
     | GetAverageFrameRateAction
-    | OpenImageClassifierAction;
+    | OpenImageClassifierAction
+    | MeetFunctionAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -2985,6 +2986,23 @@ export interface MeetCommandAction extends Action {
 
     /**
      * The arguments for the command (if any).
+     */
+    args?: any[];
+}
+
+/**
+ * An event that is used to call Jitsi Meet functions.
+ */
+export interface MeetFunctionAction extends AsyncAction {
+    type: 'meet_function';
+
+    /**
+     * The name of the function to execute.
+     */
+    functionName: string;
+
+    /**
+     * The arguments for the function (if any).
      */
     args?: any[];
 }
@@ -5937,7 +5955,8 @@ export function endRecording(taskId?: string | number): EndRecordingAction {
 
 /**
  * Creates a MeetCommandAction.
- * @param options The options that should be used.
+ * @param command The name of the command to execute.
+ * @param args The arguments for the command.
  */
 export function meetCommand(
     command: string,
@@ -5947,6 +5966,21 @@ export function meetCommand(
         type: 'meet_command',
         command,
         args,
+    };
+}
+
+/**
+ * Creates a MeetFunctionAction.
+ * @param functionName The name of the function.
+ * @param args The arguments for the function.
+ * @param taskId The ID of the async task.
+ */
+export function meetFunction(functionName: string, args: any[], taskId?: string | number): MeetFunctionAction {
+    return {
+        type: 'meet_function',
+        functionName,
+        args,
+        taskId
     };
 }
 

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -179,6 +179,7 @@ import {
     DATE_TAG_PREFIX,
     getAverageFrameRate,
     addDropGrid,
+    meetFunction,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -9173,6 +9174,16 @@ describe('AuxLibrary', () => {
                     'world'
                 );
                 expect(action.args).toEqual(['hello', 'world']);
+            });
+        });
+
+        describe('os.meetFunction()', () => {
+            it('should issue a MeetFunctionAction', () => {
+                const action: any = library.api.os.meetFunction('myFunction', 'arg1', 123, true);
+                const expected = meetFunction('myFunction', ['arg1', 123, true], context.tasks.size);
+
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -256,6 +256,7 @@ import {
     eraseFile as calcEraseFile,
     meetCommand as calcMeetCommand,
     MeetCommandAction,
+    meetFunction as calcMeetFunction,
     listDataRecord,
     recordEvent as calcRecordEvent,
     getEventCount as calcGetEventCount,
@@ -1270,6 +1271,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 endAudioRecording,
 
                 meetCommand,
+                meetFunction,
 
                 get vars() {
                     return context.global;
@@ -5494,11 +5496,24 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
     /**
      * Sends commands to the Jitsi Meet API.
+     * See https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#commands for a list of commands.
      * @param command The command to execute.
      * @param args The args for the command (if any).
      */
     function meetCommand(command: string, ...args: any): MeetCommandAction {
         return addAction(calcMeetCommand(command, ...args));
+    }
+
+    /**
+     * Executes the given function from the Jitsi Meet API and returns a promise with the result.
+     * See https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#functions for a list of functions.
+     * @param functionName The name of the function to execute.
+     * @param args The arguments to provide to the function.
+     */
+    function meetFunction(functionName: string, ...args: any[]): Promise<any> {
+        const task = context.createTask();
+        const action = calcMeetFunction(functionName, args, task.taskId);
+        return addAsyncAction(task, action);
     }
 
     /**

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8062,10 +8062,19 @@ interface Os {
 
     /**
      * Sends a command to the Jitsi Meet API.
+     * See https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#commands for a list of commands.
      * @param command The name of the command to execute.
      * @param args The arguments for the command (if any).
      */
     meetCommand(command: string, ...args: any[]): MeetCommandAction;
+
+    /**
+     * Executes the given function from the Jitsi Meet API and returns a promise with the result.
+     * See https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#functions for a list of functions.
+     * @param functionName The name of the function to execute.
+     * @param args The arguments to provide to the function.
+     */
+    meetFunction(functionName: string, ...args: any[]): Promise<any>;
 
     /**
      * Shows a QR Code that contains a link to a inst and dimension.

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiMeet.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { EventEmitter } from 'events';
 import { Prop, Watch } from 'vue-property-decorator';
 import { EventBus } from '@casual-simulation/aux-components';
+import { JitsiMeetExternalAPIOptions, JitsiApi, JitsiParticipant, JitsiVideoConferenceJoinedEvent, JitsiVideoConferenceLeftEvent } from './JitsiTypes';
 
 declare var JitsiMeetExternalAPI: {
     new (domain: string, options: JitsiMeetExternalAPIOptions): JitsiApi;
@@ -28,6 +28,10 @@ export default class JitsiMeet extends Vue {
 
     private _jitsiApi: JitsiApi;
     private _removedJitsi: boolean;
+
+    api() {
+        return this._jitsiApi;
+    }
 
     mounted() {
         this._loadScript('https://8x8.vc/external_api.js', () => {
@@ -71,6 +75,14 @@ export default class JitsiMeet extends Vue {
         this._jitsiApi.on('readyToClose', () => {
             this.$emit('closed');
         });
+
+        this._jitsiApi.on('videoConferenceJoined', (e: JitsiVideoConferenceJoinedEvent) => {
+            this.$emit('videoConferenceJoined', e);
+        });
+
+        this._jitsiApi.on('videoConferenceLeft', (e: JitsiVideoConferenceLeftEvent) => {
+            this.$emit('videoConferenceLeft', e);
+        });
     }
 
     private _removeJitsiWidget() {
@@ -87,29 +99,4 @@ export default class JitsiMeet extends Vue {
         document.querySelector('head').appendChild(scriptEl);
         scriptEl.addEventListener('load', cb);
     }
-}
-
-interface JitsiMeetExternalAPIOptions {
-    roomName?: string;
-    userInfo?: JitsiParticipant;
-    invitees?: JitsiParticipant[];
-    devices?: any;
-    onload?: () => void;
-    width?: number | string;
-    height?: number | string;
-    parentNode?: Element;
-    configOverwrite?: any;
-    interfaceConfigOverwrite?: any;
-    noSSL?: boolean;
-    jwt?: any;
-}
-
-interface JitsiParticipant {
-    email: string;
-    displayName: string;
-}
-
-interface JitsiApi extends EventEmitter {
-    executeCommand(command: string, ...args: any): void;
-    dispose(): void;
 }

--- a/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiTypes.ts
+++ b/src/aux-server/aux-web/shared/vue-components/JitsiMeet/JitsiTypes.ts
@@ -1,0 +1,38 @@
+import type { EventEmitter } from 'events';
+
+export interface JitsiMeetExternalAPIOptions {
+    roomName?: string;
+    userInfo?: JitsiParticipant;
+    invitees?: JitsiParticipant[];
+    devices?: any;
+    onload?: () => void;
+    width?: number | string;
+    height?: number | string;
+    parentNode?: Element;
+    configOverwrite?: any;
+    interfaceConfigOverwrite?: any;
+    noSSL?: boolean;
+    jwt?: any;
+}
+
+export interface JitsiParticipant {
+    email: string;
+    displayName: string;
+}
+
+export interface JitsiApi extends EventEmitter {
+    executeCommand(command: string, ...args: any): void;
+    dispose(): void;
+}
+
+export interface JitsiVideoConferenceJoinedEvent {
+    roomName: string;
+    id: string;
+    displayName: string;
+    avatarURL: string;
+    breakoutRoom: boolean;
+}
+
+export interface JitsiVideoConferenceLeftEvent {
+    roomName: string;
+}

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -8,6 +8,12 @@ import {
     calculateMeetPortalAnchorPointOffset,
     ON_MEET_LEAVE,
     ON_MEET_LOADED,
+    asyncError,
+    MeetFunctionAction,
+    asyncResult,
+    action,
+    ON_MEET_ENTERED,
+    ON_MEET_EXITED,
 } from '@casual-simulation/aux-common';
 import { appManager } from '../../AppManager';
 import { Subscription } from 'rxjs';
@@ -19,6 +25,7 @@ import {
 } from '@casual-simulation/aux-vm-browser';
 import { MeetPortalConfig } from './MeetPortalConfig';
 import { EventBus } from '@casual-simulation/aux-components';
+import { JitsiVideoConferenceJoinedEvent, JitsiVideoConferenceLeftEvent } from '../JitsiMeet/JitsiTypes';
 
 @Component({
     components: {
@@ -181,6 +188,24 @@ export default class MeetPortal extends Vue {
         }
     }
 
+    onMeetJoined(e: JitsiVideoConferenceJoinedEvent) {
+        if (this._currentSim) {
+            this._currentSim.helper.action(ON_MEET_ENTERED, null, {
+                roomName: e.roomName,
+                participantId: e.id,
+                isBreakoutRoom: e.breakoutRoom,
+            });
+        }
+    }
+
+    onMeetLeft(e: JitsiVideoConferenceLeftEvent) {
+        if (this._currentSim) {
+            this._currentSim.helper.action(ON_MEET_EXITED, null, {
+                roomName: e.roomName,
+            });
+        }
+    }
+
     private _resize(): any {
         if (!this.portalElement || !this.othersElement) {
             return;
@@ -274,9 +299,35 @@ export default class MeetPortal extends Vue {
             sim.localEvents.subscribe((e) => {
                 if (e.type === 'meet_command') {
                     EventBus.$emit('jitsiCommand', e.command, ...e.args);
+                } else if(e.type === 'meet_function') {
+                    this._executeFunction(sim, e);
                 }
             })
         );
+    }
+
+    private async _executeFunction(sim: BrowserSimulation, event: MeetFunctionAction) {
+        const jitsi = this._jitsiMeet()?.api();
+        if (jitsi) {
+            const jitsiPrototype = Object.getPrototypeOf(jitsi);
+            const prop = (jitsi as any)[event.functionName];
+            if (jitsiPrototype.hasOwnProperty(event.functionName) && typeof prop === 'function') {
+                try {
+                    const result = await prop.call(jitsi, ...event.args);
+                    if (hasValue(event.taskId)) {
+                        sim.helper.transaction(asyncResult(event.taskId, result, false));
+                    }
+                } catch (err) {
+                    if (hasValue(event.taskId)) {
+                        sim.helper.transaction(asyncError(event.taskId, err.toString()));
+                    }
+                }
+            } else if(hasValue(event.taskId)) {
+                sim.helper.transaction(asyncError(event.taskId, 'The given function name does not reference a Jitsi function.'));
+            }
+        } else if (hasValue(event.taskId)) {
+            sim.helper.transaction(asyncError(event.taskId, 'The meet portal is not open.'));
+        }
     }
 
     private _onSimulationRemoved(sim: BrowserSimulation) {
@@ -364,5 +415,9 @@ export default class MeetPortal extends Vue {
             this.extraStyle =
                 calculateMeetPortalAnchorPointOffset('fullscreen');
         }
+    }
+
+    private _jitsiMeet(): JitsiMeet {
+        return this.$refs.jitsiMeet as JitsiMeet;
     }
 }

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.ts
@@ -42,6 +42,7 @@ export default class MeetPortal extends Vue {
     currentMeet: string = null;
     extraStyle: Object = {};
     portalVisible: boolean = true;
+    meetJwt: string = null;
 
     get hasPortal(): boolean {
         return hasValue(this.currentMeet);
@@ -55,6 +56,7 @@ export default class MeetPortal extends Vue {
                     : `${appManager.config.jitsiAppName}/${this.currentMeet}`,
             interfaceConfigOverwrite: this.interfaceConfig,
             configOverwrite: this.config,
+            jwt: this.meetJwt,
             onload: () => {
                 if (this._currentSim) {
                     this._currentSim.helper.action(ON_MEET_LOADED, null, {
@@ -409,11 +411,13 @@ export default class MeetPortal extends Vue {
         if (this._currentConfig) {
             this.portalVisible = this._currentConfig.visible;
             this.extraStyle = this._currentConfig.style;
+            this.meetJwt = this._currentConfig.meetJwt;
             this._resize();
         } else {
             this.portalVisible = true;
             this.extraStyle =
                 calculateMeetPortalAnchorPointOffset('fullscreen');
+            this.meetJwt = null;
         }
     }
 

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortal.vue
@@ -6,7 +6,7 @@
             :class="{ invisible: !portalVisible }"
             :style="extraStyle"
         >
-            <jitsi-meet v-if="hasPortal" :options="jitsiOptions" @closed="onClose" />
+            <jitsi-meet ref="jitsiMeet" v-if="hasPortal" :options="jitsiOptions" @closed="onClose" @videoConferenceJoined="onMeetJoined" @videoConferenceLeft="onMeetLeft" />
         </div>
         <div ref="otherContainer" class="other-container">
             <slot></slot>

--- a/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/MeetPortal/MeetPortalConfig.ts
@@ -7,6 +7,7 @@ import {
     getBotMeetPortalAnchorPointOffset,
     DEFAULT_MEET_PORTAL_ANCHOR_POINT,
     calculateMeetPortalAnchorPointOffset,
+    calculateStringTagValue,
 } from '@casual-simulation/aux-common';
 import {
     BrowserSimulation,
@@ -28,6 +29,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     private _startWithVideoMuted: boolean;
     private _startWithAudioMuted: boolean;
     private _requireDisplayName: boolean;
+    private _meetJwt: string;
     private _updated: Subject<void>;
 
     /**
@@ -97,6 +99,17 @@ export class MeetPortalConfig implements SubscriptionLike {
         }
     }
 
+    /**
+     * Gets the JWT that was set for the meet portal.
+     */
+    get meetJwt(): string {
+        if(hasValue(this._meetJwt)) {
+            return this._meetJwt;
+        } else {
+            return null;
+        }
+    }
+
     unsubscribe(): void {
         this._sub.unsubscribe();
     }
@@ -135,6 +148,7 @@ export class MeetPortalConfig implements SubscriptionLike {
     protected _clearPortalValues() {
         this._visible = null;
         this._style = null;
+        this._meetJwt = null;
         this._updated.next();
     }
 
@@ -195,6 +209,8 @@ export class MeetPortalConfig implements SubscriptionLike {
             'meetPortalRequireDisplayName',
             null
         );
+
+        this._meetJwt = calculateStringTagValue(calc, bot, 'meetPortalJWT', null);
 
         this._updated.next();
     }


### PR DESCRIPTION
-   Added the `os.meetFunction(functionName, ...args)` function to allow querying the current meet portal meeting state.
    -   `functionName` is the name of the function that should be triggered from the [Jitsi Meet API](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/#functions).
    -   `args` is the list of arguments that should be provided to the function.
    -   Returns a promise that resolves with the result of the function call.
-   Added the `@onMeetEntered` and `@onMeetExited` shouts which are triggered whenever the current user starts/stops participating in a meet.
    -   Unlike `@onMeetLoaded`, `@onMeetEntered` is only triggered after the user clicks the "Join" button from the meeting waiting room.
    -   See the documentation for more detailed information.
-   Added the `meetPortalJWT` tag to the meetPortalBot to allow using JSON Web Tokens for authenticating moderators in meetings.
    -   See the Jitsi FAQ for more information on how to setup a moderator for a meeting: https://developer.8x8.com/jaas/docs/faq#how-can-i-set-a-user-as-moderator-for-a-meeting