### PR TITLE
Add the ability to control WebSocket rate limits separately from HTTP rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
     -   `VM_ORIGIN` is The HTTP Origin that should be used to load the inst virtual machine. Useful for securely isolating insts from each other and from the frontend. Supports `{{inst}}` to customize the origin based on the inst that is being loaded. For example setting `VM_ORIGIN` to `https://{{inst}}.example.com` will cause `?staticInst=myInst` to load inside `https://myInst.example.com`. Defaults to null, which means that no special origin is used.
 -   Added the ability to request access to private insts that the user does not have permissions for.
 -   Added the ability to customize the [MIME type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type) and bitrate of recordings made with `experiment.beginRecording()` and `experiment.endRecording()`.
+-   Added the ability to track rate limits for the WebSocket API separately from the HTTP API.
+    -   The `websocketRateLimit` property on the `SERVER_CONFIG` controls the websockets rate limits. If not specified, then the options from `rateLimit` will be used for websockets and HTTP.
+    -   Additionally, the `websocketRateLimitPrefix` in `redis` controls the namespace that values are stored at in Redis. If not specified, then the `rateLimitPrefix` will be used for both.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-records/MemoryRateLimiter.ts
+++ b/src/aux-records/MemoryRateLimiter.ts
@@ -38,6 +38,11 @@ export class MemoryRateLimiter implements RateLimiter {
         this._states.delete(key);
     }
 
+    getHits(key: string): number {
+        const state = this._getState(key);
+        return state.count;
+    }
+
     private _getState(key: string): MemoryState {
         let state = this._states.get(key);
         if (!state) {

--- a/src/aux-server/aux-backend/server/server.ts
+++ b/src/aux-server/aux-backend/server/server.ts
@@ -203,6 +203,10 @@ export class Server {
             }
         }
 
+        if (options.websocketRateLimit && options.redis) {
+            builder.useRedisWebsocketRateLimit();
+        }
+
         if (options.redis && options.redis.websocketConnectionNamespace) {
             builder.useRedisWebsocketConnectionStore();
         }

--- a/src/aux-server/aux-backend/serverless/aws/src/LoadServer.ts
+++ b/src/aux-server/aux-backend/serverless/aws/src/LoadServer.ts
@@ -102,6 +102,10 @@ export function constructServerBuilder() {
         builder.useRedisRateLimit();
     }
 
+    if (config.websocketRateLimit && config.redis) {
+        builder.useRedisWebsocketRateLimit();
+    }
+
     if (config.redis && config.redis.websocketConnectionNamespace) {
         builder.useRedisWebsocketConnectionStore();
     }


### PR DESCRIPTION
### :rocket: Features
-   Added the ability to track rate limits for the WebSocket API separately from the HTTP API.
    -   The `websocketRateLimit` property on the `SERVER_CONFIG` controls the websockets rate limits. If not specified, then the options from `rateLimit` will be used for websockets and HTTP.
    -   Additionally, the `websocketRateLimitPrefix` in `redis` controls the namespace that values are stored at in Redis. If not specified, then the `rateLimitPrefix` will be used for both.

Closes #352 