### PR TITLE
Implement Update/Delete Policies for Data Records

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx pretty-quick --staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 -   Improved the Records API to be able to return errors to allowed HTTP origins.
 -   Improved `os.meetCommand()` to return a promise.
 
+### :bug: Bug Fixes
+
+-   Fixed an issue where CasualOS would attempt to download records from the wrong origin if using a custom `endpoint` parameter.
+
 ## V3.0.9
 
 #### Date: 4/27/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@
 
 -   Improved the Records API to be able to return errors to allowed HTTP origins.
 -   Improved `os.meetCommand()` to return a promise.
+-   Added the ability to specify an options object with `os.recordData(key, address, data, options)` that can specify update and delete policies for the data.
+
+    -   These policies can be useful to restrict the set of users that can manipulate the recorded data.
+    -   `options` is an object with the following properties:
+
+        ```typescript
+        let options: {
+            /**
+             * The HTTP Endpoint that should be queried.
+             */
+            endpoint?: string;
+
+            /**
+             * The policy that should be used for updating the record.
+             * - true indicates that the value can be updated by anyone.
+             * - An array of strings indicates the list of user IDs that are allowed to update the data.
+             */
+            updatePolicy?: true | string[];
+
+            /**
+             * The policy that should be used for deleting the record.
+             * - true indicates that the value can be erased by anyone.
+             * - An array of strings indicates the list of user IDs that are allowed to delete the data.
+             * Note that even if a delete policy is used, the owner of the record can still erase any data in the record.
+             */
+            deletePolicy?: true | string[];
+        };
+        ```
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -1982,7 +1982,7 @@ const isRecordKey = os.isRecordKey(tags.myRecordKey);
 os.toast(tags.myRecordKey ' is ' + (isRecordKey ? 'a' : 'not a') + ' record key.');
 ```
 
-### `os.recordData(recordKey, address, data, endpoint?)`
+### `os.recordData(recordKey, address, data, optionsOrEndpoint?)`
 
 Stores the given <GlossaryRef term='data-record'>data</GlossaryRef> in the given <GlossaryRef term='record'>record</GlossaryRef> at the given address.
 If data already exists at the given address, it will be overwritten.
@@ -1996,7 +1996,27 @@ The **second parameter** is the address that the data should be stored at.
 The **third parameter** is the data that should be stored. This can be any value that can be serialized to JSON.
 Must be less than 300KB in size. If you need to store data larger than 300KB, you can use <ActionLink action='os.recordFile(recordKey, fileData, options?, endpoint?)' /> instead.
 
-The **fourth parameter** is optional and is the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
+The **fourth parameter** is optional and is the options that should be used to record the data. It has the following structure:
+
+```typescript
+let options: {
+    /**
+     * The HTTP Endpoint that should be queried.
+     */
+    endpoint?: string;
+
+    /**
+     * The policy that should be used for updating the record.
+     */
+    updatePolicy?: RecordUserPolicyType;
+
+    /**
+     * The policy that should be used for deleting the record.
+     */
+    deletePolicy?: RecordUserPolicyType;
+}
+```
+Alternatively, it can be the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.
 Note that when using a custom endpoint, the record key must be a valid record key for that endpoint.
 
 The returned object has the following structure:
@@ -2281,14 +2301,14 @@ while(true) {
 }
 ```
 
-### `os.recordManualApprovalData(recordKey, address, data, endpoint?)`
+### `os.recordManualApprovalData(recordKey, address, data, optionsOrEndpoint?)`
 
 Stores the given <GlossaryRef term='manual-approval-data-record'>manual approval data</GlossaryRef> in the given <GlossaryRef term='record'>record</GlossaryRef> at the given address.
 If data already exists at the given address, it will be overwritten.
 
 Returns a promise that resolves with an object that indicates if the request was successful.
 
