### PR TITLE
Media permission track release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CasualOS Changelog
 
+## V3.1.29
+
+#### Date: TBD
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where `os.getMediaPermission` would leave tracks in a MediaStream running. Some browsers/devices release these automatically, while others would leave the tracks running and cause issues with other systems that utilize audio and video hardware like augmented reality.
+
 ## V3.1.28
 
 #### Date: 3/22/2023

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -9,7 +9,7 @@ Make sure you have all the prerequisite tools installed:
 
 -   [Node.js](https://nodejs.org/en/download/) v16.18.1 or later.
     -   If installing for the first time, it is reccommended that you install it via Node Version Manager. ([Mac][nvm-mac], [Windows][nvm-windows])
-    -   Once NVM is installed, you can install the correct version of Node by running `nvm install v14.16.1` in your favorite terminal.
+    -   Once NVM is installed, you can install the correct version of Node by running `nvm install v16.18.1` in your favorite terminal.
 -   [Deno](https://deno.land/).
 -   [Rancher Desktop](https://rancherdesktop.io/)
     -   Used to make development with extra services (MongoDB, Redis, etc.) easy.

--- a/src/aux-server/aux-web/shared/scene/Game.ts
+++ b/src/aux-server/aux-web/shared/scene/Game.ts
@@ -1269,7 +1269,8 @@ export abstract class Game {
 
         navigator.mediaDevices
             .getUserMedia({ audio, video })
-            .then(() => {
+            .then((stream) => {
+                stream.getTracks().forEach((t) => t.stop());
                 sim.helper.transaction(asyncResult(e.taskId, null));
             })
             .catch((reason) => {


### PR DESCRIPTION
Fixed an issue where `os.getMediaPermission` would leave tracks in a MediaStream running. Some browsers/devices release these automatically, while others would leave the tracks running and cause issues with other systems that utilize audio and video hardware like augmented reality.