### PR TITLE
Add the ability to isolate insts from each other by using separate domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
     -   A dialog will appear on Safari asking if you want to enter XR when trying to enable AR/VR through CasualOS. This is an extra security measure enforced by Safari.
     -   visionOS currently only supports `immersive-vr` mode of WebXR sessions.
     -   Added pinch select gesture detection for. This allows for pointer-based bot interaction on the Vision Pro since Safari does not implement select events while hand tracking in WebXR.
+-   Added the ability to support domain-level isolation for insts.
+    -   The `VM_ORIGIN` environment variable can now be configured to tell CasualOS to load insts into a unique HTTP Origin so that insts are isolated from each other.
+    -   `VM_ORIGIN` is The HTTP Origin that should be used to load the inst virtual machine. Useful for securely isolating insts from each other and from the frontend. Supports `{{inst}}` to customize the origin based on the inst that is being loaded. For example setting `VM_ORIGIN` to `https://{{inst}}.example.com` will cause `?staticInst=myInst` to load inside `https://myInst.example.com`. Defaults to null, which means that no special origin is used.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-server/GettingStarted-aws.md
+++ b/src/aux-server/GettingStarted-aws.md
@@ -21,6 +21,7 @@ To deploy this project to AWS Lambda, follow these steps:
     - Configure the default cache behavior to "Redirect HTTP to HTTPS" and use the "CachingOptimized" policy.
     - Configure each distrubution to return `/index.html` when a HTTP `403` error code occurs.
     - Remember the IDs of the distributions.
