### PR TITLE
Added fade tag to support semi-transparent bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
         -   `RATE_LIMIT_MAX` - The maximum number of requests that can be recieved from an IP address over the window.
         -   `RATE_LIMIT_WINDOW_MS` - The size of the window for requests represented in miliseconds.
     -   If any of the above environment variables are not specified, then rate limiting will be disabled.
+-   Added `fade` tag, which allows bots to be semi-transparent.
+    -   A `fade` value of `0` means that the bot's mesh materials are effectively in their default opacity and transparency state.
+    -   A `fade` value `> 0` means that the bot's mesh materials become transparent and that the `fade` value is used to scale each material's default opacity level. A `fade` value of `1` would effectively make the bot invisible.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -434,6 +434,21 @@ The color of the bot.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `fade`
+
+The fade level of the bot. Allows bots to be semi-transparent.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='0'>
+    (default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Number >= 0 and <= 1'>
+    The bot will use the given fade.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `cursor`
 
 The cursor that should be used when the mouse pointer is hovering over the bot in the bot and menu portals.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -398,6 +398,7 @@ export interface BotTagMasks {
 export interface BotTags {
     // Normal bot tags
     ['color']?: unknown;
+    ['fade']?: unknown;
     ['draggable']?: unknown;
     ['draggableMode']?: unknown;
     ['destroyable']?: unknown;
@@ -2233,6 +2234,7 @@ export const KNOWN_TAGS: string[] = [
     'draggable',
     'destroyable',
     'editable',
+    'fade',
     'strokeColor',
     'strokeWidth',
     'lineTo',

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -688,6 +688,8 @@ export function buildSRGBColor(...args: (string | number)[]): Color {
 }
 
 export const DEFAULT_COLOR = Symbol('default_color');
+export const DEFAULT_OPACITY = Symbol('default_opacity');
+export const DEFAULT_TRANSPARENT = Symbol('default_transparent');
 
 /**
  * Changes the mesh's material to the given color.
@@ -712,6 +714,42 @@ export function setColor(
     } else {
         shapeMat.visible = true;
         shapeMat.color = (<any>shapeMat)[DEFAULT_COLOR] ?? new Color(0xffffff);
+    }
+}
+
+/**
+ * Changes the mesh's fade level.
+ * @param mesh The mesh.
+ * @param fade The fade value (0.0 -> 1.0)
+ */
+export function setFade(mesh: Mesh | Sprite | ThreeLineSegments, fade: number) {
+    if (!mesh) {
+        return;
+    }
+
+    const shapeMat = <
+        MeshStandardMaterial | MeshToonMaterial | LineBasicMaterial
+    >mesh.material;
+    const prevTransparent = shapeMat.transparent;
+
+    fade = clamp(fade, 0, 1);
+
+    if (fade > 0) {
+        // Use fade as a scalar on the material's default opacity.
+        const defaultOpacity = (<any>shapeMat)[DEFAULT_OPACITY] ?? 1;
+        const opacity = defaultOpacity * (1 - fade);
+
+        shapeMat.transparent = true;
+        shapeMat.opacity = opacity;
+    } else {
+        // Restore material to default values for opacity and transparency.
+        shapeMat.transparent = (<any>shapeMat)[DEFAULT_TRANSPARENT] ?? false;
+        shapeMat.opacity = (<any>shapeMat)[DEFAULT_OPACITY] ?? 1;
+    }
+
+    if (shapeMat.transparent !== prevTransparent) {
+        // Changing transparenct flag of material requires recompilation of material.
+        shapeMat.needsUpdate = true;
     }
 }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -43,7 +43,10 @@ import {
     baseAuxMeshMaterial,
     createCircle,
     DEFAULT_COLOR,
+    DEFAULT_OPACITY,
+    DEFAULT_TRANSPARENT,
     registerMaterial,
+    setFade,
 } from '../SceneUtils';
 import { createCubeStroke } from '../MeshUtils';
 import { LineSegments } from '../LineSegments';
@@ -208,6 +211,7 @@ export class BotShapeDecorator
         }
 
         this._updateColor(calc);
+        this._updateFade(calc);
         this._updateStroke(calc);
         this._updateAddress(calc, address);
         this._updateRenderOrder(calc);
@@ -546,6 +550,16 @@ export class BotShapeDecorator
         this._setColor(color);
     }
 
+    private _updateFade(calc: BotCalculationContext) {
+        const fade = calculateNumericalTagValue(
+            calc,
+            this.bot3D.bot,
+            'fade',
+            0
+        );
+        this._setFade(fade);
+    }
+
     private _setColor(color: any) {
         if (this.scene) {
             // Color all meshes inside the gltf scene.
@@ -584,6 +598,45 @@ export class BotShapeDecorator
                         },
                     });
                 }
