### PR TITLE
Add the ability to create custom user accounts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CasualOS Changelog
 
+## V3.2.20
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Added the ability to create accounts that are not associated with an email or phone number.
+    -   These accounts are also issued a session key that cannot be revoked and does not expire.
+    -   They will mostly be used for one-time subscriptions and machine users.
+
 ## V3.2.19
 
 #### Date: 4/1/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CasualOS Changelog
 
-## V3.2.20
+## V3.3.0
 
 #### Date: TBD
 

--- a/src/aux-common/rpc/ErrorCodes.spec.ts
+++ b/src/aux-common/rpc/ErrorCodes.spec.ts
@@ -78,6 +78,8 @@ describe('getStatusCode()', () => {
         ['message_not_found', 404] as const,
         ['not_found', 404] as const,
         ['invalid_connection_state', 500] as const,
+        ['user_already_exists', 400] as const,
+        ['session_is_not_revokable', 400] as const,
     ];
 
     it.each(cases)('should map error code %s to %s', (code, expectedStatus) => {

--- a/src/aux-common/rpc/ErrorCodes.ts
+++ b/src/aux-common/rpc/ErrorCodes.ts
@@ -68,7 +68,9 @@ export type KnownErrorCodes =
     | 'unacceptable_connection_id'
     | 'message_not_found'
     | 'not_found'
-    | 'invalid_connection_state';
+    | 'invalid_connection_state'
+    | 'user_already_exists'
+    | 'session_is_not_revokable';
 
 /**
  * Gets the status code that should be used for the given response.
@@ -172,6 +174,8 @@ export function getStatusCode(
             return 404;
         } else if (response.errorCode === 'invalid_connection_state') {
             return 500;
+        } else if (response.errorCode === 'user_already_exists') {
+            return 400;
         } else {
             return 400;
         }

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -5613,9 +5613,13 @@ describe('AuthController', () => {
                 const result = await controller.validateConnectionToken(token);
 
                 expect(result).toEqual({
-                    success: false,
-                    errorCode: 'invalid_token',
-                    errorMessage: INVALID_TOKEN_ERROR_MESSAGE,
+                    success: true,
+                    userId,
+                    sessionId,
+                    inst: 'inst',
+                    recordName: 'recordName',
+                    connectionId: 'connectionId',
+                    allSessionsRevokedTimeMs: 101,
                 });
             });
         });

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -314,7 +314,7 @@ describe('AuthController', () => {
                 nextSessionId: null,
                 ipAddress: '127.0.0.1',
 
-                revokable: false,
+                revocable: false,
             });
         });
     });
@@ -4833,7 +4833,7 @@ describe('AuthController', () => {
                 });
             });
 
-            it('should work if the session was granted before all sessions were revoked but the session is not revokable and also doesnt have a revoke time', async () => {
+            it('should work if the session was granted before all sessions were revoked but the session is not revocable and also doesnt have a revoke time', async () => {
                 const requestId = 'requestId';
                 const sessionId = toBase64String('sessionId');
                 const code = 'code';
@@ -4866,7 +4866,7 @@ describe('AuthController', () => {
                     revokeTimeMs: null,
                     userId,
                     ipAddress: '127.0.0.1',
-                    revokable: false,
+                    revocable: false,
                 });
 
                 nowMock.mockReturnValue(400);
@@ -5562,7 +5562,7 @@ describe('AuthController', () => {
                 });
             });
 
-            it('should work if the session was granted before all sessions were revoked but is not revokable and also has no expiration time', async () => {
+            it('should work if the session was granted before all sessions were revoked but is not revocable and also has no expiration time', async () => {
                 const requestId = 'requestId';
                 const sessionId = toBase64String('sessionId');
                 const code = 'code';
@@ -5584,7 +5584,7 @@ describe('AuthController', () => {
                     revokeTimeMs: null,
                     userId,
                     ipAddress: '127.0.0.1',
-                    revokable: false,
+                    revocable: false,
                 });
 
                 await store.saveUser({
@@ -6166,7 +6166,7 @@ describe('AuthController', () => {
                 userId,
                 ipAddress: '127.0.0.1',
 
-                revokable: false,
+                revocable: false,
             });
 
             nowMock.mockReturnValue(400);
@@ -6499,7 +6499,7 @@ describe('AuthController', () => {
             });
         });
 
-        it('should fail if the session is not revokable', async () => {
+        it('should fail if the session is not revocable', async () => {
             await store.saveSession({
                 requestId,
                 sessionId,
@@ -6513,7 +6513,7 @@ describe('AuthController', () => {
                 userId,
                 ipAddress: '127.0.0.1',
 
-                revokable: false,
+                revocable: false,
             });
 
             nowMock.mockReturnValue(200);

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -282,7 +282,7 @@ describe('AuthController', () => {
                     fromByteArray(connectionSecret),
                     Infinity
                 ),
-                expireTimeMs: Infinity,
+                expireTimeMs: null,
             });
 
             const user = await store.findUser('uuid1');

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -282,7 +282,7 @@ export class AuthController {
                     connectionSecret,
                     session.expireTimeMs ?? Infinity
                 ),
-                expireTimeMs: session.expireTimeMs ?? Infinity,
+                expireTimeMs: session.expireTimeMs,
             };
         } catch (err) {
             console.error(
@@ -2064,7 +2064,9 @@ export class AuthController {
             } else {
                 if (typeof userInfo.allSessionRevokeTimeMs === 'number') {
                     if (
-                        userInfo.allSessionRevokeTimeMs >= session.grantedTimeMs
+                        userInfo.allSessionRevokeTimeMs >=
+                            session.grantedTimeMs &&
+                        (session.revokable !== false || !!session.revokeTimeMs)
                     ) {
                         return {
                             success: false,

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -263,7 +263,7 @@ export class AuthController {
                 nextSessionId: null,
                 ipAddress: request.ipAddress,
 
-                revokable: false,
+                revocable: false,
             };
             await this._store.saveSession(session);
 
@@ -1929,7 +1929,7 @@ export class AuthController {
                     if (
                         userInfo.allSessionRevokeTimeMs >=
                             session.grantedTimeMs &&
-                        (session.revokable !== false || !!session.revokeTimeMs)
+                        (session.revocable !== false || !!session.revokeTimeMs)
                     ) {
                         return {
                             success: false,
@@ -2066,7 +2066,7 @@ export class AuthController {
                     if (
                         userInfo.allSessionRevokeTimeMs >=
                             session.grantedTimeMs &&
-                        (session.revokable !== false || !!session.revokeTimeMs)
+                        (session.revocable !== false || !!session.revokeTimeMs)
                     ) {
                         return {
                             success: false,
@@ -2177,7 +2177,7 @@ export class AuthController {
                 };
             }
 
-            if (session.revokable === false) {
+            if (session.revocable === false) {
                 return {
                     success: false,
                     errorCode: 'session_is_not_revokable',
@@ -2320,7 +2320,7 @@ export class AuthController {
                 };
             }
 
-            if (session.revokable === false) {
+            if (session.revocable === false) {
                 console.log(
                     '[AuthController] [replaceSession] Session is irrevokable.'
                 );

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -802,6 +802,16 @@ export interface AuthSession {
      * If null, then Open ID was not used for the session.
      */
     oidExpiresAtMs?: number | null;
+
+    /**
+     * Whether the session is able to be revoked by the user.
+     * Setting this to false will prevent the user from revoking the session.
+     * Additionally, users will not be able to replace the session either.
+     * If false, then the session cannot be revoked by the user.
+     * If true, then the session can be revoked by the user.
+     * Default is true.
+     */
+    revokable?: boolean;
 }
 
 /**

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -811,7 +811,7 @@ export interface AuthSession {
      * If true, then the session can be revoked by the user.
      * Default is true.
      */
-    revokable?: boolean;
+    revocable?: boolean;
 }
 
 /**

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -1831,6 +1831,30 @@ describe('RecordsServer', () => {
         );
     });
 
+    describe('POST /api/v2/createAccount', () => {
+        it('should create a new account', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    '/api/v2/createAccount',
+                    JSON.stringify({}),
+                    authenticatedHeaders
+                )
+            );
+
+            expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    userId: expect.any(String),
+                    expireTimeMs: null,
+                    connectionKey: expect.any(String),
+                    sessionKey: expect.any(String),
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+    });
+
     describe('GET /api/v2/sessions', () => {
         it('should return the list of sessions for the user', async () => {
             const result = await server.handleHttpRequest(

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -545,6 +545,31 @@ export class RecordsServer {
                         name
                     );
                 }),
+
+            createAccount: procedure()
+                .origins('account')
+                .http('POST', '/api/v2/createAccount')
+                .inputs(z.object({}))
+                .handler(async ({}, context) => {
+                    const validation = await this._validateSessionKey(
+                        context.sessionKey
+                    );
+
+                    if (validation.success === false) {
+                        if (validation.errorCode === 'no_session_key') {
+                            return NOT_LOGGED_IN_RESULT;
+                        }
+                        return validation;
+                    }
+
+                    const result = await this._auth.createAccount({
+                        userId: validation.userId,
+                        ipAddress: context.ipAddress,
+                    });
+
+                    return result;
+                }),
+
             listSessions: procedure()
                 .origins('account')
                 .http('GET', '/api/v2/sessions')

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -722,6 +722,7 @@ export class PrismaAuthStore implements AuthStore {
             nextSessionId: session.nextSessionId,
             ipAddress: session.ipAddress,
             connectionSecret: session.connectionSecret,
+            revocable: session.revocable,
         };
         await this._client.authSession.upsert({
             where: {
@@ -759,6 +760,7 @@ export class PrismaAuthStore implements AuthStore {
                         ipAddress: newSession.ipAddress,
                         previousSessionId: session.sessionId,
                         connectionSecret: newSession.connectionSecret,
+                        revocable: session.revocable,
                     },
                 },
             },

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -1189,6 +1189,8 @@ export class PrismaAuthStore implements AuthStore {
             ipAddress: session.ipAddress,
             nextSessionId: session.nextSessionId,
             connectionSecret: session.connectionSecret,
+
+            revocable: session.revocable,
         };
     }
 

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -147,8 +147,10 @@ model AuthSession {
     oidExpiresAtMs Int?
 
     grantedTime DateTime
-    expireTime DateTime
+    expireTime DateTime?
     revokeTime DateTime?
+
+    revocable  Boolean?
 
     requestId String?
     request LoginRequest? @relation(fields: [requestId], references: [requestId])

--- a/src/aux-server/aux-backend/schemas/migrations/20240402170012_allow_marking_sessions_as_revocable/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240402170012_allow_marking_sessions_as_revocable/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "AuthSession" ADD COLUMN     "revocable" BOOL;
+ALTER TABLE "AuthSession" ALTER COLUMN "expireTime" DROP NOT NULL;


### PR DESCRIPTION
### :rocket: Features

-   Added the ability to create accounts that are not associated with an email or phone number.
    -   These accounts are also issued a session key that cannot be revoked and does not expire.
    -   They will mostly be used for one-time subscriptions and machine users.
 
Closes #432 