### PR TITLE
Make `os.getCurrentInst()` always return the current inst instead of the primary inst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     -   Previously, an empty list would be returned. Now, an empty list is only returned if there are no items.
 -   Removed `os.grantRecordMarkerPermission()` and `os.revokeRecordMarkerPermission()`.
     -   These functions have been replaced by `os.grantPermission()` and `os.revokePermission()`.
+-   Changed `os.getCurrentInst()` to always return the name of the inst that the bot exists in, instead of the first inst that was loaded into the session.
 
 ### :rocket: Features
 

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -36,7 +36,7 @@ import {
     userBotTagsChanged,
 } from '@casual-simulation/aux-vm-browser';
 import { UpdatedBotInfo } from '@casual-simulation/aux-vm';
-import { intersection, isEqual } from 'lodash';
+import { intersection, isEqual, sortBy } from 'lodash';
 import { Subscription } from 'rxjs';
 import { uniqueNamesGenerator, Config } from 'unique-names-generator';
 import adjectives from '../../shared/dictionaries/adjectives';
@@ -47,6 +47,7 @@ import { getInstParameters, getPermalink } from '../UrlUtils';
 import { FormError } from '@casual-simulation/aux-records';
 import FieldErrors from '../../shared/vue-components/FieldErrors/FieldErrors';
 import { MdField } from 'vue-material/dist/components';
+import { sortInsts } from '../PlayerUtils';
 
 Vue.use(MdField);
 
@@ -821,6 +822,9 @@ export default class PlayerHome extends Vue {
             changes.staticInst !== bot.tags.inst
         ) {
             changes.inst = changes.staticInst;
+        }
+        if (hasChange && hasValue(changes.inst)) {
+            changes.inst = sortInsts(changes.inst, botManager.inst);
         }
         if (hasChange) {
             await botManager.helper.updateBot(bot, {

--- a/src/aux-server/aux-web/aux-player/PlayerUtils.spec.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerUtils.spec.ts
@@ -1,0 +1,23 @@
+import { sortInsts } from './PlayerUtils';
+
+describe('sortInsts()', () => {
+    it('should work with a single inst', () => {
+        const result = sortInsts('test', 'other');
+        expect(result).toBe('test');
+    });
+
+    it('should work with an array of one item', () => {
+        const result = sortInsts(['test'], 'other');
+        expect(result).toEqual(['test']);
+    });
+
+    it('should sort the inst matching the current one first', () => {
+        const result = sortInsts(['test', 'other', 'third'], 'other');
+        expect(result).toEqual(['other', 'test', 'third']);
+    });
+
+    it('should preserve the order of a list that is already sorted', () => {
+        const result = sortInsts(['test', 'other', 'third'], 'test');
+        expect(result).toEqual(['test', 'other', 'third']);
+    });
+});

--- a/src/aux-server/aux-web/aux-player/PlayerUtils.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerUtils.ts
@@ -4,6 +4,7 @@ import {
     calculateBotValue,
     getBotConfigDimensions,
 } from '@casual-simulation/aux-common';
+import { sortBy } from 'lodash';
 
 interface PlayerContextSearchResult {
     /**
@@ -39,5 +40,21 @@ export function safeParseURL(url: string): URL {
         return new URL(url);
     } catch (err) {
         return null;
+    }
+}
+
+/**
+ * Sorts the given insts in the order that they should be stored in the inst tag.
+ * @param insts The instance or instances.
+ * @param currentInst The instance that the tag is being stored in.
+ */
+export function sortInsts<T extends string | string[]>(
+    insts: T,
+    currentInst: string
+): T {
+    if (Array.isArray(insts)) {
+        return sortBy(insts, (i) => i !== currentInst) as T;
+    } else {
+        return insts;
     }
 }


### PR DESCRIPTION
### :boom: Breaking Changes

-   Changed `os.getCurrentInst()` to always return the name of the inst that the bot exists in, instead of the first inst that was loaded into the session.