### PR TITLE
Prompt the user for login when attempting to load a player owned inst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 -   Added the ability to use `.transferControlToOffscreen()` and `.getContext()` functions on `<canvas>` HTML elements.
 -   Added the ability to use `.setPointerCapture()` and `.releasePointerCapture()` functions on HTML elements.
 
+### :bug: Bug Fixes
+
+-   Fixed an issue where setting `?owner=player` in the URL while not being logged in would cause a public inst to be loaded instead of prompting the user to login.
+
 ## V3.2.17
 
 #### Date: 3/6/2024

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -721,7 +721,14 @@ export default class PlayerHome extends Vue {
     ) {
         this._loadedStaticInst = isStatic;
         const owner = getFirst(recordName);
-        const record = appManager.getRecordName(owner);
+        let recordInfo = appManager.getRecordName(owner);
+
+        while (recordInfo.owner === PLAYER_OWNER && !recordInfo.recordName) {
+            await appManager.auth.primary.authenticate();
+            recordInfo = appManager.getRecordName(owner);
+        }
+
+        const record = recordInfo.recordName;
         if (typeof newServer === 'string') {
             await this._loadPrimarySimulation(record, newServer, isStatic);
 

--- a/src/aux-server/aux-web/aux-player/UrlUtils.spec.ts
+++ b/src/aux-server/aux-web/aux-player/UrlUtils.spec.ts
@@ -14,6 +14,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: 'testRecord',
+            owner: 'testRecord',
             isStatic: false,
         });
     });
@@ -26,6 +27,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: 'testRecord',
+            owner: null,
             isStatic: false,
         });
     });
@@ -38,6 +40,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: ['test', 'abc'],
             recordName: 'testRecord',
+            owner: null,
             isStatic: false,
         });
     });
@@ -47,6 +50,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: null,
+            owner: null,
             isStatic: false,
         });
     });
@@ -56,6 +60,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: null,
+            owner: null,
             isStatic: false,
             story: true,
         });
@@ -66,6 +71,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: null,
+            owner: null,
             isStatic: false,
             server: true,
         });
@@ -76,6 +82,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: null,
+            owner: null,
             isStatic: true,
         });
     });
@@ -85,6 +92,7 @@ describe('getInstParameters()', () => {
         expect(params).toEqual({
             inst: 'test',
             recordName: null,
+            owner: null,
             isStatic: true,
         });
     });

--- a/src/aux-server/aux-web/aux-player/UrlUtils.ts
+++ b/src/aux-server/aux-web/aux-player/UrlUtils.ts
@@ -13,6 +13,11 @@ export interface InstParameters {
     recordName: string | null;
 
     /**
+     * The owner that was specified.
+     */
+    owner: string | null;
+
+    /**
      * Whether the inst should be static.
      */
     isStatic: boolean;
@@ -35,6 +40,7 @@ export function getInstParameters(query: any): InstParameters {
     const inst =
         query.staticInst ?? query.inst ?? query.story ?? query.server ?? null;
     const recordName = query.owner ?? query.record ?? query.player ?? null;
+    const owner = query.owner ?? null;
 
     if (!hasValue(inst)) {
         return null;
@@ -43,6 +49,7 @@ export function getInstParameters(query: any): InstParameters {
     const ret: InstParameters = {
         inst: inst,
         recordName: recordName,
+        owner,
         isStatic: inst === query.staticInst,
     };
 

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -670,15 +670,24 @@ export class AppManager {
      * Gets the name of the record that the given owner should be loaded from.
      * @param owner The owner of the record.
      */
-    getRecordName(owner: string): string {
+    getRecordName(owner: string): { recordName: string; owner: string } {
         if (owner === PLAYER_OWNER) {
-            return (
-                this.auth.primary.currentLoginStatus.authData?.userId ?? null
-            );
+            return {
+                owner,
+                recordName:
+                    this.auth?.primary?.currentLoginStatus?.authData?.userId ??
+                    null,
+            };
         } else if (owner === PUBLIC_OWNER) {
-            return null;
+            return {
+                owner,
+                recordName: null,
+            };
         } else {
-            return owner;
+            return {
+                owner: null,
+                recordName: owner,
+            };
         }
     }
 

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
@@ -34,6 +34,10 @@ export default class AuthUI extends Vue {
     showAccountInfo: boolean = false;
     loginStatus: LoginStatus = null;
 
+    get isLoggedIn() {
+        return !!this.loginStatus;
+    }
+
     /**
      * Whether the "Request Access" button should be shown on the "Not Authorized" screen.
      */
@@ -65,6 +69,7 @@ export default class AuthUI extends Vue {
             appManager.authCoordinator.onMissingPermission.subscribe((e) => {
                 this.showNotAuthorized = true;
                 this.allowRequestAccess = false;
+                this.loginStatus = appManager.auth.primary.currentLoginStatus;
                 this._simId = e.simulationId;
                 this._origin = e.origin;
                 this._missingPermissionReason = e.reason;
@@ -79,6 +84,7 @@ export default class AuthUI extends Vue {
         this._sub.add(
             appManager.authCoordinator.onNotAuthorized.subscribe((e) => {
                 this.showNotAuthorized = true;
+                this.loginStatus = appManager.auth.primary.currentLoginStatus;
                 this._simId = e.simulationId;
                 this._origin = e.origin;
             })

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
@@ -27,7 +27,9 @@
                     >
                     <span v-else>Request Access</span>
                 </md-button>
-                <md-button @click="changeLogin()">Change Login</md-button>
+                <md-button @click="changeLogin()">{{
+                    isLoggedIn ? 'Change Login' : 'Sign In'
+                }}</md-button>
                 <md-button @click="newInst()">New Inst</md-button>
             </md-dialog-actions>
         </md-dialog>

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
@@ -64,7 +64,7 @@
                 <md-button class="md-primary" @click="openAccountDashboard()"
                     >Manage Account</md-button
                 >
-                <md-button @click="logout()">Logout</md-button>
+                <md-button @click="logout()">Sign Out</md-button>
             </md-dialog-actions>
         </md-dialog>
 


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where setting `?owner=player` in the URL while not being logged in would cause a public inst to be loaded instead of prompting the user to login.

Fixes #418 