### PR TITLE
Support `@onGridClick`, `@onGridUp`, and `@onGridDown` for all loaded insts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
     -   It is an object that contains APIs from `preact/compat`.
     -   This includes, but is not limited to, `Suspense`, `lazy()`, `createPortal()`, `forwardRef()`, `memo()`, and `PureComponent`.
 -   Added `createRef()` and `createContext()` to `os.appHooks`.
+-   CasualOS will now send `@onGridClick`, `@onGridUp`, and `@onGridDown` shouts to all loaded insts.
 
 ### :bug: Bug Fixes
 
@@ -41,6 +42,8 @@
 -   Improved wording for some registration errors.
 -   Fixed an issue where it was possible for a session to not be synced while the session itself believes that it is connected.
 -   Fixed an issue where using JSX syntax would show random syntax errors in the multiline code editor.
+-   Fixed an issue where it was possible for CasualOS to waste resources by loading the portals for an inst multiple times.
+-   Fixed an issue where the miniGridPortal slider bar would interfere with the menuPortal.
 
 ## V3.2.18
 

--- a/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
+++ b/src/aux-server/aux-web/aux-player/PlayerGameView/PlayerGameView.css
@@ -85,6 +85,7 @@ html.ar-app .webxr-sessions canvas {
     bottom: 8px;
     left: 33%;
     width: 33%;
+    z-index: 3;
 }
 
 @media (max-width: 768px) {

--- a/src/aux-vm/managers/SimulationManager.ts
+++ b/src/aux-vm/managers/SimulationManager.ts
@@ -43,6 +43,7 @@ export class SimulationManager<
     private _simulationRemoved: Subject<TSimulation>;
     private _simulationSubscriptions: Map<string, Subscription>;
     private _simulationPromises: Map<string, Promise<TSimulation>>;
+    private _initializedSimulations: Map<string, TSimulation> = new Map();
 
     /**
      * The ID of the primary simulation.
@@ -70,7 +71,7 @@ export class SimulationManager<
      */
     get simulationAdded(): Observable<TSimulation> {
         return this._simulationAdded.pipe(
-            startWith(...this.simulations.values())
+            startWith(...this._initializedSimulations.values())
         );
     }
 
@@ -215,7 +216,9 @@ export class SimulationManager<
 
         await sim.init();
 
+        this._initializedSimulations.set(id, sim);
         this._simulationAdded.next(sim);
+
         return sim;
     }
 
@@ -237,6 +240,7 @@ export class SimulationManager<
             this.simulations.delete(id);
             this._simulationPromises.delete(id);
             this._simulationSubscriptions.delete(id);
+            this._initializedSimulations.delete(id);
             this._simulationRemoved.next(sim);
         }
     }


### PR DESCRIPTION
### :rocket: Features

-   CasualOS will now send `@onGridClick`, `@onGridUp`, and `@onGridDown` shouts to all loaded insts.

### :bug: Bug Fixes

-   Fixed an issue where it was possible for CasualOS to waste resources by loading the portals for an inst multiple times.
-   Fixed an issue where the miniGridPortal slider bar would interfere with the menuPortal.

Closes #425 