### PR TITLE
Added formOpacity tag to support semi-transparent bots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
         -   `RATE_LIMIT_MAX` - The maximum number of requests that can be recieved from an IP address over the window.
         -   `RATE_LIMIT_WINDOW_MS` - The size of the window for requests represented in miliseconds.
     -   If any of the above environment variables are not specified, then rate limiting will be disabled.
+-   Added `fade` tag, which allows bots to be semi-transparent.
+    -   A `fade` value of `0` means that the bot's mesh materials are effectively in their default opacity and transparency state.
+    -   A `fade` value `> 0` means that the bot's mesh materials become transparent and that the `fade` value is used to scale each material's default opacity level. A `fade` value of `1` would effectively make the bot invisible.
 
 ### :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
     -   If any of the above environment variables are not specified, then rate limiting will be disabled.
 -   Added `formOpacity` tag, which allows bots to be semi-transparent.
     -   A `formOpacity` value of `1` means that the bot's mesh materials are effectively in their default opacity and transparency state.
-    -   A `formOpacity` value `< 1` means that the bot's mesh materials become transparent and that the `formOpacity` value is used to modify each material's default opacity level. A `formOpacity` value of `0` would effectively make the bot invisible.
+    -   A `formOpacity` value `< 1` means that the bot's mesh materials become transparent and that the `formOpacity` value is used to modify each material's default opacity level.
+    -   A `formOpacity` value of `0` would effectively make the bot invisible.
 
 ### :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@
         -   `RATE_LIMIT_MAX` - The maximum number of requests that can be recieved from an IP address over the window.
         -   `RATE_LIMIT_WINDOW_MS` - The size of the window for requests represented in miliseconds.
     -   If any of the above environment variables are not specified, then rate limiting will be disabled.
--   Added `fade` tag, which allows bots to be semi-transparent.
-    -   A `fade` value of `0` means that the bot's mesh materials are effectively in their default opacity and transparency state.
-    -   A `fade` value `> 0` means that the bot's mesh materials become transparent and that the `fade` value is used to scale each material's default opacity level. A `fade` value of `1` would effectively make the bot invisible.
+-   Added `formOpacity` tag, which allows bots to be semi-transparent.
+    -   A `formOpacity` value of `1` means that the bot's mesh materials are effectively in their default opacity and transparency state.
+    -   A `formOpacity` value `< 1` means that the bot's mesh materials become transparent and that the `formOpacity` value is used to modify each material's default opacity level. A `formOpacity` value of `0` would effectively make the bot invisible.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -996,7 +996,7 @@ The opacity of the bot's form. Allows bots to be semi-transparent.
 #### Possible values are:
 
 <PossibleValuesTable>
-  <PossibleValueCode value='0'>
+  <PossibleValueCode value='1'>
     (default)
   </PossibleValueCode>
   <PossibleValue value='Any Number >= 0 and <= 1'>

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -434,21 +434,6 @@ The color of the bot.
   </PossibleValueCode>
 </PossibleValuesTable>
 
-### `fade`
-
-The fade level of the bot. Allows bots to be semi-transparent.
-
-#### Possible values are:
-
-<PossibleValuesTable>
-  <PossibleValueCode value='0'>
-    (default)
-  </PossibleValueCode>
-  <PossibleValue value='Any Number >= 0 and <= 1'>
-    The bot will use the given fade.
-  </PossibleValue>
-</PossibleValuesTable>
-
 ### `cursor`
 
 The cursor that should be used when the mouse pointer is hovering over the bot in the bot and menu portals.
@@ -1001,6 +986,21 @@ For GLTF forms, this should be the URL of the GLTF file that contains the animat
   </PossibleValueCode>
   <PossibleValue value='Any URL'>
     Use the animations from the given GLTF file.
