### PR TITLE
Implement `os.getRecordsEndpoint()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 -   Added the ability to track rate limits for the WebSocket API separately from the HTTP API.
     -   The `websocketRateLimit` property on the `SERVER_CONFIG` controls the websockets rate limits. If not specified, then the options from `rateLimit` will be used for websockets and HTTP.
     -   Additionally, the `websocketRateLimitPrefix` in `redis` controls the namespace that values are stored at in Redis. If not specified, then the `rateLimitPrefix` will be used for both.
+-   Added the `os.getRecordsEndpoint()` function to get the default records endpoint.
+    -   Records actions, like `os.recordData()`, `os.getData()`, `os.recordFile()`, etc. can be passed an endpoint which specifies which backend should be used for the request.
+    -   If no endpoint is specified, then a default is used.
+    -   `os.getRecordsEndpoint()` returns a promise that resolves to the endpoint that is used by default.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -171,7 +171,8 @@ export type AsyncActions =
     | AnalyticsRecordEventAction
     | HtmlAppMethodCallAction
     | OpenPhotoCameraAction
-    | EnableCollaborationAction;
+    | EnableCollaborationAction
+    | GetRecordsEndpointAction;
 
 export type RemoteBotActions =
     | GetRemoteCountAction
@@ -3408,6 +3409,13 @@ export interface AnalyticsRecordEventAction extends AsyncAction {
     metadata: any;
 }
 
+/**
+ * An action that is used to retrieve the default records endpoint.
+ */
+export interface GetRecordsEndpointAction extends AsyncAction {
+    type: 'get_records_endpoint';
+}
+
 /**z
  * Creates a new AddBotAction.
  * @param bot The bot that was added.
@@ -5237,6 +5245,19 @@ export function analyticsRecordEvent(
         type: 'analytics_record_event',
         name,
         metadata,
+        taskId,
+    };
+}
+
+/**
+ * Creates a GetRecordsEndpointAction.
+ * @param taskId The ID of the async task.
+ */
+export function getRecordsEndpoint(
+    taskId?: number | string
+): GetRecordsEndpointAction {
+    return {
+        type: 'get_records_endpoint',
         taskId,
     };
 }

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -136,6 +136,7 @@ import {
     getCurrentInstUpdate,
     openPhotoCamera,
     enableCollaboration,
+    getRecordsEndpoint,
 } from '@casual-simulation/aux-common/bots';
 import { types } from 'util';
 import { attachRuntime, detachRuntime } from './RuntimeEvents';
@@ -7321,6 +7322,16 @@ describe('AuxLibrary', () => {
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.getRecordsEndpoint()', () => {
+            it('should return a promise that resolves to the records endpoint', async () => {
+                const result: any = library.api.os.getRecordsEndpoint();
+                const action = result[ORIGINAL_OBJECT];
+                const expected = getRecordsEndpoint(context.tasks.size);
+                expect(action).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
         });

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -232,6 +232,7 @@ import {
     getEasing,
     enableCollaboration as calcEnableCollaboration,
     reportInst as calcReportInst,
+    getRecordsEndpoint as calcGetRecordsEndpoint,
 } from '@casual-simulation/aux-common/bots';
 import {
     AIChatOptions,
@@ -3220,6 +3221,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 countEvents,
 
                 listUserStudios,
+
+                getRecordsEndpoint,
 
                 convertGeolocationToWhat3Words,
 
@@ -9262,6 +9265,22 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
         const task = context.createTask();
         const event = calcListUserStudios(options, task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the default records endpoint. That is, the records endpoint that is used for records actions when no endpoint is specified.
+     *
+     * @example Get the default records endpoint.
+     * const endpoint = await os.getRecordsEndpoint();
+     * os.toast("The default records endpoint is: " + endpoint);
+     *
+     * @dochash actions/os/records
+     * @docname os.getRecordsEndpoint
+     */
+    function getRecordsEndpoint(): Promise<string> {
+        const task = context.createTask();
+        const event = calcGetRecordsEndpoint(task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -11890,6 +11890,18 @@ interface Os {
     listUserStudios(endpoint?: string): Promise<ListStudiosResult>;
 
     /**
+     * Gets the default records endpoint. That is, the records endpoint that is used for records actions when no endpoint is specified.
+     * 
+     * @example Get the default records endpoint.
+     * const endpoint = await os.getRecordsEndpoint();
+     * os.toast("The default records endpoint is: " + endpoint);
+     * 
+     * @dochash actions/os/records
+     * @docname os.getRecordsEndpoint
+     */
+    getRecordsEndpoint(): Promise<string>;
+
+    /**
      * Converts the given geolocation to a what3words (https://what3words.com/) address.
      * @param location The latitude and longitude that should be converted to a 3 word address.
      */

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -8,6 +8,7 @@ import {
     MemoryConnectionClient,
     WebsocketHttpResponseMessage,
     WebsocketHttpRequestMessage,
+    getRecordsEndpoint,
 } from '@casual-simulation/aux-common';
 import {
     aiChat,
@@ -7134,6 +7135,18 @@ describe('RecordsManager', () => {
                             } as ListedStudio,
                         ],
                     }),
+                ]);
+            });
+        });
+
+        describe('get_records_endpoint', () => {
+            it('should return the recordsOrigin', async () => {
+                records.handleEvents([getRecordsEndpoint(1)]);
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, 'http://localhost:3002'),
                 ]);
             });
         });

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -7,6 +7,7 @@ import {
     ConnectionClient,
     RemoteCausalRepoProtocol,
     GenericHttpRequest,
+    GetRecordsEndpointAction,
 } from '@casual-simulation/aux-common';
 import {
     ListRecordDataAction,
@@ -222,7 +223,17 @@ export class RecordsManager {
                 this._aiGenerateImage(event);
             } else if (event.type === 'list_user_studios') {
                 this._listUserStudios(event);
+            } else if (event.type === 'get_records_endpoint') {
+                this._getRecordsEndpoint(event);
             }
+        }
+    }
+
+    private _getRecordsEndpoint(event: GetRecordsEndpointAction) {
+        if (hasValue(event.taskId)) {
+            this._helper.transaction(
+                asyncResult(event.taskId, this._config.recordsOrigin)
+            );
         }
     }
 


### PR DESCRIPTION
### :rocket: Features
-   Added the `os.getRecordsEndpoint()` function to get the default records endpoint.
    -   Records actions, like `os.recordData()`, `os.getData()`, `os.recordFile()`, etc. can be passed an endpoint which specifies which backend should be used for the request.
    -   If no endpoint is specified, then a default is used.
    -   `os.getRecordsEndpoint()` returns a promise that resolves to the endpoint that is used by default.

Closes #342 