### PR TITLE
Fix `os.unloadInst()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 -   Fixed an issue where `portalBackgroundAddress` would render over `miniMapPortalBot`.
 -   Fixed an issue where `.click()`, `.focus()`, and `.blur()` methods would not work on custom app HTML elements.
 -   Fixed an issue where `os.unregisterApp()` would not trigger Preact cleanup code.
+-   Fixed an issue where `os.unloadInst()` would not work when going from 2 instances to 1 instance.
+-   Fixed an issue where menuPortal items would remain even if their inst was unloaded.
 
 ## V3.2.13
 

--- a/src/aux-server/aux-web/aux-player/MenuPortal.ts
+++ b/src/aux-server/aux-web/aux-player/MenuPortal.ts
@@ -119,6 +119,17 @@ export class MenuPortal implements SubscriptionLike {
             sub.unsubscribe();
         }
         this._simulations.delete(sim);
+        const botIds = [...this._botItemMap.keys()];
+        for (let id of botIds) {
+            const item = this._botItemMap.get(id);
+            if (item.simulationId === sim.id) {
+                this._botItemMap.delete(id);
+            }
+        }
+        let menu = [...this._botItemMap.values()];
+        let sorted = sortBy(menu, (i) => this._menuItemIndex(null, i));
+        this.items = sorted;
+        this._itemsUpdated.next(this.items);
     }
 
     private _updateMenuDimensions(

--- a/src/aux-vm/managers/SimulationManager.ts
+++ b/src/aux-vm/managers/SimulationManager.ts
@@ -119,6 +119,21 @@ export class SimulationManager<
     }
 
     /**
+     * Removes all the simulations that do not match the given ID.
+     * @param id The ID of the simulation to keep.
+     */
+    async removeNonMatchingSimulations(id: string) {
+        let promises: Promise<void>[] = [];
+        for (let [key, value] of this.simulations) {
+            if (key !== id) {
+                promises.push(this.removeSimulation(key));
+            }
+        }
+
+        await Promise.all(promises);
+    }
+
+    /**
      * Sets the primary simulation.
      * @param id The ID to load.
      * @param loadingCallback The loading progress callback to use.


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where `os.unloadInst()` would not work when going from 2 instances to 1 instance.
-   Fixed an issue where menuPortal items would remain even if their inst was unloaded.

Fixes #361 
Fixes #378