### PR TITLE
feat: Add skybox option to form tag

### DIFF
--- a/docs/docs/tags.mdx
+++ b/docs/docs/tags.mdx
@@ -812,6 +812,9 @@ The shape that the bot should be displayed as.
   <PossibleValueCode value='cube'>
     Cube mesh (default)
   </PossibleValueCode>
+  <PossibleValueCode value='skybox'>
+    A Sphere mesh optimal for "skybox" implementation.
+  </PossibleValueCode>
   <PossibleValueCode value='sphere'>
     Sphere mesh
   </PossibleValueCode>
@@ -914,7 +917,7 @@ The subtype that the form should use. Useful for specifying how a mesh should be
 
 The address that the bot should represent data from.
 
-When <TagLink tag='form'/> is set to `cube`, `sphere`, or `sprite`, the address should be the URL of the image that the bot should display.
+When <TagLink tag='form'/> is set to `cube`, `skybox`, `sphere`, or `sprite`, the address should be the URL of the image that the bot should display.
 
 When <TagLink tag='form'/> is set to `mesh` and <TagLink tag='formSubtype'/> is set to `gltf`, the address should be the URL of the GLTF file that should be displayed.
 

--- a/playwright/gridPortal.spec.ts
+++ b/playwright/gridPortal.spec.ts
@@ -506,6 +506,7 @@ test.describe('interaction', () => {
 
 test.describe('forms', () => {
     const forms = [
+        ['skybox'] as const,
         ['sphere'] as const,
         ['sprite'] as const,
         ['frustum'] as const,

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -548,6 +548,7 @@ export interface WorkspaceHex {
 export type BotShape =
     | 'cube'
     | 'circle'
+    | 'skybox'
     | 'sphere'
     | 'sprite'
     | 'mesh'

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1695,6 +1695,7 @@ export function getBotShape(calc: BotCalculationContext, bot: Bot): BotShape {
     const shape: BotShape = calculateBotValue(calc, bot, 'auxForm');
     if (
         shape === 'cube' ||
+        shape === 'skybox' ||
         shape === 'sphere' ||
         shape === 'sprite' ||
         shape === 'mesh' ||

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -857,6 +857,7 @@ export function botCalculationContextTests(
     describe('getBotShape()', () => {
         const cases = [
             ['cube'],
+            ['skybox'],
             ['sphere'],
             ['sprite'],
             ['circle'],

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -53,11 +53,19 @@ import {
 } from '@casual-simulation/aux-common';
 import { getOptionalValue } from '../SharedUtils';
 import { Simulation } from '@casual-simulation/aux-vm';
+import { BackSide } from 'three';
 
 /**
  * Gets the direction of the up vector for 3D portals.
  */
 export const WORLD_UP = new Vector3(0, 0, 1);
+
+/**
+ * Create copy of material that skybox sphere mesh should use.
+ */
+export function baseAuxSkyboxMeshMaterial() {
+    return new MeshBasicMaterial({ side: BackSide });
+}
 
 /**
  * Create copy of material that most meshes in Aux Builder/Player use.
@@ -86,6 +94,26 @@ export function baseAuxDirectionalLight() {
     // let helper = new DirectionalLightHelper(dirLight);
     // dirLight.add(helper);
     return dirLight;
+}
+
+/**
+ * Creates a new hybrid sphere mesh optimal for Skybox implementations.
+ * @param position The position of the sphere.
+ * @param color The color of the sphere in linear space.
+ * @param size The radius of the sphere in meters.
+ */
+export function createSkybox(
+    position: Vector3,
+    color: number,
+    size: number = 0.1
+) {
+    const geometry = new SphereBufferGeometry(size, 20, 18);
+    let material = baseAuxSkyboxMeshMaterial();
+    material.color = new Color(color);
+
+    const sphere = new Mesh(geometry, material.clone());
+    sphere.position.copy(position);
+    return sphere;
 }
 
 /**

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -33,6 +33,7 @@ import {
     createCube,
     isTransparent,
     disposeMesh,
+    createSkybox,
     createSphere,
     createSprite,
     disposeGroup,
@@ -689,6 +690,8 @@ export class BotShapeDecorator
 
         if (this._shape === 'cube') {
             this._createCube();
+        } else if (this._shape === 'skybox') {
+            this._createSkybox();
         } else if (this._shape === 'sphere') {
             this._createSphere();
         } else if (this._shape === 'sprite') {
@@ -939,6 +942,18 @@ export class BotShapeDecorator
 
     private _createSprite() {
         this.mesh = this.collider = createSprite(this._addressAspectRatio);
+        this.container.add(this.mesh);
+        this.bot3D.colliders.push(this.collider);
+        this.stroke = null;
+        this._canHaveStroke = false;
+    }
+
+    private _createSkybox() {
+        this.mesh = this.collider = createSkybox(
+            new Vector3(0, 0, 0),
+            0x000000,
+            0.5
+        );
         this.container.add(this.mesh);
         this.bot3D.colliders.push(this.collider);
         this.stroke = null;


### PR DESCRIPTION
The "skybox" term can be changed. I had researched any possible trademark issues and it seems clear to use.
The premise of "skybox" is to invert the normals on a typical 3js sphere allowing for images to map the interior of a sphere.
Practical uses (most common) can be found in WebXR implementations.