### PR TITLE
Better animation controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@
     -   This creates a virtual keyboard that the user can interact with.
     -   Clicking keys on the keyboard sends a `@onKeyClick` whisper to the bot.
 -   Improved the system portal diff tab to set the `editingBot`, `editingTag`, and `editingTagSpace` tags on the configBot.
+-   Added the `os.startFormAnimation(bot, animationName, options?)`, `os.stopFormAnimation(bot, options?)`, `os.listFormAnimations(botOrAddress)`, and `os.bufferFormAddressGLTF(address)` functions.
+    -   `os.startFormAnimation(bot, animationName, options?)` is used to trigger an animation on the given bot. Returns a promise that resolves when the animation has started. It accepts the following parameters:
+        -   `bot` - The bot or list of bots that the animation should be triggered on.
+        -   `animationName` - The name or index of the animation that should be started.
+        -   `options` - The additional parameters that should be used for the animation. Optional. It should be an object with the following properties:
+            -   `startTime` - The time that the animation should start playing. It should be the number of miliseconds since the Unix Epoch.
+            -   `initialTime` - The time within the animation clip that the animation should start at in miliseconds.
+            -   `timeScale` - The rate at which the animation plays.
+            -   `loop` - Options for looping. It should be an object with the following properties:
+                -   `mode` - How the animation should loop. It should be either `repeat` or `pingPong`.
+                -   `count` - The number of times that the animation should loop.
+            -   `clampWhenFinished` - Whether the final animation values should be preserved when the animation finishes.
+            -   `crossFadeDuration` - The number of miliseconds that the animation should take to cross fade from the previous animation.
+            -   `fadeDuration` - The number of miliseconds that the animation should take to fade in.
+            -   `animationAddress` - The address that the animations should be loaded from.
+    -   `os.stopFormAnimation(bot, options?)` is used to stop animations on the given bot. Returns a promise that resolves when the animation has stopped. It accepts the following parameters:
+        -   `bot` - The bot or list of bots that animations should be stopped on.
+        -   `options` - The options that should be used to stop the animations. Optional. It should be an object with the following properties:
+            -   `stopTime` - The time that the animation should stop playing. It should be the number of miliseconds since the Unix Epoch.
+            -   `fadeDuration` - The number of miliseconds that the animation should take to fade out.
+    -   `os.listFormAnimations(botOrAddress)` is used to retrieve the list of animations that are available on a form. Returns a promise that resolves with the animation list. It accepts the following parameters:
+        -   `botOrAddress` - The bot or address that the animation list should be retrieved for.
+    -   `os.bufferFormAddressGLTF(address)` is used to pre-cache the given address as a GLTF mesh for future use. Returns a promise that resolves when the address has been buffered. It accepts the following parameters:
+        -   `address` - The address that should be loaded.
+-   Added several listeners that can be used to observe animation changes on bots.
+    -   Currently, they are only sent for animations that are started via `os.startFormAnimation()`. Animations that are triggered via the `#formAnimation` tag or `experiment.localFormAnimation()` are not supported.
+    -   `@onFormAnimationStarted` and `@onAnyFormAnimationStarted` are sent when an animation has been started.
+    -   `@onFormAnimationStopped` and `@onAnyFormAnimationStopped` are sent when an animation has been manually stopped.
+    -   `@onFormAnimationFinished` and `@onAnyFormAnimationFinished` are sent when an animation finishes playing.
+    -   `@onFormAnimationLooped` and `@onAnyFormAnimationLooped` are sent when an animation restarts per the looping rules that were given in the options object.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -5933,6 +5933,117 @@ const participants = await os.meetFunction('getParticipantsInfo')
 const rooms = await os.meetFunction('listBreakoutRooms');
 ```
 
+## Form Animation Actions
+
+### `os.startFormAnimation(botOrBots, nameOrIndex, options?)`
+
+Starts the given animation on the given bot or list of bots using the given options.
+Returns a promise that resolves once the animation(s) have been started.
+
+Triggers the <TagLink tag='@onFormAnimationStarted'/> and <TagLink tag='@onAnyFormAnimationStarted'/> listeners once the animation has started.
+
+The **first parameter** is the bot or list of bots that the animation should be started on.
+
+The **second parameter** is the name of the animation that should be started. Additionally, it can be the index number of the animation that should be played.
+
+The **third paramter** is optional and are the options that should be used to play the animation. If provided, it should be an object with the following properties:
+
+```typescript
+let options: {
+    /**
+     * The Unix time in miliseconds that the animation should start at.
+     */
+    startTime?: number;
+
+    /**
+     * The time within the animation clip that the animation should start at in miliseconds.
+     */
+    initialTime?: number;
+
+    /**
+     * The rate at which the animation plays.
+     * 1 means the animation plays normally.
+     * 2 means the animation plays 2x as quickly.
+     * 0 means that the animation is paused.
+     */
+    timeScale?: number;
+
+    /**
+     * The options for looping the animation.
+     * If omitted, then the animation will play once and finish.
+     */
+    loop?: {
+        /**
+         * The looping mode that should be used.
+         */
+        mode: 'repeat' | 'pingPong';
+
+        /**
+         * The number of times that the animation should repeat for.
+         */
+        count: number;
+    };
+
+    /**
+     * Whether the final animation values should be preserved when the animation finishes.
+     */
+    clampWhenFinished?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to cross fade from the previous animation.
+     * If null, then this animation takes over immediately. Additionally, if no previous animation was playing then this animation takes over immediately.
+     */
+    crossFadeDuration?: number;
+
+    /**
+     * Whether to warp animation values during a cross fade.
+     */
+    crossFadeWarp?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to fade in.
+     * If null, then the animation will not fade in.
+     */
+    fadeDuration?: number;
+
+    /**
+     * The address that the animations should be loaded from.
+     */
+    animationAddress?: string;
+}
+```
+
+#### Examples
+
+```typescript title="Start the 'Run' animation on this bot"
+await os.startFormAnimation(thisBot, "Run");
+```
+
+```typescript title="Start the 'Run' animation on every bot in the home dimension"
+await os.startFormAnimation(getBots(inDimension('home')), "Run");
+```
+
+```typescript title="Start an animation that loops 5 times"
+await os.startFormAnimation(thisBot, "Run", {
+    loop: {
+        mode: 'repeat',
+        count: 5
+    }
+});
+```
+
+```typescript title="Start an animation which starts playing 5 seconds in the future"
+await os.startFormAnimation(thisBot, "Run", {
+    startTime: os.localTime + 5000
+});
+```
+
+```typescript title="Start an animation which plays at half its normal speed"
+await os.startFormAnimation(thisBot, "Run", {
+    timeScale: 0.5
+});
+```
+
 ## Room Actions
 
 Room actions are actions that make it easy to create your own custom multimedia chat rooms.

--- a/docs/docs/actions.mdx
+++ b/docs/docs/actions.mdx
@@ -6015,15 +6015,15 @@ let options: {
 
 #### Examples
 
-```typescript title="Start the 'Run' animation on this bot"
+```typescript title='Start the "Run" animation on this bot'
 await os.startFormAnimation(thisBot, "Run");
 ```
 
-```typescript title="Start the 'Run' animation on every bot in the home dimension"
-await os.startFormAnimation(getBots(inDimension('home')), "Run");
+```typescript title='Start the "Run" animation on every bot in the home dimension'
+await os.startFormAnimation(getBots(inDimension("home")), "Run");
 ```
 
-```typescript title="Start an animation that loops 5 times"
+```typescript title='Start an animation that loops 5 times'
 await os.startFormAnimation(thisBot, "Run", {
     loop: {
         mode: 'repeat',
@@ -6032,16 +6032,112 @@ await os.startFormAnimation(thisBot, "Run", {
 });
 ```
 
