### PR TITLE
Make `os.unregisterApp()` trigger Preact hooks cleanup code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 -   Fixed an issue where fingers would trigger click interactions while dragging a bot with the same hand.
 -   Fixed an issue where `portalBackgroundAddress` would render over `miniMapPortalBot`.
 -   Fixed an issue where `.click()`, `.focus()`, and `.blur()` methods would not work on custom app HTML elements.
+-   Fixed an issue where `os.unregisterApp()` would not trigger Preact cleanup code.
 
 ## V3.2.13
 

--- a/src/aux-vm/portals/HtmlAppBackend.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.ts
@@ -119,6 +119,12 @@ export class HtmlAppBackend implements AppBackend {
         this.botId = botId;
         this._registerTaskId = registerTaskId;
         this._sub = new Subscription();
+        this._sub.add(() => {
+            this._renderContent('');
+            this._helper.transaction(
+                unregisterHtmlApp(this.appId, this._instanceId)
+            );
+        });
 
         this._helper = helper;
         this._setupObservable = new BehaviorSubject(false);
@@ -195,9 +201,7 @@ export class HtmlAppBackend implements AppBackend {
     }
 
     dispose(): void {
-        this._helper.transaction(
-            unregisterHtmlApp(this.appId, this._instanceId)
-        );
+        this._sub.unsubscribe();
     }
 
     private _renderContent(content: any) {


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where `os.unregisterApp()` would not trigger Preact cleanup code.

Fixes #311 