### PR TITLE
Fix `os.calculateRayFromCamera()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 -   Changed the date of birth input to handle manually-typed input better.
 -   Added the ability to track some load time metrics using SimpleAnalytics events.
 
+### :bug: Bug Fixes
+
+-   Fixed an issue where `os.calculateRayFromCamera()` would return incorrect results for the ray origin.
+
 ## V3.2.16
 
 #### Date: 2/23/2024

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -948,7 +948,7 @@ export class PlayerGame extends Game {
                 rig.mainCamera
             );
 
-            const origin = convertVector3(ray.origin, gridScale);
+            const origin = convertVector3(ray.origin, 1 / gridScale);
             const direction = convertVector3(ray.direction, 1);
 
             sim.helper.transaction(


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where `os.calculateRayFromCamera()` would return incorrect results for the ray origin.