-```typescript title="Start an animation which starts playing 5 seconds in the future"
+```typescript title='Start an animation which starts playing 5 seconds in the future'
 await os.startFormAnimation(thisBot, "Run", {
     startTime: os.localTime + 5000
 });
 ```
 
-```typescript title="Start an animation which plays at half its normal speed"
+```typescript title='Start an animation which plays at half its normal speed'
 await os.startFormAnimation(thisBot, "Run", {
     timeScale: 0.5
 });
+```
+
+### `os.stopFormAnimation(botOrBots, options?)`
+
+Stops the animations that are running on the given bot or list of bots using the given options.
+Returns a promise that resolves once the animations have been stopped.
+
+This function only works for animations that have been started by <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/>.
+
+Triggers the <TagLink tag='@onFormAnimationStopped'/> and <TagLink tag='@onAnyFormAnimationStopped'/> listeners once the animation has stopped.
+
+The **first parameter** is the bot or list of bots whose animations should be stopped.
+
+The **second parameter** is optional and are the options that should be used for stopping the animations. It should be an object with the following properties:
+
+```typescript
+let options: {
+    /**
+     * The Unix time in miliseconds that the animation should be stopped at.
+     */
+    stopTime?: number;
+
+    /**
+     * The number of miliseconds that the animation should take to fade out.
+     * If null, then the animation will stop immediately.
+     */
+    fadeDuration?: number;
+};
+```
+
+#### Examples
+
+```typescript title='Stop the animations on this bot'
+await os.stopFormAnimation(thisBot);
+```
+
+```typescript title='Slowly stop the animations on this bot'
+await os.stopFormAnimation(thisBot, {
+    fadeDuration: 1000 // Take 1 second to stop the animation
+});
+```
+
+```typescript title='Stop the current animation 5 seconds in the future'
+await os.stopFormAnimation(thisBot, {
+    stopTime: os.localTime + 5000
+});
+```
+
+### `os.listFormAnimations(botOrAddress)`
+
+Retrieves the list of animations that are available on the given bot or GLTF mesh address.
+Returns a promise that resolves with a list of objects with the following form:
+
+```typescript
+let animation: {
+    /**
+     * The name of the animation.
+     */
+    name: string;
+
+    /**
+     * The index that the animation is at.
+     */
+    index: number;
+
+    /**
+     * The duration of the animation in miliseconds.
+     */
+    duration: number;
+};
+```
+
+The **first parameter** is the bot or address that the animation list should be retrieved from.
+
+#### Examples
+
+```typescript title='Get the list of animations on this bot'
+const animations = await os.listFormAnimations(thisBot);
+```
+
+```typescript title='Get the list of animations for a specific address'
+const animations = await os.listFormAnimations('https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF/Fox.gltf');
+```
+
+### `os.bufferFormAddressGLTF(address)`
+
+Pre-caches the given GLTF mesh address so that it will load instantly when used on a bot later.
+Returns a promise that resolves once the address has been cached.
+
+The **first parameter** is a string and is the address that should be cached.
+
+#### Examples
+
+```typescript title='Buffer a specific GLTF'
+await os.bufferFormAddressGLTF('https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF/Fox.gltf');
+os.toast("Buffered!");
 ```
 
 ## Room Actions