+  </PossibleValue>
+</PossibleValuesTable>
+
+### `formOpacity`
+
+The opacity of the bot's form. Allows bots to be semi-transparent.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='0'>
+    (default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Number >= 0 and <= 1'>
+    The bot's form will use the given opacity.
   </PossibleValue>
 </PossibleValuesTable>
 

--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -434,6 +434,21 @@ The color of the bot.
   </PossibleValueCode>
 </PossibleValuesTable>
 
+### `fade`
+
+The fade level of the bot. Allows bots to be semi-transparent.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='0'>
+    (default)
+  </PossibleValueCode>
+  <PossibleValue value='Any Number >= 0 and <= 1'>
+    The bot will use the given fade.
+  </PossibleValue>
+</PossibleValuesTable>
+
 ### `cursor`
 
 The cursor that should be used when the mouse pointer is hovering over the bot in the bot and menu portals.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -398,7 +398,6 @@ export interface BotTagMasks {
 export interface BotTags {
     // Normal bot tags
     ['color']?: unknown;
-    ['fade']?: unknown;
     ['draggable']?: unknown;
     ['draggableMode']?: unknown;
     ['destroyable']?: unknown;
@@ -425,6 +424,7 @@ export interface BotTags {
     ['form']?: BotShape;
     ['formAnimation']?: string;
     ['formAddress']?: string;
+    ['formOpacity']?: unknown;
     ['orientationMode']?: string;
     ['anchorPoint']?: string;
     ['creator']?: string;
@@ -2234,7 +2234,6 @@ export const KNOWN_TAGS: string[] = [
     'draggable',
     'destroyable',
     'editable',
-    'fade',
     'strokeColor',
     'strokeWidth',
     'lineTo',
@@ -2266,6 +2265,7 @@ export const KNOWN_TAGS: string[] = [
     'form',
     'formAnimation',
     'formAnimationAddress',
+    'formOpacity',
     'formRenderOrder',
     'orientationMode',
     'anchorPoint',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -398,6 +398,7 @@ export interface BotTagMasks {
 export interface BotTags {
     // Normal bot tags
     ['color']?: unknown;
+    ['fade']?: unknown;
     ['draggable']?: unknown;
     ['draggableMode']?: unknown;
     ['destroyable']?: unknown;
@@ -2233,6 +2234,7 @@ export const KNOWN_TAGS: string[] = [
     'draggable',
     'destroyable',
     'editable',
+    'fade',
     'strokeColor',
     'strokeWidth',
     'lineTo',

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -718,11 +718,14 @@ export function setColor(
 }
 
 /**
- * Changes the mesh's fade level.
+ * Changes the mesh's opacity level.
  * @param mesh The mesh.
- * @param fade The fade value (0.0 -> 1.0)
+ * @param opacity The opacity value (0.0 -> 1.0)
  */
-export function setFade(mesh: Mesh | Sprite | ThreeLineSegments, fade: number) {
+export function setOpacity(
+    mesh: Mesh | Sprite | ThreeLineSegments,
+    opacity: number
+) {
     if (!mesh) {
         return;
     }
@@ -732,15 +735,15 @@ export function setFade(mesh: Mesh | Sprite | ThreeLineSegments, fade: number) {
     >mesh.material;
     const prevTransparent = shapeMat.transparent;
 
-    fade = clamp(fade, 0, 1);
+    opacity = clamp(opacity, 0, 1);
 
-    if (fade > 0) {
-        // Use fade as a scalar on the material's default opacity.
+    if (opacity < 1) {
+        // Use given opacity as a modifier on the material's default opacity.
         const defaultOpacity = (<any>shapeMat)[DEFAULT_OPACITY] ?? 1;
-        const opacity = defaultOpacity * (1 - fade);
+        const newOpacity = defaultOpacity * opacity;
 
         shapeMat.transparent = true;
-        shapeMat.opacity = opacity;
+        shapeMat.opacity = newOpacity;
     } else {
         // Restore material to default values for opacity and transparency.
         shapeMat.transparent = (<any>shapeMat)[DEFAULT_TRANSPARENT] ?? false;
@@ -748,7 +751,7 @@ export function setFade(mesh: Mesh | Sprite | ThreeLineSegments, fade: number) {
     }
 
     if (shapeMat.transparent !== prevTransparent) {
-        // Changing transparenct flag of material requires recompilation of material.
+        // Changing transparent flag of material requires re-compilation of material.
         shapeMat.needsUpdate = true;
     }
 }

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -688,6 +688,8 @@ export function buildSRGBColor(...args: (string | number)[]): Color {
 }
 
 export const DEFAULT_COLOR = Symbol('default_color');
+export const DEFAULT_OPACITY = Symbol('default_opacity');
+export const DEFAULT_TRANSPARENT = Symbol('default_transparent');
 
 /**
  * Changes the mesh's material to the given color.
@@ -712,6 +714,42 @@ export function setColor(
     } else {
         shapeMat.visible = true;
         shapeMat.color = (<any>shapeMat)[DEFAULT_COLOR] ?? new Color(0xffffff);
+    }
+}
+
+/**
+ * Changes the mesh's fade level.
+ * @param mesh The mesh.
+ * @param fade The fade value (0.0 -> 1.0)
+ */
+export function setFade(mesh: Mesh | Sprite | ThreeLineSegments, fade: number) {
+    if (!mesh) {
+        return;
+    }
+
+    const shapeMat = <
+        MeshStandardMaterial | MeshToonMaterial | LineBasicMaterial
+    >mesh.material;
+    const prevTransparent = shapeMat.transparent;
+
+    fade = clamp(fade, 0, 1);
+
+    if (fade > 0) {
+        // Use fade as a scalar on the material's default opacity.
+        const defaultOpacity = (<any>shapeMat)[DEFAULT_OPACITY] ?? 1;
+        const opacity = defaultOpacity * (1 - fade);
+
+        shapeMat.transparent = true;
+        shapeMat.opacity = opacity;
+    } else {
+        // Restore material to default values for opacity and transparency.
+        shapeMat.transparent = (<any>shapeMat)[DEFAULT_TRANSPARENT] ?? false;
+        shapeMat.opacity = (<any>shapeMat)[DEFAULT_OPACITY] ?? 1;
+    }
+
+    if (shapeMat.transparent !== prevTransparent) {
+        // Changing transparenct flag of material requires recompilation of material.
+        shapeMat.needsUpdate = true;
     }
 }
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -43,7 +43,10 @@ import {
     baseAuxMeshMaterial,
     createCircle,
     DEFAULT_COLOR,
+    DEFAULT_OPACITY,
+    DEFAULT_TRANSPARENT,
     registerMaterial,
+    setFade,
 } from '../SceneUtils';
 import { createCubeStroke } from '../MeshUtils';
 import { LineSegments } from '../LineSegments';
@@ -208,6 +211,7 @@ export class BotShapeDecorator
         }
 
         this._updateColor(calc);
+        this._updateFade(calc);
         this._updateStroke(calc);
         this._updateAddress(calc, address);
         this._updateRenderOrder(calc);
@@ -546,6 +550,16 @@ export class BotShapeDecorator
         this._setColor(color);
     }
 
+    private _updateFade(calc: BotCalculationContext) {
+        const fade = calculateNumericalTagValue(
+            calc,
+            this.bot3D.bot,
+            'fade',
+            0
+        );
+        this._setFade(fade);
+    }
+
     private _setColor(color: any) {
         if (this.scene) {
             // Color all meshes inside the gltf scene.
@@ -584,6 +598,45 @@ export class BotShapeDecorator
                         },
                     });
                 }
+            }
+        }
+    }
+
+    private _setFade(fade: number) {
+        if (this.scene) {
+            // Set fade on all meshes inside the gltf scene.
+            this.scene.traverse((obj) => {
+                if (obj instanceof Mesh) {
+                    setFade(obj, fade);
+                }
+            });
+        } else {
+            setFade(this.mesh, fade);
+        }
+
+        if (this._keyboard) {
+            const defaultOpacity = 1;
+            const opacity = defaultOpacity * (1 - fade);
+
+            // let firstPanel = (this._keyboard as any).panels[0];
+            for (let panel of (this._keyboard as any).panels) {
+                panel.set({
+                    backgroundOpacity: opacity,
+                });
+            }
+
+            for (let key of (this._keyboard as any).keys) {
+                // Update each key state with new backgroundOpacity.
+                const states = key.states;
+                for (let stateId in states) {
+                    const attributes = states[stateId].attributes;
+                    attributes.backgroundOpacity = opacity;
+
+                    key.setupState({ stateId, attributes });
+                }
+
+                // Set the current backgroundOpacity for the key.
+                key.set({ backgroundOpacity: opacity });
             }
         }
     }
@@ -846,11 +899,23 @@ export class BotShapeDecorator
                     if (material.color) {
                         material[DEFAULT_COLOR] = material.color;
                     }
+
+                    if (
+                        typeof material.opacity === 'number' &&
+                        !Number.isNaN(material.opacity)
+                    ) {
+                        material[DEFAULT_OPACITY] = material.opacity;
+                    }
+
+                    if (typeof material.transparent === 'boolean') {
+                        material[DEFAULT_TRANSPARENT] = material.transparent;
+                    }
                 }
             }
         });
 
         this._updateColor(null);
+        this._updateFade(null);
         this._updateRenderOrder(null);
         this.bot3D.updateMatrixWorld(true);
     }
@@ -956,12 +1021,14 @@ export class BotShapeDecorator
         }
 
         this._keyboard = keyboard;
