### PR TITLE
Add basic support for rate limiting

### DIFF
--- a/.aws/auth.buildspec.yml
+++ b/.aws/auth.buildspec.yml
@@ -19,6 +19,8 @@ version: 0.2
 # $LIVEKIT_SECRET_KEY - The Secret Key that should be used to create livekit session tokens.
 # $TEXT_IT_API_KEY - The API Key that should be used to access TextIt.
 # $TEXT_IT_FLOW_ID - The ID of the TextIt flow that should be triggered in order to send login codes to users.
+# $RATE_LIMIT_MAX - The maximum number of requests that can be made from a single IP over the window
+# $RATE_LIMIT_WINDOW_MS - The number of miliseconds that determines the window for rate limiting.
 
 # Description:
 # This buildspec is able to build and deploy the aux-auth package to AWS.
@@ -79,7 +81,7 @@ phases:
                 sam deploy --template-file template-out.yaml --stack-name $STACK_NAME \
                   --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
                   --no-execute-changeset \
-                  --parameter-overrides "MagicSecretKeyParameter='$MAGIC_SECRET_KEY' RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisRecordsNamespaceParameter='$REDIS_RECORDS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' FileRecordsS3StorageClassParameter='$FILES_STORAGE_CLASS' AllowedApiOriginsParameter='$ALLOWED_API_ORIGINS' AllowedOriginsParameter='$ALLOWED_ORIGINS' LivekitEndpointParameter='$LIVEKIT_ENDPOINT' LivekitAPIKeyParameter='$LIVEKIT_API_KEY' LivekitSecretKeyParameter='$LIVEKIT_SECRET_KEY' TextItAPIKeyParameter='$TEXT_IT_API_KEY' TextItFlowIDParameter='$TEXT_IT_FLOW_ID' StripeSecretKeyParameter='$STRIPE_SECRET_KEY' StripePublishableKeyParameter='$STRIPE_PUBLISHABLE_KEY' SubscriptionConfigParameter='$SUBSCRIPTION_CONFIG'" \
+                  --parameter-overrides "MagicSecretKeyParameter='$MAGIC_SECRET_KEY' RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisRecordsNamespaceParameter='$REDIS_RECORDS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' FileRecordsS3StorageClassParameter='$FILES_STORAGE_CLASS' AllowedApiOriginsParameter='$ALLOWED_API_ORIGINS' AllowedOriginsParameter='$ALLOWED_ORIGINS' LivekitEndpointParameter='$LIVEKIT_ENDPOINT' LivekitAPIKeyParameter='$LIVEKIT_API_KEY' LivekitSecretKeyParameter='$LIVEKIT_SECRET_KEY' TextItAPIKeyParameter='$TEXT_IT_API_KEY' TextItFlowIDParameter='$TEXT_IT_FLOW_ID' StripeSecretKeyParameter='$STRIPE_SECRET_KEY' StripePublishableKeyParameter='$STRIPE_PUBLISHABLE_KEY' SubscriptionConfigParameter='$SUBSCRIPTION_CONFIG' RateLimitMaxParameter='$RATE_LIMIT_MAX' RateLimitWindowMSParameter='$RATE_LIMIT_WINDOW_MS'" \
                   --tags Customer=casualos
 
             # - aws cloudformation deploy --template-file template.yml --stack-name $STACK_NAME --s3-bucket $LAMBDA_S3_BUCKET --no-execute-changeset --parameter-overrides MagicSecretKeyParameter=$MAGIC_SECRET_KEY

--- a/.github/workflows/auxbackend-apiary-release-workflow.yml
+++ b/.github/workflows/auxbackend-apiary-release-workflow.yml
@@ -43,7 +43,7 @@ jobs:
                     --profile casualos
                   sam deploy --template-file template-out.yaml --stack-name $STACK_NAME \
                     --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset \
-                    --parameter-overrides "RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisNamespaceParameter='$REDIS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' WebsocketURLParameter='$WEBSOCKET_URL' MaxRedisBatchSizeParameter='$REDIS_MAX_BATCH_SIZE' MaxBranchSizeParameter='$REDIS_MAX_BRANCH_SIZE' MergeUpdatesOnMaxSizeExceededParameter='$MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED'" \
+                    --parameter-overrides "RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisNamespaceParameter='$REDIS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' WebsocketURLParameter='$WEBSOCKET_URL' MaxRedisBatchSizeParameter='$REDIS_MAX_BATCH_SIZE' MaxBranchSizeParameter='$REDIS_MAX_BRANCH_SIZE' MergeUpdatesOnMaxSizeExceededParameter='$MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED' RateLimitMaxParameter='$RATE_LIMIT_MAX' RateLimitWindowMSParameter='$RATE_LIMIT_WINDOW_MS'" \
                     --tags Customer=casualos \
                     --profile casualos
               env:
@@ -58,4 +58,6 @@ jobs:
                   REDIS_MAX_BATCH_SIZE: '0'
                   REDIS_MAX_BRANCH_SIZE: '25000000' # 25 MB
                   MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED: 'true'
+                  RATE_LIMIT_MAX: '100' # 100 requests/minute = 144k requests/day
+                  RATE_LIMIT_WINDOW_MS: '60000' # 60 seconds
                   STACK_NAME: auxbackend-apiary

--- a/.github/workflows/boormanlabs-apiary-release-workflow.yml
+++ b/.github/workflows/boormanlabs-apiary-release-workflow.yml
@@ -43,7 +43,7 @@ jobs:
                     --profile casualos
                   sam deploy --template-file template-out.yaml --stack-name $STACK_NAME \
                     --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset \
-                    --parameter-overrides "RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisNamespaceParameter='$REDIS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' WebsocketURLParameter='$WEBSOCKET_URL' MaxRedisBatchSizeParameter='$REDIS_MAX_BATCH_SIZE' MaxBranchSizeParameter='$REDIS_MAX_BRANCH_SIZE' MergeUpdatesOnMaxSizeExceededParameter='$MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED'" \
+                    --parameter-overrides "RedisPortParameter='$REDIS_PORT' RedisHostParameter='$REDIS_HOST' RedisUseTLSParameter='$REDIS_USE_TLS' RedisNamespaceParameter='$REDIS_NAMESPACE' RedisPasswordParameter='$REDIS_PASSWORD' WebsocketURLParameter='$WEBSOCKET_URL' MaxRedisBatchSizeParameter='$REDIS_MAX_BATCH_SIZE' MaxBranchSizeParameter='$REDIS_MAX_BRANCH_SIZE' MergeUpdatesOnMaxSizeExceededParameter='$MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED' RateLimitMaxParameter='$RATE_LIMIT_MAX' RateLimitWindowMSParameter='$RATE_LIMIT_WINDOW_MS'" \
                     --tags Customer=casualos \
                     --profile casualos
               env:
@@ -58,4 +58,6 @@ jobs:
                   REDIS_MAX_BATCH_SIZE: '0'
                   REDIS_MAX_BRANCH_SIZE: '1000000' # 1 MB
                   MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED: 'true'
+                  RATE_LIMIT_MAX: '5' # 5 requests/minute = 7200 requests/day
+                  RATE_LIMIT_WINDOW_MS: '60000' # 60 seconds
                   STACK_NAME: boormanlabs-apiary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 -   Fixed an issue where `os.getMediaPermission` would leave tracks in a MediaStream running. Some browsers/devices release these automatically, while others would leave the tracks running and cause issues with other systems that utilize audio and video hardware like augmented reality.
 -   Fixed an issue where `data:` URLs would not work in the `formAddress` tag without a workaround.
+-   Fixed an issue where it was impossible to create record keys on deployments that did not have a subscription configuration.
 
 ## V3.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
         -   `neededSizeInBytes` - The number of bytes that would be needed to store the data that was placed in the space.
     -   Note that this only applies to persistent storage. That is, if you create a bot in the `shared` space and receive this shout, then it is possible that the bot was not persistently stored and shared, but it is still available by scripts until the browser tab is refreshed or the PC is restarted.
     -   Generally, if you receive this shout, then it is a good idea to backup your inst.
+-   Added configurable support for IP-based rate limiting.
+    -   Applies to websockets as well as the API.
+    -   Requires a Redis connection and is configurable by the following environment variables:
+        -   `RATE_LIMIT_MAX` - The maximum number of requests that can be recieved from an IP address over the window.
+        -   `RATE_LIMIT_WINDOW_MS` - The size of the window for requests represented in miliseconds.
+    -   If any of the above environment variables are not specified, then rate limiting will be disabled.
 
 ### :bug: Bug Fixes
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -38,7 +38,7 @@ services:
     livekit:
         image: livekit/livekit-server:latest
         command: --config /etc/livekit.yaml
-        restart: unless-stopped
+        restart: always
         depends_on:
             - redis
         ports:

--- a/jakefile.js
+++ b/jakefile.js
@@ -42,7 +42,7 @@ let folders = [
     `${__dirname}/src/timesync`,
     `${__dirname}/src/js-interpreter`,
     `${__dirname}/src/vue-shortkey`,
-    `${__dirname}/src/redis-rate-limit`,
+    `${__dirname}/src/rate-limit-redis`,
 ];
 
 let patterns = [

--- a/jakefile.js
+++ b/jakefile.js
@@ -42,6 +42,7 @@ let folders = [
     `${__dirname}/src/timesync`,
     `${__dirname}/src/js-interpreter`,
     `${__dirname}/src/vue-shortkey`,
+    `${__dirname}/src/redis-rate-limit`,
 ];
 
 let patterns = [

--- a/src/aux-auth/package.json
+++ b/src/aux-auth/package.json
@@ -45,6 +45,7 @@
         "@casual-simulation/aux-records-aws": "^3.1.26",
         "@casual-simulation/aux-vm": "^3.1.28",
         "@casual-simulation/aux-vm-browser": "^3.1.28",
+        "@casual-simulation/rate-limit-redis": "^3.0.1",
         "@casual-simulation/vue-shortkey": "^3.1.20",
         "aws-sdk": "^2.968.0",
         "axios": "0.25.0",

--- a/src/aux-auth/server/MongoDBRateLimiter.ts
+++ b/src/aux-auth/server/MongoDBRateLimiter.ts
@@ -1,0 +1,124 @@
+import {
+    RateLimiter,
+    RateLimiterIncrementResult,
+    RateLimiterOptions,
+} from '@casual-simulation/rate-limit-redis';
+import { Collection, FilterQuery, MongoClient, Db } from 'mongodb';
+
+export class MongoDBRateLimiter implements RateLimiter {
+    private _collection: Collection<MongoDBRateLimitRecord>;
+    private _windowMs: number;
+
+    private _updatedIndex: boolean = false;
+
+    constructor(collection: Collection<MongoDBRateLimitRecord>) {
+        this._collection = collection;
+    }
+
+    /**
+     * Initializes the rate limiter with the given options.
+     * @param options The options.
+     */
+    init(options: RateLimiterOptions): void {
+        this._windowMs = options.windowMs;
+    }
+
+    /**
+     * Increments the number of hits that the given key has recieved by the given amount.
+     * Returns a promise that resolves with the total number of hits that the key has recieved.
+     * @param key The key.
+     * @param amount The amount to increment the key by. Defaults to 1.
+     */
+    async increment(
+        key: string,
+        amount?: number
+    ): Promise<RateLimiterIncrementResult> {
+        await this._updateCollection();
+        const expirationDate = new Date(Date.now() + this._windowMs);
+
+        const result = await this._collection.findOneAndUpdate(
+            {
+                _id: { $eq: key },
+            },
+            {
+                $inc: { count: amount ?? 1 },
+                $setOnInsert: {
+                    expirationDate: expirationDate,
+                },
+            },
+            {
+                upsert: true,
+                returnDocument: 'after',
+            }
+        );
+
+        const record = result.value;
+
+        return {
+            totalHits: record.count,
+            resetTime: record.expirationDate,
+        };
+    }
+
+    /**
+     * Decrements the number of hits that the given key has recieved by the given amount.
+     * @param key The key.
+     * @param amount The amount to decrement the key by. Defaults to 1.
+     */
+    async decrement(key: string, amount?: number): Promise<void> {
+        await this._updateCollection();
+        const expirationDate = new Date(Date.now() + this._windowMs);
+
+        await this._collection.findOneAndUpdate(
+            {
+                _id: { $eq: key },
+            },
+            {
+                $inc: { count: -(amount ?? 1) },
+                $setOnInsert: {
+                    expirationDate: expirationDate,
+                },
+            },
+            {
+                upsert: true,
+            }
+        );
+    }
+
+    /**
+     * Resets the given key to zero hits.
+     * @param key The key to reset.
+     */
+    async resetKey(key: string): Promise<void> {
+        await this._updateCollection();
+        await this._collection.deleteOne({
+            _id: { $eq: key },
+        });
+    }
+
+    private async _updateCollection() {
+        if (this._updatedIndex) return;
+
+        this._updatedIndex = true;
+        await this._collection.createIndex(
+            { expirationDateMs: 1 },
+            {
+                expireAfterSeconds: 0,
+            }
+        );
+    }
+}
+
+export interface MongoDBRateLimitRecord {
+    _id: string;
+
+    /**
+     * The current count.
+     */
+    count: number;
+
+    /**
+     * The expiration date in UTC-0.
+     */
+    expirationDate: Date;
+}

--- a/src/aux-auth/server/index.ts
+++ b/src/aux-auth/server/index.ts
@@ -200,13 +200,17 @@ async function start() {
     const eventManager = new EventRecordsController(recordsManager, eventStore);
 
     const rateLimiter = new MongoDBRateLimiter(rateLimits);
-    const rateManager =
-        RATE_LIMIT_MAX && RATE_LIMIT_WINDOW_MS
-            ? new RateLimitController(rateLimiter, {
-                  maxHits: RATE_LIMIT_MAX,
-                  windowMs: RATE_LIMIT_WINDOW_MS,
-              })
-            : null;
+    let rateManager: RateLimitController = null;
+
+    if (RATE_LIMIT_MAX && RATE_LIMIT_WINDOW_MS) {
+        console.log('[AuxAuth] Enabling rate limiting.');
+        rateManager = new RateLimitController(rateLimiter, {
+            maxHits: RATE_LIMIT_MAX,
+            windowMs: RATE_LIMIT_WINDOW_MS,
+        });
+    } else {
+        console.log('[AuxAuth] Disabling rate limiting.');
+    }
 
     const manualDataStore = new MongoDBDataRecordsStore(
         manualRecordsDataCollection

--- a/src/aux-auth/server/index.ts
+++ b/src/aux-auth/server/index.ts
@@ -29,6 +29,7 @@ import {
     JsonParseResult,
     StripeInterface,
     tryParseSubscriptionConfig,
+    RateLimitController,
 } from '@casual-simulation/aux-records';
 import { MongoDBRecordsStore } from './MongoDBRecordsStore';
 import { MongoDBDataRecordsStore, DataRecord } from './MongoDBDataRecordsStore';
@@ -47,6 +48,10 @@ import {
 } from './MongoDBAuthStore';
 import { ConsoleAuthMessenger } from '@casual-simulation/aux-records/ConsoleAuthMessenger';
 import { StripeIntegration } from '../shared/StripeIntegration';
+import {
+    MongoDBRateLimiter,
+    MongoDBRateLimitRecord,
+} from './MongoDBRateLimiter';
 import * as dotenv from 'dotenv';
 import Stripe from 'stripe';
 
@@ -88,6 +93,13 @@ const MONGO_USE_NEW_URL_PARSER =
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY ?? null;
 const STRIPE_PUBLISHABLE_KEY = process.env.STRIPE_PUBLISHABLE_KEY ?? null;
 const SUBSCRIPTION_CONFIG = process.env.SUBSCRIPTION_CONFIG ?? null;
+
+const RATE_LIMIT_MAX: number = process.env.RATE_LIMIT_MAX
+    ? parseInt(process.env.RATE_LIMIT_MAX)
+    : null;
+const RATE_LIMIT_WINDOW_MS: number = process.env.RATE_LIMIT_WINDOW_MS
+    ? parseInt(process.env.RATE_LIMIT_WINDOW_MS)
+    : null;
 
 function getAuthMessenger(): AuthMessenger {
     const API_KEY = process.env.TEXT_IT_API_KEY;
@@ -167,6 +179,7 @@ async function start() {
     const recordsEventsCollection = db.collection<any>('recordsEvents');
     const emailRules = db.collection<any>('emailRules');
     const smsRules = db.collection<any>('smsRules');
+    const rateLimits = db.collection<any>('rateLimits');
     const tempRecords = [] as AppRecord[];
 
     const authStore = new MongoDBAuthStore(
@@ -185,6 +198,15 @@ async function start() {
     const dataManager = new DataRecordsController(recordsManager, dataStore);
     const eventStore = new MongoDBEventRecordsStore(recordsEventsCollection);
     const eventManager = new EventRecordsController(recordsManager, eventStore);
+
+    const rateLimiter = new MongoDBRateLimiter(rateLimits);
+    const rateManager =
+        RATE_LIMIT_MAX && RATE_LIMIT_WINDOW_MS
+            ? new RateLimitController(rateLimiter, {
+                  maxHits: RATE_LIMIT_MAX,
+                  windowMs: RATE_LIMIT_WINDOW_MS,
+              })
+            : null;
 
     const manualDataStore = new MongoDBDataRecordsStore(
         manualRecordsDataCollection
@@ -272,7 +294,8 @@ async function start() {
         dataManager,
         manualDataManager,
         fileController,
-        subscriptionController
+        subscriptionController,
+        rateManager
     );
 
     async function handleRequest(req: Request, res: Response) {

--- a/src/aux-auth/serverless/aws/src/handlers/Records.ts
+++ b/src/aux-auth/serverless/aws/src/handlers/Records.ts
@@ -64,11 +64,6 @@ const LIVEKIT_API_KEY = process.env.LIVEKIT_API_KEY;
 const LIVEKIT_SECRET_KEY = process.env.LIVEKIT_SECRET_KEY;
 const LIVEKIT_ENDPOINT = process.env.LIVEKIT_ENDPOINT;
 
-// const USERS_TABLE = process.env.USERS_TABLE;
-
-// const EMAIL_TABLE = process.env.EMAIL_TABLE;
-// const SMS_TABLE = process.env.SMS_TABLE;
-
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY ?? null;
 const STRIPE_PUBLISHABLE_KEY = process.env.STRIPE_PUBLISHABLE_KEY ?? null;
 const SUBSCRIPTION_CONFIG = process.env.SUBSCRIPTION_CONFIG ?? null;
@@ -224,7 +219,8 @@ const httpServer = new RecordsHttpServer(
     dataController,
     manualDataController,
     filesController,
-    subscriptionController
+    subscriptionController,
+    null // Don't use a rate limiter
 );
 
 async function handleEventBridgeEvent(event: EventBridgeEvent<any, any>) {

--- a/src/aux-auth/serverless/aws/template.yml
+++ b/src/aux-auth/serverless/aws/template.yml
@@ -67,6 +67,14 @@ Parameters:
     AllowedApiOriginsParameter:
         Type: String
         Description: The allowed origin domains that are able to make requests for the records APIs. This value should be a space-separated string that includes the origins that are allowed to request/publish records to this site.
+    RateLimitMaxParameter:
+        Type: String
+        Description: The maximum number of requests that can be made from an IP address over the window. If set to an empty string, then there is no rate limiting.
+        Default: ''
+    RateLimitWindowMSParameter:
+        Type: String
+        Description: The window, in milliseconds, that requests are allowed to be made over for rate limiting. i.e. if set to 1000, then RateLimitMaxParameter number of requests can be made over 1 second. If set to an empty string, then there is no rate limiting.
+        Default: ''
 
 Globals:
     Api:
@@ -151,6 +159,13 @@ Resources:
                     SESSIONS_TABLE: !Ref SessionsTable
                     EMAIL_TABLE: !Ref EmailRulesTable
                     SMS_TABLE: !Ref SmsRulesTable
+                    REDIS_HOST: !Ref RedisHostParameter
+                    REDIS_PORT: !Ref RedisPortParameter
+                    REDIS_PASS: !Ref RedisPasswordParameter
+                    REDIS_TLS: !Ref RedisUseTLSParameter
+                    REDIS_NAMESPACE: !Ref RedisRecordsNamespaceParameter
+                    RATE_LIMIT_MAX: !Ref RateLimitMaxParameter
+                    RATE_LIMIT_WINDOW_MS: !Ref RateLimitWindowMSParameter
             Events:
                 CreateRecordKey:
                     Type: Api

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -2578,6 +2578,34 @@ describe('AuthController', () => {
             });
         });
 
+        it('should work if there is no subscription config', async () => {
+            subscriptionConfig = null as any;
+            controller = new AuthController(
+                authStore,
+                messenger,
+                subscriptionConfig,
+                false
+            );
+
+            const result = await controller.getUserInfo({
+                userId,
+                sessionKey,
+            });
+
+            expect(result).toEqual({
+                success: true,
+                userId: userId,
+                email: 'email',
+                phoneNumber: 'phonenumber',
+                name: 'Test',
+                avatarUrl: 'avatar url',
+                avatarPortraitUrl: 'avatar portrait url',
+                hasActiveSubscription: false,
+                subscriptionTier: null,
+                openAiKey: null,
+            });
+        });
+
         it('should include the openAiKey if the user has an active subscription', async () => {
             await authStore.saveUser({
                 id: userId,

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -1019,12 +1019,12 @@ export class AuthController {
 
             let sub: SubscriptionConfiguration['subscriptions'][0];
             if (result.subscriptionId) {
-                sub = this._subscriptionConfig.subscriptions.find(
+                sub = this._subscriptionConfig?.subscriptions.find(
                     (s) => s.id === result.subscriptionId
                 );
             }
             if (!sub) {
-                sub = this._subscriptionConfig.subscriptions.find(
+                sub = this._subscriptionConfig?.subscriptions.find(
                     (s) => s.defaultSubscription
                 );
                 if (sub) {
@@ -1035,7 +1035,7 @@ export class AuthController {
             }
 
             if (!sub) {
-                sub = this._subscriptionConfig.subscriptions[0];
+                sub = this._subscriptionConfig?.subscriptions[0];
                 if (sub) {
                     console.log(
                         '[AuthController] [getUserInfo] Using first subscription for user.'

--- a/src/aux-records/MemoryRateLimiter.ts
+++ b/src/aux-records/MemoryRateLimiter.ts
@@ -8,7 +8,7 @@ import {
  * Defines a rate limiter that stores everything in-memory.
  */
 export class MemoryRateLimiter implements RateLimiter {
-    private _states: Map<string, MemoryState>;
+    private _states: Map<string, MemoryState> = new Map();
 
     windowMs: number = 1000;
 
@@ -47,7 +47,7 @@ export class MemoryRateLimiter implements RateLimiter {
             };
             this._states.set(key, state);
         }
-        if (state.resetTimeMs > Date.now()) {
+        if (state.resetTimeMs < Date.now()) {
             state.count = 0;
             state.resetTimeMs = Date.now() + this.windowMs;
         }

--- a/src/aux-records/MemoryRateLimiter.ts
+++ b/src/aux-records/MemoryRateLimiter.ts
@@ -1,0 +1,61 @@
+import {
+    RateLimiter,
+    RateLimiterIncrementResult,
+    RateLimiterOptions,
+} from '@casual-simulation/rate-limit-redis';
+
+/**
+ * Defines a rate limiter that stores everything in-memory.
+ */
+export class MemoryRateLimiter implements RateLimiter {
+    private _states: Map<string, MemoryState>;
+
+    windowMs: number = 1000;
+
+    init(options: RateLimiterOptions): void {
+        this.windowMs = options.windowMs;
+    }
+
+    async increment(
+        key: string,
+        amount: number = 1
+    ): Promise<RateLimiterIncrementResult> {
+        const state = this._getState(key);
+        state.count += amount;
+
+        return {
+            totalHits: state.count,
+            resetTime: new Date(state.resetTimeMs),
+        };
+    }
+
+    async decrement(key: string, amount?: number): Promise<void> {
+        const state = this._getState(key);
+        state.count += amount;
+    }
+
+    async resetKey(key: string): Promise<void> {
+        this._states.delete(key);
+    }
+
+    private _getState(key: string): MemoryState {
+        let state = this._states.get(key);
+        if (!state) {
+            state = {
+                count: 0,
+                resetTimeMs: Date.now() + this.windowMs,
+            };
+            this._states.set(key, state);
+        }
+        if (state.resetTimeMs > Date.now()) {
+            state.count = 0;
+            state.resetTimeMs = Date.now() + this.windowMs;
+        }
+        return state;
+    }
+}
+
+interface MemoryState {
+    count: number;
+    resetTimeMs: number;
+}

--- a/src/aux-records/RateLimitController.spec.ts
+++ b/src/aux-records/RateLimitController.spec.ts
@@ -1,0 +1,48 @@
+import { MemoryRateLimiter } from './MemoryRateLimiter';
+import { RateLimitController } from './RateLimitController';
+
+console.log = jest.fn();
+
+describe('RateLimitController', () => {
+    let rateLimiter: MemoryRateLimiter;
+    let subject: RateLimitController;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+
+        rateLimiter = new MemoryRateLimiter();
+        subject = new RateLimitController(rateLimiter, {
+            windowMs: 100,
+            maxHits: 2,
+        });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('checkRateLimit()', () => {
+        it('should return success if the rate limit has not been exceeded', async () => {
+            const result = await subject.checkRateLimit({
+                ipAddress: '123.456.789',
+            });
+
+            expect(result).toEqual({
+                success: true,
+            });
+        });
+
+        it('should return an unsuccessful result if the rate limit has been exceeded', async () => {
+            await rateLimiter.increment('123.456.789', 2);
+            const result = await subject.checkRateLimit({
+                ipAddress: '123.456.789',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'rate_limit_exceeded',
+                errorMessage: 'Rate limit exceeded.',
+            });
+        });
+    });
+});

--- a/src/aux-records/RateLimitController.spec.ts
+++ b/src/aux-records/RateLimitController.spec.ts
@@ -8,7 +8,9 @@ describe('RateLimitController', () => {
     let subject: RateLimitController;
 
     beforeEach(() => {
-        jest.useFakeTimers();
+        jest.useFakeTimers({
+            now: 0,
+        });
 
         rateLimiter = new MemoryRateLimiter();
         subject = new RateLimitController(rateLimiter, {
@@ -42,6 +44,18 @@ describe('RateLimitController', () => {
                 success: false,
                 errorCode: 'rate_limit_exceeded',
                 errorMessage: 'Rate limit exceeded.',
+            });
+        });
+
+        it('should return an successful result if the extra request is outside the rate limit window', async () => {
+            await rateLimiter.increment('123.456.789', 10);
+            jest.advanceTimersByTime(101);
+            const result = await subject.checkRateLimit({
+                ipAddress: '123.456.789',
+            });
+
+            expect(result).toEqual({
+                success: true,
             });
         });
     });

--- a/src/aux-records/RateLimitController.ts
+++ b/src/aux-records/RateLimitController.ts
@@ -1,0 +1,81 @@
+import { RateLimiter } from '@casual-simulation/rate-limit-redis';
+import { ServerError } from 'Errors';
+
+/**
+ * Defines a controller that is able to handle rate limiting.
+ */
+export class RateLimitController {
+    private _rateLimiter: RateLimiter;
+    private _maxHits: number;
+
+    constructor(rateLimiter: RateLimiter, config: RateLimitConfig) {
+        this._rateLimiter = rateLimiter;
+        this._rateLimiter.init({
+            windowMs: config.windowMs,
+        });
+        this._maxHits = config.maxHits;
+    }
+
+    /**
+     * Checks that the given request is allowed to proceed due to not exceeding the rate limit.
+     * @param request The request to check.
+     */
+    async checkRateLimit(
+        request: CheckRateLimitRequest
+    ): Promise<CheckRateLimitResponse> {
+        try {
+            console.log(
+                `[RateLimitController] Checking rate limit for ${request.ipAddress}.`
+            );
+            const hits = await this._rateLimiter.increment(request.ipAddress);
+
+            if (hits.totalHits > this._maxHits) {
+                console.log(
+                    `[RateLimitController] Rate limit exceeded! (Hits: ${hits.totalHits} Limit: ${this._maxHits})`
+                );
+                return {
+                    success: false,
+                    errorCode: 'rate_limit_exceeded',
+                    errorMessage: 'Rate limit exceeded.',
+                };
+            }
+
+            return {
+                success: true,
+            };
+        } catch (err) {
+            console.error(
+                `[RateLimitController] An error occurred while checking the rate limit.`,
+                err
+            );
+            return {
+                success: false,
+                errorCode: 'server_error',
+                errorMessage: 'A server error occurred.',
+            };
+        }
+    }
+}
+
+export interface RateLimitConfig {
+    windowMs: number;
+    maxHits: number;
+}
+
+export interface CheckRateLimitRequest {
+    ipAddress: string;
+}
+
+export type CheckRateLimitResponse =
+    | CheckRateLimitSuccess
+    | CheckRateLimitFailure;
+
+export interface CheckRateLimitSuccess {
+    success: true;
+}
+
+export interface CheckRateLimitFailure {
+    success: false;
+    errorCode: ServerError | 'rate_limit_exceeded';
+    errorMessage: string;
+}

--- a/src/aux-records/RateLimitController.ts
+++ b/src/aux-records/RateLimitController.ts
@@ -1,5 +1,5 @@
 import { RateLimiter } from '@casual-simulation/rate-limit-redis';
-import { ServerError } from 'Errors';
+import { ServerError } from './Errors';
 
 /**
  * Defines a controller that is able to handle rate limiting.

--- a/src/aux-records/RecordsHttpServer.spec.ts
+++ b/src/aux-records/RecordsHttpServer.spec.ts
@@ -3951,6 +3951,33 @@ describe('RecordsHttpServer', () => {
                 },
             });
         });
+
+        it('should skip rate limit checks if the server has no rate limiter', async () => {
+            jest.useFakeTimers({
+                now: 0,
+            });
+
+            server = new RecordsHttpServer(
+                allowedAccountOrigins,
+                allowedApiOrigins,
+                authController,
+                livekitController,
+                recordsController,
+                eventsController,
+                dataController,
+                manualDataController,
+                filesController,
+                subscriptionController,
+                null as any
+            );
+
+            await rateLimiter.increment(ip, 100);
+
+            const request = createRequest();
+            const result = await server.handleRequest(request);
+
+            expect(result.statusCode).not.toEqual(429);
+        });
     }
 
     function httpGet(

--- a/src/aux-records/RecordsHttpServer.spec.ts
+++ b/src/aux-records/RecordsHttpServer.spec.ts
@@ -35,6 +35,9 @@ import { getHash } from '@casual-simulation/crypto';
 import { SubscriptionController } from './SubscriptionController';
 import { StripeInterface, StripeProduct } from './StripeInterface';
 import { SubscriptionConfiguration } from './SubscriptionConfiguration';
+import { RateLimitController } from './RateLimitController';
+import { MemoryRateLimiter } from './MemoryRateLimiter';
+import { RateLimiter } from '@casual-simulation/rate-limit-redis';
 
 console.log = jest.fn();
 
@@ -55,6 +58,9 @@ describe('RecordsHttpServer', () => {
     let dataStore: DataRecordsStore;
     let manualDataController: DataRecordsController;
     let manualDataStore: DataRecordsStore;
+
+    let rateLimiter: RateLimiter;
+    let rateLimitController: RateLimitController;
 
     let filesStore: FileRecordsStore;
     let filesController: FileRecordsController;
@@ -162,6 +168,12 @@ describe('RecordsHttpServer', () => {
             filesStore
         );
 
+        rateLimiter = new MemoryRateLimiter();
+        rateLimitController = new RateLimitController(rateLimiter, {
+            maxHits: 5,
+            windowMs: 1000,
+        });
+
         stripe = stripeMock = {
             publishableKey: 'publishable_key',
             getProductAndPriceInfo: jest.fn(),
@@ -210,7 +222,8 @@ describe('RecordsHttpServer', () => {
             dataController,
             manualDataController,
             filesController,
-            subscriptionController
+            subscriptionController,
+            rateLimitController
         );
         defaultHeaders = {
             origin: 'test.com',
@@ -275,6 +288,10 @@ describe('RecordsHttpServer', () => {
         }
 
         recordKey = recordKeyResult.recordKey;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     describe('GET /api/{userId}/metadata', () => {
@@ -507,6 +524,8 @@ describe('RecordsHttpServer', () => {
                 headers: accountCorsHeaders,
             });
         });
+
+        testRateLimit('GET', `/api/{userId:${userId}}/metadata`);
     });
 
     describe('PUT /api/{userId}/metadata', () => {
@@ -680,6 +699,11 @@ describe('RecordsHttpServer', () => {
                 body,
                 authenticatedHeaders
             )
+        );
+        testRateLimit('PUT', `/api/{userId:${userId}}/metadata`, () =>
+            JSON.stringify({
+                name: 'Kal',
+            })
         );
     });
 
@@ -919,6 +943,8 @@ describe('RecordsHttpServer', () => {
                 headers: accountCorsHeaders,
             });
         });
+
+        testRateLimit('GET', `/api/{userId:${userId}}/subscription`);
     });
 
     describe('POST /api/{userId}/subscription/manage', () => {
@@ -1193,6 +1219,12 @@ describe('RecordsHttpServer', () => {
                 headers: accountCorsHeaders,
             });
         });
+
+        testRateLimit(
+            'POST',
+            `/api/{userId:${userId}}/subscription/manage`,
+            () => ''
+        );
     });
 
     describe('POST /api/stripeWebhook', () => {
@@ -1314,7 +1346,7 @@ describe('RecordsHttpServer', () => {
     });
 
     describe('GET /api/smsRules', () => {
-        it('should get the list of sms rules', async () => {
+        it('should return a 404', async () => {
             authStore.smsRules.push(
                 {
                     type: 'allow',
@@ -1400,6 +1432,7 @@ describe('RecordsHttpServer', () => {
         testAuthorization(() =>
             httpGet('/api/v2/sessions', authenticatedHeaders)
         );
+        testRateLimit('GET', `/api/v2/sessions`);
     });
 
     describe('POST /api/v2/replaceSession', () => {
@@ -1446,6 +1479,7 @@ describe('RecordsHttpServer', () => {
         testAuthorization(() =>
             httpPost('/api/v2/replaceSession', '', authenticatedHeaders)
         );
+        testRateLimit('POST', `/api/v2/replaceSession`, () => '');
     });
 
     describe('POST /api/v2/revokeAllSessions', () => {
@@ -1473,6 +1507,11 @@ describe('RecordsHttpServer', () => {
         });
 
         testUrl('POST', '/api/v2/revokeAllSessions', () =>
+            JSON.stringify({
+                userId,
+            })
+        );
+        testRateLimit('POST', `/api/v2/revokeAllSessions`, () =>
             JSON.stringify({
                 userId,
             })
@@ -1540,6 +1579,12 @@ describe('RecordsHttpServer', () => {
         });
 
         testUrl('POST', '/api/v2/revokeSession', () =>
+            JSON.stringify({
+                userId,
+                sessionId,
+            })
+        );
+        testRateLimit('POST', `/api/v2/revokeSession`, () =>
             JSON.stringify({
                 userId,
                 sessionId,
@@ -1669,6 +1714,13 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/completeLogin', body, authenticatedHeaders)
         );
+        testRateLimit('POST', `/api/v2/completeLogin`, () =>
+            JSON.stringify({
+                userId,
+                requestId,
+                code,
+            })
+        );
     });
 
     describe('POST /api/v2/login', () => {
@@ -1730,6 +1782,12 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/login', body, authenticatedHeaders)
         );
+        testRateLimit('POST', `/api/v2/login`, () =>
+            JSON.stringify({
+                address: 'test@example.com',
+                addressType: 'email',
+            })
+        );
     });
 
     describe('POST /api/v2/meet/token', () => {
@@ -1771,6 +1829,12 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/meet/token', body, {
                 origin: apiOrigin,
+            })
+        );
+        testRateLimit('POST', `/api/v2/meet/token`, () =>
+            JSON.stringify({
+                roomName,
+                userName,
             })
         );
     });
@@ -1930,6 +1994,13 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/records/events/count', body, apiHeaders)
         );
+        testRateLimit('POST', `/api/v2/records/events/count`, () =>
+            JSON.stringify({
+                recordKey,
+                eventName: 'testEvent',
+                count: 2,
+            })
+        );
     });
 
     describe('GET /api/v2/records/events/count', () => {
@@ -2022,6 +2093,7 @@ describe('RecordsHttpServer', () => {
             'GET',
             `/api/v2/records/events/count?recordName=recordName&eventName=testEvent`
         );
+        testRateLimit('GET', `/api/v2/records/events/count`);
     });
 
     describe('DELETE /api/v2/records/manual/data', () => {
@@ -2160,6 +2232,12 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpDelete('/api/v2/records/manual/data', body, apiHeaders)
         );
+        testRateLimit('DELETE', `/api/v2/records/manual/data`, () =>
+            JSON.stringify({
+                recordKey,
+                address: 'testAddress',
+            })
+        );
     });
 
     describe('GET /api/v2/records/manual/data', () => {
@@ -2254,6 +2332,12 @@ describe('RecordsHttpServer', () => {
                 headers: corsHeaders(defaultHeaders['origin']),
             });
         });
+
+        testRateLimit(() =>
+            httpGet(
+                `/api/v2/records/manual/data?recordName=${recordName}&address=testAddress`
+            )
+        );
     });
 
     describe('POST /api/v2/records/manual/data', () => {
@@ -2436,6 +2520,13 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost(`/api/v2/records/manual/data`, body, apiHeaders)
         );
+        testRateLimit('POST', `/api/v2/records/manual/data`, () =>
+            JSON.stringify({
+                recordKey,
+                address: 'testAddress',
+                data: 'hello, world',
+            })
+        );
     });
 
     describe('DELETE /api/v2/records/file', () => {
@@ -2598,6 +2689,12 @@ describe('RecordsHttpServer', () => {
 
         testBodyIsJson((body) =>
             httpDelete('/api/v2/records/file', body, apiHeaders)
+        );
+        testRateLimit('DELETE', `/api/v2/records/file`, () =>
+            JSON.stringify({
+                recordKey,
+                fileUrl,
+            })
         );
     });
 
@@ -2875,6 +2972,16 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/records/file', body, apiHeaders)
         );
+
+        testRateLimit('POST', `/api/v2/records/file`, () =>
+            JSON.stringify({
+                recordKey,
+                fileSha256Hex: 'hash',
+                fileByteLength: 10,
+                fileMimeType: 'application/json',
+                fileDescription: 'description',
+            })
+        );
     });
 
     describe('OPTIONS /api/v2/records/file/*', () => {
@@ -3054,6 +3161,13 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpDelete('/api/v2/records/data', body, apiHeaders)
         );
+
+        testRateLimit('DELETE', `/api/v2/records/data`, () =>
+            JSON.stringify({
+                recordKey,
+                address: 'testAddress',
+            })
+        );
     });
 
     describe('GET /api/v2/records/data', () => {
@@ -3148,6 +3262,13 @@ describe('RecordsHttpServer', () => {
                 headers: corsHeaders(defaultHeaders['origin']),
             });
         });
+
+        testRateLimit(() =>
+            httpGet(
+                `/api/v2/records/data?recordName=${recordName}&address=testAddress`,
+                defaultHeaders
+            )
+        );
     });
 
     describe('GET /api/v2/records/data/list', () => {
@@ -3257,6 +3378,13 @@ describe('RecordsHttpServer', () => {
                 headers: corsHeaders(defaultHeaders['origin']),
             });
         });
+
+        testRateLimit(() =>
+            httpGet(
+                `/api/v2/records/data/list?recordName=${recordName}`,
+                defaultHeaders
+            )
+        );
     });
 
     describe('POST /api/v2/records/data', () => {
@@ -3433,6 +3561,17 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost(`/api/v2/records/data`, body, apiHeaders)
         );
+        testRateLimit(() =>
+            httpPost(
+                `/api/v2/records/data`,
+                JSON.stringify({
+                    recordKey,
+                    address: 'testAddress',
+                    data: 'hello, world',
+                }),
+                defaultHeaders
+            )
+        );
     });
 
     describe('POST /api/v2/records/key', () => {
@@ -3555,6 +3694,17 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpPost('/api/v2/records/key', body, apiHeaders)
         );
+
+        testRateLimit(() =>
+            httpPost(
+                '/api/v2/records/key',
+                JSON.stringify({
+                    recordName: 'test',
+                    policy: 'subjectfull',
+                }),
+                defaultHeaders
+            )
+        );
     });
 
     describe('OPTIONS /api/v2/records', () => {
@@ -3624,6 +3774,7 @@ describe('RecordsHttpServer', () => {
         testBodyIsJson((body) =>
             httpRequest(method, url, body, authenticatedHeaders)
         );
+        testRateLimit(method, url, createBody);
     }
 
     function testOrigin(
@@ -3749,18 +3900,49 @@ describe('RecordsHttpServer', () => {
         });
     }
 
-    function testRateLimit(getRequest: (body: string) => GenericHttpRequest) {
+    function testRateLimit(createRequest: () => GenericHttpRequest): void;
+    function testRateLimit(
+        method: GenericHttpRequest['method'],
+        url: string,
+        createBody?: () => string | null
+    ): void;
+    function testRateLimit(
+        createRequestOrMethod:
+            | (() => GenericHttpRequest)
+            | GenericHttpRequest['method'],
+        url?: string,
+        createBody?: () => string | null
+    ): void {
+        const createRequestBody = createBody ?? (() => null);
+        const ip = '123.456.789';
+        const createRequest: () => GenericHttpRequest =
+            typeof createRequestOrMethod === 'function'
+                ? createRequestOrMethod
+                : () =>
+                      httpRequest(
+                          createRequestOrMethod,
+                          url as string,
+                          createRequestBody(),
+                          defaultHeaders,
+                          ip
+                      );
+
         it('should return a 429 status code when the rate limit is exceeded', async () => {
-            const request = getRequest('{');
+            jest.useFakeTimers({
+                now: 0,
+            });
+
+            await rateLimiter.increment(ip, 100);
+
+            const request = createRequest();
             const result = await server.handleRequest(request);
 
             expect(result).toEqual({
-                statusCode: 400,
+                statusCode: 429,
                 body: JSON.stringify({
                     success: false,
-                    errorCode: 'unacceptable_request',
-                    errorMessage:
-                        'The request body was not properly formatted. It should be valid JSON.',
+                    errorCode: 'rate_limit_exceeded',
+                    errorMessage: 'Rate limit exceeded.',
                 }),
                 headers: {
                     'Access-Control-Allow-Origin': request.headers.origin,

--- a/src/aux-records/RecordsHttpServer.spec.ts
+++ b/src/aux-records/RecordsHttpServer.spec.ts
@@ -3749,6 +3749,28 @@ describe('RecordsHttpServer', () => {
         });
     }
 
+    function testRateLimit(getRequest: (body: string) => GenericHttpRequest) {
+        it('should return a 429 status code when the rate limit is exceeded', async () => {
+            const request = getRequest('{');
+            const result = await server.handleRequest(request);
+
+            expect(result).toEqual({
+                statusCode: 400,
+                body: JSON.stringify({
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage:
+                        'The request body was not properly formatted. It should be valid JSON.',
+                }),
+                headers: {
+                    'Access-Control-Allow-Origin': request.headers.origin,
+                    'Access-Control-Allow-Headers':
+                        'Content-Type, Authorization',
+                },
+            });
+        });
+    }
+
     function httpGet(
         url: string,
         headers: GenericHttpHeaders = defaultHeaders,

--- a/src/aux-records/RecordsHttpServer.ts
+++ b/src/aux-records/RecordsHttpServer.ts
@@ -193,7 +193,12 @@ export class RecordsHttpServer {
         request: GenericHttpRequest
     ): Promise<GenericHttpResponse> {
         let skipRateLimitCheck = false;
-        if (request.method == 'POST' && request.path === '/api/stripeWebhook') {
+        if (!this._rateLimit) {
+            skipRateLimitCheck = true;
+        } else if (
+            request.method == 'POST' &&
+            request.path === '/api/stripeWebhook'
+        ) {
             skipRateLimitCheck = true;
         }
 

--- a/src/aux-records/Utils.spec.ts
+++ b/src/aux-records/Utils.spec.ts
@@ -473,6 +473,7 @@ describe('getStatusCode()', () => {
         ['other', 400] as const,
         ['price_does_not_match', 412] as const,
         ['user_is_banned', 403] as const,
+        ['rate_limit_exceeded', 429] as const,
     ];
 
     it.each(cases)('should map error code %s to %s', (code, expectedStatus) => {

--- a/src/aux-records/Utils.ts
+++ b/src/aux-records/Utils.ts
@@ -374,6 +374,8 @@ export function getStatusCode(
             return 412;
         } else if (response.errorCode === 'user_is_banned') {
             return 403;
+        } else if (response.errorCode === 'rate_limit_exceeded') {
+            return 429;
         } else {
             return 400;
         }

--- a/src/aux-records/index.ts
+++ b/src/aux-records/index.ts
@@ -21,3 +21,5 @@ export * from './RecordsHttpServer';
 
 export * from './SubscriptionController';
 export * from './StripeInterface';
+
+export * from './MemoryRateLimiter';

--- a/src/aux-records/index.ts
+++ b/src/aux-records/index.ts
@@ -23,3 +23,4 @@ export * from './SubscriptionController';
 export * from './StripeInterface';
 
 export * from './MemoryRateLimiter';
+export * from './RateLimitController';

--- a/src/aux-records/package.json
+++ b/src/aux-records/package.json
@@ -38,6 +38,7 @@
     },
     "dependencies": {
         "@casual-simulation/crypto": "^3.1.23",
+        "@casual-simulation/rate-limit-redis": "^3.0.1",
         "livekit-server-sdk": "1.0.2",
         "tweetnacl": "1.0.3"
     }

--- a/src/aux-records/tsconfig.json
+++ b/src/aux-records/tsconfig.json
@@ -10,5 +10,5 @@
     },
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "lib", "**/*.spec.ts"],
-    "references": [{ "path": "../crypto" }]
+    "references": [{ "path": "../crypto" }, { "path": "../rate-limit-redis" }]
 }

--- a/src/casual-apiary-aws/package.json
+++ b/src/casual-apiary-aws/package.json
@@ -25,6 +25,7 @@
         "@casual-simulation/fast-json-stable-stringify": "^3.1.11",
         "@casual-simulation/casual-apiary": "^3.1.28",
         "@casual-simulation/casual-apiary-redis": "^3.1.28",
+        "@casual-simulation/rate-limit-redis": "^3.0.1",
         "aws-sdk": "^2.968.0",
         "axios": "0.25.0",
         "base64-js": "^1.5.1",

--- a/src/casual-apiary-aws/template.yml
+++ b/src/casual-apiary-aws/template.yml
@@ -40,6 +40,14 @@ Parameters:
         Type: String
         Description: Whether instance updates should be merged when the space size limit is exceeded.
         Default: 'false'
+    RateLimitMaxParameter:
+        Type: String
+        Description: The maximum number of requests that can be made from an IP address over the window. If set to an empty string, then there is no rate limiting.
+        Default: ''
+    RateLimitWindowMSParameter:
+        Type: String
+        Description: The window, in milliseconds, that requests are allowed to be made over for rate limiting. i.e. if set to 1000, then RateLimitMaxParameter number of requests can be made over 1 second. If set to an empty string, then there is no rate limiting.
+        Default: ''
     WebsocketURLParameter:
         Type: String
         Description: The URL of the API Gateway endpoint that server messages should be sent through.
@@ -291,6 +299,8 @@ Resources:
                     MERGE_UPDATES_ON_MAX_SIZE_EXCEEDED: !Ref MergeUpdatesOnMaxSizeExceededParameter
                     WEBSOCKET_URL: !Ref WebsocketURLParameter
                     MESSAGES_BUCKET: !Ref MessagesBucket
+                    RATE_LIMIT_MAX: !Ref RateLimitMaxParameter
+                    RATE_LIMIT_WINDOW_MS: !Ref RateLimitWindowMSParameter
     HandleMessagePermission:
         Type: AWS::Lambda::Permission
         DependsOn:

--- a/src/casual-apiary-aws/tsconfig.json
+++ b/src/casual-apiary-aws/tsconfig.json
@@ -15,6 +15,7 @@
         { "path": "../aux-records" },
         { "path": "../aux-records-aws" },
         { "path": "../casual-apiary" },
-        { "path": "../casual-apiary-redis" }
+        { "path": "../casual-apiary-redis" },
+        { "path": "../rate-limit-redis" }
     ]
 }

--- a/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
+++ b/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
@@ -2172,7 +2172,7 @@ describe('ApiaryCausalRepoServer', () => {
             ]);
         });
 
-        it.only('should merge updates when the max size was exceeded if configured', async () => {
+        it('should merge updates when the max size was exceeded if configured', async () => {
             updateStore.maxAllowedInstSize = 180;
             server.mergeUpdatesOnMaxSizeExceeded = true;
 

--- a/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
+++ b/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
@@ -2181,6 +2181,7 @@ describe('ApiaryCausalRepoServer', () => {
                 type: 'yjs',
             });
 
+            p.doc.clientID = 9999;
             p.doc.on('update', (update: Uint8Array) => {
                 createdUpdates.push(fromByteArray(update));
             });

--- a/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
+++ b/src/casual-apiary/src/ApiaryCausalRepoServer.spec.ts
@@ -2172,8 +2172,8 @@ describe('ApiaryCausalRepoServer', () => {
             ]);
         });
 
-        it('should merge updates when the max size was exceeded if configured', async () => {
-            updateStore.maxAllowedInstSize = 180;
+        it.only('should merge updates when the max size was exceeded if configured', async () => {
+            updateStore.maxAllowedInstSize = 150;
             server.mergeUpdatesOnMaxSizeExceeded = true;
 
             let createdUpdates = [] as string[];

--- a/src/rate-limit-redis/.gitignore
+++ b/src/rate-limit-redis/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+coverage/
+
+.idea/
+.vscode/
+
+*.log
+*.tgz
+*.bak
+*.tmp
+
+yarn.lock
+pnpm-lock.yaml

--- a/src/rate-limit-redis/.gitignore
+++ b/src/rate-limit-redis/.gitignore
@@ -12,3 +12,10 @@ coverage/
 
 yarn.lock
 pnpm-lock.yaml
+
+*.js
+*.js.map
+*.d.ts
+!typings/**/*
+docs
+package-lock.json

--- a/src/rate-limit-redis/changelog.md
+++ b/src/rate-limit-redis/changelog.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v3.0.1](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v3.0.1)
+
+### Changed
+
+-   Updated documentation related to `ioredis` integration [#48](https://github.com/wyattjoh/rate-limit-redis/pull/48)
+
+## [v3.0.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v3.0.0)
+
+### Added
+
+-   Added issue and PR templates.
+-   The `release` action now publishes a GitHub release when a new tag is pushed
+    with a built `.tgz` file so you can install the package from npm and GitHub.
+-   [BREAKING] Added the `sendCommand` option to replace the `client` option
+    -   `sendCommand` is a function that takes the raw command as a string array and
+        returns the numeric response from redis.
+    -   this makes the store compatible with all clients that have a public method
+        to send raw commands to redis.
+-   Added a changelog and a contributing guide.
+
+### Changed
+
+-   Rewrote library and tests in Typescript.
+-   Use `esbuild` to build both ES and CommonJS modules and use
+    `dts-bundle-generator` to generate a single type declaration file.
+-   Added `express` >= 4 and `express-rate-limit` >= 6 as peer dependencies.
+
+### Removed
+
+-   [BREAKING] Removed the `expiry` option, as we now get that from the rate
+    limiting middleware in the `init` method.
+-   [BREAKING] Removed the `client` option, as it is now replaced by the
+    `sendCommand` option
+-   [BREAKING] Removed the `passIfNotConnected` option, as developers now need to
+    handle connection using a client of their choice
+
+## [v2.1.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v2.1.0)
+
+### Added
+
+-   Added the `passIfNotConnected` option.
+    -   If set to `true`, if the client is not connected to Redis, the store will
+        allow the request to pass through as a failover.
+
+### Removed
+
+-   Dropped support for Node 6.
+
+## [v2.0.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v2.0.0)
+
+### Changed
+
+-   [BREAKING] Bumped `node-redis` version from `2.8.0` to `3.0.2`.
+
+## [v1.7.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.7.0)
+
+### Added
+
+-   Added support for passing a redis connection string instead of a client
+    instance to the constructor.
+
+## [v1.6.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.6.0)
+
+### Added
+
+-   Added example of connecting to a UDP socket to the readme.
+-   Added support for returning the reset date to the rate limit middleware.
+
+## [v1.5.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.5.0)
+
+### Added
+
+-   Added the `resetExpiryOnChange` option.
+    -   If set to `true`, the store sets the expiry time back to `windowMs` when
+        incrementing/decrementing. This aligns better with how the default handler
+        in the rate limiting middleware displays the time in the `Retry-After`
+        header.
+
+## [v1.4.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.4.0)
+
+### Added
+
+-   Added support for the `decrement` and `reset` functions (see
+    https://github.com/nfriedly/express-rate-limit/commit/c9194780b6826d9cdb14b3395907cf7fb93e59f6)
+
+## [v1.3.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.3.0)
+
+### Added
+
+-   Added support for millisecond precision in the `expiry` option.
+
+## [v1.1.0](https://github.com/wyattjoh/rate-limit-redis/releases/tag/v1.1.0)
+
+### Added
+
+-   Added better support for IORedis.

--- a/src/rate-limit-redis/index.ts
+++ b/src/rate-limit-redis/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/src/rate-limit-redis/index.ts
+++ b/src/rate-limit-redis/index.ts
@@ -1,1 +1,3 @@
 export * from './src/index';
+
+export { default } from './src/index';

--- a/src/rate-limit-redis/license.md
+++ b/src/rate-limit-redis/license.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2021 Wyatt Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/rate-limit-redis/package.json
+++ b/src/rate-limit-redis/package.json
@@ -1,19 +1,18 @@
 {
     "name": "@casual-simulation/rate-limit-redis",
-    "version": "3.0.1",
+    "version": "3.1.23",
     "description": "A Redis store for the `express-rate-limit` middleware",
-    "author": {
-        "name": "Wyatt Johnson",
-        "url": "https://github.com/wyattjoh"
-    },
+    "homepage": "https://github.com/casual-simulation/casualos",
     "license": "MIT",
-    "homepage": "https://github.com/wyattjoh/rate-limit-redis",
-    "repository": "https://github.com/wyattjoh/rate-limit-redis",
-    "type": "module",
-    "main": "./src/index.js",
-    "types": "./src/index.d.ts",
-    "module": "./src/index",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "module": "index",
+    "directories": {
+        "lib": "."
+    },
     "files": [
+        "/README.md",
+        "/LICENSE.txt",
         "**/*.js",
         "**/*.js.map",
         "**/*.d.ts",
@@ -23,11 +22,26 @@
         "license.md",
         "changelog.md"
     ],
-    "engines": {
-        "node": ">= 14.5.0"
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/casual-simulation/casualos.git"
     },
     "scripts": {
-        "test": "jest"
+        "watch": "tsc --watch",
+        "watch:player": "npm run watch",
+        "build": "echo \"Nothing to do.\"",
+        "test": "jest",
+        "test:watch": "jest --watchAll"
+    },
+    "bugs": {
+        "url": "https://github.com/casual-simulation/casualos/issues"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "author": {
+        "name": "Wyatt Johnson",
+        "url": "https://github.com/wyattjoh"
     },
     "dependencies": {
         "express-rate-limit": "^6"

--- a/src/rate-limit-redis/package.json
+++ b/src/rate-limit-redis/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@casual-simulation/rate-limit-redis",
+    "version": "3.0.1",
+    "description": "A Redis store for the `express-rate-limit` middleware",
+    "author": {
+        "name": "Wyatt Johnson",
+        "url": "https://github.com/wyattjoh"
+    },
+    "license": "MIT",
+    "homepage": "https://github.com/wyattjoh/rate-limit-redis",
+    "repository": "https://github.com/wyattjoh/rate-limit-redis",
+    "type": "module",
+    "main": "./src/index.js",
+    "types": "./src/index.d.ts",
+    "module": "./src/index",
+    "files": [
+        "**/*.js",
+        "**/*.js.map",
+        "**/*.d.ts",
+        "tsconfig.json",
+        "package.json",
+        "readme.md",
+        "license.md",
+        "changelog.md"
+    ],
+    "engines": {
+        "node": ">= 14.5.0"
+    },
+    "scripts": {
+        "test": "jest"
+    },
+    "dependencies": {
+        "express-rate-limit": "^6"
+    },
+    "devDependencies": {
+        "@types/ioredis-mock": "^5.6.0",
+        "@types/ioredis": "4.28.10",
+        "ioredis": "^4.28.3",
+        "ioredis-mock": "^5.8.1"
+    }
+}

--- a/src/rate-limit-redis/readme.md
+++ b/src/rate-limit-redis/readme.md
@@ -1,0 +1,163 @@
+# <div align="center"> `rate-limit-redis` </div>
+
+<div align="center">
+	<img alt="Github Workflow Status" src="https://img.shields.io/github/workflow/status/wyattjoh/rate-limit-redis/CI"/>
+	<img alt="npm version" src="https://img.shields.io/npm/v/rate-limit-redis.svg"/>
+	<img alt="GitHub Stars" src="https://img.shields.io/github/stars/wyattjoh/rate-limit-redis"/>
+	<img alt="npm downloads" src="https://img.shields.io/npm/dm/rate-limit-redis"/>
+</div>
+
+<br>
+
+<div align="center">
+
+A [`redis`](https://github.com/redis/redis) store for the
+[`express-rate-limit`](https://github.com/nfriedly/express-rate-limit)
+middleware.
+
+</div>
+
+## Installation
+
+From the npm registry:
+
+```sh
+# Using npm
+> npm install rate-limit-redis
+# Using yarn or pnpm
+> yarn/pnpm add rate-limit-redis
+```
+
+From Github Releases:
+
+```sh
+# Using npm
+> npm install https://github.com/wyattjoh/rate-limit-redis/releases/download/v{version}/rate-limit-redis.tgz
+# Using yarn or pnpm
+> yarn/pnpm add https://github.com/wyattjoh/rate-limit-redis/releases/download/v{version}/rate-limit-redis.tgz
+```
+
+Replace `{version}` with the version of the package that you want to your, e.g.:
+`3.0.0`.
+
+## Usage
+
+### Importing
+
+This library is provided in ESM as well as CJS forms, and works with both
+Javascript and Typescript projects.
+
+**This package requires you to use Node 14 or above.**
+
+Import it in a CommonJS project (`type: commonjs` or no `type` field in
+`package.json`) as follows:
+
+```ts
+const RedisStore = require('rate-limit-redis');
+```
+
+Import it in a ESM project (`type: module` in `package.json`) as follows:
+
+```ts
+import RedisStore from 'rate-limit-redis';
+```
+
+### Examples
+
+To use it with a [`node-redis`](https://github.com/redis/node-redis) client:
+
+```ts
+import rateLimit from 'express-rate-limit';
+import RedisStore from 'rate-limit-redis';
+import { createClient } from 'redis';
+
+// Create a `node-redis` client
+const client = createClient({
+    // ... (see https://github.com/redis/node-redis/blob/master/docs/client-configuration.md)
+});
+// Then connect to the Redis server
+await client.connect();
+
+// Create and use the rate limiter
+const limiter = rateLimit({
+    // Rate limiter configuration
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+
+    // Redis store configuration
+    store: new RedisStore({
+        sendCommand: (...args: string[]) => client.sendCommand(args),
+    }),
+});
+app.use(limiter);
+```
+
+To use it with a [`ioredis`](https://github.com/luin/ioredis) client:
+
+```ts
+import rateLimit from 'express-rate-limit';
+import RedisStore from 'rate-limit-redis';
+import RedisClient from 'ioredis';
+
+// Create a `ioredis` client
+const client = new RedisClient();
+// ... (see https://github.com/luin/ioredis#connect-to-redis)
+
+// Create and use the rate limiter
+const limiter = rateLimit({
+    // Rate limiter configuration
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+
+    // Redis store configuration
+    store: new RedisStore({
+        // @ts-expect-error - Known issue: the `call` function is not present in @types/ioredis
+        sendCommand: (...args: string[]) => client.call(...args),
+    }),
+});
+app.use(limiter);
+```
+
+### Configuration
+
+#### `sendCommand`
+
+The function used to send commands to Redis. The function signature is as
+follows:
+
+```ts
+(...args: string[]) => Promise<number> | number
+```
+
+The raw command sending function varies from library to library; some are given
+below:
+
+| Library                                                            | Function                                                          |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| [`node-redis`](https://github.com/redis/node-redis)                | `async (...args: string[]) => client.sendCommand(args)`           |
+| [`ioredis`](https://github.com/luin/ioredis)                       | `async (...args: string[]) => client.call(...args)`               |
+| [`handy-redis`](https://github.com/mmkal/handy-redis)              | `async (...args: string[]) => client.nodeRedis.sendCommand(args)` |
+| [`tedis`](https://github.com/silkjs/tedis)                         | `async (...args: string[]) => client.command(...args)`            |
+| [`redis-fast-driver`](https://github.com/h0x91b/redis-fast-driver) | `async (...args: string[]) => client.rawCallAsync(args)`          |
+| [`yoredis`](https://github.com/djanowski/yoredis)                  | `async (...args: string[]) => (await client.callMany([args]))[0]` |
+| [`noderis`](https://github.com/wallneradam/noderis)                | `async (...args: string[]) => client.callRedis(...args)`          |
+
+#### `prefix`
+
+The text to prepend to the key in Redis.
+
+Defaults to `rl:`.
+
+#### `resetExpiryOnChange`
+
+Whether to reset the expiry for a particular key whenever its hit count changes.
+
+Defaults to `false`.
+
+## License
+
+MIT © [Wyatt Johnson](https://github.com/wyattjoh)

--- a/src/rate-limit-redis/src/RateLimiter.ts
+++ b/src/rate-limit-redis/src/RateLimiter.ts
@@ -1,0 +1,59 @@
+/**
+ * Defines an interface that contains options for a rate limiter.
+ */
+export interface RateLimiterOptions {
+    /**
+     * The length of time that requests should be remembered for.
+     */
+    readonly windowMs: number;
+}
+
+/**
+ * Defines an interface that contains the result of incrementing a key in rate limiter.
+ */
+export interface RateLimiterIncrementResult {
+    /**
+     * The number of hits that the given key has recieved over the window.
+     */
+    totalHits: number;
+
+    /**
+     * The time when the counter will reset.
+     */
+    resetTime: Date | undefined;
+}
+
+/**
+ * Defines an interface for a rate limiter.
+ */
+export interface RateLimiter {
+    /**
+     * Initializes the rate limiter with the given options.
+     * @param options The options.
+     */
+    init(options: RateLimiterOptions): void;
+
+    /**
+     * Increments the number of hits that the given key has recieved by the given amount.
+     * Returns a promise that resolves with the total number of hits that the key has recieved.
+     * @param key The key.
+     * @param amount The amount to increment the key by. Defaults to 1.
+     */
+    increment(
+        key: string,
+        amount?: number
+    ): Promise<RateLimiterIncrementResult>;
+
+    /**
+     * Decrements the number of hits that the given key has recieved by the given amount.
+     * @param key The key.
+     * @param amount The amount to decrement the key by. Defaults to 1.
+     */
+    decrement(key: string, amount?: number): Promise<void>;
+
+    /**
+     * Resets the given key to zero hits.
+     * @param key The key to reset.
+     */
+    resetKey(key: string): Promise<void>;
+}

--- a/src/rate-limit-redis/src/index.ts
+++ b/src/rate-limit-redis/src/index.ts
@@ -1,0 +1,5 @@
+// Re-export all type definitions
+export * from './types.js';
+
+// Export the RedisStore class as the default export
+export { default } from './lib.js';

--- a/src/rate-limit-redis/src/index.ts
+++ b/src/rate-limit-redis/src/index.ts
@@ -3,3 +3,5 @@ export * from './types';
 
 // Export the RedisStore class as the default export
 export { default } from './lib';
+
+export * from './RateLimiter';

--- a/src/rate-limit-redis/src/index.ts
+++ b/src/rate-limit-redis/src/index.ts
@@ -1,5 +1,5 @@
 // Re-export all type definitions
-export * from './types.js';
+export * from './types';
 
 // Export the RedisStore class as the default export
-export { default } from './lib.js';
+export { default } from './lib';

--- a/src/rate-limit-redis/src/lib.spec.ts
+++ b/src/rate-limit-redis/src/lib.spec.ts
@@ -30,7 +30,7 @@ const sendCommand = async (
         const shasum = createHash('sha1');
         shasum.update(args[2]);
         scriptSha = shasum.digest('hex');
-        await client.eval(args[2], 1, '__test', '0', '100');
+        await client.eval(args[2], 1, '__test', '0', '100', '1');
 
         // Return the SHA to the store.
         return scriptSha;
@@ -42,6 +42,8 @@ const sendCommand = async (
         return client.evalsha(scriptSha!, ...args.slice(2)) as number[];
     // `DECR` decrements the count for a client.
     if (args[0] === 'DECR') return client.decr(args[1]);
+    // `DECRBY` decrements the count for a client by an amount.
+    if (args[0] === 'DECRBY') return client.decrby(args[1], args[2] as any);
     // `DEL` resets the count for a client by deleting the key.
     if (args[0] === 'DEL') return client.del(args[1]);
 

--- a/src/rate-limit-redis/src/lib.spec.ts
+++ b/src/rate-limit-redis/src/lib.spec.ts
@@ -1,0 +1,208 @@
+import { createHash } from 'node:crypto';
+
+// import { jest as Jest } from '@jest/globals';
+import { Options } from 'express-rate-limit';
+import MockRedisClient, { Redis } from 'ioredis-mock';
+
+import RedisStore, { RedisReply } from '../src/index.js';
+
+// The SHA of the script to evaluate
+let scriptSha: string | undefined;
+
+/**
+ * A wrapper around the mock redis client to call the right function, as the
+ * `ioredis-mock` library does not have a send-raw-command function.
+ *
+ * @param {Redis} client - The mock Redis client.
+ * @param {string[]} args - The raw command to send.
+ *
+ * @return {RedisReply | RedisReply[]} The reply returned by Redis.
+ */
+const sendCommand = async (
+    client: Redis,
+    args: string[]
+): Promise<RedisReply | RedisReply[]> => {
+    // `SCRIPT LOAD`, called when the store is initialized. This loads the lua script
+    // for incrementing a client's hit counter.
+    if (args[0] === 'SCRIPT') {
+        // `ioredis-mock` doesn't have a `SCRIPT LOAD` function, so we have to compute
+        // the SHA manually and `EVAL` the script to get it saved.
+        const shasum = createHash('sha1');
+        shasum.update(args[2]);
+        scriptSha = shasum.digest('hex');
+        await client.eval(args[2], 1, '__test', '0', '100');
+
+        // Return the SHA to the store.
+        return scriptSha;
+    }
+
+    // `EVALSHA` executes the script that was loaded already with the given arguments
+    if (args[0] === 'EVALSHA')
+        // @ts-expect-error Wrong types :/
+        return client.evalsha(scriptSha!, ...args.slice(2)) as number[];
+    // `DECR` decrements the count for a client.
+    if (args[0] === 'DECR') return client.decr(args[1]);
+    // `DEL` resets the count for a client by deleting the key.
+    if (args[0] === 'DEL') return client.del(args[1]);
+
+    // This should not happen
+    return -99;
+};
+
+describe('redis store test', () => {
+    // Mock timers so we can fast forward time instead of waiting for n seconds
+    // in the timer section
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    it('supports custom prefixes', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+            prefix: 'test-',
+        });
+        store.init({ windowMs: 10 } as Options);
+
+        const key = 'store';
+
+        await store.increment(key);
+
+        // Ensure the hit count is 1, and the expiry is 10 milliseconds (value of
+        // `windowMs`).
+        expect(Number(await client.get('test-store'))).toEqual(1);
+        expect(Number(await client.pttl('test-store'))).toEqual(10);
+    });
+
+    it('sets the value to 1 on first call to `increment`', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+        });
+        store.init({ windowMs: 10 } as Options);
+
+        const key = 'test-store';
+
+        const { totalHits } = await store.increment(key); // => 1
+
+        // Ensure the hit count is 1, and the expiry is 10 milliseconds (value of
+        // `windowMs`).
+        expect(totalHits).toEqual(1);
+        expect(Number(await client.get('rl:test-store'))).toEqual(1);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(10);
+    });
+
+    it('increments the key for the store when `increment` is called', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+        });
+        store.init({ windowMs: 10 } as Options);
+
+        const key = 'test-store';
+
+        await store.increment(key); // => 1
+        const { totalHits } = await store.increment(key); // => 2
+
+        // Ensure the hit count is 2, and the expiry is 10 milliseconds (value of
+        // `windowMs`).
+        expect(totalHits).toEqual(2);
+        expect(Number(await client.get('rl:test-store'))).toEqual(2);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(10);
+    });
+
+    it('decrements the key for the store when `decrement` is called', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+        });
+        store.init({ windowMs: 10 } as Options);
+
+        const key = 'test-store';
+
+        await store.increment(key); // => 1
+        await store.increment(key); // => 2
+        await store.decrement(key); // => 1
+        const { totalHits } = await store.increment(key); // => 2
+
+        // Ensure the hit count is 2, and the expiry is 10 milliseconds (value of
+        // `windowMs`).
+        expect(totalHits).toEqual(2);
+        expect(Number(await client.get('rl:test-store'))).toEqual(2);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(10);
+    });
+
+    it('resets the count for a key in the store when `resetKey` is called', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+        });
+        store.init({ windowMs: 10 } as Options);
+
+        const key = 'test-store';
+
+        await store.increment(key); // => 1
+        await store.resetKey(key); // => undefined
+
+        const { totalHits } = await store.increment(key); // => 1
+
+        // Ensure the hit count is 1, and the expiry is 10 milliseconds (value of
+        // `windowMs`).
+        expect(totalHits).toEqual(1);
+        expect(Number(await client.get('rl:test-store'))).toEqual(1);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(10);
+    });
+
+    it('resets expiry time on change if `resetExpiryOnChange` is set to `true`', async () => {
+        const client = new MockRedisClient();
+        const store = new RedisStore({
+            sendCommand: async (...args: string[]) => sendCommand(client, args),
+            resetExpiryOnChange: true,
+        });
+        store.init({ windowMs: 60 } as Options);
+
+        const key = 'test-store';
+
+        await store.increment(key); // => 1
+
+        // Ensure the hit count is 1, and the expiry is 60 milliseconds (value of
+        // `windowMs`).
+        expect(Number(await client.get('rl:test-store'))).toEqual(1);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(60);
+
+        await store.increment(key); // => 2
+
+        // Ensure the hit count is 1, and the expiry is 60 milliseconds (value of
+        // `windowMs`).
+        expect(Number(await client.get('rl:test-store'))).toEqual(2);
+        expect(Number(await client.pttl('rl:test-store'))).toEqual(60);
+    });
+
+    describe('reset time', () => {
+        beforeEach(() => jest.useFakeTimers());
+        afterEach(() => jest.useRealTimers());
+
+        it('resets the count for all the keys in the store when the timeout is reached', async () => {
+            const client = new MockRedisClient();
+            const store = new RedisStore({
+                sendCommand: async (...args: string[]) =>
+                    sendCommand(client, args),
+            });
+            store.init({ windowMs: 50 } as Options);
+
+            const keyOne = 'test-store-one';
+            const keyTwo = 'test-store-two';
+
+            await store.increment(keyOne);
+            await store.increment(keyTwo);
+
+            jest.advanceTimersByTime(60);
+
+            // Ensure that the keys have been deleted
+            expect(await client.get('rl:test-store-one')).toEqual(null);
+            expect(await client.get('rl:test-store-two')).toEqual(null);
+        });
+    });
+});

--- a/src/rate-limit-redis/src/lib.spec.ts
+++ b/src/rate-limit-redis/src/lib.spec.ts
@@ -1,10 +1,10 @@
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 
 // import { jest as Jest } from '@jest/globals';
 import { Options } from 'express-rate-limit';
 import MockRedisClient, { Redis } from 'ioredis-mock';
 
-import RedisStore, { RedisReply } from '../src/index.js';
+import RedisStore, { RedisReply } from './index';
 
 // The SHA of the script to evaluate
 let scriptSha: string | undefined;

--- a/src/rate-limit-redis/src/lib.ts
+++ b/src/rate-limit-redis/src/lib.ts
@@ -1,0 +1,167 @@
+import {
+    Store,
+    IncrementResponse,
+    Options as RateLimitConfiguration,
+} from 'express-rate-limit';
+
+import { Options, SendCommandFn } from './types.js';
+
+/**
+ * A `Store` for the `express-rate-limit` package that stores hit counts in
+ * Redis.
+ */
+class RedisStore implements Store {
+    /**
+     * The function used to send raw commands to Redis.
+     */
+    sendCommand: SendCommandFn;
+
+    /**
+     * The text to prepend to the key in Redis.
+     */
+    prefix: string;
+
+    /**
+     * Whether to reset the expiry for a particular key whenever its hit count
+     * changes.
+     */
+    resetExpiryOnChange: boolean;
+
+    /**
+     * Stores the loaded SHA1 of the LUA script for executing the increment operations.
+     */
+    loadedScriptSha1: Promise<string>;
+
+    /**
+     * The number of milliseconds to remember that user's requests.
+     */
+    windowMs!: number;
+
+    /**
+     * @constructor for `RedisStore`.
+     *
+     * @param options {Options} - The configuration options for the store.
+     */
+    constructor(options: Options) {
+        this.sendCommand = options.sendCommand;
+        this.prefix = options.prefix ?? 'rl:';
+        this.resetExpiryOnChange = options.resetExpiryOnChange ?? false;
+
+        // So that the script loading can occur non-blocking, this will send
+        // the script to be loaded, and will capture the value within the
+        // promise return. This way, if increments start being called before
+        // the script has finished loading, it will wait until it is loaded
+        // before it continues.
+        this.loadedScriptSha1 = this.loadScript();
+    }
+
+    async loadScript(): Promise<string> {
+        const result = await this.sendCommand(
+            'SCRIPT',
+            'LOAD',
+            `
+        local totalHits = redis.call("INCR", KEYS[1])
+        local timeToExpire = redis.call("PTTL", KEYS[1])
+        if timeToExpire <= 0 or ARGV[1] == "1"
+        then
+            redis.call("PEXPIRE", KEYS[1], tonumber(ARGV[2]))
+            timeToExpire = tonumber(ARGV[2])
+        end
+
+        return { totalHits, timeToExpire }
+    `
+                // Ensure that code changes that affect whitespace do not affect
+                // the script contents.
+                .replace(/^\s+/gm, '')
+                .trim()
+        );
+
+        if (typeof result !== 'string') {
+            throw new TypeError('unexpected reply from redis client');
+        }
+
+        return result;
+    }
+
+    /**
+     * Method to prefix the keys with the given text.
+     *
+     * @param key {string} - The key.
+     *
+     * @returns {string} - The text + the key.
+     */
+    prefixKey(key: string): string {
+        return `${this.prefix}${key}`;
+    }
+
+    /**
+     * Method that actually initializes the store.
+     *
+     * @param options {RateLimitConfiguration} - The options used to setup the middleware.
+     */
+    init(options: RateLimitConfiguration) {
+        this.windowMs = options.windowMs;
+    }
+
+    /**
+     * Method to increment a client's hit counter.
+     *
+     * @param key {string} - The identifier for a client
+     *
+     * @returns {IncrementResponse} - The number of hits and reset time for that client
+     */
+    async increment(key: string): Promise<IncrementResponse> {
+        const results = await this.sendCommand(
+            'EVALSHA',
+            await this.loadedScriptSha1,
+            '1',
+            this.prefixKey(key),
+            this.resetExpiryOnChange ? '1' : '0',
+            this.windowMs.toString()
+        );
+
+        if (!Array.isArray(results)) {
+            throw new TypeError('Expected result to be array of values');
+        }
+
+        if (results.length !== 2) {
+            throw new Error(`Expected 2 replies, got ${results.length}`);
+        }
+
+        const totalHits = results[0];
+        if (typeof totalHits !== 'number') {
+            throw new TypeError('Expected value to be a number');
+        }
+
+        const timeToExpire = results[1];
+        if (typeof timeToExpire !== 'number') {
+            throw new TypeError('Expected value to be a number');
+        }
+
+        const resetTime = new Date(Date.now() + timeToExpire);
+        return {
+            totalHits,
+            resetTime,
+        };
+    }
+
+    /**
+     * Method to decrement a client's hit counter.
+     *
+     * @param key {string} - The identifier for a client
+     */
+    async decrement(key: string): Promise<void> {
+        await this.sendCommand('DECR', this.prefixKey(key));
+    }
+
+    /**
+     * Method to reset a client's hit counter.
+     *
+     * @param key {string} - The identifier for a client
+     */
+    async resetKey(key: string): Promise<void> {
+        await this.sendCommand('DEL', this.prefixKey(key));
+    }
+}
+
+export default RedisStore;

--- a/src/rate-limit-redis/src/lib.ts
+++ b/src/rate-limit-redis/src/lib.ts
@@ -111,7 +111,7 @@ class RedisStore implements Store {
      * @returns {IncrementResponse} - The number of hits and reset time for that client
      */
     async increment(key: string): Promise<IncrementResponse> {
-        const results = this._runScript(this.prefixKey(key));
+        const results = await this._runScript(this.prefixKey(key));
 
         if (!Array.isArray(results)) {
             throw new TypeError('Expected result to be array of values');

--- a/src/rate-limit-redis/src/lib.ts
+++ b/src/rate-limit-redis/src/lib.ts
@@ -4,7 +4,7 @@ import {
     Options as RateLimitConfiguration,
 } from 'express-rate-limit';
 
-import { Options, SendCommandFn } from './types.js';
+import { Options, RedisReply, SendCommandFn } from './types.js';
 
 /**
  * A `Store` for the `express-rate-limit` package that stores hit counts in
@@ -156,7 +156,7 @@ class RedisStore implements Store {
         await this.sendCommand('DEL', this.prefixKey(key));
     }
 
-    private _runScript(key: string) {
+    private async _runScript(key: string): Promise<RedisReply | RedisReply[]> {
         try {
             return await this.sendCommand(
                 'EVALSHA',

--- a/src/rate-limit-redis/src/types.ts
+++ b/src/rate-limit-redis/src/types.ts
@@ -8,7 +8,7 @@ export type RedisReply = number | string;
  * 'raw-command-sending' functions for each redis client.
  */
 export type SendCommandFn = (
-    ...args: string[]
+    ...args: (string | number)[]
 ) => Promise<RedisReply | RedisReply[]>;
 
 /**

--- a/src/rate-limit-redis/src/types.ts
+++ b/src/rate-limit-redis/src/types.ts
@@ -1,0 +1,33 @@
+/**
+ * The type of data Redis might return to us.
+ */
+export type RedisReply = number | string;
+
+/**
+ * The library sends Redis raw commands, so all we need to know are the
+ * 'raw-command-sending' functions for each redis client.
+ */
+export type SendCommandFn = (
+    ...args: string[]
+) => Promise<RedisReply | RedisReply[]>;
+
+/**
+ * The configuration options for the store.
+ */
+export interface Options {
+    /**
+     * The function used to send commands to Redis.
+     */
+    readonly sendCommand: SendCommandFn;
+
+    /**
+     * The text to prepend to the key in Redis.
+     */
+    readonly prefix?: string;
+
+    /**
+     * Whether to reset the expiry for a particular key whenever its hit count
+     * changes.
+     */
+    readonly resetExpiryOnChange?: boolean;
+}

--- a/src/rate-limit-redis/tsconfig.json
+++ b/src/rate-limit-redis/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "include": ["src/"],
+    "exclude": ["node_modules/"],
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "esnext",
+        "declaration": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "moduleResolution": "node",
+        "esModuleInterop": true
+    }
+}

--- a/src/rate-limit-redis/tsconfig.json
+++ b/src/rate-limit-redis/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "include": ["src/"],
-    "exclude": ["node_modules/"],
+    "exclude": ["node_modules", "lib", "**/*.spec.ts"],
     "compilerOptions": {
         "baseUrl": ".",
         "outDir": ".",

--- a/src/rate-limit-redis/tsconfig.json
+++ b/src/rate-limit-redis/tsconfig.json
@@ -3,14 +3,16 @@
     "include": ["src/"],
     "exclude": ["node_modules/"],
     "compilerOptions": {
-        "target": "esnext",
-        "module": "esnext",
+        "baseUrl": ".",
+        "outDir": ".",
         "declaration": true,
-        "strict": true,
+        "declarationMap": true,
         "noUnusedLocals": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
         "moduleResolution": "node",
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "composite": true,
+        "incremental": true
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
         { "path": "./src/websocket" },
         { "path": "./src/js-interpreter" },
         { "path": "./src/multi-streams-mixer" },
-        { "path": "./src/vue-shortkey" }
+        { "path": "./src/vue-shortkey" },
+        { "path": "./src/rate-limit-redis" }
     ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -45,6 +45,7 @@
         { "path": "./src/expect" },
         { "path": "./src/chalk" },
         { "path": "./src/websocket" },
-        { "path": "./src/js-interpreter" }
+        { "path": "./src/js-interpreter" },
+        { "path": "./src/rate-limit-redis" }
     ]
 }


### PR DESCRIPTION
### :rocket: Improvements

-   Added configurable support for IP-based rate limiting.
    -   Applies to websockets as well as the API.
    -   Requires a Redis connection and is configurable by the following environment variables:
        -   `RATE_LIMIT_MAX` - The maximum number of requests that can be recieved from an IP address over the window.
        -   `RATE_LIMIT_WINDOW_MS` - The size of the window for requests represented in miliseconds.
    -   If any of the above environment variables are not specified, then rate limiting will be disabled.