### PR TITLE
Fixed MediaAudioRecorder when set to stream mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     -   This fixes a reported bug with `lineTo` to updating correctly while using the `transformer` tag. [Issue #276](https://github.com/casual-simulation/casualos/issues/276)
 -   Fixed an issue where the `color` tag would not apply to all materials in a gltf model.
 -   Fixed an issue where gltf models with multiple materials and textures would not be properly disposed.
+-   Fixed an issue where `os.beginAudioRecording` would fail to provide audio chunks in stream mode if the mimeType was anything other than `audio/x-raw`.
 
 ## V3.1.28
 

--- a/src/aux-server/aux-web/shared/AudioRecorder.ts
+++ b/src/aux-server/aux-web/shared/AudioRecorder.ts
@@ -143,28 +143,23 @@ export class MediaAudioRecorder implements AudioRecorder {
                 try {
                     console.log('[MediaAudioRecorder] Stop Recording.');
                     recorder.stop();
+                    const finalBlob = await finalBlobPromise;
                     dataAvailable.complete();
-                    return await finalBlobPromise;
+                    return finalBlob;
                 } finally {
                     for (let track of media.getTracks()) {
                         track.stop();
                     }
                 }
             },
-            dataAvailable: dataAvailable.pipe(
-                bufferTime(options.bufferRateMiliseconds ?? 500),
-                map(
-                    (chunks) =>
-                        new Blob(chunks, {
-                            type: recorder.mimeType,
-                        })
-                ),
-                share()
-            ),
+            dataAvailable,
         };
 
+        let timeslice = stream
+            ? options.bufferRateMiliseconds ?? DEFAULT_BUFFER_RATE
+            : undefined;
         console.log('[MediaAudioRecorder] Start Recording.');
-        recorder.start();
+        recorder.start(timeslice);
 
         return recording;
     }


### PR DESCRIPTION
This PR fixes a bug with `os.beginAudioRecording` when set to `stream: true` and a `mimeType` of anything other than `audio/x-raw`. 

Previously `MediaAudioRecorder` was providing empty `Blob` data to `@onAudioChunk` when running the `MediaAudioRecorder` with `stream: true` and an audio encoding format (ie `mimeType: 'audio/webm'`). The fix is to provide the buffer rate to the recorder's `start()` function which accepts a `timeslice` argument. When `timeslice` is provided, the recorder's `dataavailable` event gets triggered properly and `@onAudioChunk` gets the `Blob` chunks as originally intended. 

Another alteration included in this PR is to await the `finalBlobPromise` before invoking `dataAvailable.complete()`. This gives the recorder time to stop and call its final `dataavailable` event with the remaining `Blob` data before finalizing and cleaning up.