### PR TITLE
Make `os.getCurrentInst()` work for static insts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 -   Added the ability to use `.transferControlToOffscreen()` and `.getContext()` functions on `<canvas>` HTML elements.
 -   Added the ability to use `.setPointerCapture()` and `.releasePointerCapture()` functions on HTML elements.
 
+### :bug: Bug Fixes
+
+-   Fixed an issue where `os.getCurrentInst()` would return `undefined` if the inst is a static inst.
+
 ## V3.2.17
 
 #### Date: 3/6/2024

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -4608,6 +4608,25 @@ describe('AuxLibrary', () => {
                 expect(result).toBeUndefined();
             });
 
+            it('should return the staticInst when inst is not set', () => {
+                player.tags.staticInst = 'staticInst';
+                const result = library.api.os.getCurrentInst();
+                expect(result).toEqual('staticInst');
+            });
+
+            it('should return the first staticInst when set to an array', () => {
+                player.tags.staticInst = ['staticInst', 'otherInst'];
+                const result = library.api.os.getCurrentInst();
+                expect(result).toEqual('staticInst');
+            });
+
+            it('should return prefer inst over staticInst', () => {
+                player.tags.inst = ['inst', 'randomInst'];
+                player.tags.staticInst = ['staticInst', 'otherInst'];
+                const result = library.api.os.getCurrentInst();
+                expect(result).toEqual('inst');
+            });
+
             it.each(numberCases)(
                 'should return "%s" when given %s',
                 (expected, given) => {

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -6771,7 +6771,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function getCurrentServer(): string {
         const user = context.playerBot;
         if (user) {
-            let inst = getTag(user, 'inst');
+            let inst = getTag(user, 'inst') ?? getTag(user, 'staticInst');
             if (hasValue(inst)) {
                 if (Array.isArray(inst)) {
                     return inst[0].toString();


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where `os.getCurrentInst()` would return `undefined` if the inst is a static inst.

Fixes #415 