+        (window as any).keyboard = this._keyboard;
         this.container.add(keyboard);
         this.stroke = null;
         this.mesh = null;
         this.collider = null;
         this._canHaveStroke = false;
         this._updateColor(null);
+        this._updateFade(null);
         this._updateRenderOrder(null);
 
         // Force the mesh UI to update
@@ -1005,6 +1072,7 @@ export class BotShapeDecorator
             let material = baseAuxMeshMaterial();
             this.mesh.material = material;
             this._updateColor(null);
+            this._updateFade(null);
             this._updateRenderOrder(null);
         }
     }
@@ -1017,6 +1085,7 @@ export class BotShapeDecorator
         if (await this._loadGLTF(EggUrl, false, token)) {
             this.mesh = this.scene.children[0] as Mesh;
             this._updateColor(null);
+            this._updateFade(null);
             this._updateRenderOrder(null);
         }
     }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -1021,7 +1021,6 @@ export class BotShapeDecorator
         }
 
         this._keyboard = keyboard;
-        (window as any).keyboard = this._keyboard;
         this.container.add(keyboard);
         this.stroke = null;
         this.mesh = null;

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -46,7 +46,7 @@ import {
     DEFAULT_OPACITY,
     DEFAULT_TRANSPARENT,
     registerMaterial,
-    setFade,
+    setOpacity,
 } from '../SceneUtils';
 import { createCubeStroke } from '../MeshUtils';
 import { LineSegments } from '../LineSegments';
