### PR TITLE
Transformed bot bounding objects fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 -   Fixed an issue where `os.getMediaPermission` would leave tracks in a MediaStream running. Some browsers/devices release these automatically, while others would leave the tracks running and cause issues with other systems that utilize audio and video hardware like augmented reality.
 -   Fixed an issue where `data:` URLs would not work in the `formAddress` tag without a workaround.
 -   Fixed an issue where it was impossible to create record keys on deployments that did not have a subscription configuration.
+-   Fixed an issue where the bounding objects of a transformed bot did not update if its `transformer` moved.
+    -   This fixes a reported bug with `lineTo` to updating correctly while using the `transformer` tag. [PR #276](https://github.com/casual-simulation/casualos/issues/276)
 
 ## V3.1.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 -   Fixed an issue where `data:` URLs would not work in the `formAddress` tag without a workaround.
 -   Fixed an issue where it was impossible to create record keys on deployments that did not have a subscription configuration.
 -   Fixed an issue where the bounding objects of a transformed bot did not update if its `transformer` moved.
-    -   This fixes a reported bug with `lineTo` to updating correctly while using the `transformer` tag. [PR #276](https://github.com/casual-simulation/casualos/issues/276)
+    -   This fixes a reported bug with `lineTo` to updating correctly while using the `transformer` tag. [Issue #276](https://github.com/casual-simulation/casualos/issues/276)
 
 ## V3.1.28
 

--- a/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxBot3D.ts
@@ -191,6 +191,7 @@ export class AuxBot3D extends GameObject implements AuxBotVisualizer {
         this.display = new Group();
         this.scaleContainer = new Group();
         this.transformContainer = new Group();
+        this.transformContainer.userData.isBotTransformContainer = true;
         this.add(this.container);
         this.container.add(this.scaleContainer);
         this.scaleContainer.add(this.display);

--- a/src/aux-server/aux-web/shared/scene/DimensionGroup3D.ts
+++ b/src/aux-server/aux-web/shared/scene/DimensionGroup3D.ts
@@ -119,6 +119,7 @@ export class DimensionGroup3D extends GameObject implements DimensionGroup {
         this._helper = new DimensionGroupHelper<AuxBot3D>(bot);
         this.domain = domain;
         this.display = new Group();
+        this.display.userData.isDimensionGroupDisplay = true;
         this._decoratorFactory = decoratorFactory;
         this._portalTag = portalTag;
         this._coordinateTransformer = null;

--- a/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/DimensionPositionDecorator.ts
@@ -88,6 +88,7 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
     private _rotationObj: Object3D;
     private _game: Game;
     private _tween: any;
+    private _transformerWorldPos: Vector3;
 
     constructor(
         bot3D: AuxBot3D,
@@ -379,6 +380,37 @@ export class DimensionPositionDecorator extends AuxBot3DDecoratorBase {
                     euler.x = 0;
                     euler.y = 0;
                     this._rotationObj.setRotationFromEuler(euler);
+                }
+            }
+
+            // Update bounding objects if trasnformer bot moves.
+            const transformer = getBotTransformer(calc, this.bot3D.bot);
+
+            if (transformer) {
+                const bots =
+                    this.bot3D.dimensionGroup.simulation3D.findBotsById(
+                        transformer
+                    );
+                const parentBot = bots.length ? bots[0] : null;
+
+                if (parentBot instanceof AuxBot3D) {
+                    if (!this._transformerWorldPos) {
+                        this._transformerWorldPos = new Vector3();
+                        parentBot.getWorldPosition(this._transformerWorldPos);
+                        this.bot3D.forceComputeBoundingObjects();
+                    } else {
+                        const lastTransformerPos =
+                            this._transformerWorldPos.clone();
+                        parentBot.getWorldPosition(this._transformerWorldPos);
+
+                        if (
+                            !this._transformerWorldPos.equals(
+                                lastTransformerPos
+                            )
+                        ) {
+                            this.bot3D.forceComputeBoundingObjects();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR fixes an issue with bots being transformed by other bots not updating their bounding objects (bounding box, bounding sphere, etc). This was the cause for the bug reported in Issue #276 

The `DimensionPositionDecorator` simply keeps track of the world position of its transformer (if it has one). If the transformer changes world position then the `DimensionPositionDecorator` will update the bounding objects of the transformed bot.

Before: 
![casualos_lineTo_transformer_before](https://user-images.githubusercontent.com/1583792/236498364-71e66962-436e-47f7-b639-054cfc14df1c.gif)

After:
![casualos_lineTo_transformer_fixed](https://user-images.githubusercontent.com/1583792/236498436-20288bc4-921c-41f0-9d95-389c3dd92727.gif)