-Works the same as <ActionLink action='os.recordData(recordKey, address, data, endpoint?)'/> except that manual approval data records require the user to allow the operation manually.
+Works the same as <ActionLink action='os.recordData(recordKey, address, data, optionsOrEndpoint?)'/> except that manual approval data records require the user to allow the operation manually.
 
 ### `os.eraseManualApprovalData(recordKey, address,  endpoint?)`
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -2007,13 +2007,18 @@ let options: {
 
     /**
      * The policy that should be used for updating the record.
+     * - true indicates that the value can be updated by anyone.
+     * - An array of strings indicates the list of user IDs that are allowed to update the data.
      */
-    updatePolicy?: RecordUserPolicyType;
+    updatePolicy?: true | string[];
 
     /**
      * The policy that should be used for deleting the record.
+     * - true indicates that the value can be erased by anyone.
+     * - An array of strings indicates the list of user IDs that are allowed to delete the data.
+     * Note that even if a delete policy is used, the owner of the record can still erase any data in the record.
      */
-    deletePolicy?: RecordUserPolicyType;
+    deletePolicy?: true | string[];
 }
 ```
 Alternatively, it can be the HTTP Endpoint of the records website that the data should be recorded to. If omitted, then the preconfigured records endpoint will be used.

--- a/docs/docs/glossary/DataRecord.mdx
+++ b/docs/docs/glossary/DataRecord.mdx
@@ -9,5 +9,5 @@ Data records are most useful for storing relatively lightweight information that
 #### See Also
 
 -   <GlossaryRef term='record'>Record</GlossaryRef>
--   <ActionLink action='os.recordData(recordKey, address, data, endpoint?)' />
+-   <ActionLink action='os.recordData(recordKey, address, data, optionsOrEndpoint?)' />
 -   <ActionLink action='os.getData(recordKeyOrName, address, endpoint?)' />

--- a/docs/docs/glossary/ManualApprovalDataRecord.mdx
+++ b/docs/docs/glossary/ManualApprovalDataRecord.mdx
@@ -7,5 +7,5 @@ A Manual Approval Data Record is a <GlossaryRef term='data-record'>data record</
 
 -   <GlossaryRef term='data-record'>Data Record</GlossaryRef>
 -   <GlossaryRef term='record'>Record</GlossaryRef>
--   <ActionLink action='os.recordManualApprovalData(recordKey, address, data, endpoint?)' />
+-   <ActionLink action='os.recordManualApprovalData(recordKey, address, data, optionsOrEndpoint?)' />
 -   <ActionLink action='os.getManualApprovalData(recordKeyOrName, address, endpoint?)' />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9978,12 +9978,6 @@
 				}
 			}
 		},
-		"compare-versions": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-			"dev": true
-		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -13321,15 +13315,6 @@
 				"locate-path": "^3.0.0"
 			}
 		},
-		"find-versions": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-			"integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
-			"dev": true,
-			"requires": {
-				"semver-regex": "^3.1.2"
-			}
-		},
 		"findup-sync": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
@@ -14917,22 +14902,10 @@
 			}
 		},
 		"husky": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
-			"integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.0.0",
-				"ci-info": "^2.0.0",
-				"compare-versions": "^3.6.0",
-				"cosmiconfig": "^7.0.0",
-				"find-versions": "^4.0.0",
-				"opencollective-postinstall": "^2.0.2",
-				"pkg-dir": "^5.0.0",
-				"please-upgrade-node": "^3.2.0",
-				"slash": "^3.0.0",
-				"which-pm-runs": "^1.0.0"
-			}
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+			"integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+			"dev": true
 		},
 		"hyperscript-attribute-to-property": {
 			"version": "1.0.2",
@@ -21433,73 +21406,10 @@
 				"node-modules-regexp": "^1.0.0"
 			}
 		},
-		"pkg-dir": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"dev": true,
-			"requires": {
-				"find-up": "^5.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				}
-			}
-		},
 		"platform": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
 			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
-		},
-		"please-upgrade-node": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-			"dev": true,
-			"requires": {
-				"semver-compare": "^1.0.0"
-			}
 		},
 		"pngjs": {
 			"version": "3.4.0",
@@ -23265,12 +23175,6 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
-		"semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-			"dev": true
-		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
@@ -23288,12 +23192,6 @@
 			"requires": {
 				"sver-compat": "^1.5.0"
 			}
-		},
-		"semver-regex": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-			"integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
-			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -26826,12 +26724,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
-		},
 		"which-typed-array": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
@@ -27646,12 +27538,6 @@
 			"requires": {
 				"lib0": "^0.2.43"
 			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,6 @@
         "esbuild": "node ./script/dev-server.js",
         "vite": "lerna exec --no-prefix --scope @casual-simulation/aux-server -- npm run vite"
     },
-    "husky": {
-        "hooks": {
-            "pre-commit": "pretty-quick --staged"
-        }
-    },
     "devDependencies": {
         "@babel/core": "^7.14.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -109,7 +104,7 @@
         "del": "^3.0.0",
         "gulp": "^4.0.0",
         "handlebars": "^4.4.2",
-        "husky": "^4.3.0",
+        "husky": "^7.0.4",
         "jest": "^27.3.1",
         "jest-html-reporter": "^3.4.1",
         "jest-junit": "^6.3.0",

--- a/src/aux-auth/server/MongoDBDataRecordsStore.ts
+++ b/src/aux-auth/server/MongoDBDataRecordsStore.ts
@@ -6,6 +6,7 @@ import {
     GetDataStoreResult,
     EraseDataStoreResult,
     ListDataStoreResult,
+    UserPolicy,
 } from '@casual-simulation/aux-records';
 import { Collection, FilterQuery } from 'mongodb';
 
@@ -21,7 +22,9 @@ export class MongoDBDataRecordsStore implements DataRecordsStore {
         address: string,
         data: any,
         publisherId: string,
-        subjectId: string
+        subjectId: string,
+        updatePolicy: UserPolicy,
+        deletePolicy: UserPolicy
     ): Promise<SetDataResult> {
         await this._collection.updateOne(
             {
@@ -35,6 +38,8 @@ export class MongoDBDataRecordsStore implements DataRecordsStore {
                     data: data,
                     publisherId: publisherId,
                     subjectId: subjectId,
+                    updatePolicy: updatePolicy,
+                    deletePolicy: deletePolicy,
                 },
             },
             {
@@ -62,6 +67,8 @@ export class MongoDBDataRecordsStore implements DataRecordsStore {
                 data: record.data,
                 publisherId: record.publisherId,
                 subjectId: record.subjectId,
+                updatePolicy: record.updatePolicy,
+                deletePolicy: record.deletePolicy,
             };
         }
 
@@ -124,4 +131,6 @@ export interface DataRecord {
     data: any;
     publisherId: string;
     subjectId: string;
+    updatePolicy: UserPolicy;
+    deletePolicy: UserPolicy;
 }

--- a/src/aux-auth/server/index.ts
+++ b/src/aux-auth/server/index.ts
@@ -140,7 +140,7 @@ async function start() {
         '/api/v2/records/data',
         asyncMiddleware(async (req, res) => {
             handleRecordsCorsHeaders(req, res);
-            const { recordKey, address, data } = req.body;
+            const { recordKey, address, data, updatePolicy, deletePolicy } = req.body;
             const authorization = req.headers.authorization;
 
             const userId = getUserId(authorization);
@@ -148,7 +148,9 @@ async function start() {
                 recordKey as string,
                 address as string,
                 data,
-                userId
+                userId,
+                updatePolicy,
+                deletePolicy
             );
 
             return returnResponse(res, result);
@@ -208,7 +210,7 @@ async function start() {
         '/api/v2/records/manual/data',
         asyncMiddleware(async (req, res) => {
             handleRecordsCorsHeaders(req, res);
-            const { recordKey, address, data } = req.body;
+            const { recordKey, address, data, updatePolicy, deletePolicy } = req.body;
             const authorization = req.headers.authorization;
 
             const userId = getUserId(authorization);
@@ -216,7 +218,9 @@ async function start() {
                 recordKey as string,
                 address as string,
                 data,
-                userId
+                userId,
+                updatePolicy,
+                deletePolicy,
             );
 
             return returnResponse(res, result);

--- a/src/aux-auth/serverless/aws/src/handlers/RecordsV2.ts
+++ b/src/aux-auth/serverless/aws/src/handlers/RecordsV2.ts
@@ -158,7 +158,7 @@ async function baseRecordData(
     const authorization = findHeader(event, 'authorization');
     const body = JSON.parse(event.body);
 
-    const { recordKey, address, data } = body;
+    const { recordKey, address, data, updatePolicy, deletePolicy } = body;
 
     if (!recordKey || typeof recordKey !== 'string') {
         return {
@@ -184,7 +184,9 @@ async function baseRecordData(
         recordKey,
         address,
         data,
-        userId
+        userId,
+        updatePolicy,
+        deletePolicy
     );
 
     return {

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -3251,13 +3251,47 @@ export interface DefineGlobalBotAction extends AsyncAction {
 export const APPROVED_SYMBOL = Symbol('approved');
 
 /**
- * Defines an interface that represents the base for actions that deal with records.
+ * Defines an interface that represents the base for options for a records action.
  */
-export interface RecordsAction extends AsyncAction {
+export interface RecordActionOptions {
     /**
      * The HTTP endpoint that the request should interface with.
      */
     endpoint?: string;
+}
+
+/**
+ * Defines an interface that represents the base for actions that deal with records.
+ */
+export interface RecordsAction extends AsyncAction {
+    /**
+     * The options that the action should use.
+     */
+    options: RecordActionOptions;
+}
+
+/**
+ * Defines a type that represents a policy that indicates which users are allowed to affect a record.
+ * 
+ * True indicates that any user can edit the record.
+ * An array of strings indicates the list of users that are allowed to edit the record.
+ */
+export type RecordUserPolicyType = true | string[];
+
+/**
+ * The options for data record actions.
+ */
+export interface DataRecordOptions extends RecordActionOptions {
+
+    /**
+     * The policy that should be used for updating the record.
+     */
+    updatePolicy?: RecordUserPolicyType;
+
+    /**
+     * The policy that should be used for deleting the record.
+     */
+    deletePolicy?: RecordUserPolicyType;
 }
 
 /**
@@ -3298,6 +3332,8 @@ export interface RecordDataAction extends DataRecordAction {
      * The data that should be recorded.
      */
     data: any;
+
+    options: DataRecordOptions;
 }
 
 /**
@@ -6219,7 +6255,7 @@ export function getPublicRecordKey(
  * @param address The address that the data should be stored at in the record.
  * @param data The data to store.
  * @param requiresApproval Whether to try to record data that requires approval.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID of the task.
  */
 export function recordData(
@@ -6227,7 +6263,7 @@ export function recordData(
     address: string,
     data: any,
     requiresApproval: boolean,
-    endpoint: string,
+    options: DataRecordOptions,
     taskId: number | string
 ): RecordDataAction {
     return {
@@ -6236,7 +6272,7 @@ export function recordData(
         address,
         data,
         requiresApproval,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6246,14 +6282,14 @@ export function recordData(
  * @param recordName The name of the record to retrieve.
  * @param address The address of the data to retrieve.
  * @param requiresApproval Whether to try to get a record that requires manual approval.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID of the task.
  */
 export function getRecordData(
     recordName: string,
     address: string,
     requiresApproval: boolean,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): GetRecordDataAction {
     return {
@@ -6261,7 +6297,7 @@ export function getRecordData(
         recordName,
         address,
         requiresApproval,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6270,13 +6306,13 @@ export function getRecordData(
  * Creates a ListRecordDataAction.
  * @param recordName The name of the record.
  * @param startingAddress The address that the list should start with.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID of the task.
  */
 export function listDataRecord(
     recordName: string,
     startingAddress: string,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): ListRecordDataAction {
     return {
@@ -6284,7 +6320,7 @@ export function listDataRecord(
         recordName,
         startingAddress,
         requiresApproval: false,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6294,14 +6330,14 @@ export function listDataRecord(
  * @param recordKey The key that should be used to access the record.
  * @param address The address of the data to erase.
  * @param requiresApproval Whether to try to erase a record that requires manual approval.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID of the task.
  */
 export function eraseRecordData(
     recordKey: string,
     address: string,
     requiresApproval: boolean,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): EraseRecordDataAction {
     return {
@@ -6309,7 +6345,7 @@ export function eraseRecordData(
         recordKey,
         address,
         requiresApproval,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6331,14 +6367,14 @@ export function approveDataRecord<T extends DataRecordAction>(action: T): T {
  * @param data The data to store.
  * @param description The description of the file.
  * @param mimeType The MIME type of the file.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  */
 export function recordFile(
     recordKey: string,
     data: any,
     description: string,
     mimeType: string,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): RecordFileAction {
     return {
@@ -6347,7 +6383,7 @@ export function recordFile(
         data,
         description,
         mimeType,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6356,20 +6392,20 @@ export function recordFile(
  * Creates a EraseFileAction.
  * @param recordKey The key that should be used to access the record.
  * @param fileUrl The URL that the file was stored at.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID of the task.
  */
 export function eraseFile(
     recordKey: string,
     fileUrl: string,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): EraseFileAction {
     return {
         type: 'erase_file',
         recordKey,
         fileUrl,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6379,14 +6415,14 @@ export function eraseFile(
  * @param recordKey The key that should be used to access the record.
  * @param eventName The name of the event.
  * @param count The number of times that the event occurred.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The Id of the task.
  */
 export function recordEvent(
     recordKey: string,
     eventName: string,
     count: number,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): RecordEventAction {
     return {
@@ -6394,7 +6430,7 @@ export function recordEvent(
         recordKey,
         eventName,
         count,
-        endpoint,
+        options,
         taskId,
     };
 }
@@ -6403,20 +6439,20 @@ export function recordEvent(
  * Creates a GetEventCountAction.
  * @param recordName The name of the record.
  * @param eventName The name of the events.
- * @param endpoint The HTTP Origin that should be used for the records request.
+ * @param options The options that should be used for the action.
  * @param taskId The ID.
  */
 export function getEventCount(
     recordName: string,
     eventName: string,
-    endpoint: string,
+    options: RecordActionOptions,
     taskId?: number | string
 ): GetEventCountAction {
     return {
         type: 'get_event_count',
         recordName,
         eventName,
-        endpoint,
+        options,
         taskId,
     };
 }

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -4531,7 +4531,7 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4550,7 +4550,31 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     false,
-                    'myEndpoint',
+                    {
+                        endpoint: 'myEndpoint'
+                    },
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom options', async () => {
+                const action: any = library.api.os.recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    { updatePolicy: true, endpoint: 'myEndpoint' }
+                );
+                const expected = recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    false,
+                    {
+                        updatePolicy: true,
+                        endpoint: 'myEndpoint'
+                    },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4573,7 +4597,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4598,7 +4622,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4618,7 +4642,7 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4637,7 +4661,26 @@ describe('AuxLibrary', () => {
                     'address',
                     { data: true },
                     true,
-                    'myEndpoint',
+                    { endpoint: 'myEndpoint' },
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support custom options', async () => {
+                const action: any = library.api.os.recordManualApprovalData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    { updatePolicy: true, endpoint: 'myEndpoint'}
+                );
+                const expected = recordData(
+                    'recordKey',
+                    'address',
+                    { data: true },
+                    true,
+                    { updatePolicy: true, endpoint: 'myEndpoint' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4660,7 +4703,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4685,7 +4728,7 @@ describe('AuxLibrary', () => {
                         },
                     },
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4703,7 +4746,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4720,7 +4763,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
-                    'myEndpoint',
+                    { endpoint: 'myEndpoint'},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4736,7 +4779,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     false,
-                    null,
+                    { },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4752,7 +4795,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4770,7 +4813,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4787,7 +4830,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
-                    'myEndpoint',
+                    { endpoint: 'myEndpoint' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4803,7 +4846,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4819,7 +4862,7 @@ describe('AuxLibrary', () => {
                     'recordName',
                     'address',
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4833,7 +4876,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     null,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4849,7 +4892,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     null,
-                    'myEndpoint',
+                    { endpoint: 'myEndpoint' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4864,7 +4907,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     'address',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4879,7 +4922,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     'address',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4894,7 +4937,7 @@ describe('AuxLibrary', () => {
                 const expected = listDataRecord(
                     'recordName',
                     'address',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4912,7 +4955,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4929,7 +4972,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     false,
-                    'myEndpoint',
+                    { endpoint: 'myEndpoint' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4971,7 +5014,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -4988,7 +5031,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'address',
                     true,
-                    'myEndpoint',
+                    { endpoint:'myEndpoint' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5037,7 +5080,7 @@ describe('AuxLibrary', () => {
                     'data',
                     'description',
                     undefined,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5058,7 +5101,7 @@ describe('AuxLibrary', () => {
                     'data',
                     'description',
                     undefined,
-                    'https://localhost:5000',
+                    { endpoint: 'https://localhost:5000' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5075,7 +5118,7 @@ describe('AuxLibrary', () => {
                     'data',
                     undefined,
                     undefined,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5095,7 +5138,7 @@ describe('AuxLibrary', () => {
                     'data',
                     undefined,
                     'image/png',
-                    null,
+                    { },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5136,7 +5179,7 @@ describe('AuxLibrary', () => {
                     },
                     undefined,
                     undefined,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5213,7 +5256,7 @@ describe('AuxLibrary', () => {
                 const expected = eraseFile(
                     'recordKey',
                     'fileUrl',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5229,7 +5272,7 @@ describe('AuxLibrary', () => {
                 const expected = eraseFile(
                     'recordKey',
                     'fileUrl',
-                    'http://localhost:5000',
+                    { endpoint: 'http://localhost:5000' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5267,7 +5310,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'eventName',
                     1,
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5284,7 +5327,7 @@ describe('AuxLibrary', () => {
                     'recordKey',
                     'eventName',
                     1,
-                    'http://localhost:5000',
+                    { endpoint: 'http://localhost:5000' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5325,7 +5368,7 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordKey',
                     'eventName',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5341,7 +5384,7 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordKey',
                     'eventName',
-                    'http://localhost:5000',
+                    { endpoint: 'http://localhost:5000' },
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5356,7 +5399,7 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordName',
                     'eventName',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
@@ -5371,7 +5414,7 @@ describe('AuxLibrary', () => {
                 const expected = getEventCount(
                     'recordName',
                     'eventName',
-                    null,
+                    {},
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -270,6 +270,8 @@ import {
     parseBotDate,
     SnapGrid,
     AddDropGridTargetsAction,
+    DataRecordOptions,
+    RecordActionOptions,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -3402,10 +3404,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
-     * @param endpoint The records endpoint that should be queried. Optional.
+     * @param endpointOrOptions The options that should be used. Optional.
      */
-    function recordData(recordKey: string, address: string, data: any, endpoint: string = null) {
-        return baseRecordData(recordKey, address, data, false, endpoint);
+    function recordData(recordKey: string, address: string, data: any, endpointOrOptions?: string | DataRecordOptions) {
+        return baseRecordData(recordKey, address, data, false, endpointOrOptions);
     }
 
     /**
@@ -3415,15 +3417,15 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
-     * @param endpoint The records endpoint that should be queried. Optional.
+     * @param endpointOrOptions The options that should be used. Optional.
      */
     function recordManualApprovalData(
         recordKey: string,
         address: string,
         data: any,
-        endpoint: string = null
+        endpointOrOptions?: string | DataRecordOptions
     ) {
-        return baseRecordData(recordKey, address, data, true, endpoint);
+        return baseRecordData(recordKey, address, data, true, endpointOrOptions);
     }
 
     /**
@@ -3431,22 +3433,30 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
-     * @param endpoint The records endpoint that should be queried. Optional.
+     * @param endpointOrOptions The options that should be used. Optional.
      */
     function baseRecordData(
         recordKey: string,
         address: string,
         data: any,
         requiresApproval: boolean,
-        endpoint: string = null
+        endpointOrOptions: string | DataRecordOptions = null
     ): Promise<RecordDataResult> {
         const task = context.createTask();
+        let options: DataRecordOptions = {};
+        if (hasValue(endpointOrOptions)) {
+            if (typeof endpointOrOptions === 'string') {
+                options.endpoint = endpointOrOptions;
+            } else {
+                options = endpointOrOptions;
+            }
+        }
         const event = calcRecordData(
             recordKey,
             address,
             convertToCopiableValue(data),
             requiresApproval,
-            endpoint,
+            options,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3495,12 +3505,16 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         let recordName = isRecordKey(recordKeyOrName)
             ? parseRecordKey(recordKeyOrName)[0]
             : recordKeyOrName;
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
         const task = context.createTask();
         const event = getRecordData(
             recordName,
             address,
             requiresApproval,
-            endpoint,
+            options,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3520,8 +3534,12 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         let recordName = isRecordKey(recordKeyOrName)
             ? parseRecordKey(recordKeyOrName)[0]
             : recordKeyOrName;
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
         const task = context.createTask();
-        const event = listDataRecord(recordName, startingAddress, endpoint, task.taskId);
+        const event = listDataRecord(recordName, startingAddress, options, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3577,13 +3595,17 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         } else if (typeof address !== 'string') {
             throw new Error('address must be a string.');
         }
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
 
         const task = context.createTask();
         const event = eraseRecordData(
             recordKey,
             address,
             requiresApproval,
-            endpoint,
+            options,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3612,13 +3634,18 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             throw new Error('data must be provided.');
         }
 
+        let recordOptions: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            recordOptions.endpoint = endpoint;
+        }
+
         const task = context.createTask();
         const event = calcRecordFile(
             recordKey,
             convertToCopiableValue(data),
             options?.description,
             options?.mimeType,
-            endpoint,
+            recordOptions,
             task.taskId
         );
         return addAsyncAction(task, event);
@@ -3726,8 +3753,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             url = fileUrlOrRecordFileResult.url;
         }
 
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
+
         const task = context.createTask();
-        const event = calcEraseFile(recordKey, url, endpoint, task.taskId);
+        const event = calcEraseFile(recordKey, url, options, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3754,8 +3786,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             throw new Error('eventName must be a string.');
         }
 
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
+
         const task = context.createTask();
-        const event = calcRecordEvent(recordKey, eventName, 1, endpoint, task.taskId);
+        const event = calcRecordEvent(recordKey, eventName, 1, options, task.taskId);
         return addAsyncAction(task, event);
     }
 
@@ -3786,8 +3823,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             ? parseRecordKey(recordNameOrKey)[0]
             : recordNameOrKey;
 
+        let options: RecordActionOptions = {};
+        if (hasValue(endpoint)) {
+            options.endpoint = endpoint;
+        }
+
         const task = context.createTask();
-        const event = calcGetEventCount(recordName, eventName, endpoint, task.taskId);
+        const event = calcGetEventCount(recordName, eventName, options, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -3079,7 +3079,33 @@ export type NotLoggedInError = 'not_logged_in';
 
 export type RecordNotFoundError = 'record_not_found';
 
+/**
+ * Defines a type that represents a policy that indicates which users are allowed to affect a record.
+ * 
+ * True indicates that any user can edit the record.
+ * An array of strings indicates the list of users that are allowed to edit the record.
+ */
+export type RecordUserPolicyType = true | string[];
 
+/**
+ * The options for data record actions.
+ */
+ export interface RecordDataOptions {
+    /**
+     * The HTTP Endpoint that should be queried.
+     */
+    endpoint?: string;
+
+    /**
+     * The policy that should be used for updating the record.
+     */
+    updatePolicy?: RecordUserPolicyType;
+
+    /**
+     * The policy that should be used for deleting the record.
+     */
+    deletePolicy?: RecordUserPolicyType;
+}
 
 export type RecordDataResult = RecordDataSuccess | RecordDataFailure;
 
@@ -8587,13 +8613,13 @@ interface Os {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
-     * @param endpoint The records endpoint that should be queried. Optional.
+     * @param optionsOrEndpoint The options that should be used for recording the data. Alternatively, the records endpoint that should be queried. Optional.
      */
     recordData(
         recordKey: string,
         address: string,
         data: any,
-        endpoint?: string
+        optionsOrEndpoint?: RecordDataOptions | string
     ): Promise<RecordDataResult>;
 
     /**
@@ -8631,13 +8657,13 @@ interface Os {
      * @param recordKey The key that should be used to access the record.
      * @param address The address that the data should be stored at inside the record.
      * @param data The data that should be stored.
-     * @param endpoint The records endpoint that should be queried. Optional.
+     * @param optionsOrEndpoint The options that should be used for recording the data. Alternatively, the records endpoint that should be queried. Optional.
      */
     recordManualApprovalData(
         recordKey: string,
         address: string,
         data: any,
-        endpoint?: string
+        optionsOrEndpoint?: RecordDataOptions | string
     ): Promise<RecordDataResult>;
 
     /**

--- a/src/aux-records-aws/DynamoDBDataStore.spec.ts
+++ b/src/aux-records-aws/DynamoDBDataStore.spec.ts
@@ -40,7 +40,9 @@ describe('DynamoDBDataStore', () => {
                     myData: 'abc',
                 },
                 'publisherId',
-                'subjectId'
+                'subjectId',
+                true,
+                true
             );
 
             expect(result).toEqual({
@@ -58,6 +60,8 @@ describe('DynamoDBDataStore', () => {
                     publisherId: 'publisherId',
                     subjectId: 'subjectId',
                     publishTime: expect.any(Number),
+                    updatePolicy: true,
+                    deletePolicy: true,
                 },
             });
 
@@ -81,7 +85,9 @@ describe('DynamoDBDataStore', () => {
                     myData: 'abc',
                 },
                 'publisherId',
-                'subjectId'
+                'subjectId',
+                true,
+                true
             );
 
             expect(result).toEqual({

--- a/src/aux-records-aws/DynamoDBDataStore.spec.ts
+++ b/src/aux-records-aws/DynamoDBDataStore.spec.ts
@@ -111,6 +111,8 @@ describe('DynamoDBDataStore', () => {
                         publisherId: 'publisherId',
                         subjectId: 'subjectId',
                         publishTime: 123456789,
+                        updatePolicy: ['abc'],
+                        deletePolicy: ['def'],
                     },
                 })
             );
@@ -124,6 +126,8 @@ describe('DynamoDBDataStore', () => {
                 },
                 publisherId: 'publisherId',
                 subjectId: 'subjectId',
+                updatePolicy: ['abc'],
+                deletePolicy: ['def'],
             });
         });
 

--- a/src/aux-records-aws/DynamoDBDataStore.ts
+++ b/src/aux-records-aws/DynamoDBDataStore.ts
@@ -33,7 +33,7 @@ export class DynamoDBDataStore implements DataRecordsStore {
         publisherId: string,
         subjectId: string,
         updatePolicy: UserPolicy,
-        deletePolicy: UserPolicy,
+        deletePolicy: UserPolicy
     ): Promise<SetDataResult> {
         const item: StoredData = {
             recordName: recordName,
@@ -128,6 +128,8 @@ export class DynamoDBDataStore implements DataRecordsStore {
                 data: item.data,
                 publisherId: item.publisherId,
                 subjectId: item.subjectId,
+                updatePolicy: item.updatePolicy,
+                deletePolicy: item.deletePolicy,
             };
         }
 

--- a/src/aux-records-aws/DynamoDBDataStore.ts
+++ b/src/aux-records-aws/DynamoDBDataStore.ts
@@ -8,6 +8,7 @@ import {
     GetDataStoreResult,
     EraseDataStoreResult,
     ListDataStoreResult,
+    UserPolicy,
 } from '@casual-simulation/aux-records/DataRecordsStore';
 import dynamodb from 'aws-sdk/clients/dynamodb';
 
@@ -30,7 +31,9 @@ export class DynamoDBDataStore implements DataRecordsStore {
         address: string,
         data: any,
         publisherId: string,
-        subjectId: string
+        subjectId: string,
+        updatePolicy: UserPolicy,
+        deletePolicy: UserPolicy,
     ): Promise<SetDataResult> {
         const item: StoredData = {
             recordName: recordName,
@@ -39,6 +42,8 @@ export class DynamoDBDataStore implements DataRecordsStore {
             publisherId: publisherId,
             subjectId: subjectId,
             publishTime: Date.now(),
+            updatePolicy: updatePolicy,
+            deletePolicy: deletePolicy,
         };
         const result = await this._dynamo
             .put({
@@ -241,4 +246,14 @@ interface StoredData {
      * The time that the data was published in miliseconds since January 1 1970 00:00:00 UTC.
      */
     publishTime: number;
+
+    /**
+     * The update policy for the item.
+     */
+    updatePolicy?: UserPolicy;
+
+    /**
+     * The delete policy for the item.
+     */
+    deletePolicy?: UserPolicy;
 }

--- a/src/aux-records/DataRecordsController.spec.ts
+++ b/src/aux-records/DataRecordsController.spec.ts
@@ -110,7 +110,9 @@ describe('DataRecordsController', () => {
 
             expect(result.success).toBe(false);
             expect(result.errorCode).toBe('not_authorized');
-            expect(result.errorMessage).toBe('The updatePolicy does not permit this user to update the data record.');
+            expect(result.errorMessage).toBe(
+                'The updatePolicy does not permit this user to update the data record.'
+            );
         });
 
         it('should reject the request if attempts to use an invalid update policy', async () => {
@@ -125,7 +127,26 @@ describe('DataRecordsController', () => {
 
             expect(result.success).toBe(false);
             expect(result.errorCode).toBe('invalid_update_policy');
-            expect(result.errorMessage).toBe('The given updatePolicy is invalid or not supported.');
+            expect(result.errorMessage).toBe(
+                'The given updatePolicy is invalid or not supported.'
+            );
+        });
+
+        it('should reject the request if using a subjectless key to set an update policy', async () => {
+            const result = (await manager.recordData(
+                subjectlessKey,
+                'address',
+                'data',
+                'subjectId',
+                ['test'],
+                null
+            )) as RecordDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('invalid_record_key');
+            expect(result.errorMessage).toBe(
+                'It is not possible to set update policies using a subjectless key.'
+            );
         });
 
         it('should reject the request if attempts to use an invalid delete policy', async () => {
@@ -135,12 +156,31 @@ describe('DataRecordsController', () => {
                 'data',
                 'subjectId',
                 null,
-                123 as unknown as UserPolicy,
+                123 as unknown as UserPolicy
             )) as RecordDataFailure;
 
             expect(result.success).toBe(false);
             expect(result.errorCode).toBe('invalid_delete_policy');
-            expect(result.errorMessage).toBe('The given deletePolicy is invalid or not supported.');
+            expect(result.errorMessage).toBe(
+                'The given deletePolicy is invalid or not supported.'
+            );
+        });
+
+        it('should reject the request if using a subjectless key to set a delete policy', async () => {
+            const result = (await manager.recordData(
+                subjectlessKey,
+                'address',
+                'data',
+                'subjectId',
+                null,
+                ['test']
+            )) as RecordDataFailure;
+
+            expect(result.success).toBe(false);
+            expect(result.errorCode).toBe('invalid_record_key');
+            expect(result.errorMessage).toBe(
+                'It is not possible to set delete policies using a subjectless key.'
+            );
         });
 
         it('should reject the request if given a null subject ID', async () => {
@@ -170,7 +210,7 @@ describe('DataRecordsController', () => {
             expect(result.success).toBe(true);
             expect(result.recordName).toBe('testRecord');
             expect(result.address).toBe('address');
-            
+
             await expect(
                 store.getData('testRecord', 'address')
             ).resolves.toEqual({
@@ -196,7 +236,7 @@ describe('DataRecordsController', () => {
             expect(result.success).toBe(true);
             expect(result.recordName).toBe('testRecord');
             expect(result.address).toBe('address');
-            
+
             await expect(
                 store.getData('testRecord', 'address')
             ).resolves.toEqual({
@@ -231,7 +271,7 @@ describe('DataRecordsController', () => {
                 publisherId: 'testUser',
                 subjectId: 'subjectId',
                 updatePolicy: ['abc'],
-                deletePolicy: true
+                deletePolicy: true,
             });
         });
     });

--- a/src/aux-records/DataRecordsController.ts
+++ b/src/aux-records/DataRecordsController.ts
@@ -48,7 +48,7 @@ export class DataRecordsController {
         data: string,
         subjectId: string,
         updatePolicy: UserPolicy,
-        deletePolicy: UserPolicy,
+        deletePolicy: UserPolicy
     ): Promise<RecordDataResult> {
         try {
             const result = await this._manager.validatePublicRecordKey(
@@ -66,7 +66,8 @@ export class DataRecordsController {
                 return {
                     success: false,
                     errorCode: 'not_logged_in',
-                    errorMessage: 'The user must be logged in in order to record data.',
+                    errorMessage:
+                        'The user must be logged in in order to record data.',
                 };
             }
 
@@ -85,7 +86,8 @@ export class DataRecordsController {
                 return {
                     success: false,
                     errorCode: 'invalid_update_policy',
-                    errorMessage: 'The given updatePolicy is invalid or not supported.'
+                    errorMessage:
+                        'The given updatePolicy is invalid or not supported.',
                 };
             }
 
@@ -93,21 +95,47 @@ export class DataRecordsController {
                 return {
                     success: false,
                     errorCode: 'invalid_delete_policy',
-                    errorMessage: 'The given deletePolicy is invalid or not supported.'
+                    errorMessage:
+                        'The given deletePolicy is invalid or not supported.',
                 };
             }
 
+            if (result.policy === 'subjectless') {
+                if (updatePolicy !== true) {
+                    return {
+                        success: false,
+                        errorCode: 'invalid_record_key',
+                        errorMessage:
+                            'It is not possible to set update policies using a subjectless key.',
+                    };
+                }
+
+                if (deletePolicy !== true) {
+                    return {
+                        success: false,
+                        errorCode: 'invalid_record_key',
+                        errorMessage:
+                            'It is not possible to set delete policies using a subjectless key.',
+                    };
+                }
+            }
+
             const recordName = result.recordName;
-            const existingRecord = await this._store.getData(recordName, address);
+            const existingRecord = await this._store.getData(
+                recordName,
+                address
+            );
 
             if (existingRecord.success) {
-                const existingUpdatePolicy = existingRecord.updatePolicy ?? true;
+                const existingUpdatePolicy =
+                    existingRecord.updatePolicy ?? true;
                 if (!doesSubjectMatchPolicy(existingUpdatePolicy, subjectId)) {
                     return {
                         success: false,
                         errorCode: 'not_authorized',
-                        errorMessage: 'The updatePolicy does not permit this user to update the data record.',
-                    }
+                        errorMessage:
+                            'The updatePolicy does not permit this user to update the data record.',
+                    };
                 }
             }
 

--- a/src/aux-records/DataRecordsStore.spec.ts
+++ b/src/aux-records/DataRecordsStore.spec.ts
@@ -1,0 +1,36 @@
+import { doesSubjectMatchPolicy, isValidUserPolicy, UserPolicy } from './DataRecordsStore';
+
+describe('isValidUserPolicy()', () => {
+    const cases: [boolean, any][] = [
+        [true, true],
+        [true, ['abc']],
+        [true, ['abc', 'def']],
+        [false, false],
+        [false, null],
+        [false, 123],
+        [false, {}],
+        [false, ['abc', 123]],
+        [false, ['abc', false]],
+        [false, [123, 'abc']],
+    ];
+
+    it.each(cases)('should return %s when given %s', (expected, given) => {
+        expect(isValidUserPolicy(given)).toBe(expected);
+    });
+});
+
+describe('doesSubjectMatchPolicy()', () => {
+    const cases: [boolean, UserPolicy, string][] = [
+        [true, true, 'subject'],
+        [true, true, null],
+        [true, ['subject'], 'subject'],
+        [true, ['not_subject', 'subject'], 'subject'],
+        [false, [], 'subject'],
+        [false, ['not_subject'], 'subject'],
+        [false, ['not_subject'], null]
+    ];
+
+    it.each(cases)('should return %s when given (%s, %s)', (expected, policy, subject) => {
+        expect(doesSubjectMatchPolicy(policy, subject)).toBe(expected)
+    });
+});

--- a/src/aux-records/DataRecordsStore.ts
+++ b/src/aux-records/DataRecordsStore.ts
@@ -11,13 +11,17 @@ export interface DataRecordsStore {
      * @param data The data that should be saved.
      * @param publisherId The ID of the user that owns the record this data is being published to.
      * @param subjectId The ID of the user that was logged in when the data was published.
+     * @param updatePolicy The update policy that should be stored.
+     * @param deletePolicy The delete policy that should be stored.
      */
     setData(
         recordName: string,
         address: string,
         data: any,
         publisherId: string,
-        subjectId: string
+        subjectId: string,
+        updatePolicy: UserPolicy,
+        deletePolicy: UserPolicy,
     ): Promise<SetDataResult>;
 
     /**
@@ -65,6 +69,8 @@ export interface GetDataStoreResult {
     data?: any;
     publisherId?: string;
     subjectId?: string;
+    updatePolicy?: UserPolicy;
+    deletePolicy?: UserPolicy;
 
     errorCode?: 'data_not_found' | ServerError;
     errorMessage?: string;
@@ -87,4 +93,39 @@ export interface ListDataStoreResult {
     }[];
     errorCode?: ServerError;
     errorMessage?: string;
+}
+
+
+/**
+ * Defines a type that represents a policy that indicates which users are allowed to affect a record.
+ * 
+ * True indicates that any user can edit the record.
+ * An array of strings indicates the list of users that are allowed to edit the record.
+ */
+export type UserPolicy = true | string[];
+
+/**
+ * Determines if the given value represents a valid user policy.
+ */
+export function isValidUserPolicy(value: unknown): boolean {
+    if(value === true) {
+        return true;
+    } else if (Array.isArray(value)) {
+        return value.every(v => typeof v === 'string');
+    }
+
+    return false;
+}
+
+/**
+ * Determines if the given policy allows the given subject ID.
+ * @param policy The policy.
+ * @param subjectId The subject ID.
+ */
+export function doesSubjectMatchPolicy(policy: UserPolicy, subjectId: string): boolean {
+    if (policy === true) {
+        return true;
+    } else {
+        return policy.some(id => id === subjectId);
+    }
 }

--- a/src/aux-records/Errors.ts
+++ b/src/aux-records/Errors.ts
@@ -7,3 +7,8 @@ export type ServerError = 'server_error';
  * Defines an error that occurs when the user is not logged in but they are required to be in order to perform an action.
  */
 export type NotLoggedInError = 'not_logged_in';
+
+/**
+ * Defines an error that occurs when the user does not have the right permissions to perform an action.
+ */
+export type NotAuthorizedError = 'not_authorized';

--- a/src/aux-records/MemoryDataRecordsStore.ts
+++ b/src/aux-records/MemoryDataRecordsStore.ts
@@ -4,6 +4,7 @@ import {
     GetDataStoreResult,
     ListDataStoreResult,
     SetDataResult,
+    UserPolicy,
 } from './DataRecordsStore';
 
 export class MemoryDataRecordsStore implements DataRecordsStore {
@@ -14,13 +15,17 @@ export class MemoryDataRecordsStore implements DataRecordsStore {
         address: string,
         data: any,
         publisherId: string,
-        subjectId: string
+        subjectId: string,
+        updatePolicy: UserPolicy,
+        deletePolicy: UserPolicy,
     ): Promise<SetDataResult> {
         let record = this._getRecord(recordName);
         record.set(address, {
             data: data,
             publisherId: publisherId,
             subjectId: subjectId,
+            updatePolicy,
+            deletePolicy
         });
         return {
             success: true,
@@ -46,6 +51,8 @@ export class MemoryDataRecordsStore implements DataRecordsStore {
             data: data.data,
             publisherId: data.publisherId,
             subjectId: data.subjectId,
+            updatePolicy: data.updatePolicy,
+            deletePolicy: data.deletePolicy,
         };
     }
 
@@ -104,4 +111,6 @@ interface RecordData {
     data: any;
     publisherId: string;
     subjectId: string;
+    updatePolicy: UserPolicy;
+    deletePolicy: UserPolicy;
 }

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -8,7 +8,11 @@ import {
 import { setupChannel, waitForLoad } from '../html/IFrameHelpers';
 import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { AuthData, hasValue } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult, parseRecordKey, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
+import {
+    CreatePublicRecordKeyResult,
+    parseRecordKey,
+    PublicRecordKeyPolicy,
+} from '@casual-simulation/aux-records';
 
 // Save the query string that was used when the site loaded
 const query = typeof location !== 'undefined' ? location.search : null;
@@ -50,10 +54,6 @@ export class AuthEndpointHelper implements AuthHelperInterface {
 
     get origin(): string {
         return this._origin;
-    }
-
-    get recordsOrigin(): string {
-        return this._recordsOrigin ?? this._defaultRecordsOrigin ?? this._origin;
     }
 
     get loginStatus() {
@@ -147,7 +147,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
             this._recordsOrigin = await this._proxy.getRecordsOrigin();
         }
 
-        this._loginUIStatus.subscribe(status => {
+        this._loginUIStatus.subscribe((status) => {
             if (!this._iframe) {
                 return;
             }
@@ -198,7 +198,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
      * Requests that the user become authenticated entirely in the background.
      * This will not show any UI to the user but may also mean that the user will not be able to be authenticated.
      */
-     async authenticateInBackground() {
+    async authenticateInBackground() {
         if (!hasValue(this._origin)) {
             return null;
         }
@@ -234,7 +234,21 @@ export class AuthEndpointHelper implements AuthHelperInterface {
         return await this._proxy.createPublicRecordKey(recordName, policy);
     }
 
-    async getRecordKeyPolicy(recordKey: string): Promise<PublicRecordKeyPolicy> {
+    async getRecordsOrigin(): Promise<string> {
+        if (!hasValue(this._origin)) {
+            return null;
+        }
+        if (!this._initialized) {
+            await this._init();
+        }
+        return (
+            this._recordsOrigin ?? this._defaultRecordsOrigin ?? this._origin
+        );
+    }
+
+    async getRecordKeyPolicy(
+        recordKey: string
+    ): Promise<PublicRecordKeyPolicy> {
         const keyInfo = parseRecordKey(recordKey);
         if (!keyInfo) {
             return null;
@@ -295,7 +309,10 @@ export class AuthEndpointHelper implements AuthHelperInterface {
         );
     }
 
-    async provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void> {
+    async provideSmsNumber(
+        sms: string,
+        acceptedTermsOfService: boolean
+    ): Promise<void> {
         if (!hasValue(this._origin)) {
             return;
         }
@@ -305,10 +322,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
         if (this._protocolVersion < 3) {
             return;
         }
-        return await this._proxy.provideSmsNumber(
-            sms,
-            acceptedTermsOfService
-        );
+        return await this._proxy.provideSmsNumber(sms, acceptedTermsOfService);
     }
 
     async cancelLogin() {

--- a/src/aux-vm/managers/AuthHelperInterface.ts
+++ b/src/aux-vm/managers/AuthHelperInterface.ts
@@ -1,5 +1,8 @@
 import { AuthData } from '@casual-simulation/aux-common';
-import { CreatePublicRecordKeyResult, PublicRecordKeyPolicy } from '@casual-simulation/aux-records';
+import {
+    CreatePublicRecordKeyResult,
+    PublicRecordKeyPolicy,
+} from '@casual-simulation/aux-records';
 import { Observable, SubscriptionLike } from 'rxjs';
 import { LoginStatus, LoginUIStatus } from '../auth/AuxAuth';
 
@@ -11,11 +14,6 @@ export interface AuthHelperInterface extends SubscriptionLike {
      * The HTTP Origin that this helper interface loaded.
      */
     origin: string;
-
-    /**
-     * The HTTP Origin that hosts the records API for this authentication service.
-     */
-    recordsOrigin: string;
 
     /**
      * Gets whether this inst supports authentication.
@@ -31,6 +29,11 @@ export interface AuthHelperInterface extends SubscriptionLike {
      * Gets an observable that resolves whenever the login UI should be updated.
      */
     loginUIStatus: Observable<LoginUIStatus>;
+
+    /**
+     * Gets the HTTP origin that should be queried for Records API requests.
+     */
+    getRecordsOrigin(): Promise<string>;
 
     /**
      * Determines whether the user is currently authenticated.
@@ -60,7 +63,7 @@ export interface AuthHelperInterface extends SubscriptionLike {
      */
     createPublicRecordKey(
         recordName: string,
-        policy: PublicRecordKeyPolicy,
+        policy: PublicRecordKeyPolicy
     ): Promise<CreatePublicRecordKeyResult>;
 
     /**
@@ -89,7 +92,10 @@ export interface AuthHelperInterface extends SubscriptionLike {
      * @param sms The email address that the user provided.
      * @param acceptedTermsOfService Whether the user accepted the terms of service.
      */
-    provideSmsNumber(sms: string, acceptedTermsOfService: boolean): Promise<void>
+    provideSmsNumber(
+        sms: string,
+        acceptedTermsOfService: boolean
+    ): Promise<void>;
 
     /**
      * Cancels the current login if it is using the custom UI flow.

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -226,6 +226,68 @@ describe('RecordsManager', () => {
                 expect(authMock.getAuthToken).toBeCalled();
             });
 
+            it('should include the update and delete policies', async () => {
+                setResponse({
+                    data: {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    },
+                });
+
+                authMock.isAuthenticated.mockResolvedValueOnce(true);
+                authMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    recordData(
+                        'myToken',
+                        'myAddress',
+                        {
+                            myRecord: true,
+                        },
+                        false,
+                        {
+                            updatePolicy: true,
+                            deletePolicy: ['user1']
+                        },
+                        1
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(getLastPost()).toEqual([
+                    'http://localhost:3002/api/v2/records/data',
+                    {
+                        recordKey: 'myToken',
+                        address: 'myAddress',
+                        data: {
+                            myRecord: true,
+                        },
+                        updatePolicy: true,
+                        deletePolicy: ['user1']
+                    },
+                    {
+                        headers: {
+                            Authorization: 'Bearer authToken',
+                        },
+                    },
+                ]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        recordName: 'testRecord',
+                        address: 'myAddress',
+                    }),
+                ]);
+                expect(authMock.isAuthenticated).toBeCalled();
+                expect(authMock.authenticate).not.toBeCalled();
+                expect(authMock.getAuthToken).toBeCalled();
+            });
+
             it('should support custom endpoints', async () => {
                 setResponse({
                     data: {

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -78,6 +78,9 @@ describe('RecordsManager', () => {
             provideSmsNumber: jest.fn(),
             authenticateInBackground: jest.fn(),
             getRecordKeyPolicy: jest.fn(),
+            getRecordsOrigin: jest
+                .fn()
+                .mockResolvedValue('http://localhost:3002'),
             get supportsAuthentication() {
                 return true;
             },
@@ -87,9 +90,6 @@ describe('RecordsManager', () => {
             get origin() {
                 return 'http://localhost:3002';
             },
-            get recordsOrigin() {
-                return 'http://localhost:3002';
-            }
         };
 
         customAuthMock = customAuth = {
@@ -107,6 +107,9 @@ describe('RecordsManager', () => {
             provideSmsNumber: jest.fn(),
             authenticateInBackground: jest.fn(),
             getRecordKeyPolicy: jest.fn(),
+            getRecordsOrigin: jest
+                .fn()
+                .mockResolvedValue('http://localhost:9999'),
             get supportsAuthentication() {
                 return true;
             },
@@ -116,19 +119,17 @@ describe('RecordsManager', () => {
             get origin() {
                 return 'http://localhost:9999';
             },
-            get recordsOrigin() {
-                return 'http://localhost:9999';
-            }
         };
 
-        authFactory = (endpoint: string) => endpoint === 'http://localhost:9999' ? customAuth : auth;
+        authFactory = (endpoint: string) =>
+            endpoint === 'http://localhost:9999' ? customAuth : auth;
 
         records = new RecordsManager(
             {
                 version: '1.0.0',
                 versionHash: '1234567890abcdef',
                 recordsOrigin: 'http://localhost:3002',
-                authOrigin: 'http://localhost:3002'
+                authOrigin: 'http://localhost:3002',
             },
             helper,
             authFactory
@@ -248,7 +249,7 @@ describe('RecordsManager', () => {
                         false,
                         {
                             updatePolicy: true,
-                            deletePolicy: ['user1']
+                            deletePolicy: ['user1'],
                         },
                         1
                     ),
@@ -265,7 +266,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         updatePolicy: true,
-                        deletePolicy: ['user1']
+                        deletePolicy: ['user1'],
                     },
                     {
                         headers: {
@@ -580,7 +581,9 @@ describe('RecordsManager', () => {
                         address: 'myAddress',
                     },
                 });
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
                 records.handleEvents([
@@ -631,7 +634,9 @@ describe('RecordsManager', () => {
                         address: 'myAddress',
                     },
                 });
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
                 records.handleEvents([
@@ -735,7 +740,13 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, { endpoint:'http://localhost:9999' }, 1),
+                    getRecordData(
+                        'testRecord',
+                        'myAddress',
+                        false,
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -814,7 +825,13 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        getRecordData('testRecord', 'myAddress', true, { endpoint: 'http://localhost:9999' }, 1)
+                        getRecordData(
+                            'testRecord',
+                            'myAddress',
+                            true,
+                            { endpoint: 'http://localhost:9999' },
+                            1
+                        )
                     ),
                 ]);
 
@@ -956,7 +973,12 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    listDataRecord('testRecord', 'myAddress', { endpoint: 'http://localhost:9999' }, 1),
+                    listDataRecord(
+                        'testRecord',
+                        'myAddress',
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -997,7 +1019,9 @@ describe('RecordsManager', () => {
 
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([listDataRecord('testRecord', null, {}, 1)]);
+                records.handleEvents([
+                    listDataRecord('testRecord', null, {}, 1),
+                ]);
 
                 await waitAsync();
 
@@ -1085,7 +1109,13 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, { endpoint: 'http://localhost:9999' }, 1),
+                    eraseRecordData(
+                        'myToken',
+                        'myAddress',
+                        false,
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -1178,7 +1208,13 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        eraseRecordData('myToken', 'myAddress', true, { endpoint: 'http://localhost:9999' }, 1)
+                        eraseRecordData(
+                            'myToken',
+                            'myAddress',
+                            true,
+                            { endpoint: 'http://localhost:9999' },
+                            1
+                        )
                     ),
                 ]);
 
@@ -1354,7 +1390,9 @@ describe('RecordsManager', () => {
                         address: 'myAddress',
                     },
                 });
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
 
                 records.handleEvents([
                     eraseRecordData('myToken', 'myAddress', false, {}, 1),
@@ -1395,10 +1433,14 @@ describe('RecordsManager', () => {
                         address: 'myAddress',
                     },
                 });
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
 
                 records.handleEvents([
-                    approveDataRecord(eraseRecordData('myToken', 'myAddress', true, {}, 1))
+                    approveDataRecord(
+                        eraseRecordData('myToken', 'myAddress', true, {}, 1)
+                    ),
                 ]);
 
                 await waitAsync();
@@ -1454,7 +1496,14 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', undefined, {}, 1),
+                    recordFile(
+                        'myToken',
+                        'myFile',
+                        'test.txt',
+                        undefined,
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -1518,7 +1567,14 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', 'text/xml', {}, 1),
+                    recordFile(
+                        'myToken',
+                        'myFile',
+                        'test.txt',
+                        'text/xml',
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -1648,7 +1704,14 @@ describe('RecordsManager', () => {
                 const json = stringify(obj);
 
                 records.handleEvents([
-                    recordFile('myToken', obj, 'test.json', 'text/plain', {}, 1),
+                    recordFile(
+                        'myToken',
+                        obj,
+                        'test.json',
+                        'text/plain',
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -1766,7 +1829,14 @@ describe('RecordsManager', () => {
                 const blob = new Blob([html], { type: 'text/html' });
 
                 records.handleEvents([
-                    recordFile('myToken', blob, 'test.html', 'text/plain', {}, 1),
+                    recordFile(
+                        'myToken',
+                        blob,
+                        'test.html',
+                        'text/plain',
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -2036,7 +2106,14 @@ describe('RecordsManager', () => {
                 }
 
                 records.handleEvents([
-                    recordFile('myToken', buffer, 'test.html', undefined, {}, 1),
+                    recordFile(
+                        'myToken',
+                        buffer,
+                        'test.html',
+                        undefined,
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -2168,7 +2245,14 @@ describe('RecordsManager', () => {
                 const doubles = new Float64Array(buffer);
 
                 records.handleEvents([
-                    recordFile('myToken', doubles, 'test.html', undefined, {}, 1),
+                    recordFile(
+                        'myToken',
+                        doubles,
+                        'test.html',
+                        undefined,
+                        {},
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -2336,7 +2420,14 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, { endpoint: 'http://localhost:9999' }, 1),
+                    recordFile(
+                        'myToken',
+                        true,
+                        'test.html',
+                        undefined,
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -2412,7 +2503,14 @@ describe('RecordsManager', () => {
                     authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                     records.handleEvents([
-                        recordFile('myToken', value, 'test.html', undefined, {}, 1),
+                        recordFile(
+                            'myToken',
+                            value,
+                            'test.html',
+                            undefined,
+                            {},
+                            1
+                        ),
                     ]);
 
                     await waitAsync();
@@ -2662,7 +2760,7 @@ describe('RecordsManager', () => {
                     asyncResult(1, {
                         success: false,
                         errorCode: 'not_logged_in',
-                        errorMessage: 'The user is not logged in.'
+                        errorMessage: 'The user is not logged in.',
                     }),
                 ]);
 
@@ -2690,7 +2788,9 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(false);
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
 
                 records.handleEvents([
                     recordFile('myToken', true, 'test.html', undefined, {}, 1),
@@ -2758,7 +2858,9 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(true);
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
+                records.handleEvents([
+                    eraseFile('myToken', 'myFileUrl', {}, 1),
+                ]);
 
                 await waitAsync();
 
@@ -2801,7 +2903,14 @@ describe('RecordsManager', () => {
                 customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', { endpoint: 'http://localhost:9999' }, 1)]);
+                records.handleEvents([
+                    eraseFile(
+                        'myToken',
+                        'myFileUrl',
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
+                ]);
 
                 await waitAsync();
 
@@ -2845,7 +2954,9 @@ describe('RecordsManager', () => {
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
+                records.handleEvents([
+                    eraseFile('myToken', 'myFileUrl', {}, 1),
+                ]);
 
                 await waitAsync();
 
@@ -2889,7 +3000,9 @@ describe('RecordsManager', () => {
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
+                records.handleEvents([
+                    eraseFile('myToken', 'myFileUrl', {}, 1),
+                ]);
 
                 await waitAsync();
 
@@ -2901,7 +3014,7 @@ describe('RecordsManager', () => {
                     asyncResult(1, {
                         success: false,
                         errorCode: 'not_logged_in',
-                        errorMessage: 'The user is not logged in.'
+                        errorMessage: 'The user is not logged in.',
                     }),
                 ]);
                 expect(authMock.isAuthenticated).toBeCalled();
@@ -2918,12 +3031,16 @@ describe('RecordsManager', () => {
                     },
                 });
 
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
                 authMock.isAuthenticated.mockResolvedValueOnce(false);
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
+                records.handleEvents([
+                    eraseFile('myToken', 'myFileUrl', {}, 1),
+                ]);
 
                 await waitAsync();
 
@@ -3018,7 +3135,13 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, { endpoint: 'http://localhost:9999' }, 1),
+                    recordEvent(
+                        'recordKey',
+                        'eventName',
+                        10,
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -3145,7 +3268,9 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(false);
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
-                authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
+                authMock.getRecordKeyPolicy.mockResolvedValueOnce(
+                    'subjectless'
+                );
 
                 records.handleEvents([
                     recordEvent('recordKey', 'eventName', 10, {}, 1),
@@ -3258,7 +3383,12 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', { endpoint: 'http://localhost:9999' }, 1),
+                    getEventCount(
+                        'testRecord',
+                        'myAddress',
+                        { endpoint: 'http://localhost:9999' },
+                        1
+                    ),
                 ]);
 
                 await waitAsync();
@@ -3282,23 +3412,54 @@ describe('RecordsManager', () => {
 
         describe('Common Errors', () => {
             const events = [
-                ['record_data', recordData(
-                    'myToken',
-                    'myAddress',
-                    {
-                        myRecord: true,
-                    },
-                    false,
-                    {},
-                    1
-                )] as const,
-                ['get_record_data', getRecordData('testRecord', 'myAddress', false, {}, 1)] as const,
-                ['list_record_data', listDataRecord('testRecord', null, {}, 1)] as const,
-                ['erase_record_data', eraseRecordData('myToken', 'myAddress', false, {}, 1)] as const,
-                ['record_file', recordFile('myToken', 'myFile', 'test.txt', undefined, {}, 1)] as const,
-                ['erase_file', eraseFile('myToken', 'myFileUrl', {}, 1)] as const,
-                ['record_event', recordEvent('recordKey', 'eventName', 10, {}, 1)] as const,
-                ['get_event_count', getEventCount('testRecord', 'myAddress', {}, 1)] as const
+                [
+                    'record_data',
+                    recordData(
+                        'myToken',
+                        'myAddress',
+                        {
+                            myRecord: true,
+                        },
+                        false,
+                        {},
+                        1
+                    ),
+                ] as const,
+                [
+                    'get_record_data',
+                    getRecordData('testRecord', 'myAddress', false, {}, 1),
+                ] as const,
+                [
+                    'list_record_data',
+                    listDataRecord('testRecord', null, {}, 1),
+                ] as const,
+                [
+                    'erase_record_data',
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
+                ] as const,
+                [
+                    'record_file',
+                    recordFile(
+                        'myToken',
+                        'myFile',
+                        'test.txt',
+                        undefined,
+                        {},
+                        1
+                    ),
+                ] as const,
+                [
+                    'erase_file',
+                    eraseFile('myToken', 'myFileUrl', {}, 1),
+                ] as const,
+                [
+                    'record_event',
+                    recordEvent('recordKey', 'eventName', 10, {}, 1),
+                ] as const,
+                [
+                    'get_event_count',
+                    getEventCount('testRecord', 'myAddress', {}, 1),
+                ] as const,
             ];
 
             describe.each(events)('%s', (desc, event) => {
@@ -3309,7 +3470,7 @@ describe('RecordsManager', () => {
                             version: '1.0.0',
                             versionHash: '1234567890abcdef',
                             authOrigin: 'https://localhost:321',
-                            recordsOrigin: 'https://localhost:145'
+                            recordsOrigin: 'https://localhost:145',
                         },
                         helper,
                         factory
@@ -3317,9 +3478,7 @@ describe('RecordsManager', () => {
 
                     factory.mockReturnValueOnce(null);
 
-                    records.handleEvents([
-                        event,
-                    ]);
+                    records.handleEvents([event]);
 
                     await waitAsync();
 
@@ -3327,7 +3486,8 @@ describe('RecordsManager', () => {
                         asyncResult(1, {
                             success: false,
                             errorCode: 'not_supported',
-                            errorMessage: 'Records are not supported on this inst.',
+                            errorMessage:
+                                'Records are not supported on this inst.',
                         }),
                     ]);
 
@@ -3340,7 +3500,7 @@ describe('RecordsManager', () => {
                         {
                             version: '1.0.0',
                             versionHash: '1234567890abcdef',
-                            authOrigin: null
+                            authOrigin: null,
                         },
                         helper,
                         factory
@@ -3348,9 +3508,7 @@ describe('RecordsManager', () => {
 
                     factory.mockReturnValueOnce(null);
 
-                    records.handleEvents([
-                        event,
-                    ]);
+                    records.handleEvents([event]);
 
                     await waitAsync();
 
@@ -3358,7 +3516,8 @@ describe('RecordsManager', () => {
                         asyncResult(1, {
                             success: false,
                             errorCode: 'not_supported',
-                            errorMessage: 'Records are not supported on this inst.',
+                            errorMessage:
+                                'Records are not supported on this inst.',
                         }),
                     ]);
 
@@ -3371,7 +3530,7 @@ describe('RecordsManager', () => {
                         {
                             version: '1.0.0',
                             versionHash: '1234567890abcdef',
-                            authOrigin: null
+                            authOrigin: null,
                         },
                         helper,
                         factory
@@ -3381,15 +3540,13 @@ describe('RecordsManager', () => {
                         ...event,
                         options: {
                             ...event.options,
-                            endpoint: 'http://localhost:999'
-                        }
+                            endpoint: 'http://localhost:999',
+                        },
                     };
 
                     factory.mockReturnValueOnce(null);
 
-                    records.handleEvents([
-                        e,
-                    ]);
+                    records.handleEvents([e]);
 
                     await waitAsync();
 
@@ -3397,7 +3554,8 @@ describe('RecordsManager', () => {
                         asyncResult(1, {
                             success: false,
                             errorCode: 'not_supported',
-                            errorMessage: 'Records are not supported on this inst.',
+                            errorMessage:
+                                'Records are not supported on this inst.',
                         }),
                     ]);
 

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -189,7 +189,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -246,7 +246,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
-                        'http://localhost:9999',
+                        { endpoint: 'http://localhost:9999' },
                         1
                     ),
                 ]);
@@ -304,7 +304,7 @@ describe('RecordsManager', () => {
                                 myRecord: true,
                             },
                             true,
-                            null,
+                            {},
                             1
                         )
                     ),
@@ -363,7 +363,7 @@ describe('RecordsManager', () => {
                                 myRecord: true,
                             },
                             true,
-                            'http://localhost:9999',
+                            { endpoint: 'http://localhost:9999' },
                             1
                         )
                     ),
@@ -422,7 +422,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -454,7 +454,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -493,7 +493,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         true,
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -529,7 +529,7 @@ describe('RecordsManager', () => {
                             myRecord: true,
                         },
                         false,
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -581,7 +581,7 @@ describe('RecordsManager', () => {
                                 myRecord: true,
                             },
                             true,
-                            null,
+                            {},
                             1
                         )
                     ),
@@ -635,7 +635,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, null, 1),
+                    getRecordData('testRecord', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -673,7 +673,7 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, 'http://localhost:9999', 1),
+                    getRecordData('testRecord', 'myAddress', false, { endpoint:'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -712,7 +712,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        getRecordData('testRecord', 'myAddress', true, null, 1)
+                        getRecordData('testRecord', 'myAddress', true, {}, 1)
                     ),
                 ]);
 
@@ -752,7 +752,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        getRecordData('testRecord', 'myAddress', true, 'http://localhost:9999', 1)
+                        getRecordData('testRecord', 'myAddress', true, { endpoint: 'http://localhost:9999' }, 1)
                     ),
                 ]);
 
@@ -788,7 +788,7 @@ describe('RecordsManager', () => {
                 );
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', false, null, 1),
+                    getRecordData('testRecord', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -817,7 +817,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getRecordData('testRecord', 'myAddress', true, null, 1),
+                    getRecordData('testRecord', 'myAddress', true, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -852,7 +852,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    listDataRecord('testRecord', 'myAddress', null, 1),
+                    listDataRecord('testRecord', 'myAddress', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -894,7 +894,7 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    listDataRecord('testRecord', 'myAddress', 'http://localhost:9999', 1),
+                    listDataRecord('testRecord', 'myAddress', { endpoint: 'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -935,7 +935,7 @@ describe('RecordsManager', () => {
 
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([listDataRecord('testRecord', null, null, 1)]);
+                records.handleEvents([listDataRecord('testRecord', null, {}, 1)]);
 
                 await waitAsync();
 
@@ -978,7 +978,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, null, 1),
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1023,7 +1023,7 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, 'http://localhost:9999', 1),
+                    eraseRecordData('myToken', 'myAddress', false, { endpoint: 'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -1069,7 +1069,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        eraseRecordData('myToken', 'myAddress', true, null, 1)
+                        eraseRecordData('myToken', 'myAddress', true, {}, 1)
                     ),
                 ]);
 
@@ -1116,7 +1116,7 @@ describe('RecordsManager', () => {
 
                 records.handleEvents([
                     approveDataRecord(
-                        eraseRecordData('myToken', 'myAddress', true, 'http://localhost:9999', 1)
+                        eraseRecordData('myToken', 'myAddress', true, { endpoint: 'http://localhost:9999' }, 1)
                     ),
                 ]);
 
@@ -1161,7 +1161,7 @@ describe('RecordsManager', () => {
                 );
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, null, 1),
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1188,7 +1188,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', true, null, 1),
+                    eraseRecordData('myToken', 'myAddress', true, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1217,7 +1217,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, null, 1),
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1263,7 +1263,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, null, 1),
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1295,7 +1295,7 @@ describe('RecordsManager', () => {
                 authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
 
                 records.handleEvents([
-                    eraseRecordData('myToken', 'myAddress', false, null, 1),
+                    eraseRecordData('myToken', 'myAddress', false, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1336,7 +1336,7 @@ describe('RecordsManager', () => {
                 authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
 
                 records.handleEvents([
-                    approveDataRecord(eraseRecordData('myToken', 'myAddress', true, null, 1))
+                    approveDataRecord(eraseRecordData('myToken', 'myAddress', true, {}, 1))
                 ]);
 
                 await waitAsync();
@@ -1392,7 +1392,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', undefined, null, 1),
+                    recordFile('myToken', 'myFile', 'test.txt', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1456,7 +1456,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 'myFile', 'test.txt', 'text/xml', null, 1),
+                    recordFile('myToken', 'myFile', 'test.txt', 'text/xml', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1521,7 +1521,7 @@ describe('RecordsManager', () => {
                 const json = stringify(obj);
 
                 records.handleEvents([
-                    recordFile('myToken', obj, 'test.json', undefined, null, 1),
+                    recordFile('myToken', obj, 'test.json', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1586,7 +1586,7 @@ describe('RecordsManager', () => {
                 const json = stringify(obj);
 
                 records.handleEvents([
-                    recordFile('myToken', obj, 'test.json', 'text/plain', null, 1),
+                    recordFile('myToken', obj, 'test.json', 'text/plain', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1645,7 +1645,7 @@ describe('RecordsManager', () => {
                 const blob = new Blob([html], { type: 'text/html' });
 
                 records.handleEvents([
-                    recordFile('myToken', blob, 'test.html', undefined, null, 1),
+                    recordFile('myToken', blob, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1704,7 +1704,7 @@ describe('RecordsManager', () => {
                 const blob = new Blob([html], { type: 'text/html' });
 
                 records.handleEvents([
-                    recordFile('myToken', blob, 'test.html', 'text/plain', null, 1),
+                    recordFile('myToken', blob, 'test.html', 'text/plain', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1773,7 +1773,7 @@ describe('RecordsManager', () => {
                 };
 
                 records.handleEvents([
-                    recordFile('myToken', file, 'test.html', undefined, null, 1),
+                    recordFile('myToken', file, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1836,7 +1836,7 @@ describe('RecordsManager', () => {
                 };
 
                 records.handleEvents([
-                    recordFile('myToken', file, 'test.html', undefined, null, 1),
+                    recordFile('myToken', file, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -1910,7 +1910,7 @@ describe('RecordsManager', () => {
                         file,
                         'test.html',
                         'application/octet-stream',
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -1974,7 +1974,7 @@ describe('RecordsManager', () => {
                 }
 
                 records.handleEvents([
-                    recordFile('myToken', buffer, 'test.html', undefined, null, 1),
+                    recordFile('myToken', buffer, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2041,7 +2041,7 @@ describe('RecordsManager', () => {
                         buffer,
                         'test.html',
                         'application/zip',
-                        null,
+                        {},
                         1
                     ),
                 ]);
@@ -2106,7 +2106,7 @@ describe('RecordsManager', () => {
                 const doubles = new Float64Array(buffer);
 
                 records.handleEvents([
-                    recordFile('myToken', doubles, 'test.html', undefined, null, 1),
+                    recordFile('myToken', doubles, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2162,7 +2162,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', 10, 'test.html', undefined, null, 1),
+                    recordFile('myToken', 10, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2218,7 +2218,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, null, 1),
+                    recordFile('myToken', true, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2274,7 +2274,7 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, 'http://localhost:9999', 1),
+                    recordFile('myToken', true, 'test.html', undefined, { endpoint: 'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -2350,7 +2350,7 @@ describe('RecordsManager', () => {
                     authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                     records.handleEvents([
-                        recordFile('myToken', value, 'test.html', undefined, null, 1),
+                        recordFile('myToken', value, 'test.html', undefined, {}, 1),
                     ]);
 
                     await waitAsync();
@@ -2380,7 +2380,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, null, 1),
+                    recordFile('myToken', true, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2461,7 +2461,7 @@ describe('RecordsManager', () => {
                                 true,
                                 'test.html',
                                 undefined,
-                                null,
+                                {},
                                 1
                             ),
                         ]);
@@ -2520,7 +2520,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, null, 1),
+                    recordFile('myToken', true, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2590,7 +2590,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, null, 1),
+                    recordFile('myToken', true, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2631,7 +2631,7 @@ describe('RecordsManager', () => {
                 authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
 
                 records.handleEvents([
-                    recordFile('myToken', true, 'test.html', undefined, null, 1),
+                    recordFile('myToken', true, 'test.html', undefined, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2696,7 +2696,7 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(true);
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', null, 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
 
                 await waitAsync();
 
@@ -2739,7 +2739,7 @@ describe('RecordsManager', () => {
                 customAuthMock.isAuthenticated.mockResolvedValueOnce(true);
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', 'http://localhost:9999', 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', { endpoint: 'http://localhost:9999' }, 1)]);
 
                 await waitAsync();
 
@@ -2783,7 +2783,7 @@ describe('RecordsManager', () => {
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', null, 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
 
                 await waitAsync();
 
@@ -2827,7 +2827,7 @@ describe('RecordsManager', () => {
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', null, 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
 
                 await waitAsync();
 
@@ -2861,7 +2861,7 @@ describe('RecordsManager', () => {
                 authMock.authenticate.mockResolvedValueOnce({});
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
-                records.handleEvents([eraseFile('myToken', 'myFileUrl', null, 1)]);
+                records.handleEvents([eraseFile('myToken', 'myFileUrl', {}, 1)]);
 
                 await waitAsync();
 
@@ -2910,7 +2910,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, null, 1),
+                    recordEvent('recordKey', 'eventName', 10, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -2956,7 +2956,7 @@ describe('RecordsManager', () => {
                 customAuthMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, 'http://localhost:9999', 1),
+                    recordEvent('recordKey', 'eventName', 10, { endpoint: 'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -3003,7 +3003,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, null, 1),
+                    recordEvent('recordKey', 'eventName', 10, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -3050,7 +3050,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce(null);
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, null, 1),
+                    recordEvent('recordKey', 'eventName', 10, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -3086,7 +3086,7 @@ describe('RecordsManager', () => {
                 authMock.getRecordKeyPolicy.mockResolvedValueOnce('subjectless');
 
                 records.handleEvents([
-                    recordEvent('recordKey', 'eventName', 10, null, 1),
+                    recordEvent('recordKey', 'eventName', 10, {}, 1),
                 ]);
 
                 await waitAsync();
@@ -3137,7 +3137,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', null, 1),
+                    getEventCount('testRecord', 'myAddress', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -3169,7 +3169,7 @@ describe('RecordsManager', () => {
                 );
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', null, 1),
+                    getEventCount('testRecord', 'myAddress', {}, 1),
                 ]);
 
                 await waitAsync();
@@ -3196,7 +3196,7 @@ describe('RecordsManager', () => {
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
                 records.handleEvents([
-                    getEventCount('testRecord', 'myAddress', 'http://localhost:9999', 1),
+                    getEventCount('testRecord', 'myAddress', { endpoint: 'http://localhost:9999' }, 1),
                 ]);
 
                 await waitAsync();
@@ -3227,16 +3227,16 @@ describe('RecordsManager', () => {
                         myRecord: true,
                     },
                     false,
-                    null,
+                    {},
                     1
                 )] as const,
-                ['get_record_data', getRecordData('testRecord', 'myAddress', false, null, 1)] as const,
-                ['list_record_data', listDataRecord('testRecord', null, null, 1)] as const,
-                ['erase_record_data', eraseRecordData('myToken', 'myAddress', false, null, 1)] as const,
-                ['record_file', recordFile('myToken', 'myFile', 'test.txt', undefined, null, 1)] as const,
-                ['erase_file', eraseFile('myToken', 'myFileUrl', null, 1)] as const,
-                ['record_event', recordEvent('recordKey', 'eventName', 10, null, 1)] as const,
-                ['get_event_count', getEventCount('testRecord', 'myAddress', null, 1)] as const
+                ['get_record_data', getRecordData('testRecord', 'myAddress', false, {}, 1)] as const,
+                ['list_record_data', listDataRecord('testRecord', null, {}, 1)] as const,
+                ['erase_record_data', eraseRecordData('myToken', 'myAddress', false, {}, 1)] as const,
+                ['record_file', recordFile('myToken', 'myFile', 'test.txt', undefined, {}, 1)] as const,
+                ['erase_file', eraseFile('myToken', 'myFileUrl', {}, 1)] as const,
+                ['record_event', recordEvent('recordKey', 'eventName', 10, {}, 1)] as const,
+                ['get_event_count', getEventCount('testRecord', 'myAddress', {}, 1)] as const
             ];
 
             describe.each(events)('%s', (desc, event) => {
@@ -3317,7 +3317,10 @@ describe('RecordsManager', () => {
 
                     let e = {
                         ...event,
-                        endpoint: 'http://localhost:999'
+                        options: {
+                            ...event.options,
+                            endpoint: 'http://localhost:999'
+                        }
                     };
 
                     factory.mockReturnValueOnce(null);

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -111,6 +111,20 @@ export class RecordsManager {
             }
 
             console.log('[RecordsManager] Recording data...', event);
+            let requestData: any = {
+                recordKey: event.recordKey,
+                address: event.address,
+                data: event.data,
+            };
+
+            if (hasValue(event.options.updatePolicy)) {
+                requestData.updatePolicy = event.options.updatePolicy;
+            }
+
+            if (hasValue(event.options.deletePolicy)) {
+                requestData.deletePolicy = event.options.deletePolicy;
+            }
+
             const result: AxiosResponse<RecordDataResult> = await axios.post(
                 this._publishUrl(
                     info.auth,
@@ -118,11 +132,7 @@ export class RecordsManager {
                         ? '/api/v2/records/data'
                         : '/api/v2/records/manual/data'
                 ),
-                {
-                    recordKey: event.recordKey,
-                    address: event.address,
-                    data: event.data,
-                },
+                requestData,
                 {
                     headers: info.headers,
                 }

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -151,7 +151,7 @@ export class RecordsManager {
             return;
         }
         try {
-            const auth = this._getAuthFromEvent(event);
+            const auth = this._getAuthFromEvent(event.options);
 
             if (!auth) {
                 if (hasValue(event.taskId)) {
@@ -200,7 +200,7 @@ export class RecordsManager {
             return;
         }
         try {
-            const auth = this._getAuthFromEvent(event);
+            const auth = this._getAuthFromEvent(event.options);
 
             if (!auth) {
                 if (hasValue(event.taskId)) {
@@ -546,7 +546,7 @@ export class RecordsManager {
 
     private async _getEventCount(event: GetEventCountAction) {
         try {
-            const auth = this._getAuthFromEvent(event);
+            const auth = this._getAuthFromEvent(event.options);
 
             if (!auth) {
                 if (hasValue(event.taskId)) {
@@ -585,7 +585,7 @@ export class RecordsManager {
     }
 
     private async _resolveInfoForEvent(event: RecordFileAction | EraseFileAction | RecordDataAction | EraseRecordDataAction | RecordEventAction): Promise< { error: boolean, auth: AuthHelperInterface, headers: { [key: string]: string } }> {
-        const auth = this._getAuthFromEvent(event);
+        const auth = this._getAuthFromEvent(event.options);
 
         if (!auth) {
             if (hasValue(event.taskId)) {

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -671,7 +671,7 @@ export class RecordsManager {
         } else {
             auth = this._authFactory(endpoint);
             this._auths.set(endpoint, auth);
-    }
+        }
         return auth;
     }
 


### PR DESCRIPTION
### :rocket: Improvements
-   Added the ability to specify an options object with `os.recordData(key, address, data, options)` that can specify update and delete policies for the data.

    -   These policies can be useful to restrict the set of users that can manipulate the recorded data.
    -   `options` is an object with the following properties:

        ```typescript
        let options: {
            /**
             * The HTTP Endpoint that should be queried.
             */
            endpoint?: string;

            /**
             * The policy that should be used for updating the record.
             * - true indicates that the value can be updated by anyone.
             * - An array of strings indicates the list of user IDs that are allowed to update the data.
             */
            updatePolicy?: true | string[];

            /**
             * The policy that should be used for deleting the record.
             * - true indicates that the value can be erased by anyone.
             * - An array of strings indicates the list of user IDs that are allowed to delete the data.
             * Note that even if a delete policy is used, the owner of the record can still erase any data in the record.
             */
            deletePolicy?: true | string[];
        };
        ```

### :bug: Bug Fixes

-   Fixed an issue where CasualOS would attempt to download records from the wrong origin if using a custom `endpoint` parameter.