### PR TITLE
Implement case-insensitive matching for email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CasualOS Changelog
 
+## V3.2.17
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Support case-insensitive matching of email address when logging in.
+    -   Previous versions would create separate accounts for email addresses that differed only in case.
+    -   Now, if an exact match is not found, a case-insensitive search will be made for users when attempting to login by email.
+    -   This will prevent cases where a user gets a new account because they mistakenly changed the case of their email address.
+    -   Technically, email addresses are supposed to be case-sensitive, but pretty much every email server treats them as case-insensitive.
+
 ## V3.2.16
 
 #### Date: 2/23/2024

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -126,7 +126,7 @@ export class PrismaAuthStore implements AuthStore {
         if (!address) {
             return null;
         }
-        const user = await this._client.user.findUnique({
+        let user = await this._client.user.findUnique({
             where:
                 addressType === 'email'
                     ? {
@@ -136,6 +136,18 @@ export class PrismaAuthStore implements AuthStore {
                           phoneNumber: address,
                       },
         });
+
+        // If no exact match was found for email, then try to find a case-insensitive match.
+        if (!user && addressType === 'email') {
+            user = await this._client.user.findFirst({
+                where: {
+                    email: {
+                        equals: address,
+                        mode: 'insensitive',
+                    },
+                },
+            });
+        }
 
         return this._convertToAuthUser(user);
     }

--- a/src/aux-server/aux-backend/server/server.ts
+++ b/src/aux-server/aux-backend/server/server.ts
@@ -492,14 +492,16 @@ export class Server {
             console.log('[Server] Websockets integration disabled.');
         }
 
-        interval(30 * 1000)
-            .pipe(
-                concatMap(
-                    async () =>
-                        await websocketController.savePermanentBranches()
+        if (websocketController) {
+            interval(30 * 1000)
+                .pipe(
+                    concatMap(
+                        async () =>
+                            await websocketController.savePermanentBranches()
+                    )
                 )
-            )
-            .subscribe();
+                .subscribe();
+        }
 
         function handleRecordsCorsHeaders(req: Request, res: Response) {
             if (allowedRecordsOrigins.has(req.headers.origin as string)) {


### PR DESCRIPTION
### :rocket: Features

-   Support case-insensitive matching of email address when logging in.
    -   Previous versions would create separate accounts for email addresses that differed only in case.
    -   Now, if an exact match is not found, a case-insensitive search will be made for users when attempting to login by email.
    -   This will prevent cases where a user gets a new account because they mistakenly changed the case of their email address.
    -   Technically, email addresses are supposed to be case-sensitive, but pretty much every email server treats them as case-insensitive.

Closes #330 