### PR TITLE
Mesh glTF form fixes - Color & Disposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 -   Fixed an issue where `os.getMediaPermission` would leave tracks in a MediaStream running. Some browsers/devices release these automatically, while others would leave the tracks running and cause issues with other systems that utilize audio and video hardware like augmented reality.
 -   Fixed an issue where `data:` URLs would not work in the `formAddress` tag without a workaround.
 -   Fixed an issue where it was impossible to create record keys on deployments that did not have a subscription configuration.
+-   Fixed an issue where the `color` tag would not apply to all materials in a gltf model.
+-   Fixed an issue where gltf models with multiple materials and textures would not be properly disposed.
 
 ## V3.1.28
 

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -501,28 +501,11 @@ export function disposeMesh(
 export function disposeObject3D(
     object3d: Object3D,
     disposeGeometry: boolean = true,
-    disposeMaterial: boolean = true
+    disposeMat: boolean = true,
+    disposeTextures: boolean = false
 ) {
-    if (!object3d) return;
-
-    if (disposeGeometry) {
-        let geometry = (<any>object3d).geometry;
-        if (geometry) {
-            geometry.dispose();
-        }
-    }
-
-    if (disposeMaterial) {
-        let material = (<any>object3d).material;
-        if (material) {
-            if (Array.isArray(material)) {
-                for (let i = 0; i < material.length; i++) {
-                    material[i].dispose();
-                }
-            } else {
-                material.dispose();
-            }
-        }
+    if (object3d instanceof Mesh) {
+        disposeMesh(object3d, disposeGeometry, disposeMat, disposeTextures);
     }
 }
 
@@ -530,11 +513,18 @@ export function disposeObject3D(
  * Disposes of the entire group.
  * @param group The group to dispose.
  */
-export function disposeGroup(group: Group) {
+export function disposeGroup(
+    group: Group,
+    disposeGeometry: boolean = true,
+    disposeMat: boolean = true,
+    disposeTextures: boolean = false
+) {
     if (!group) {
         return;
     }
-    group.traverse((obj) => disposeObject3D(obj));
+    group.traverse((obj) =>
+        disposeObject3D(obj, disposeGeometry, disposeMat, disposeTextures)
+    );
 }
 
 /**

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -501,11 +501,28 @@ export function disposeMesh(
 export function disposeObject3D(
     object3d: Object3D,
     disposeGeometry: boolean = true,
-    disposeMat: boolean = true,
-    disposeTextures: boolean = false
+    disposeMaterial: boolean = true
 ) {
-    if (object3d instanceof Mesh) {
-        disposeMesh(object3d, disposeGeometry, disposeMat, disposeTextures);
+    if (!object3d) return;
+
+    if (disposeGeometry) {
+        let geometry = (<any>object3d).geometry;
+        if (geometry) {
+            geometry.dispose();
+        }
+    }
+
+    if (disposeMaterial) {
+        let material = (<any>object3d).material;
+        if (material) {
+            if (Array.isArray(material)) {
+                for (let i = 0; i < material.length; i++) {
+                    material[i].dispose();
+                }
+            } else {
+                material.dispose();
+            }
+        }
     }
 }
 
@@ -513,18 +530,11 @@ export function disposeObject3D(
  * Disposes of the entire group.
  * @param group The group to dispose.
  */
-export function disposeGroup(
-    group: Group,
-    disposeGeometry: boolean = true,
-    disposeMat: boolean = true,
-    disposeTextures: boolean = false
-) {
+export function disposeGroup(group: Group) {
     if (!group) {
         return;
     }
-    group.traverse((obj) =>
-        disposeObject3D(obj, disposeGeometry, disposeMat, disposeTextures)
-    );
+    group.traverse((obj) => disposeObject3D(obj));
 }
 
 /**

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -494,7 +494,7 @@ export class BotShapeDecorator
             this.container.remove(this._iframe.object3d);
             disposeObject3D(this._iframe.object3d);
         }
-        disposeGroup(this.scene);
+        disposeGroup(this.scene, true, true, true);
 
         if (this._keyboard) {
             for (let key of (this._keyboard as any).keys) {
@@ -538,7 +538,16 @@ export class BotShapeDecorator
     }
 
     private _setColor(color: any) {
-        setColor(this.mesh, color);
+        if (this.scene) {
+            // Color all meshes inside the gltf scene.
+            this.scene.traverse((obj) => {
+                if (obj instanceof Mesh) {
+                    setColor(obj, color);
+                }
+            });
+        } else {
+            setColor(this.mesh, color);
+        }
 
         if (this._keyboard) {
             let expectedColor = color
@@ -819,13 +828,18 @@ export class BotShapeDecorator
             );
         }
 
-        const material: any = this.mesh.material;
-        if (material) {
-            registerMaterial(material);
-        }
-        if (material && material.color) {
-            material[DEFAULT_COLOR] = material.color;
-        }
+        this.scene.traverse((obj) => {
+            if (obj instanceof Mesh) {
+                const material = obj.material;
+                if (material) {
+                    registerMaterial(material);
+
+                    if (material.color) {
+                        material[DEFAULT_COLOR] = material.color;
+                    }
+                }
+            }
+        });
 
         this._updateColor(null);
         this._updateRenderOrder(null);

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -494,7 +494,16 @@ export class BotShapeDecorator
             this.container.remove(this._iframe.object3d);
             disposeObject3D(this._iframe.object3d);
         }
-        disposeGroup(this.scene, true, true, true);
+
+        if (this.scene) {
+            this.scene.traverse((obj) => {
+                if (obj instanceof Mesh) {
+                    disposeMesh(obj, true, true, true);
+                } else {
+                    disposeObject3D(obj);
+                }
+            });
+        }
 
         if (this._keyboard) {
             for (let key of (this._keyboard as any).keys) {


### PR DESCRIPTION
This PR adds support for the `color` tag on all meshes and materials of a bot loading a glTF model. Previously CasualOS would only apply the `color` tag value to the first mesh child of glTF. This PR also fixes material texture registration and disposal for glTF models that have many materials and textures.

Before:
![color_develop](https://user-images.githubusercontent.com/1583792/236341392-18f73908-f280-4211-8d3f-351bbb981493.png)

After:
![color_gltf-fixes](https://user-images.githubusercontent.com/1583792/236341417-0cdbd897-a27a-4d45-a51e-50bad91a9d67.png)