--- a/docs/docs/listen-tags.mdx
+++ b/docs/docs/listen-tags.mdx
@@ -489,6 +489,68 @@ let that: {
 };
 ```
 
+### `@onFormAnimationStarted`
+
+A whisper that is sent whenever an animation is started via the <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> function.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The animation that was started.
+     */
+    animation: string | number;
+};
+```
+
+### `@onFormAnimationStopped`
+
+A whisper that is sent whenever an animation is stopped via the <ActionLink action='os.stopFormAnimation(botOrBots, options?)'/> function.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The animation that was stopped.
+     */
+    animation: string | number;
+};
+```
+
+### `@onFormAnimationLooped`
+
+A whisper that is sent whenever an animation finishes and starts to repeat based on the loop rules given to <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> in the options.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The animation that was looped.
+     */
+    animation: string | number;
+
+    /**
+     * The number of loops that have been completed.
+     */
+    loopCount: number;
+};
+```
+
+### `@onFormAnimationFinished`
+
+A whisper that is sent whenever an animation that was started by <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> stops.
+This whisper is sent both for when the animation is manually stopped (by calling <ActionLink action='os.stopFormAnimation(botOrBots, options?)'/>) and also when it stops because it shouldn't repeat.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The animation that finished.
+     */
+    animation: string | number;
+};
+```
+
 ## Shout Tags
 
 Shouts are events which are sent to all bots.
@@ -1884,5 +1946,87 @@ let that: {
          */
         screen: boolean;
     };
+};
+```
+
+### `@onAnyFormAnimationStarted`
+
+A shout that is sent to all bots whenever an animation is started via the <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> function.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The bot that the animation was started on.
+     */
+    bot: Bot;
+
+    /**
+     * The animation that was started.
+     */
+    animation: string | number;
+};
+```
+
+### `@onAnyFormAnimationStopped`
+
+A shout that is sent to all bots whenever an animation is stopped via the <ActionLink action='os.stopFormAnimation(botOrBots, options?)'/> function.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The bot that the animation was stopped on.
+     */
+    bot: Bot;
+
+    /**
+     * The animation that was stopped.
+     */
+    animation: string | number;
+};
+```
+
+### `@onAnyFormAnimationLooped`
+
+A shout that is sent to all bots whenever an animation finishes and starts to repeat based on the loop rules given to <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> in the options.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The bot that the animation was looped on.
+     */
+    bot: Bot;
+
+    /**
+     * The animation that was looped.
+     */
+    animation: string | number;
+
+    /**
+     * The number of loops that have been completed.
+     */
+    loopCount: number;
+};
+```
+
+### `@onAnyFormAnimationFinished`
+
+A shout that is sent to all bots whenever an animation that was started by <ActionLink action='os.startFormAnimation(botOrBots, nameOrIndex, options?)'/> stops.
+This shout is sent both for when the animation is manually stopped (by calling <ActionLink action='os.stopFormAnimation(botOrBots, options?)'/>) and also when it stops because it shouldn't repeat.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The bot that the animation was finished on.
+     */
+    bot: Bot;
+
+    /**
+     * The animation that finished.
+     */
+    animation: string | number;
 };
 ```

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1698,6 +1698,49 @@ export const ON_ROOM_REMOTE_LEAVE: string = 'onRoomRemoteLeave';
 export const ON_ROOM_OPTIONS_CHANGED: string = 'onRoomOptionsChanged';
 
 /**
+ * The name of the event that is triggered when a form animation is started.
+ */
+export const ON_FORM_ANIMATION_STARTED: string = 'onFormAnimationStarted';
+
+/**
+ * The name of the event that is triggered for all bots when a form animation is started.
+ */
+export const ON_ANY_FORM_ANIMATION_STARTED: string =
+    'onAnyFormAnimationStarted';
+
+/**
+ * The name of the event that is triggered when a form animation is finished.
+ */
+export const ON_FORM_ANIMATION_FINISHED: string = 'onFormAnimationFinished';
+
+/**
+ * The name of the event that is triggered for all bots when a form animation is finished.
+ */
+export const ON_ANY_FORM_ANIMATION_FINISHED: string =
+    'onAnyFormAnimationFinished';
+
+/**
+ * The name of the event that is triggered when a form animation is stopped.
+ */
+export const ON_FORM_ANIMATION_STOPPED: string = 'onFormAnimationStopped';
+
+/**
+ * The name of the event that is triggered for all bots when a form animation is stopped.
+ */
+export const ON_ANY_FORM_ANIMATION_STOPPED: string =
+    'onAnyFormAnimationStopped';
+
+/**
+ * The name of the event that is triggered when a form animation loops.
+ */
+export const ON_FORM_ANIMATION_LOOPED: string = 'onFormAnimationLooped';
+
+/**
+ * The name of the event that is triggered for all bots when a form animation loops.
+ */
+export const ON_ANY_FORM_ANIMATION_LOOPED: string = 'onAnyFormAnimationLooped';
+
+/**
  * The current bot format version for AUX Bots.
  * This number increments whenever there are any changes between AUX versions.
  * As a result, it will allow us to make breaking changes but still upgrade people's bots
@@ -2301,6 +2344,15 @@ export const KNOWN_TAGS: string[] = [
     ON_ROOM_REMOTE_JOINED,
     ON_ROOM_REMOTE_LEAVE,
     ON_ROOM_OPTIONS_CHANGED,
+
+    ON_FORM_ANIMATION_STARTED,
+    ON_ANY_FORM_ANIMATION_STARTED,
+    ON_FORM_ANIMATION_FINISHED,
+    ON_ANY_FORM_ANIMATION_FINISHED,
+    ON_FORM_ANIMATION_STOPPED,
+    ON_ANY_FORM_ANIMATION_STOPPED,
+    ON_FORM_ANIMATION_LOOPED,
+    ON_ANY_FORM_ANIMATION_LOOPED,
 ];
 
 export function onClickArg(

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -233,7 +233,8 @@ export type AsyncActions =
     | GetRoomRemoteOptionsAction
     | RaycastFromCameraAction
     | RaycastInPortalAction
-    | CalculateRayFromCameraAction;
+    | CalculateRayFromCameraAction
+    | BufferFormAddressGLTFAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -3988,6 +3989,18 @@ export interface CalculateRayFromCameraAction extends AsyncAction {
     viewportCoordinates: Point2D;
 }
 
+/**
+ * Defines an event that requests the pre-caching of a GLTF mesh.
+ */
+export interface BufferFormAddressGLTFAction extends AsyncAction {
+    type: 'buffer_form_address_gltf';
+
+    /**
+     * The address that should be buffered.
+     */
+    address: string;
+}
+
 export type CameraPortal = 'grid' | 'miniGrid' | 'map' | 'miniMap';
 
 export interface Point2D {
@@ -7173,6 +7186,22 @@ export function calculateRayFromCamera(
         type: 'calculate_camera_ray',
         portal,
         viewportCoordinates,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new BufferFormAddressGLTFAction.
+ * @param address The address that should be cached.
+ * @param taskId The ID of the async task.
+ */
+export function bufferFormAddressGltf(
+    address: string,
+    taskId?: number | string
+): BufferFormAddressGLTFAction {
+    return {
+        type: 'buffer_form_address_gltf',
+        address,
         taskId,
     };
 }

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -237,7 +237,7 @@ export type AsyncActions =
     | BufferFormAddressGLTFAction
     | StartFormAnimationAction
     | StopFormAnimationAction
-    | GetFormAnimationsAction;
+    | ListFormAnimationsAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -4122,13 +4122,33 @@ export interface StopFormAnimationAction
 /**
  * Defines an event that retrieves a list of animations for a given form or bot.
  */
-export interface GetFormAnimationsAction extends AsyncAction {
-    type: 'get_form_animations';
+export interface ListFormAnimationsAction extends AsyncAction {
+    type: 'list_form_animations';
 
     /**
      * The address that the animations should be retrieved from.
      */
     address: string;
+}
+
+/**
+ * Defines an interface that contains animation information.
+ */
+export interface FormAnimationData {
+    /**
+     * The name of the animation.
+     */
+    name: string;
+
+    /**
+     * The index that the animation is at.
+     */
+    index: number;
+
+    /**
+     * The duration of the animation in miliseconds.
+     */
+    duration: number;
 }
 
 export type CameraPortal = 'grid' | 'miniGrid' | 'map' | 'miniMap';
@@ -7377,12 +7397,12 @@ export function stopFormAnimation(
     };
 }
 
-export function getFormAnimations(
+export function listFormAnimations(
     address: string,
     taskId?: number | string
-): GetFormAnimationsAction {
+): ListFormAnimationsAction {
     return {
-        type: 'get_form_animations',
+        type: 'list_form_animations',
         address,
         taskId,
     };

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -234,7 +234,10 @@ export type AsyncActions =
     | RaycastFromCameraAction
     | RaycastInPortalAction
     | CalculateRayFromCameraAction
-    | BufferFormAddressGLTFAction;
+    | BufferFormAddressGLTFAction
+    | StartFormAnimationAction
+    | StopFormAnimationAction
+    | GetFormAnimationsAction;
 
 /**
  * Defines an interface for actions that represent asynchronous tasks.
@@ -4001,6 +4004,133 @@ export interface BufferFormAddressGLTFAction extends AsyncAction {
     address: string;
 }
 
+/**
+ * Defines an interface that contains a bunch of options for starting an animation.
+ */
+export interface StartFormAnimationOptions {
+    /**
+     * The Unix time in miliseconds that the animation should start at.
+     */
+    startTime?: number;
+
+    /**
+     * The time within the animation clip that the animation should start at in miliseconds.
+     */
+    initialTime?: number;
+
+    /**
+     * The rate at which the animation plays.
+     * 1 means the animation plays normally.
+     * 2 means the animation plays 2x as quickly.
+     * 0 means that the animation is paused.
+     */
+    timeScale?: number;
+
+    /**
+     * The options for looping the animation.
+     * If omitted, then the animation will play once and finish.
+     */
+    loop?: {
+        /**
+         * The looping mode that should be used.
+         */
+        mode: 'repeat' | 'pingPong';
+
+        /**
+         * The number of times that the animation should repeat for.
+         */
+        count: number;
+    };
+
+    /**
+     * Whether the final animation values should be preserved when the animation finishes.
+     */
+    clampWhenFinished?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to cross fade from the previous animation.
+     * If null, then this animation takes over immediately. Additionally, if no previous animation was playing then this animation takes over immediately.
+     */
+    crossFadeDuration?: number;
+
+    /**
+     * Whether to warp animation values during a cross fade.
+     */
+    crossFadeWarp?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to fade in.
+     * If null, then the animation will not fade in.
+     */
+    fadeDuration?: number;
+
+    /**
+     * The address that the animations should be loaded from.
+     */
+    animationAddress?: string;
+}
+
+/**
+ * Defines an event that starts a given animation on a bot/bots.
+ */
+export interface StartFormAnimationAction
+    extends AsyncAction,
+        StartFormAnimationOptions {
+    type: 'start_form_animation';
+
+    /**
+     * The list of bot IDs that the animation should be run for.
+     */
+    botIds: string[];
+
+    /**
+     * The name or index of the animation that should be started.
+     */
+    nameOrIndex: string | number;
+}
+
+/**
+ * Defines an interface that contains a bunch of options for stopping an animation.
+ */
+export interface StopFormAnimationOptions {
+    /**
+     * The Unix time in miliseconds that the animation should be stopped at.
+     */
+    stopTime?: number;
+
+    /**
+     * The number of miliseconds that the animation should take to fade out.
+     * If null, then the animation will stop immediately.
+     */
+    fadeDuration?: number;
+}
+
+/**
+ * Defines an event that stops an animation on a bot/bots.
+ */
+export interface StopFormAnimationAction
+    extends AsyncAction,
+        StopFormAnimationOptions {
+    type: 'stop_form_animation';
+
+    /**
+     * The list of Bot IDs that the animation should be stopped on.
+     */
+    botIds: string[];
+}
+
+/**
+ * Defines an event that retrieves a list of animations for a given form or bot.
+ */
+export interface GetFormAnimationsAction extends AsyncAction {
+    type: 'get_form_animations';
+
+    /**
+     * The address that the animations should be retrieved from.
+     */
+    address: string;
+}
+
 export type CameraPortal = 'grid' | 'miniGrid' | 'map' | 'miniMap';
 
 export interface Point2D {
@@ -7201,6 +7331,58 @@ export function bufferFormAddressGltf(
 ): BufferFormAddressGLTFAction {
     return {
         type: 'buffer_form_address_gltf',
+        address,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new StartFormAnimationAction.
+ * @param botIds The IDs of the bots that the animation should be started for.
+ * @param nameOrIndex The name of the animation.
+ * @param options The options that should be used for the animation.
+ * @param taskId The ID of the async task.
+ */
+export function startFormAnimation(
+    botIds: string[],
+    nameOrIndex: string | number,
+    options: StartFormAnimationOptions,
+    taskId?: number | string
+): StartFormAnimationAction {
+    return {
+        type: 'start_form_animation',
+        botIds,
+        nameOrIndex,
+        ...options,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new StopFormAnimationAction.
+ * @param botIds The IDs of the bots that the animation should be stopped on.
+ * @param options The options that should be used.
+ * @param taskId The ID of the async task.
+ */
+export function stopFormAnimation(
+    botIds: string[],
+    options: StopFormAnimationOptions,
+    taskId?: number | string
+): StopFormAnimationAction {
+    return {
+        type: 'stop_form_animation',
+        botIds,
+        ...options,
+        taskId,
+    };
+}
+
+export function getFormAnimations(
+    address: string,
+    taskId?: number | string
+): GetFormAnimationsAction {
+    return {
+        type: 'get_form_animations',
         address,
         taskId,
     };

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -197,6 +197,8 @@ import {
     raycastInPortal,
     calculateRayFromCamera,
     bufferFormAddressGltf,
+    startFormAnimation,
+    stopFormAnimation,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -5804,6 +5806,166 @@ describe('AuxLibrary', () => {
                     library.api.os.bufferFormAddressGLTF('address');
                 const expected = bufferFormAddressGltf(
                     'address',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.startFormAnimation()', () => {
+            it('should emit a StartFormAnimationAction', () => {
+                const promise: any = library.api.os.startFormAnimation(
+                    bot1,
+                    'test',
+                    {
+                        startTime: 1,
+                        initialTime: 2,
+                        timeScale: 3,
+                        loop: {
+                            mode: 'repeat',
+                            count: 4,
+                        },
+                        clampWhenFinished: true,
+                        crossFadeDuration: 5,
+                        fadeDuration: 6,
+                        animationAddress: 'other',
+                    }
+                );
+                const expected = startFormAnimation(
+                    [bot1.id],
+                    'test',
+                    {
+                        startTime: 1,
+                        initialTime: 2,
+                        timeScale: 3,
+                        loop: {
+                            mode: 'repeat',
+                            count: 4,
+                        },
+                        clampWhenFinished: true,
+                        crossFadeDuration: 5,
+                        fadeDuration: 6,
+                        animationAddress: 'other',
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support no custom options', () => {
+                const promise: any = library.api.os.startFormAnimation(
+                    bot1,
+                    'test'
+                );
+                const expected = startFormAnimation(
+                    [bot1.id],
+                    'test',
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support an array of bots', () => {
+                const promise: any = library.api.os.startFormAnimation(
+                    [bot1, bot2],
+                    'test'
+                );
+                const expected = startFormAnimation(
+                    [bot1.id, bot2.id],
+                    'test',
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support animation indexes', () => {
+                const promise: any = library.api.os.startFormAnimation(
+                    [bot1, bot2],
+                    1
+                );
+                const expected = startFormAnimation(
+                    [bot1.id, bot2.id],
+                    1,
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support Bot IDs', () => {
+                const promise: any = library.api.os.startFormAnimation(
+                    [bot2.id, bot1.id],
+                    1
+                );
+                const expected = startFormAnimation(
+                    [bot2.id, bot1.id],
+                    1,
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.stopFormAnimation()', () => {
+            it('should emit a StartFormAnimationAction', () => {
+                const promise: any = library.api.os.stopFormAnimation(bot1, {
+                    stopTime: 1,
+                    fadeDuration: 2,
+                });
+                const expected = stopFormAnimation(
+                    [bot1.id],
+                    {
+                        stopTime: 1,
+                        fadeDuration: 2,
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support no custom options', () => {
+                const promise: any = library.api.os.stopFormAnimation(bot1);
+                const expected = stopFormAnimation(
+                    [bot1.id],
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support an array of bots', () => {
+                const promise: any = library.api.os.stopFormAnimation([
+                    bot1,
+                    bot2,
+                ]);
+                const expected = stopFormAnimation(
+                    [bot1.id, bot2.id],
+                    {},
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support Bot IDs', () => {
+                const promise: any = library.api.os.stopFormAnimation([
+                    bot2.id,
+                    bot1.id,
+                ]);
+                const expected = stopFormAnimation(
+                    [bot2.id, bot1.id],
+                    {},
                     context.tasks.size
                 );
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -5997,6 +5997,18 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
 
+            it('should prefer the formAnimationAddress tag over formAddress', () => {
+                bot1.tags.formAddress = 'wrong';
+                bot1.tags.formAnimationAddress = 'address';
+                const promise: any = library.api.os.listFormAnimations(bot1);
+                const expected = listFormAnimations(
+                    'address',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
             it('should support being given a bot ID', () => {
                 bot1.tags.formAddress = 'address';
                 const promise: any = library.api.os.listFormAnimations(bot1.id);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -196,6 +196,7 @@ import {
     raycastFromCamera,
     raycastInPortal,
     calculateRayFromCamera,
+    bufferFormAddressGltf,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -5790,6 +5791,19 @@ describe('AuxLibrary', () => {
                         x: 1,
                         y: 2,
                     },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.bufferFormAddressGLTF()', () => {
+            it('should emit a BufferFormAddressGLTFAction', () => {
+                const promise: any =
+                    library.api.os.bufferFormAddressGLTF('address');
+                const expected = bufferFormAddressGltf(
+                    'address',
                     context.tasks.size
                 );
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);

--- a/src/aux-common/runtime/AuxLibrary.spec.ts
+++ b/src/aux-common/runtime/AuxLibrary.spec.ts
@@ -199,6 +199,7 @@ import {
     bufferFormAddressGltf,
     startFormAnimation,
     stopFormAnimation,
+    listFormAnimations,
 } from '../bots';
 import { types } from 'util';
 import {
@@ -5970,6 +5971,68 @@ describe('AuxLibrary', () => {
                 );
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.listFormAnimations()', () => {
+            it('should emit a ListFormAnimationsAction', () => {
+                const promise: any =
+                    library.api.os.listFormAnimations('address');
+                const expected = listFormAnimations(
+                    'address',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support being given a bot', () => {
+                bot1.tags.formAddress = 'address';
+                const promise: any = library.api.os.listFormAnimations(bot1);
+                const expected = listFormAnimations(
+                    'address',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support being given a bot ID', () => {
+                bot1.tags.formAddress = 'address';
+                const promise: any = library.api.os.listFormAnimations(bot1.id);
+                const expected = listFormAnimations(
+                    'address',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should return an empty array if given a null address', async () => {
+                const result = await Promise.race([
+                    library.api.os.listFormAnimations(null as any),
+                    Promise.resolve(false),
+                ]);
+                expect(result).toEqual([]);
+                expect(context.actions).toEqual([]);
+            });
+
+            it('should return an empty array if given an empty address', async () => {
+                const result = await Promise.race([
+                    library.api.os.listFormAnimations(''),
+                    Promise.resolve(false),
+                ]);
+                expect(result).toEqual([]);
+                expect(context.actions).toEqual([]);
+            });
+
+            it('should return an empty array if the bot does not have a form address', async () => {
+                const result = await Promise.race([
+                    library.api.os.listFormAnimations(bot1),
+                    Promise.resolve(false),
+                ]);
+                expect(result).toEqual([]);
+                expect(context.actions).toEqual([]);
             });
         });
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -295,6 +295,11 @@ import {
     raycastInPortal as calcRaycastInPortal,
     calculateRayFromCamera as calcCalculateRayFromCamera,
     bufferFormAddressGltf,
+    StartFormAnimationOptions,
+    startFormAnimation as calcStartFormAnimation,
+    stopFormAnimation as calcStopFormAnimation,
+    getFormAnimations as calcGetFormAnimations,
+    StopFormAnimationOptions,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -1517,6 +1522,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 raycast,
                 calculateRayFromCamera,
                 bufferFormAddressGLTF,
+                startFormAnimation,
+                stopFormAnimation,
 
                 setupInst: setupServer,
                 remotes,
@@ -4293,6 +4300,52 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function bufferFormAddressGLTF(address: string): Promise<void> {
         const task = context.createTask();
         const event = bufferFormAddressGltf(address, task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Starts the given animation on the given bot(s).
+     * @param botOrBots The bot or list of bots that the animation should be started on.
+     * @param nameOrIndex The name of the animation.
+     * @param options The options for the animation.
+     */
+    function startFormAnimation(
+        botOrBots: Bot | string | (Bot | string)[],
+        nameOrIndex: string | number,
+        options?: StartFormAnimationOptions
+    ): Promise<void> {
+        const task = context.createTask();
+
+        const botIds = Array.isArray(botOrBots)
+            ? botOrBots.map((b) => (isBot(b) ? b.id : b))
+            : [isBot(botOrBots) ? botOrBots.id : botOrBots];
+
+        const event = calcStartFormAnimation(
+            botIds,
+            nameOrIndex,
+            options ?? {},
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Stops the animation on the given bot(s).
+     * Returns a promise that resolves when the animations have been stopped.
+     * @param botOrBots The bot or list of bots that the animation(s) should be stopped on.
+     * @param options The options that should be used.
+     */
+    function stopFormAnimation(
+        botOrBots: Bot | string | (Bot | string)[],
+        options?: StopFormAnimationOptions
+    ): Promise<void> {
+        const task = context.createTask();
+
+        const botIds = Array.isArray(botOrBots)
+            ? botOrBots.map((b) => (isBot(b) ? b.id : b))
+            : [isBot(botOrBots) ? botOrBots.id : botOrBots];
+
+        const event = calcStopFormAnimation(botIds, options ?? {}, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -4364,12 +4364,13 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             ? botOrAddress
             : context.state[botOrAddress];
         if (bot) {
-            address = calculateStringTagValue(
-                null,
-                bot,
-                'auxFormAddress',
-                null
-            );
+            address =
+                calculateStringTagValue(
+                    null,
+                    bot,
+                    'auxFormAnimationAddress',
+                    null
+                ) ?? calculateStringTagValue(null, bot, 'auxFormAddress', null);
         } else if (typeof botOrAddress === 'string') {
             address = botOrAddress;
         }

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -298,8 +298,10 @@ import {
     StartFormAnimationOptions,
     startFormAnimation as calcStartFormAnimation,
     stopFormAnimation as calcStopFormAnimation,
-    getFormAnimations as calcGetFormAnimations,
+    listFormAnimations as calcListFormAnimations,
     StopFormAnimationOptions,
+    FormAnimationData,
+    calculateStringTagValue,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -1524,6 +1526,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 bufferFormAddressGLTF,
                 startFormAnimation,
                 stopFormAnimation,
+                listFormAnimations,
 
                 setupInst: setupServer,
                 remotes,
@@ -4346,6 +4349,37 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             : [isBot(botOrBots) ? botOrBots.id : botOrBots];
 
         const event = calcStopFormAnimation(botIds, options ?? {}, task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the list of animations that are included in the given the form or bot.
+     * @param botOrAddress The bot, bot ID, or address that the animations should be retrieved from.
+     */
+    function listFormAnimations(
+        botOrAddress: Bot | string
+    ): Promise<FormAnimationData[]> {
+        let address: string;
+        let bot = isBot(botOrAddress)
+            ? botOrAddress
+            : context.state[botOrAddress];
+        if (bot) {
+            address = calculateStringTagValue(
+                null,
+                bot,
+                'auxFormAddress',
+                null
+            );
+        } else if (typeof botOrAddress === 'string') {
+            address = botOrAddress;
+        }
+
+        if (!hasValue(address)) {
+            return Promise.resolve([]);
+        }
+
+        const task = context.createTask();
+        const event = calcListFormAnimations(address, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibrary.ts
+++ b/src/aux-common/runtime/AuxLibrary.ts
@@ -294,6 +294,7 @@ import {
     raycastFromCamera as calcRaycastFromCamera,
     raycastInPortal as calcRaycastInPortal,
     calculateRayFromCamera as calcCalculateRayFromCamera,
+    bufferFormAddressGltf,
 } from '../bots';
 import { sortBy, every, cloneDeep, union, isEqual, flatMap } from 'lodash';
 import {
@@ -1515,6 +1516,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 raycastFromCamera,
                 raycast,
                 calculateRayFromCamera,
+                bufferFormAddressGLTF,
 
                 setupInst: setupServer,
                 remotes,
@@ -4281,6 +4283,16 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             { x: viewportCoordinates.x, y: viewportCoordinates.y },
             task.taskId
         );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Requests that the given address be pre-cached so that it is available for use on a bot.
+     * @param address The address that should be cached.
+     */
+    function bufferFormAddressGLTF(address: string): Promise<void> {
+        const task = context.createTask();
+        const event = bufferFormAddressGltf(address, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8921,6 +8921,26 @@ export interface StopFormAnimationOptions {
     fadeDuration?: number;
 }
 
+/**
+ * Defines an interface that contains animation information.
+ */
+ export interface FormAnimationData {
+    /**
+     * The name of the animation.
+     */
+    name: string;
+
+    /**
+     * The index that the animation is at.
+     */
+    index: number;
+
+    /**
+     * The duration of the animation in miliseconds.
+     */
+    duration: number;
+}
+
 interface Os {
     /**
          * Sleeps for time in ms.
@@ -10075,6 +10095,12 @@ interface Os {
      * @param options The options that should be used.
      */
     stopFormAnimation(botOrBots: Bot | string | (Bot | string)[], options?: StopFormAnimationOptions): Promise<void>;
+
+    /**
+     * Gets the list of animations that are included in the given the form or bot.
+     * @param botOrAddress The bot, bot ID, or address that the animations should be retrieved from.
+     */
+    listFormAnimations(botOrAddress: Bot | string): Promise<FormAnimationData[]>;
 
     /**
      * Specifies that the given prefix should be interpreted as code.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -8838,6 +8838,89 @@ interface RecordFileOptions {
     mimeType?: string;
 }
 
+
+/**
+ * Defines an interface that contains a bunch of options for starting an animation.
+ */
+export interface StartFormAnimationOptions {
+    /**
+     * The Unix time in miliseconds that the animation should start at.
+     */
+    startTime?: number;
+
+    /**
+     * The time within the animation clip that the animation should start at in miliseconds.
+     */
+    initialTime?: number;
+
+    /**
+     * The rate at which the animation plays.
+     * 1 means the animation plays normally.
+     * 2 means the animation plays 2x as quickly.
+     * 0 means that the animation is paused.
+     */
+    timeScale?: number;
+
+    /**
+     * The options for looping the animation.
+     * If omitted, then the animation will play once and finish.
+     */
+    loop?: {
+        /**
+         * The looping mode that should be used.
+         */
+        mode: 'repeat' | 'pingPong';
+
+        /**
+         * The number of times that the animation should repeat for.
+         */
+        count: number;
+    };
+
+    /**
+     * Whether the final animation values should be preserved when the animation finishes.
+     */
+    clampWhenFinished?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to cross fade from the previous animation.
+     * If null, then this animation takes over immediately. Additionally, if no previous animation was playing then this animation takes over immediately.
+     */
+    crossFadeDuration?: number;
+
+    /**
+     * Whether to warp animation values during a cross fade.
+     */
+    crossFadeWarp?: boolean;
+
+    /**
+     * The number of miliseconds that the animation should take to fade in.
+     * If null, then the animation will not fade in.
+     */
+    fadeDuration?: number;
+
+    /**
+     * The address that the animations should be loaded from.
+     */
+    animationAddress?: string;
+}
+
+/**
+ * Defines an interface that contains a bunch of options for stopping an animation.
+ */
+export interface StopFormAnimationOptions {
+    /**
+     * The Unix time in miliseconds that the animation should be stopped at.
+     */
+    stopTime?: number;
+
+    /**
+     * The number of miliseconds that the animation should take to fade out.
+     * If null, then the animation will stop immediately.
+     */
+    fadeDuration?: number;
+}
+
 interface Os {
     /**
          * Sleeps for time in ms.
@@ -9963,9 +10046,35 @@ interface Os {
 
     /**
      * Requests that the given address be pre-cached so that it is available for use on a bot.
+     * Returns a promise that resolves once the address has been cached.
      * @param address The address that should be cached.
      */
     bufferFormAddressGLTF(address: string): Promise<void>;
+
+    /**
+     * Starts the given animation on the given bot.
+     * Returns a promise that resolves once the animation has been started.
+     * @param bot The Bot that the animation should be started on.
+     * @param nameOrIndex The name or index of the animation that should be started.
+     * @param options The options that should be used for the animation.
+     */
+    startFormAnimation(bot: Bot, nameOrIndex: string | number, options?: StartFormAnimationOptions): Promise<void>;
+    /**
+     * Starts the given animation on the given bot(s).
+     * Returns a promise that resolves once the animation(s) have been started.
+     * @param botOrBots The bot or list of bots that the animation should be started on.
+     * @param nameOrIndex The name of the animation.
+     * @param options The options for the animation.
+     */
+    startFormAnimation(botOrBots: Bot | string | (Bot | string)[], nameOrIndex: string | number, options?: StartFormAnimationOptions): Promise<void>;
+
+    /**
+     * Stops the animation on the given bot(s).
+     * Returns a promise that resolves when the animations have been stopped.
+     * @param botOrBots The bot or list of bots that the animation(s) should be stopped on.
+     * @param options The options that should be used.
+     */
+    stopFormAnimation(botOrBots: Bot | string | (Bot | string)[], options?: StopFormAnimationOptions): Promise<void>;
 
     /**
      * Specifies that the given prefix should be interpreted as code.

--- a/src/aux-common/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-common/runtime/AuxLibraryDefinitions.def
@@ -9962,6 +9962,12 @@ interface Os {
     calculateRayFromCamera(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', viewportCoordinates: Vector2): Promise<RaycastRay>;
 
     /**
+     * Requests that the given address be pre-cached so that it is available for use on a bot.
+     * @param address The address that should be cached.
+     */
+    bufferFormAddressGLTF(address: string): Promise<void>;
+
+    /**
      * Specifies that the given prefix should be interpreted as code.
      * @param prefix The prefix that code tags should start with.
      * @param options The options that should be used for the prefix.

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -69,6 +69,7 @@ import {
     BufferFormAddressGLTFAction,
     StartFormAnimationAction,
     StopFormAnimationAction,
+    ListFormAnimationsAction,
 } from '@casual-simulation/aux-common';
 import {
     baseAuxAmbientLight,
@@ -819,6 +820,8 @@ export class PlayerGame extends Game {
                     this._startFormAnimation(sim, e);
                 } else if (e.type === 'stop_form_animation') {
                     this._stopFormAnimation(sim, e);
+                } else if (e.type === 'list_form_animations') {
+                    this._listFormAnimations(sim, e);
                 }
             })
         );
@@ -973,6 +976,28 @@ export class PlayerGame extends Game {
             await Promise.all(promises);
 
             sim.helper.transaction(asyncResult(e.taskId, null));
+        } catch (err) {
+            sim.helper.transaction(asyncError(e.taskId, err.toString()));
+        }
+    }
+
+    private async _listFormAnimations(
+        sim: Simulation,
+        e: ListFormAnimationsAction
+    ) {
+        try {
+            const sim3Ds = this.getSimulations().filter(
+                (s) => s.simulation === sim
+            );
+
+            for (let sim3D of sim3Ds) {
+                const animations = await sim3D.animation.listFormAnimations(e);
+                sim.helper.transaction(asyncResult(e.taskId, animations));
+
+                return;
+            }
+
+            sim.helper.transaction(asyncResult(e.taskId, []));
         } catch (err) {
             sim.helper.transaction(asyncError(e.taskId, err.toString()));
         }

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -66,6 +66,7 @@ import {
     asyncError,
     createBotLink,
     CalculateRayFromCameraAction,
+    BufferFormAddressGLTFAction,
 } from '@casual-simulation/aux-common';
 import {
     baseAuxAmbientLight,
@@ -94,9 +95,10 @@ import { CoordinateSystem } from '../../shared/scene/CoordinateSystem';
 import { ExternalRenderers, SpatialReference } from '../MapUtils';
 import { PlayerMapSimulation3D } from './PlayerMapSimulation3D';
 import { MiniMapSimulation3D } from './MiniMapSimulation3D';
-import { XRFrame } from 'aux-web/shared/scene/xr/WebXRTypes';
+import { XRFrame } from '../../shared/scene/xr/WebXRTypes';
 import { AuxBot3D } from '../../shared/scene/AuxBot3D';
 import { Physics } from '../../shared/scene/Physics';
+import { gltfPool } from '../../shared/scene/decorators/BotShapeDecorator';
 
 const MINI_PORTAL_SLIDER_HALF_HEIGHT = 36 / 2;
 const MINI_PORTAL_SLIDER_HALF_WIDTH = 30 / 2;
@@ -809,6 +811,8 @@ export class PlayerGame extends Game {
                     this._raycastInPortal(sim, e);
                 } else if (e.type === 'calculate_camera_ray') {
                     this._calculateCameraRay(sim, e);
+                } else if (e.type === 'buffer_form_address_gltf') {
+                    this._bufferFormAddressGltf(sim, e);
                 }
             })
         );
@@ -903,6 +907,18 @@ export class PlayerGame extends Game {
             );
         } else {
             sim.helper.transaction(asyncResult(e.taskId, null));
+        }
+    }
+
+    private async _bufferFormAddressGltf(
+        sim: Simulation,
+        e: BufferFormAddressGLTFAction
+    ) {
+        try {
+            await gltfPool.loadGLTF(e.address);
+            sim.helper.transaction(asyncResult(e.taskId, null));
+        } catch (err) {
+            sim.helper.transaction(asyncError(e.taskId, err.toString()));
         }
     }
 

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -68,6 +68,7 @@ import {
     CalculateRayFromCameraAction,
     BufferFormAddressGLTFAction,
     StartFormAnimationAction,
+    StopFormAnimationAction,
 } from '@casual-simulation/aux-common';
 import {
     baseAuxAmbientLight,
@@ -816,6 +817,8 @@ export class PlayerGame extends Game {
                     this._bufferFormAddressGltf(sim, e);
                 } else if (e.type === 'start_form_animation') {
                     this._startFormAnimation(sim, e);
+                } else if (e.type === 'stop_form_animation') {
+                    this._stopFormAnimation(sim, e);
                 }
             })
         );
@@ -937,6 +940,31 @@ export class PlayerGame extends Game {
 
             for (let sim of sim3Ds) {
                 const promise = sim.animation.startAnimation(e);
+                if (promise) {
+                    promises.push(promise);
+                }
+            }
+
+            await Promise.all(promises);
+
+            sim.helper.transaction(asyncResult(e.taskId, null));
+        } catch (err) {
+            sim.helper.transaction(asyncError(e.taskId, err.toString()));
+        }
+    }
+
+    private async _stopFormAnimation(
+        sim: Simulation,
+        e: StopFormAnimationAction
+    ) {
+        try {
+            const sim3Ds = this.getSimulations().filter(
+                (s) => s.simulation === sim
+            );
+            let promises = [] as Promise<any>[];
+
+            for (let sim of sim3Ds) {
+                const promise = sim.animation.stopAnimation(e);
                 if (promise) {
                     promises.push(promise);
                 }

--- a/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
@@ -462,6 +462,10 @@ export class AnimationHelper {
                     mixer.subscriptions.splice(index, 1);
                     mixer.group.uncache(sub.object);
                 }
+
+                if (mixer.subscriptions.length <= 0) {
+                    this._mixers.delete(botId);
+                }
             },
         };
     }

--- a/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
@@ -28,6 +28,8 @@ import {
     ON_FORM_ANIMATION_STOPPED,
     ON_ANY_FORM_ANIMATION_STOPPED,
     StopFormAnimationAction,
+    ListFormAnimationsAction,
+    FormAnimationData,
 } from '@casual-simulation/aux-common';
 import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
 import { Simulation } from '@casual-simulation/aux-vm';
@@ -116,6 +118,20 @@ export class AnimationHelper {
         } catch (err) {
             throw err;
         }
+    }
+
+    async listFormAnimations(
+        event: ListFormAnimationsAction
+    ): Promise<FormAnimationData[]> {
+        const gltf = await gltfPool.loadGLTF(event.address);
+        return gltf.animations.map(
+            (anim, index) =>
+                ({
+                    name: anim.name,
+                    index: index,
+                    duration: anim.duration * 1000,
+                } as FormAnimationData)
+        );
     }
 
     private _startAnimationForBot(

--- a/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
+++ b/src/aux-server/aux-web/shared/scene/AnimationHelper.ts
@@ -1,0 +1,217 @@
+import {
+    AnimationObjectGroup,
+    AnimationMixer,
+    Object3D,
+    AnimationAction,
+    LoopOnce,
+} from '@casual-simulation/three';
+import { SubscriptionLike } from 'rxjs';
+import { GLTF } from '@casual-simulation/three/examples/jsm/loaders/GLTFLoader';
+import { gltfPool } from './decorators/BotShapeDecorator';
+import {
+    calculateBotValue,
+    StartFormAnimationAction,
+    StartFormAnimationOptions,
+    hasValue,
+    asyncResult,
+    asyncError,
+} from '@casual-simulation/aux-common';
+import { BrowserSimulation } from '@casual-simulation/aux-vm-browser';
+import { Simulation } from '@casual-simulation/aux-vm';
+
+export interface AnimationMixerHandle extends SubscriptionLike {
+    mixer: AnimationMixer;
+}
+
+export interface MixerSubscription {
+    object: Object3D;
+    stopLocalMixer: () => void;
+    startLocalMixer: () => void;
+}
+
+interface MixerGroup {
+    mixer: AnimationMixer;
+    group: AnimationObjectGroup;
+    subscriptions: MixerSubscription[];
+
+    addresses: Map<
+        string,
+        {
+            clips: AnimationAction[];
+            clipMap: Map<string, AnimationAction>;
+        }
+    >;
+    currentClip: AnimationAction;
+
+    state: 'playing' | 'stopped';
+}
+
+export class AnimationHelper {
+    private _mixers: Map<string, MixerGroup> = new Map();
+
+    private _simulation: Simulation;
+
+    constructor(simulation: Simulation) {
+        this._simulation = simulation;
+    }
+
+    // 3DBots register with the helper.
+    // Helper receives new animation events.
+    // 3DBots get told by the helper when to start and stop their animation mixer.
+
+    update(deltaTime: number) {
+        for (let [id, group] of this._mixers) {
+            group.mixer.update(deltaTime);
+            for (let sub of group.subscriptions) {
+                sub.object.updateMatrixWorld(true);
+            }
+        }
+    }
+
+    async startAnimation(event: StartFormAnimationAction): Promise<void> {
+        try {
+            let promises = event.botIds.map((id) =>
+                this._startAnimationForBot(id, event)
+            );
+            await Promise.all(promises);
+
+            this._simulation.helper.transaction(
+                asyncResult(event.taskId, null)
+            );
+        } catch (err) {
+            this._simulation.helper.transaction(
+                asyncError(event.taskId, err.toString())
+            );
+        }
+    }
+
+    private async _startAnimationForBot(
+        botId: string,
+        options: StartFormAnimationAction
+    ) {
+        const mixer = this._getMixerForBot(botId);
+        const bot = this._simulation.helper.botsState[botId];
+        const animationAddress =
+            options.animationAddress ??
+            calculateBotValue(null, bot, 'auxFormAddress');
+        if (!hasValue(animationAddress)) {
+            throw new Error(
+                'Cannot start animation because the bot has no formAddress.'
+            );
+        }
+
+        let addressClips = mixer.addresses.get(animationAddress);
+        if (!addressClips) {
+            const gltf = await gltfPool.loadGLTF(animationAddress);
+            const clips = this._processGLTFAnimations(gltf, mixer.mixer);
+            mixer.addresses.set(animationAddress, clips);
+            addressClips = clips;
+        }
+
+        const clip =
+            typeof options.nameOrIndex === 'string'
+                ? addressClips.clipMap.get(options.nameOrIndex)
+                : addressClips.clips[options.nameOrIndex];
+
+        if (clip) {
+            // Play clip
+            mixer.state = 'playing';
+
+            if (mixer.currentClip) {
+                mixer.currentClip.stop();
+            }
+
+            clip.play();
+            clip.setLoop(LoopOnce, 1);
+
+            mixer.currentClip = clip;
+
+            for (let sub of mixer.subscriptions) {
+                sub.stopLocalMixer();
+            }
+
+            const listener = () => {
+                console.log('[AnimationHelper] Finished Animation!');
+                mixer.mixer.removeEventListener('finished', listener);
+
+                mixer.state = 'stopped';
+                for (let sub of mixer.subscriptions) {
+                    sub.startLocalMixer();
+                }
+            };
+
+            mixer.mixer.addEventListener('finished', listener);
+        }
+    }
+
+    getAnimationMixerHandle(
+        botId: string,
+        sub: MixerSubscription
+    ): AnimationMixerHandle {
+        let mixer = this._getMixerForBot(botId);
+
+        const index = mixer.subscriptions.indexOf(sub);
+        if (index < 0) {
+            mixer.subscriptions.push(sub);
+            mixer.group.add(sub.object);
+        }
+
+        if (mixer.state === 'playing') {
+            sub.stopLocalMixer();
+        }
+
+        let closed = false;
+        return {
+            mixer: mixer.mixer,
+
+            get closed() {
+                return closed;
+            },
+
+            unsubscribe() {
+                const index = mixer.subscriptions.indexOf(sub);
+                if (index >= 0) {
+                    mixer.subscriptions.splice(index, 1);
+                    mixer.group.uncache(sub.object);
+                }
+            },
+        };
+    }
+
+    private _getMixerForBot(botId: string) {
+        let mixer = this._mixers.get(botId);
+        if (!mixer) {
+            const group = new AnimationObjectGroup();
+            const anim = new AnimationMixer(group);
+            mixer = {
+                mixer: anim,
+                group: group,
+                subscriptions: [],
+                addresses: new Map(),
+                currentClip: null,
+                state: 'stopped',
+            };
+            this._mixers.set(botId, mixer);
+        }
+
+        return mixer;
+    }
+
+    private _processGLTFAnimations(gltf: GLTF, mixer: AnimationMixer) {
+        // Animations
+        let clipMap = new Map<string, AnimationAction>();
+        let clips = [] as AnimationAction[];
+        if (gltf.animations.length > 0) {
+            for (let anim of gltf.animations) {
+                const action = mixer.clipAction(anim);
+                clips.push(action);
+                clipMap.set(anim.name, action);
+            }
+        }
+
+        return {
+            clips,
+            clipMap,
+        };
+    }
+}

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -42,6 +42,7 @@ import { DimensionGroup3D } from './DimensionGroup3D';
 import { AuxBot3D } from './AuxBot3D';
 import { Grid3D } from './Grid3D';
 import { CoordinateSystem } from './CoordinateSystem';
+import { AnimationHelper } from './AnimationHelper';
 
 /**
  * Defines a class that is able to render a simulation.
@@ -154,6 +155,8 @@ export abstract class Simulation3D
      */
     private _waitingEvents: QueuedBotEvent[] = [];
 
+    private _animationHelper: AnimationHelper;
+
     /**
      * Gets the list of bots that are in this simulation.
      */
@@ -205,6 +208,10 @@ export abstract class Simulation3D
         return parent as Scene;
     }
 
+    get animation() {
+        return this._animationHelper;
+    }
+
     /**
      * Creates a new Simulation3D object that can be used to render the given simulation.
      * @param game The game.
@@ -220,6 +227,7 @@ export abstract class Simulation3D
         this._dimensionGroups = new Map();
         this._dimensionTagsMap = new Map();
         this._botMap = new Map();
+        this._animationHelper = new AnimationHelper(simulation);
     }
 
     /**
@@ -495,6 +503,8 @@ export abstract class Simulation3D
             this._queueEventForBot(e, e.botId);
         } else if (e.type === 'local_tween') {
             this._queueEventForBot(e, e.botId, e.dimension);
+        } else if (e.type === 'start_form_animation') {
+            this._animationHelper.startAnimation(e);
         }
     }
 
@@ -687,6 +697,7 @@ export abstract class Simulation3D
                 bot.frameUpdate(this._currentContext);
             }
         }
+        this.animation.update(this._game.getTime().deltaTime);
     }
 
     private _addExistingBotsToGroup(

--- a/src/aux-server/aux-web/shared/scene/Simulation3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Simulation3D.ts
@@ -503,8 +503,6 @@ export abstract class Simulation3D
             this._queueEventForBot(e, e.botId);
         } else if (e.type === 'local_tween') {
             this._queueEventForBot(e, e.botId, e.dimension);
-        } else if (e.type === 'start_form_animation') {
-            this._animationHelper.startAnimation(e);
         }
     }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -764,11 +764,9 @@ export class BotShapeDecorator
                 {
                     object: this.scene,
                     startLocalMixer: () => {
-                        console.log('[BotShapeDecorator] Start local mixer!');
                         this._animationEnabled = true;
                     },
                     stopLocalMixer: () => {
-                        console.log('[BotShapeDecorator] Stop local mixer!');
                         this._animationEnabled = false;
                     },
                 }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -69,7 +69,7 @@ import Enter from 'three-mesh-ui/examples/assets/enter.png';
 import Shift from 'three-mesh-ui/examples/assets/shift.png';
 import { Keyboard, Block, update as updateMeshUI } from 'three-mesh-ui';
 
-const gltfPool = getGLTFPool('main');
+export const gltfPool = getGLTFPool('main');
 
 const KEYBOARD_COLORS = {
     keyboardBack: 0x858585,

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -14,6 +14,7 @@ import {
     BotScaleMode,
     getBotScaleMode,
     calculateStringTagValue,
+    StartFormAnimationAction,
 } from '@casual-simulation/aux-common';
 import {
     Mesh,
@@ -68,6 +69,7 @@ import Backspace from 'three-mesh-ui/examples/assets/backspace.png';
 import Enter from 'three-mesh-ui/examples/assets/enter.png';
 import Shift from 'three-mesh-ui/examples/assets/shift.png';
 import { Keyboard, Block, update as updateMeshUI } from 'three-mesh-ui';
+import { AnimationMixerHandle } from '../AnimationHelper';
 
 export const gltfPool = getGLTFPool('main');
 
@@ -90,12 +92,15 @@ export class BotShapeDecorator
     private _animation: any = null;
     private _scaleMode: BotScaleMode = null;
     private _canHaveStroke = false;
+    // private _animationMode: 'tag' | 'action' = 'tag';
     private _animationMixer: AnimationMixer;
+    private _animationEnabled: boolean = true;
     private _animClips: AnimationAction[];
     private _animClipMap: Map<string, AnimationAction>;
     private _animationAddress: string;
     private _addressAspectRatio: number = 1;
     private _keyboard: Keyboard = null;
+    private _animationHandle: AnimationMixerHandle = null;
 
     /**
      * The 3d plane object used to display an iframe.
@@ -136,7 +141,7 @@ export class BotShapeDecorator
     }
 
     frameUpdate() {
-        if (this._game && this._animationMixer) {
+        if (this._game && this._animationMixer && this._animationEnabled) {
             this._animationMixer.update(this._game.getTime().deltaTime);
             this.scene?.updateMatrixWorld(true);
         }
@@ -220,8 +225,16 @@ export class BotShapeDecorator
 
     localEvent(event: LocalActions, calc: BotCalculationContext) {
         if (event.type === 'local_form_animation') {
-            this._playAnimation(event.animation);
+            this._playLocalAnimation(event.animation);
         }
+    }
+
+    async startAnimation(event: StartFormAnimationAction): Promise<void> {
+        const gltf = await gltfPool.loadGLTF(
+            event.animationAddress ?? this._address
+        );
+
+        const anim = gltf.animations.find((a) => a.name === event.nameOrIndex);
     }
 
     private _needsUpdate(
@@ -312,7 +325,7 @@ export class BotShapeDecorator
         this._addressAspectRatio = aspectRatio;
     }
 
-    private _playAnimation(animation: string | number) {
+    private _playLocalAnimation(animation: string | number) {
         if (!this._animationMixer) {
             return;
         }
@@ -491,6 +504,12 @@ export class BotShapeDecorator
             }
             this.container.remove(this._keyboard);
             this._keyboard = null;
+        }
+
+        if (this._animationHandle) {
+            this._animationHandle.unsubscribe();
+            this._animationHandle = null;
+            this._animationEnabled = true;
         }
 
         this._animationMixer = null;
@@ -736,6 +755,24 @@ export class BotShapeDecorator
 
         if (!hasValue(this._animationAddress)) {
             this._processGLTFAnimations(gltf);
+        }
+
+        const sim = this.bot3D.dimensionGroup?.simulation3D;
+        if (sim) {
+            this._animationHandle = sim.animation.getAnimationMixerHandle(
+                this.bot3D.bot.id,
+                {
+                    object: this.scene,
+                    startLocalMixer: () => {
+                        console.log('[BotShapeDecorator] Start local mixer!');
+                        this._animationEnabled = true;
+                    },
+                    stopLocalMixer: () => {
+                        console.log('[BotShapeDecorator] Stop local mixer!');
+                        this._animationEnabled = false;
+                    },
+                }
+            );
         }
 
         const material: any = this.mesh.material;


### PR DESCRIPTION
### :rocket: Improvements

-   Added the `os.startFormAnimation(bot, animationName, options?)`, `os.stopFormAnimation(bot, options?)`, `os.listFormAnimations(botOrAddress)`, and `os.bufferFormAddressGLTF(address)` functions.
    -   `os.startFormAnimation(bot, animationName, options?)` is used to trigger an animation on the given bot. Returns a promise that resolves when the animation has started. It accepts the following parameters:
        -   `bot` - The bot or list of bots that the animation should be triggered on.
        -   `animationName` - The name or index of the animation that should be started.
        -   `options` - The additional parameters that should be used for the animation. Optional. It should be an object with the following properties:
            -   `startTime` - The time that the animation should start playing. It should be the number of miliseconds since the Unix Epoch.
            -   `initialTime` - The time within the animation clip that the animation should start at in miliseconds.
            -   `timeScale` - The rate at which the animation plays.
            -   `loop` - Options for looping. It should be an object with the following properties:
                -   `mode` - How the animation should loop. It should be either `repeat` or `pingPong`.
                -   `count` - The number of times that the animation should loop.
            -   `clampWhenFinished` - Whether the final animation values should be preserved when the animation finishes.
            -   `crossFadeDuration` - The number of miliseconds that the animation should take to cross fade from the previous animation.
            -   `fadeDuration` - The number of miliseconds that the animation should take to fade in.
            -   `animationAddress` - The address that the animations should be loaded from.
    -   `os.stopFormAnimation(bot, options?)` is used to stop animations on the given bot. Returns a promise that resolves when the animation has stopped. It accepts the following parameters:
        -   `bot` - The bot or list of bots that animations should be stopped on.
        -   `options` - The options that should be used to stop the animations. Optional. It should be an object with the following properties:
            -   `stopTime` - The time that the animation should stop playing. It should be the number of miliseconds since the Unix Epoch.
            -   `fadeDuration` - The number of miliseconds that the animation should take to fade out.
    -   `os.listFormAnimations(botOrAddress)` is used to retrieve the list of animations that are available on a form. Returns a promise that resolves with the animation list. It accepts the following parameters:
        -   `botOrAddress` - The bot or address that the animation list should be retrieved for.
    -   `os.bufferFormAddressGLTF(address)` is used to pre-cache the given address as a GLTF mesh for future use. Returns a promise that resolves when the address has been buffered. It accepts the following parameters:
        -   `address` - The address that should be loaded.
-   Added several listeners that can be used to observe animation changes on bots.
    -   Currently, they are only sent for animations that are started via `os.startFormAnimation()`. Animations that are triggered via the `#formAnimation` tag or `experiment.localFormAnimation()` are not supported.
    -   `@onFormAnimationStarted` and `@onAnyFormAnimationStarted` are sent when an animation has been started.
    -   `@onFormAnimationStopped` and `@onAnyFormAnimationStopped` are sent when an animation has been manually stopped.
    -   `@onFormAnimationFinished` and `@onAnyFormAnimationFinished` are sent when an animation finishes playing.
    -   `@onFormAnimationLooped` and `@onAnyFormAnimationLooped` are sent when an animation restarts per the looping rules that were given in the options object.