@@ -211,7 +211,7 @@ export class BotShapeDecorator
         }
 
         this._updateColor(calc);
-        this._updateFade(calc);
+        this._updateOpacity(calc);
         this._updateStroke(calc);
         this._updateAddress(calc, address);
         this._updateRenderOrder(calc);
@@ -550,14 +550,14 @@ export class BotShapeDecorator
         this._setColor(color);
     }
 
-    private _updateFade(calc: BotCalculationContext) {
-        const fade = calculateNumericalTagValue(
+    private _updateOpacity(calc: BotCalculationContext) {
+        const opacity = calculateNumericalTagValue(
             calc,
             this.bot3D.bot,
-            'fade',
-            0
+            'formOpacity',
+            1
         );
-        this._setFade(fade);
+        this._setOpacity(opacity);
     }
 
     private _setColor(color: any) {
@@ -602,26 +602,25 @@ export class BotShapeDecorator
         }
     }
 
-    private _setFade(fade: number) {
+    private _setOpacity(opacity: number) {
         if (this.scene) {
-            // Set fade on all meshes inside the gltf scene.
+            // Set opacity on all meshes inside the gltf scene.
             this.scene.traverse((obj) => {
                 if (obj instanceof Mesh) {
-                    setFade(obj, fade);
+                    setOpacity(obj, opacity);
                 }
             });
         } else {
-            setFade(this.mesh, fade);
+            setOpacity(this.mesh, opacity);
         }
 
         if (this._keyboard) {
             const defaultOpacity = 1;
-            const opacity = defaultOpacity * (1 - fade);
+            const newOpacity = defaultOpacity * opacity;
 
-            // let firstPanel = (this._keyboard as any).panels[0];
             for (let panel of (this._keyboard as any).panels) {
                 panel.set({
-                    backgroundOpacity: opacity,
+                    backgroundOpacity: newOpacity,
                 });
             }
 
@@ -630,13 +629,13 @@ export class BotShapeDecorator
                 const states = key.states;
                 for (let stateId in states) {
                     const attributes = states[stateId].attributes;
-                    attributes.backgroundOpacity = opacity;
+                    attributes.backgroundOpacity = newOpacity;
 
                     key.setupState({ stateId, attributes });
                 }
 
                 // Set the current backgroundOpacity for the key.
-                key.set({ backgroundOpacity: opacity });
+                key.set({ backgroundOpacity: newOpacity });
             }
         }
     }
@@ -915,7 +914,7 @@ export class BotShapeDecorator
         });
 
         this._updateColor(null);
-        this._updateFade(null);
+        this._updateOpacity(null);
         this._updateRenderOrder(null);
         this.bot3D.updateMatrixWorld(true);
     }
@@ -1027,7 +1026,7 @@ export class BotShapeDecorator
         this.collider = null;
         this._canHaveStroke = false;
         this._updateColor(null);
-        this._updateFade(null);
+        this._updateOpacity(null);
         this._updateRenderOrder(null);
 
         // Force the mesh UI to update
@@ -1071,7 +1070,7 @@ export class BotShapeDecorator
             let material = baseAuxMeshMaterial();
             this.mesh.material = material;
             this._updateColor(null);
-            this._updateFade(null);
+            this._updateOpacity(null);
             this._updateRenderOrder(null);
         }
     }
@@ -1084,7 +1083,7 @@ export class BotShapeDecorator
         if (await this._loadGLTF(EggUrl, false, token)) {
             this.mesh = this.scene.children[0] as Mesh;
             this._updateColor(null);
-            this._updateFade(null);
+            this._updateOpacity(null);
             this._updateRenderOrder(null);
         }
     }


### PR DESCRIPTION
This PR adds support for a new `formOpacity` tag. 

The `formOpacity` tag is used as a modifier on  the default opacity value of all materials on a bot shape.
This allows bot shapes to be semi-transparent. 

- A `formOpacity` value of `1` means that the bot's mesh materials are effectively in their default opacity and transparency state.
- A `formOpacity` value `< 1` means that the bot's mesh materials become transparent and that the `formOpacity` value is used to modify each material's default opacity level.
- A `formOpacity` value of `0` would make the bot invisible.

`formOpacity` is implemented for all mesh and material based bot shapes, including custom glTF models and the keyboard.

![casualos_formOpacity](https://github.com/casual-simulation/casualos/assets/1583792/163c6459-4b1e-4f85-8add-79d9b25badec)