+            }
+        }
+    }
+
+    private _setFade(fade: number) {
+        if (this.scene) {
+            // Set fade on all meshes inside the gltf scene.
+            this.scene.traverse((obj) => {
+                if (obj instanceof Mesh) {
+                    setFade(obj, fade);
+                }
+            });
+        } else {
+            setFade(this.mesh, fade);
+        }
+
+        if (this._keyboard) {
+            const defaultOpacity = 1;
+            const opacity = defaultOpacity * (1 - fade);
+
+            // let firstPanel = (this._keyboard as any).panels[0];
+            for (let panel of (this._keyboard as any).panels) {
+                panel.set({
+                    backgroundOpacity: opacity,
+                });
+            }
+
+            for (let key of (this._keyboard as any).keys) {
+                // Update each key state with new backgroundOpacity.
+                const states = key.states;
+                for (let stateId in states) {
+                    const attributes = states[stateId].attributes;
+                    attributes.backgroundOpacity = opacity;
+
+                    key.setupState({ stateId, attributes });
+                }
+
+                // Set the current backgroundOpacity for the key.
+                key.set({ backgroundOpacity: opacity });
             }
         }
     }
@@ -846,11 +899,23 @@ export class BotShapeDecorator
                     if (material.color) {
                         material[DEFAULT_COLOR] = material.color;
                     }
+
+                    if (
+                        typeof material.opacity === 'number' &&
+                        !Number.isNaN(material.opacity)
+                    ) {
+                        material[DEFAULT_OPACITY] = material.opacity;
+                    }
+
+                    if (typeof material.transparent === 'boolean') {
+                        material[DEFAULT_TRANSPARENT] = material.transparent;
+                    }
                 }
             }
         });
 
         this._updateColor(null);
+        this._updateFade(null);
         this._updateRenderOrder(null);
         this.bot3D.updateMatrixWorld(true);
     }
@@ -956,12 +1021,14 @@ export class BotShapeDecorator
         }
 
         this._keyboard = keyboard;
+        (window as any).keyboard = this._keyboard;
         this.container.add(keyboard);
         this.stroke = null;
         this.mesh = null;
         this.collider = null;
         this._canHaveStroke = false;
         this._updateColor(null);
+        this._updateFade(null);
         this._updateRenderOrder(null);
 
         // Force the mesh UI to update
@@ -1005,6 +1072,7 @@ export class BotShapeDecorator
             let material = baseAuxMeshMaterial();
             this.mesh.material = material;
             this._updateColor(null);
+            this._updateFade(null);
             this._updateRenderOrder(null);
         }
     }
@@ -1017,6 +1085,7 @@ export class BotShapeDecorator
         if (await this._loadGLTF(EggUrl, false, token)) {
             this.mesh = this.scene.children[0] as Mesh;
             this._updateColor(null);
+            this._updateFade(null);
             this._updateRenderOrder(null);
         }
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -1021,7 +1021,6 @@ export class BotShapeDecorator
         }
 
         this._keyboard = keyboard;
-        (window as any).keyboard = this._keyboard;
         this.container.add(keyboard);
         this.stroke = null;
         this.mesh = null;


### PR DESCRIPTION
This PR adds support for a new `fade` tag. 

The `fade` tag is used to scale the default opacity value of all materials on a bot. 

- A `fade` value of `0` means that the bot's mesh materials are effectively in their default opacity and transparency state. 
- A `fade` value `> 0` means that the bot's mesh materials become transparent and that the `fade` value is used to scale each material's default opacity level. 
- A `fade` value of `1` would effectively make the bot invisible.

`fade` is implemented for all mesh-based bot forms, including custom glTF models and the keyboard.

![casualos_fade](https://github.com/casual-simulation/casualos/assets/1583792/c16e3a6f-4970-498e-b9ba-8796bfd4e3cf)