+    - (Optional) Configure the player CloudFront distribution (the distribution for the player website files) to support a wildcard subdomains.
 3. Setup a CockroachDB database.
     - You can do this either through the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-3zbkzekdohwly?ref_=unifiedsearch) or the [Cockroach Labs website](https://www.cockroachlabs.com/).
     - We recommend starting with their free option.
@@ -44,6 +45,7 @@ To deploy this project to AWS Lambda, follow these steps:
         - `CAUSAL_REPO_CONNECTION_PROTOCOL` - Set this to `apiary-aws`.
         - `SHARED_PARTITIONS_VERSION` - Set this to `v2`.
         - `SES_IDENTITY_NAME` - The Simple Email Service identity that emails should be allowed to be sent from. Only used for granting permissions to send emails to the lambda function. Use `SERVER_CONFIG` to actually configure the server to use SES. (Optional)
+        - `VM_ORIGIN` - Set this to `https://{{inst}}.[playerWebsiteDomain]` where `[playerWebsiteDomain]` is the domain that is used for the player CloudFront distribution - Used to isolate insts from each other. See the below for more info on `VM_ORIGIN`.
         - Configure any other optional environment variables listed below.
 5. Run a build.
 6. After the build, go to CloudFormation and find the stack update.
@@ -94,6 +96,7 @@ Use the following environment variables to configure the inst collaboration feat
     -   The default options are: `enter join code,local inst,studio inst,free inst,sign in,sign up,sign out`.
 -   `DEFAULT_BIOS_OPTION`: The BIOS option that should be selected by default when the BIOS is shown.
 -   `AUTOMATIC_BIOS_OPTION`: The BIOS option that should be executed automatically by the BIOS. Setting this to a valid BIOS value will skip the BIOS screen.
+-   `VM_ORIGIN`: The HTTP Origin that should be used to load the inst virtual machine. Useful for securely isolating insts from each other and from the frontend. Supports `{{inst}}` to customize the origin based on the inst that is being loaded. For example setting `VM_ORIGIN` to `https://{{inst}}.example.com` will cause `?staticInst=myInst` to load inside `https://myInst.example.com`. Defaults to null, which means that no special origin is used. Recommended for high-security deployments.
 
 #### Privo Features
 

--- a/src/aux-server/GettingStarted-standalone.md
+++ b/src/aux-server/GettingStarted-standalone.md
@@ -118,6 +118,7 @@ Use the following environment variables to configure the inst collaboration feat
     -   The default options are: `enter join code,local inst,studio inst,free inst,sign in,sign up,sign out`.
 -   `DEFAULT_BIOS_OPTION`: The BIOS option that should be selected by default when the BIOS is shown.
 -   `AUTOMATIC_BIOS_OPTION`: The BIOS option that should be executed automatically by the BIOS. Setting this to a valid BIOS value will skip the BIOS screen.
+-   `VM_ORIGIN`: The HTTP Origin that should be used to load the inst virtual machine. Useful for securely isolating insts from each other and from the frontend. Supports `{{inst}}` to customize the origin based on the inst that is being loaded. For example setting `VM_ORIGIN` to `https://{{inst}}.example.com` will cause `?staticInst=myInst` to load inside `https://myInst.example.com`. Defaults to null, which means that no special origin is used. Recommended for high-security deployments.
 
 #### Privo Features
 

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -706,7 +706,7 @@ export default class PlayerHome extends Vue {
             }
             await appManager.simulationManager.updateSimulations(
                 newServer.map((s) => ({
-                    id: getSimulationId(record, s),
+                    id: getSimulationId(record, s, isStatic),
                     options: {
                         recordName: record,
                         inst: s,

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -79,6 +79,7 @@ interface StoredInst {
     id: string;
     origin: SimulationOrigin;
     isStatic: boolean;
+    version?: VersionInfo;
 }
 
 const SAVE_CONFIG_TIMEOUT_MILISECONDS = 5000;
@@ -170,6 +171,20 @@ export class AppManager {
                       this._config.causalRepoConnectionUrl
                   );
 
+            const storedInst = await getItem<StoredInst>(
+                this._db,
+                isStatic ? STATIC_INSTS_STORE : INSTS_STORE,
+                id
+            );
+
+            let relaxOrigin = false;
+            if (isStatic && storedInst && !storedInst.version) {
+                console.log(
+                    `[AppManager] old static inst already exists for "${id}". Relaxing origin.`
+                );
+                relaxOrigin = true;
+            }
+
             putItem<StoredInst>(
                 this._db,
                 isStatic ? STATIC_INSTS_STORE : INSTS_STORE,
@@ -177,17 +192,22 @@ export class AppManager {
                     id: id,
                     origin,
                     isStatic: isStatic,
+                    version: storedInst ? storedInst.version : this.version,
                 }
             );
 
             return new BotManager(
                 origin,
                 config,
-                new AuxVMImpl(id, {
-                    configBotId: configBotId,
-                    config,
-                    partitions,
-                }),
+                new AuxVMImpl(
+                    id,
+                    {
+                        configBotId: configBotId,
+                        config,
+                        partitions,
+                    },
+                    relaxOrigin
+                ),
                 this._auth
             );
         };
@@ -635,7 +655,7 @@ export class AppManager {
         inst: string,
         isStatic: boolean
     ) {
-        const simulationId = getSimulationId(recordName, inst);
+        const simulationId = getSimulationId(recordName, inst, isStatic);
         if (
             (this.simulationManager.primary &&
                 this.simulationManager.primary.id === simulationId) ||
@@ -917,13 +937,15 @@ export class AppManager {
  * Gets the ID for a simulation with the given origin.
  * @param recordName The name of the record for the simulation.
  * @param inst The name of the inst for the simulation.
+ * @param isStatic whether the simulation is static.
  */
 export function getSimulationId(
     recordName: string | null,
-    inst: string
+    inst: string,
+    isStatic: boolean
 ): string {
-    if (recordName) {
-        return `${recordName ?? ''}/${inst}`;
+    if (!isStatic) {
+        return `${recordName ?? 'null'}/${inst}`;
     } else {
         return inst;
     }

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -80,6 +80,7 @@ interface StoredInst {
     origin: SimulationOrigin;
     isStatic: boolean;
     version?: VersionInfo;
+    vmOrigin: string;
 }
 
 const SAVE_CONFIG_TIMEOUT_MILISECONDS = 5000;
@@ -178,7 +179,11 @@ export class AppManager {
             );
 
             let relaxOrigin = false;
-            if (isStatic && storedInst && !storedInst.version) {
+            if (
+                isStatic &&
+                storedInst &&
+                config.vmOrigin !== storedInst.vmOrigin
+            ) {
                 console.log(
                     `[AppManager] old static inst already exists for "${id}". Relaxing origin.`
                 );
@@ -192,6 +197,9 @@ export class AppManager {
                     id: id,
                     origin,
                     isStatic: isStatic,
+                    vmOrigin: storedInst
+                        ? storedInst.vmOrigin
+                        : config.vmOrigin,
                     version: storedInst ? storedInst.version : this.version,
                 }
             );

--- a/src/aux-vm-browser/vm/AuxVMImpl.ts
+++ b/src/aux-vm-browser/vm/AuxVMImpl.ts
@@ -35,6 +35,7 @@ import {
     RuntimeActions,
     RuntimeStateVersion,
 } from '@casual-simulation/aux-runtime';
+import { getVMOrigin } from './AuxVMUtils';
 
 export const DEFAULT_IFRAME_ALLOW_ATTRIBUTE =
     'accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking';
@@ -129,7 +130,11 @@ export class AuxVMImpl implements AuxVM {
     }
 
     private async _init(): Promise<void> {
-        const origin = this._config.config.vmOrigin || location.origin;
+        const origin = getVMOrigin(
+            this._config.config.vmOrigin,
+            location.origin,
+            this._id
+        );
         const iframeUrl = new URL('/aux-vm-iframe.html', origin).href;
 
         this._connectionStateChanged.next({

--- a/src/aux-vm-browser/vm/AuxVMUtils.spec.ts
+++ b/src/aux-vm-browser/vm/AuxVMUtils.spec.ts
@@ -1,4 +1,6 @@
-import { getVMOrigin } from './AuxVMUtils';
+import { getBaseOrigin, getVMOrigin } from './AuxVMUtils';
+
+console.warn = jest.fn();
 
 describe('getVMOrigin()', () => {
     it('should return the configured origin if it is set', () => {
@@ -28,8 +30,35 @@ describe('getVMOrigin()', () => {
         const result = getVMOrigin(
             'configuredOrigin/{{inst}}',
             'defaultOrigin',
-            '&instId$%'
+            '&instId$%.'
         );
-        expect(result).toEqual('configuredOrigin/-instId--');
+        expect(result).toEqual('configuredOrigin/-instId---');
+    });
+});
+
+describe('getBaseOrigin()', () => {
+    it('should return the base origin of the origin', () => {
+        const result = getBaseOrigin('https://test.com');
+        expect(result).toEqual('https://test.com');
+    });
+
+    it('should work with simple domains', () => {
+        const result = getBaseOrigin('https://localhost');
+        expect(result).toEqual('https://localhost');
+    });
+
+    it('should support port numbers', () => {
+        const result = getBaseOrigin('https://localhost:1234');
+        expect(result).toEqual('https://localhost:1234');
+    });
+
+    it('should remove only the top subdomains from the origin', () => {
+        const result = getBaseOrigin('https://abc.def.ghi.test.com');
+        expect(result).toEqual('https://def.ghi.test.com');
+    });
+
+    it('should return the origin if it is not a valid URL', () => {
+        const result = getBaseOrigin('not-a-valid-url');
+        expect(result).toEqual('not-a-valid-url');
     });
 });

--- a/src/aux-vm-browser/vm/AuxVMUtils.spec.ts
+++ b/src/aux-vm-browser/vm/AuxVMUtils.spec.ts
@@ -1,0 +1,35 @@
+import { getVMOrigin } from './AuxVMUtils';
+
+describe('getVMOrigin()', () => {
+    it('should return the configured origin if it is set', () => {
+        const result = getVMOrigin(
+            'configuredOrigin',
+            'defaultOrigin',
+            'instId'
+        );
+        expect(result).toEqual('configuredOrigin');
+    });
+
+    it('should return the default origin if no configured origin is provided', () => {
+        const result = getVMOrigin(null, 'defaultOrigin', 'instId');
+        expect(result).toEqual('defaultOrigin');
+    });
+
+    it('should interpolate the instId into the configured origin if possible', () => {
+        const result = getVMOrigin(
+            'configuredOrigin/{{inst}}',
+            'defaultOrigin',
+            'instId'
+        );
+        expect(result).toEqual('configuredOrigin/instId');
+    });
+
+    it('should replace non-alphanumeric characters with dashes', () => {
+        const result = getVMOrigin(
+            'configuredOrigin/{{inst}}',
+            'defaultOrigin',
+            '&instId$%'
+        );
+        expect(result).toEqual('configuredOrigin/-instId--');
+    });
+});

--- a/src/aux-vm-browser/vm/AuxVMUtils.ts
+++ b/src/aux-vm-browser/vm/AuxVMUtils.ts
@@ -32,3 +32,22 @@ export function getVMOrigin(
 
     return configuredOrigin;
 }
+
+/**
+ * Gets the base domain of the given origin. That is, the hostname but with all subdomains removed.
+ * @param origin The origin that should be used.
+ */
+export function getBaseOrigin(origin: string): string {
+    try {
+        let url = new URL(origin);
+        let parts = url.hostname.split('.');
+        if (parts.length < 3) {
+            return url.origin;
+        }
+        url.hostname = parts.slice(1).join('.');
+        return url.origin;
+    } catch (err) {
+        console.warn('[AuxVMUtils] Could not parse origin:', origin, err);
+        return origin;
+    }
+}

--- a/src/aux-vm-browser/vm/AuxVMUtils.ts
+++ b/src/aux-vm-browser/vm/AuxVMUtils.ts
@@ -1,0 +1,34 @@
+/**
+ * Gets the origin for the VM.
+ * @param configuredOrigin The origin that was configured.
+ * @param defaultOrigin The default that should be used if the configured origin is not set.
+ * @param instId The ID of the inst.
+ */
+export function getVMOrigin(
+    configuredOrigin: string | null,
+    defaultOrigin: string,
+    instId: string
+): string {
+    if (!configuredOrigin) {
+        return defaultOrigin;
+    }
+
+    let indexOfBraces = configuredOrigin.indexOf('{{');
+    if (indexOfBraces >= 0) {
+        let endOfBraces = configuredOrigin.indexOf('}}', indexOfBraces);
+        if (
+            endOfBraces >= 0 &&
+            configuredOrigin.substring(indexOfBraces + 2, endOfBraces) ===
+                'inst'
+        ) {
+            instId = instId.replace(/[^a-zA-Z0-9]/g, '-');
+            return (
+                configuredOrigin.substring(0, indexOfBraces) +
+                instId +
+                configuredOrigin.substring(endOfBraces + 2)
+            );
+        }
+    }
+
+    return configuredOrigin;
+}


### PR DESCRIPTION
When merged, this PR will allow the `VM_ORIGIN` environment variable to be configured to isolate insts from each other and from the frontend.

e.g. Setting `VM_ORIGIN` to `https://{{inst}}.example.com` will cause a static inst `myInst` to use the HTTP origin `https://myInst.example.com`, which causes it to be isolated from `myOtherInst` which would use the HTTP origin `https://myOtherInst.example.com`.

This change is backwards-compatible, meaning that static insts which already exist on a device should not be affected.

Fixes #367 