### PR TITLE
fix: labels now display properly when 'labelPosition' and 'labelAlign…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 ### :bug: Bug Fixes
 
 -   Fixed an issue where setting cube bots with scale 0 did not receive pointer events
+-   Fixed an issue where labels were broken when setting labelPosition and labelAlignment to left or right
 
 ## V3.2.6
 

--- a/src/aux-server/aux-web/shared/scene/Text3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Text3D.ts
@@ -638,7 +638,7 @@ export class Text3D extends Object3D {
                 targetSize,
                 'y',
                 textAlign,
-                -1,
+                1,
                 new Vector3(
                     targetCenter.x +
                         targetSize.x * positionMultiplier +
@@ -659,7 +659,7 @@ export class Text3D extends Object3D {
                 targetSize,
                 'y',
                 textAlign,
-                1,
+                -1,
                 new Vector3(
                     targetCenter.x -
                         targetSize.x * positionMultiplier -


### PR DESCRIPTION
…ment' are both set to left or right

chore: update CHANGELOG