### PR TITLE
Fix `miniGridPortal` and `miniMapPortal` resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 -   Fixed an issue where `os.calculateRayFromCamera()` would return incorrect results for the ray origin.
 -   Improved CasualOS to delay installation of the service worker until either the inst is fully loaded or the BIOS is shown.
+-   Fixed an issue where the `miniMapPortal` and `miniGridPortal` were not able to be resized.
 
 ## V3.2.16
 

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
@@ -125,6 +125,8 @@ html.ar-app .webxr-sessions canvas {
     overscroll-behavior: none;
     overflow-y: hidden;
     touch-action: none;
+
+    z-index: 2;
 }
 
 .md-badge.md-primary.menu-badge {


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where the `miniMapPortal` and `miniGridPortal` were not able to be resized.

Fixes #409 