### PR TITLE
Add a command line interface for CasualOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CasualOS Changelog
 
+## V3.3.0
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Added a command line interface (CLI) for CasualOS.
+    -   It is available on NPM as `casualos`, and provides functionality to query the CasualOS backend API.
+    -   It currently provides the following operations:
+        -   `login` - Authenticates the cilent to a CasualOS backend.
+        -   `query` - Queries a CasualOS backend.
+        -   `repl` - A Read-eval-print-loop (REPL) that makes interacting with the CasualOS backend via JavaScript really easy.
+
 ## V3.2.19
 
 #### Date: 4/1/2024

--- a/jakefile.js
+++ b/jakefile.js
@@ -35,6 +35,7 @@ let folders = [
     `${__dirname}/src/rate-limit-redis`,
     `${__dirname}/src/aux-websocket`,
     `${__dirname}/src/aux-websocket-aws`,
+    `${__dirname}/src/casualos-cli`,
 ];
 
 let patterns = [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "bench": "npm run build:libs && lerna exec --scope @casual-simulation/aux-benchmarks -- npm run bench",
         "bench:profile": "npm run build:libs && lerna exec --scope @casual-simulation/aux-benchmarks -- npm run bench:profile",
         "cloc": "cloc src --exclude-dir=node_modules --exclude-ext=js,json,def",
-        "vite": "lerna exec --no-prefix --scope @casual-simulation/aux-server -- npm run vite"
+        "vite": "lerna exec --no-prefix --scope @casual-simulation/aux-server -- npm run vite",
+        "cli": "lerna exec --no-prefix --scope casualos -- npm run dev"
     },
     "devDependencies": {
         "@babel/core": "^7.14.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1472,18 +1472,22 @@ importers:
       '@casual-simulation/aux-records':
         specifier: ^3.2.19
         version: link:../aux-records
-      '@types/prompts':
-        specifier: ^2.4.9
-        version: 2.4.9
       axios:
         specifier: 1.6.2
         version: 1.6.2
       commander:
         specifier: 12.0.0
         version: 12.0.0
+      conf:
+        specifier: 12.0.0
+        version: 12.0.0
       prompts:
         specifier: 2.4.2
         version: 2.4.2
+    devDependencies:
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
 
   src/chalk: {}
 
@@ -7865,6 +7869,7 @@ packages:
     dependencies:
       '@types/node': 18.19.3
       kleur: 3.0.3
+    dev: true
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
@@ -8741,6 +8746,13 @@ packages:
 
   /atob-lite@2.0.0:
     resolution: {integrity: sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==}
+    dev: false
+
+  /atomically@2.0.2:
+    resolution: {integrity: sha512-Xfmb4q5QV7uqTlVdMSTtO5eF4DCHfNOdaPyKlbFShkzeNP+3lj3yjjcbdjSmEY4+pDBKJ9g26aP+ImTe88UHoQ==}
+    dependencies:
+      stubborn-fs: 1.2.5
+      when-exit: 2.1.2
     dev: false
 
   /autobind-decorator@2.4.0:
@@ -10034,6 +10046,21 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /conf@12.0.0:
+    resolution: {integrity: sha512-fIWyWUXrJ45cHCIQX+Ck1hrZDIf/9DR0P0Zewn3uNht28hbt5OfGUq8rRWsxi96pZWPyBEd0eY9ama01JTaknA==}
+    engines: {node: '>=18'}
+    dependencies:
+      ajv: 8.12.0
+      ajv-formats: 2.1.1(ajv@8.12.0)
+      atomically: 2.0.2
+      debounce-fn: 5.1.2
+      dot-prop: 8.0.2
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.1
+      semver: 7.5.4
+      uint8array-extras: 0.3.0
+    dev: false
+
   /config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
     dependencies:
@@ -10773,6 +10800,13 @@ packages:
   /de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
+  /debounce-fn@5.1.2:
+    resolution: {integrity: sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: false
+
   /debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -11208,6 +11242,13 @@ packages:
       is-obj: 2.0.0
     dev: false
 
+  /dot-prop@8.0.2:
+    resolution: {integrity: sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      type-fest: 3.13.1
+    dev: false
+
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
     engines: {node: '>=12'}
@@ -11367,6 +11408,11 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
     dev: true
+
+  /env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /env-string@1.0.1:
     resolution: {integrity: sha512-/DhCJDf5DSFK32joQiWRpWrT0h7p3hVQfMKxiBb7Nt8C8IF8BYyPtclDnuGGLOoj16d/8udKeiE7JbkotDmorQ==}
@@ -14741,6 +14787,10 @@ packages:
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  /json-schema-typed@8.0.1:
+    resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
+    dev: false
+
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
@@ -16182,6 +16232,11 @@ packages:
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -20310,6 +20365,10 @@ packages:
       through: 2.3.8
     dev: true
 
+  /stubborn-fs@1.2.5:
+    resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
+    dev: false
+
   /style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
     dependencies:
@@ -20906,6 +20965,11 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+    dev: false
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -20998,6 +21062,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /uint8array-extras@0.3.0:
+    resolution: {integrity: sha512-erJsJwQ0tKdwuqI0359U8ijkFmfiTcq25JvvzRVc1VP+2son1NJRXhxcAKJmAW3ajM8JSGAfsAXye8g4s+znxA==}
+    engines: {node: '>=18'}
+    dev: false
 
   /umd@3.0.3:
     resolution: {integrity: sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==}
@@ -21975,6 +22044,10 @@ packages:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
     dev: true
+
+  /when-exit@2.1.2:
+    resolution: {integrity: sha512-u9J+toaf3CCxCAzM/484qNAxQE75rFdVgiFEEV8Xps2gzYhf0tx73s1WXDQhkwV17E3MxRMz40m7Ekd2/121Lg==}
+    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1464,6 +1464,27 @@ importers:
         specifier: 7.5.7
         version: 7.5.7
 
+  src/casualos-cli:
+    dependencies:
+      '@casual-simulation/aux-common':
+        specifier: ^3.2.19
+        version: link:../aux-common
+      '@casual-simulation/aux-records':
+        specifier: ^3.2.19
+        version: link:../aux-records
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
+      axios:
+        specifier: 1.6.2
+        version: 1.6.2
+      commander:
+        specifier: 12.0.0
+        version: 12.0.0
+      prompts:
+        specifier: 2.4.2
+        version: 2.4.2
+
   src/chalk: {}
 
   src/crypto:
@@ -7844,7 +7865,6 @@ packages:
     dependencies:
       '@types/node': 18.19.3
       kleur: 3.0.3
-    dev: true
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
@@ -9898,6 +9918,11 @@ packages:
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
+    dev: false
+
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
     dev: false
 
   /commander@2.20.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1481,6 +1481,9 @@ importers:
       conf:
         specifier: 12.0.0
         version: 12.0.0
+      open:
+        specifier: 10.1.0
+        version: 10.1.0
       prompts:
         specifier: 2.4.2
         version: 2.4.2
@@ -9352,6 +9355,13 @@ packages:
       semver: 7.5.4
     dev: true
 
+  /bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      run-applescript: 7.0.0
+    dev: false
+
   /byte-size@8.1.1:
     resolution: {integrity: sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg==}
     engines: {node: '>=12.17'}
@@ -10901,6 +10911,19 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  /default-browser-id@5.0.0:
+    resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /default-browser@5.2.1:
+    resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
+    engines: {node: '>=18'}
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.0
+    dev: false
+
   /default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
     engines: {node: '>= 10'}
@@ -10930,6 +10953,11 @@ packages:
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -13742,6 +13770,12 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  /is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dev: false
+
   /is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -13781,6 +13815,14 @@ packages:
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+    dev: false
+
+  /is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      is-docker: 3.0.0
     dev: false
 
   /is-installed-globally@0.4.0:
@@ -13986,6 +14028,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+
+  /is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
+    dependencies:
+      is-inside-container: 1.0.0
+    dev: false
 
   /is-yarn-global@0.4.1:
     resolution: {integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==}
@@ -17099,6 +17148,16 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
 
+  /open@10.1.0:
+    resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
+    engines: {node: '>=18'}
+    dependencies:
+      default-browser: 5.2.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 3.1.0
+    dev: false
+
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -19437,6 +19496,11 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.32
       strip-json-comments: 3.1.1
+    dev: false
+
+  /run-applescript@7.0.0:
+    resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
+    engines: {node: '>=18'}
     dev: false
 
   /run-async@2.4.1:

--- a/src/aux-common/rpc/GenericRPCInterface.spec.ts
+++ b/src/aux-common/rpc/GenericRPCInterface.spec.ts
@@ -1,4 +1,8 @@
-import { procedure } from './GenericRPCInterface';
+import {
+    getProcedureMetadata,
+    getSchemaMetadata,
+    procedure,
+} from './GenericRPCInterface';
 import z from 'zod';
 
 describe('procedure()', () => {
@@ -17,4 +21,250 @@ describe('procedure()', () => {
         });
         expect(proc.allowedOrigins).toBe(true);
     });
+});
+
+describe('getProcedureMetadata()', () => {
+    it('should return a metadata object for the procedures', () => {
+        const procedures = {
+            proc: procedure()
+                .origins(true)
+                .inputs(z.string())
+                .handler(async (str) => ({
+                    success: true,
+                    value: `hello ${str}`,
+                })),
+            proc2: procedure()
+                .origins('account')
+                .http('POST', '/api/proc2')
+                .inputs(z.object({ name: z.string() }))
+                .handler(async (input) => ({
+                    success: true,
+                    value: `hello ${input.name}`,
+                })),
+            proc3: procedure()
+                .origins('account')
+                .http('POST', '/api/proc2')
+                .handler(async () => ({
+                    success: true,
+                    value: `hello`,
+                })),
+        };
+
+        const meta = getProcedureMetadata(procedures);
+
+        expect(meta).toEqual({
+            procedures: [
+                {
+                    name: 'proc',
+                    origins: true,
+                    inputs: {
+                        type: 'string',
+                    },
+                    http: undefined,
+                },
+                {
+                    name: 'proc2',
+                    origins: 'account',
+                    inputs: {
+                        type: 'object',
+                        schema: {
+                            name: {
+                                type: 'string',
+                            },
+                        },
+                    },
+                    http: {
+                        method: 'POST',
+                        path: '/api/proc2',
+                    },
+                },
+                {
+                    name: 'proc3',
+                    origins: 'account',
+                    inputs: undefined,
+                    http: {
+                        method: 'POST',
+                        path: '/api/proc2',
+                    },
+                },
+            ],
+        });
+    });
+});
+
+describe('getSchemaMetadata()', () => {
+    const cases = [
+        ['string', z.string(), { type: 'string' }] as const,
+        ['boolean', z.boolean(), { type: 'boolean' }] as const,
+        ['number', z.number(), { type: 'number' }] as const,
+        ['any', z.any(), { type: 'any' }] as const,
+        ['null', z.null(), { type: 'null' }] as const,
+        ['object', z.object({}), { type: 'object', schema: {} }] as const,
+        [
+            'object with properties',
+            z.object({
+                abc: z.number(),
+                def: z.string(),
+                bool: z.boolean(),
+            }),
+            {
+                type: 'object',
+                schema: {
+                    abc: { type: 'number' },
+                    def: { type: 'string' },
+                    bool: { type: 'boolean' },
+                },
+            },
+        ] as const,
+        [
+            'object with catchall',
+            z.object({}).catchall(z.number()),
+            { type: 'object', schema: {}, catchall: { type: 'number' } },
+        ] as const,
+        [
+            'array',
+            z.array(z.string()),
+            { type: 'array', schema: { type: 'string' } },
+        ] as const,
+        [
+            'array with exact length',
+            z.array(z.string()).length(2),
+            { type: 'array', schema: { type: 'string' }, exactLength: 2 },
+        ] as const,
+        [
+            'array with min length',
+            z.array(z.string()).min(2),
+            { type: 'array', schema: { type: 'string' }, minLength: 2 },
+        ] as const,
+        [
+            'array with max length',
+            z.array(z.string()).max(2),
+            { type: 'array', schema: { type: 'string' }, maxLength: 2 },
+        ] as const,
+        [
+            'literal string',
+            z.literal('abc'),
+            { type: 'literal', value: 'abc' },
+        ] as const,
+        [
+            'literal number',
+            z.literal(123),
+            { type: 'literal', value: 123 },
+        ] as const,
+        [
+            'literal boolean',
+            z.literal(true),
+            { type: 'literal', value: true },
+        ] as const,
+        [
+            'enum',
+            z.enum(['abc', 'def', 'ghi']),
+            { type: 'enum', values: ['abc', 'def', 'ghi'] },
+        ] as const,
+        ['date', z.date(), { type: 'date' }] as const,
+        [
+            'effects',
+            z.preprocess((value) => value, z.string()),
+            { type: 'string' },
+        ] as const,
+        [
+            'union',
+            z.union([z.string(), z.number()]),
+            {
+                type: 'union',
+                options: [{ type: 'string' }, { type: 'number' }],
+            },
+        ] as const,
+        [
+            'discriminated union',
+            z.discriminatedUnion('abc', [
+                z.object({
+                    abc: z.literal(123),
+                }),
+                z.object({
+                    abc: z.literal(456),
+                }),
+            ]),
+            {
+                type: 'union',
+                discriminator: 'abc',
+                options: [
+                    {
+                        type: 'object',
+                        schema: {
+                            abc: { type: 'literal', value: 123 },
+                        },
+                    },
+                    {
+                        type: 'object',
+                        schema: {
+                            abc: { type: 'literal', value: 456 },
+                        },
+                    },
+                ],
+            },
+        ] as const,
+    ] as const;
+
+    it.each(cases)(
+        'should return the metadata for %s',
+        (name, schema, expected) => {
+            expect(getSchemaMetadata(schema)).toEqual(expected);
+        }
+    );
+
+    it.each(cases)(
+        'should support nullable metadata for %s',
+        (name, schema, expected) => {
+            expect(getSchemaMetadata(schema.nullable())).toEqual({
+                ...expected,
+                nullable: true,
+            });
+        }
+    );
+
+    it.each(cases)(
+        'should support default metadata for %s',
+        (name, schema, expected) => {
+            expect(
+                getSchemaMetadata((schema as any).default(123 as any))
+            ).toEqual({ ...expected, hasDefault: true, defaultValue: 123 });
+        }
+    );
+
+    it.each(cases)(
+        'should support optional metadata for %s',
+        (name, schema, expected) => {
+            expect(getSchemaMetadata(schema.optional())).toEqual({
+                ...expected,
+                optional: true,
+            });
+        }
+    );
+
+    it.each(cases)(
+        'should support nullable and optional metadata for %s',
+        (name, schema, expected) => {
+            expect(getSchemaMetadata(schema.optional().nullable())).toEqual({
+                ...expected,
+                optional: true,
+                nullable: true,
+            });
+        }
+    );
+
+    it.each(cases)(
+        'should support descriptions for %s',
+        (name, schema, expected) => {
+            if (schema instanceof z.ZodEffects) {
+            } else {
+                expect(
+                    getSchemaMetadata(schema.describe('this is a description'))
+                ).toEqual({
+                    ...expected,
+                    description: 'this is a description',
+                });
+            }
+        }
+    );
 });

--- a/src/aux-common/rpc/GenericRPCInterface.ts
+++ b/src/aux-common/rpc/GenericRPCInterface.ts
@@ -93,6 +93,11 @@ export interface CallProcedureOptions {
      * The endpoint that should be used instead of the one that is currently set on the client.
      */
     endpoint?: string;
+
+    /**
+     * The headers that should be included in the request.
+     */
+    headers?: Record<string, string>;
 }
 
 export type OnlyFirstArg<T> = T extends (input: infer U, ...args: any[]) => any

--- a/src/aux-records/RecordsClient.spec.ts
+++ b/src/aux-records/RecordsClient.spec.ts
@@ -255,6 +255,11 @@ describe('createRecordsClient()', () => {
         );
     });
 
+    it('should return undefined for Promise properties', () => {
+        expect((client as any).then).toBeUndefined();
+        expect((client as any).catch).toBeUndefined();
+    });
+
     describe('proxied methods', () => {
         it('should have all the methods that the client has', () => {
             expect(client).toHaveProperty('callProcedure');

--- a/src/aux-records/RecordsClient.ts
+++ b/src/aux-records/RecordsClient.ts
@@ -25,6 +25,10 @@ export class RecordsClient {
         this._sessionKey = value;
     }
 
+    get endpoint() {
+        return this._endpoint;
+    }
+
     constructor(endpoint: string) {
         this._endpoint = endpoint;
         this._sessionKey = null;

--- a/src/aux-records/RecordsClient.ts
+++ b/src/aux-records/RecordsClient.ts
@@ -28,6 +28,19 @@ export class RecordsClient {
     constructor(endpoint: string) {
         this._endpoint = endpoint;
         this._sessionKey = null;
+
+        Object.defineProperties(this, {
+            then: {
+                value: undefined,
+                configurable: false,
+                writable: false,
+            },
+            catch: {
+                value: undefined,
+                configurable: false,
+                writable: false,
+            },
+        });
     }
 
     /**

--- a/src/aux-records/RecordsClient.ts
+++ b/src/aux-records/RecordsClient.ts
@@ -58,7 +58,10 @@ export class RecordsClient {
             `${options?.endpoint ?? this._endpoint}/api/v3/callProcedure`,
             { procedure: name, input },
             {
-                headers: this._authenticationHeaders(options),
+                headers: {
+                    ...(options?.headers ?? {}),
+                    ...this._authenticationHeaders(options),
+                },
                 validateStatus: () => true,
             }
         );

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -658,6 +658,42 @@ describe('RecordsServer', () => {
         jest.useRealTimers();
     });
 
+    describe('GET /api/v2/procedures', () => {
+        it('should return the list of procedures', async () => {
+            const result = await server.handleHttpRequest(
+                httpGet('/api/v2/procedures', defaultHeaders)
+            );
+
+            const body = expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    procedures: expect.any(Object),
+                },
+                headers: corsHeaders(defaultHeaders.origin),
+            });
+
+            expect(body).toMatchSnapshot();
+        });
+
+        it('should support procedures', async () => {
+            const result = await server.handleHttpRequest(
+                procedureRequest('listProcedures', {}, defaultHeaders)
+            );
+
+            const body = expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    procedures: expect.any(Object),
+                },
+                headers: corsHeaders(defaultHeaders.origin),
+            });
+
+            expect(body).toMatchSnapshot();
+        });
+    });
+
     describe('GET /api/{userId}/metadata', () => {
         it('should return the metadata for the given userId', async () => {
             const result = await server.handleHttpRequest(

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -1355,12 +1355,7 @@ export class RecordsServer {
                         recordName: RECORD_NAME_VALIDATION,
                         address: ADDRESS_VALIDATION.nullable().optional(),
                         marker: MARKER_VALIDATION.optional(),
-                        sort: z
-                            .union([
-                                z.literal('ascending'),
-                                z.literal('descending'),
-                            ])
-                            .optional(),
+                        sort: z.enum(['ascending', 'descending']).optional(),
                         instances: INSTANCES_ARRAY_VALIDATION.optional(),
                     })
                 )

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -35,6 +35,7 @@ import {
     RPCContext,
     RemoteProcedures,
     ResourceKinds,
+    getProcedureMetadata,
     procedure,
 } from '@casual-simulation/aux-common';
 import {
@@ -2851,6 +2852,16 @@ export class RecordsServer {
                         success: true,
                         ...data,
                     };
+                }),
+
+            listProcedures: procedure()
+                .origins(true)
+                .http('GET', '/api/v2/procedures')
+                .inputs(z.object({}))
+                .handler(async ({}, context) => {
+                    const procedures = this._procedures;
+                    const metadata = getProcedureMetadata(procedures);
+                    return { success: true, ...metadata };
                 }),
         };
     }

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1,0 +1,5307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecordsServer GET /api/v2/procedures should return the list of procedures 1`] = `
+Object {
+  "procedures": Array [
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/email/valid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "email": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "isEmailValid",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/displayName/valid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "displayName": Object {
+            "type": "string",
+          },
+          "name": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "isDisplayNameValid",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/createAccount",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "createAccount",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/sessions",
+      },
+      "inputs": Object {
+        "defaultValue": Object {},
+        "hasDefault": true,
+        "schema": Object {
+          "expireTimeMs": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listSessions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/replaceSession",
+      },
+      "name": "replaceSession",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/revokeAllSessions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeAllSessions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/revokeSession",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "sessionId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "sessionKey": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeSession",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/completeLogin",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "code": Object {
+            "type": "string",
+          },
+          "requestId": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "addressType": Object {
+            "type": "enum",
+            "values": Array [
+              "email",
+              "phone",
+            ],
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login/privo",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "requestPrivoLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/oauth/code",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "code": Object {
+            "type": "string",
+          },
+          "state": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "processOAuthCode",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/oauth/complete",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "requestId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeOAuthLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/register/privo",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "dateOfBirth": Object {
+            "type": "date",
+          },
+          "displayName": Object {
+            "type": "string",
+          },
+          "email": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "name": Object {
+            "type": "string",
+          },
+          "parentEmail": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestPrivoSignUp",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/register/options",
+      },
+      "name": "getWebAuthnRegistrationOptions",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/register",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "response": Object {
+            "schema": Object {
+              "authenticatorAttachment": Object {
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "cross-platform",
+                  "platform",
+                ],
+              },
+              "clientExtensionResults": Object {
+                "schema": Object {
+                  "appid": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                  "credProps": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "rk": Object {
+                        "optional": true,
+                        "type": "boolean",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "hmacCreateSecret": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                },
+                "type": "object",
+              },
+              "id": Object {
+                "type": "string",
+              },
+              "rawId": Object {
+                "type": "string",
+              },
+              "response": Object {
+                "schema": Object {
+                  "attestationObject": Object {
+                    "type": "string",
+                  },
+                  "authenticatorData": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "clientDataJSON": Object {
+                    "type": "string",
+                  },
+                  "publicKey": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "publicKeyAlgorithm": Object {
+                    "optional": true,
+                    "type": "number",
+                  },
+                  "transports": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "public-key",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "registerWebAuthn",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/login/options",
+      },
+      "name": "getWebAuthnLoginOptions",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/login",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "requestId": Object {
+            "type": "string",
+          },
+          "response": Object {
+            "schema": Object {
+              "authenticatorAttachment": Object {
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "cross-platform",
+                  "platform",
+                ],
+              },
+              "clientExtensionResults": Object {
+                "schema": Object {
+                  "appid": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                  "credProps": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "rk": Object {
+                        "optional": true,
+                        "type": "boolean",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "hmacCreateSecret": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                },
+                "type": "object",
+              },
+              "id": Object {
+                "type": "string",
+              },
+              "rawId": Object {
+                "type": "string",
+              },
+              "response": Object {
+                "schema": Object {
+                  "authenticatorData": Object {
+                    "type": "string",
+                  },
+                  "clientDataJSON": Object {
+                    "type": "string",
+                  },
+                  "signature": Object {
+                    "type": "string",
+                  },
+                  "userHandle": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "public-key",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeWebAuthnLogin",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/authenticators",
+      },
+      "name": "listUserAuthenticators",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/authenticators/delete",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "authenticatorId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteUserAuthenticator",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/meet/token",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "roomName": Object {
+            "type": "string",
+          },
+          "userName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createMeetToken",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "ownerId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createRecord",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/events/count",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "count": Object {
+            "type": "number",
+          },
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "addEventCount",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/events/count",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getEventCount",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/events/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "eventName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listEvents",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/events",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "count": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateEvent",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteManualData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getManualData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "data": Object {
+            "type": "any",
+          },
+          "deletePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+          "updatePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordManualData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "fileUrl": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/file/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listFiles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileUrl": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "eraseFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileByteLength": Object {
+            "type": "number",
+          },
+          "fileDescription": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "fileMimeType": Object {
+            "type": "string",
+          },
+          "fileSha256Hex": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "PUT",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileUrl": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "eraseData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/data/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "marker": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "sort": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "ascending",
+              },
+              Object {
+                "type": "literal",
+                "value": "descending",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "data": Object {
+            "type": "any",
+          },
+          "deletePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+          "updatePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listRecords",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/key",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "policy": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createRecordKey",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/permissions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "permission": Object {
+            "discriminator": "resourceKind",
+            "options": Array [
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "data",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "options": Object {
+                    "schema": Object {
+                      "allowedMimeTypes": Object {
+                        "optional": true,
+                        "options": Array [
+                          Object {
+                            "type": "literal",
+                            "value": true,
+                          },
+                          Object {
+                            "schema": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                      "maxFileSizeInBytes": Object {
+                        "optional": true,
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "file",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "increment",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "count",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "event",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "assign",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "unassign",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "grantPermission",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "revokePermission",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "marker",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "grant",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "revoke",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "options": Object {
+                    "schema": Object {
+                      "maxDurationMs": Object {
+                        "optional": true,
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "role",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "updateData",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "sendAction",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "inst",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+            ],
+            "type": "union",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "grantPermission",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/permissions/revoke",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "permissionId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokePermission",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/permissions/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "marker": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "resourceId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "resourceKind": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "data",
+              },
+              Object {
+                "type": "literal",
+                "value": "file",
+              },
+              Object {
+                "type": "literal",
+                "value": "event",
+              },
+              Object {
+                "type": "literal",
+                "value": "marker",
+              },
+              Object {
+                "type": "literal",
+                "value": "role",
+              },
+              Object {
+                "type": "literal",
+                "value": "inst",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listPermissions",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/user/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listUserRoles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/inst/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listInstRoles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/assignments/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "startingRole": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listRoleAssignments",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/role/grant",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "expireTimeMs": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "grantRole",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/role/revoke",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeRole",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/chat",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "frequencyPenalty": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "messages": Object {
+            "minLength": 1,
+            "schema": Object {
+              "schema": Object {
+                "author": Object {
+                  "optional": true,
+                  "type": "string",
+                },
+                "content": Object {
+                  "options": Array [
+                    Object {
+                      "type": "string",
+                    },
+                    Object {
+                      "schema": Object {
+                        "options": Array [
+                          Object {
+                            "schema": Object {
+                              "text": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          Object {
+                            "schema": Object {
+                              "base64": Object {
+                                "type": "string",
+                              },
+                              "mimeType": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          Object {
+                            "schema": Object {
+                              "url": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                  "type": "union",
+                },
+                "role": Object {
+                  "options": Array [
+                    Object {
+                      "type": "literal",
+                      "value": "system",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "user",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "assistant",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "function",
+                    },
+                  ],
+                  "type": "union",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "model": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "presencePenalty": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "stopWords": Object {
+            "maxLength": 4,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "temperature": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "topP": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "aiChat",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/skybox",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "blockadeLabs": Object {
+            "optional": true,
+            "schema": Object {
+              "remixImagineId": Object {
+                "optional": true,
+                "type": "number",
+              },
+              "seed": Object {
+                "optional": true,
+                "type": "number",
+              },
+              "skyboxStyleId": Object {
+                "optional": true,
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "negativePrompt": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createAiSkybox",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/ai/skybox",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "skyboxId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getAiSkybox",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/image",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "cfgScale": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "clipGuidancePreset": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "height": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "model": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "negativePrompt": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "numberOfImages": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+          "sampler": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "seed": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "steps": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "stylePreset": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "width": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createAiImage",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "displayName": Object {
+            "type": "string",
+          },
+          "ownerStudioComId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "PUT",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comIdConfig": Object {
+            "optional": true,
+            "schema": Object {
+              "allowedStudioCreators": Object {
+                "description": "Who is allowed to create studios in this comId.",
+                "options": Array [
+                  Object {
+                    "type": "literal",
+                    "value": "anyone",
+                  },
+                  Object {
+                    "type": "literal",
+                    "value": "only-members",
+                  },
+                ],
+                "type": "union",
+              },
+            },
+            "type": "object",
+          },
+          "displayName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "id": Object {
+            "type": "string",
+          },
+          "logoUrl": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "playerConfig": Object {
+            "description": "The configuration that the comId provides which overrides the default player configuration.",
+            "optional": true,
+            "schema": Object {
+              "ab1BootstrapURL": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "allowedBiosOptions": Object {
+                "nullable": true,
+                "optional": true,
+                "schema": Object {
+                  "type": "enum",
+                  "values": Array [
+                    "enter join code",
+                    "join inst",
+                    "static inst",
+                    "local inst",
+                    "local",
+                    "public inst",
+                    "private inst",
+                    "free inst",
+                    "free",
+                    "studio inst",
+                    "studio",
+                    "sign in",
+                    "sign up",
+                    "sign out",
+                  ],
+                },
+                "type": "array",
+              },
+              "arcGisApiKey": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "automaticBiosOption": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "enter join code",
+                  "join inst",
+                  "static inst",
+                  "local inst",
+                  "local",
+                  "public inst",
+                  "private inst",
+                  "free inst",
+                  "free",
+                  "studio inst",
+                  "studio",
+                  "sign in",
+                  "sign up",
+                  "sign out",
+                ],
+              },
+              "defaultBiosOption": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "enter join code",
+                  "join inst",
+                  "static inst",
+                  "local inst",
+                  "local",
+                  "public inst",
+                  "private inst",
+                  "free inst",
+                  "free",
+                  "studio inst",
+                  "studio",
+                  "sign in",
+                  "sign up",
+                  "sign out",
+                ],
+              },
+              "jitsiAppName": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "what3WordsApiKey": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios/requestComId",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "type": "string",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestStudioComId",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listStudios",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios/members/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listStudioMembers",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios/members",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "addedEmail": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "addedPhoneNumber": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "addedUserId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "role": Object {
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "admin",
+              },
+              Object {
+                "type": "literal",
+                "value": "member",
+              },
+            ],
+            "type": "union",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "addStudioMember",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/studios/members",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "removedUserId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "removeStudioMember",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/player/config",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getPlayerConfig",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/subscriptions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getSubscriptions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/subscriptions/manage",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "expectedPrice": Object {
+            "optional": true,
+            "schema": Object {
+              "cost": Object {
+                "type": "number",
+              },
+              "currency": Object {
+                "type": "string",
+              },
+              "interval": Object {
+                "type": "enum",
+                "values": Array [
+                  "month",
+                  "year",
+                  "week",
+                  "day",
+                ],
+              },
+              "intervalLength": Object {
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "subscriptionId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getManageSubscriptionLink",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/insts/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listInsts",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/insts",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordKey": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteInst",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/insts/report",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "automaticReport": Object {
+            "type": "boolean",
+          },
+          "inst": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "reportReason": Object {
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "poor-performance",
+              },
+              Object {
+                "type": "literal",
+                "value": "spam",
+              },
+              Object {
+                "type": "literal",
+                "value": "harassment",
+              },
+              Object {
+                "type": "literal",
+                "value": "copyright-infringement",
+              },
+              Object {
+                "type": "literal",
+                "value": "obscene",
+              },
+              Object {
+                "type": "literal",
+                "value": "illegal",
+              },
+              Object {
+                "type": "literal",
+                "value": "other",
+              },
+            ],
+            "type": "union",
+          },
+          "reportReasonText": Object {
+            "type": "string",
+          },
+          "reportedPermalink": Object {
+            "type": "string",
+          },
+          "reportedUrl": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "reportInst",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/instData",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "branch": Object {
+            "defaultValue": "default",
+            "hasDefault": true,
+            "type": "string",
+          },
+          "inst": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getInstData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/procedures",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "listProcedures",
+      "origins": true,
+    },
+  ],
+  "success": true,
+}
+`;
+
+exports[`RecordsServer GET /api/v2/procedures should support procedures 1`] = `
+Object {
+  "procedures": Array [
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/email/valid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "email": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "isEmailValid",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/displayName/valid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "displayName": Object {
+            "type": "string",
+          },
+          "name": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "isDisplayNameValid",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/createAccount",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "createAccount",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/sessions",
+      },
+      "inputs": Object {
+        "defaultValue": Object {},
+        "hasDefault": true,
+        "schema": Object {
+          "expireTimeMs": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listSessions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/replaceSession",
+      },
+      "name": "replaceSession",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/revokeAllSessions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeAllSessions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/revokeSession",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "sessionId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "sessionKey": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeSession",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/completeLogin",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "code": Object {
+            "type": "string",
+          },
+          "requestId": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "addressType": Object {
+            "type": "enum",
+            "values": Array [
+              "email",
+              "phone",
+            ],
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login/privo",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "requestPrivoLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/oauth/code",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "code": Object {
+            "type": "string",
+          },
+          "state": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "processOAuthCode",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/oauth/complete",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "requestId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeOAuthLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/register/privo",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "dateOfBirth": Object {
+            "type": "date",
+          },
+          "displayName": Object {
+            "type": "string",
+          },
+          "email": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "name": Object {
+            "type": "string",
+          },
+          "parentEmail": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestPrivoSignUp",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/register/options",
+      },
+      "name": "getWebAuthnRegistrationOptions",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/register",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "response": Object {
+            "schema": Object {
+              "authenticatorAttachment": Object {
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "cross-platform",
+                  "platform",
+                ],
+              },
+              "clientExtensionResults": Object {
+                "schema": Object {
+                  "appid": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                  "credProps": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "rk": Object {
+                        "optional": true,
+                        "type": "boolean",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "hmacCreateSecret": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                },
+                "type": "object",
+              },
+              "id": Object {
+                "type": "string",
+              },
+              "rawId": Object {
+                "type": "string",
+              },
+              "response": Object {
+                "schema": Object {
+                  "attestationObject": Object {
+                    "type": "string",
+                  },
+                  "authenticatorData": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "clientDataJSON": Object {
+                    "type": "string",
+                  },
+                  "publicKey": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "publicKeyAlgorithm": Object {
+                    "optional": true,
+                    "type": "number",
+                  },
+                  "transports": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "public-key",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "registerWebAuthn",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/login/options",
+      },
+      "name": "getWebAuthnLoginOptions",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/login",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "requestId": Object {
+            "type": "string",
+          },
+          "response": Object {
+            "schema": Object {
+              "authenticatorAttachment": Object {
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "cross-platform",
+                  "platform",
+                ],
+              },
+              "clientExtensionResults": Object {
+                "schema": Object {
+                  "appid": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                  "credProps": Object {
+                    "optional": true,
+                    "schema": Object {
+                      "rk": Object {
+                        "optional": true,
+                        "type": "boolean",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "hmacCreateSecret": Object {
+                    "optional": true,
+                    "type": "boolean",
+                  },
+                },
+                "type": "object",
+              },
+              "id": Object {
+                "type": "string",
+              },
+              "rawId": Object {
+                "type": "string",
+              },
+              "response": Object {
+                "schema": Object {
+                  "authenticatorData": Object {
+                    "type": "string",
+                  },
+                  "clientDataJSON": Object {
+                    "type": "string",
+                  },
+                  "signature": Object {
+                    "type": "string",
+                  },
+                  "userHandle": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "public-key",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "completeWebAuthnLogin",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/webauthn/authenticators",
+      },
+      "name": "listUserAuthenticators",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/webauthn/authenticators/delete",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "authenticatorId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteUserAuthenticator",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/meet/token",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "roomName": Object {
+            "type": "string",
+          },
+          "userName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createMeetToken",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "ownerId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createRecord",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/events/count",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "count": Object {
+            "type": "number",
+          },
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "addEventCount",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/events/count",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getEventCount",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/events/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "eventName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listEvents",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/events",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "count": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "eventName": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateEvent",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteManualData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getManualData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/manual/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "data": Object {
+            "type": "any",
+          },
+          "deletePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+          "updatePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordManualData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "fileUrl": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/file/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listFiles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileUrl": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "eraseFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileByteLength": Object {
+            "type": "number",
+          },
+          "fileDescription": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "fileMimeType": Object {
+            "type": "string",
+          },
+          "fileSha256Hex": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "PUT",
+        "path": "/api/v2/records/file",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "fileUrl": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateFile",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "eraseData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/data/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "marker": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "sort": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "ascending",
+              },
+              Object {
+                "type": "literal",
+                "value": "descending",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/data",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "address": Object {
+            "type": "string",
+          },
+          "data": Object {
+            "type": "any",
+          },
+          "deletePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "markers": Object {
+            "maxLength": 10,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordKey": Object {
+            "type": "string",
+          },
+          "updatePolicy": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": true,
+              },
+              Object {
+                "schema": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "recordData",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listRecords",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/key",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "policy": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createRecordKey",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/permissions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "permission": Object {
+            "discriminator": "resourceKind",
+            "options": Array [
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "data",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "options": Object {
+                    "schema": Object {
+                      "allowedMimeTypes": Object {
+                        "optional": true,
+                        "options": Array [
+                          Object {
+                            "type": "literal",
+                            "value": true,
+                          },
+                          Object {
+                            "schema": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                      "maxFileSizeInBytes": Object {
+                        "optional": true,
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "file",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "increment",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "count",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "event",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "assign",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "unassign",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "grantPermission",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "revokePermission",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "marker",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "grant",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "revoke",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "options": Object {
+                    "schema": Object {
+                      "maxDurationMs": Object {
+                        "optional": true,
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "role",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "create",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "read",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "update",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "updateData",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "delete",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "list",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "sendAction",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "inst",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "options": Array [
+                      Object {
+                        "type": "literal",
+                        "value": "user",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "inst",
+                      },
+                      Object {
+                        "type": "literal",
+                        "value": "role",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                },
+                "type": "object",
+              },
+            ],
+            "type": "union",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "grantPermission",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/permissions/revoke",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "permissionId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokePermission",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/permissions/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "marker": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "resourceId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "resourceKind": Object {
+            "optional": true,
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "data",
+              },
+              Object {
+                "type": "literal",
+                "value": "file",
+              },
+              Object {
+                "type": "literal",
+                "value": "event",
+              },
+              Object {
+                "type": "literal",
+                "value": "marker",
+              },
+              Object {
+                "type": "literal",
+                "value": "role",
+              },
+              Object {
+                "type": "literal",
+                "value": "inst",
+              },
+            ],
+            "type": "union",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listPermissions",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/user/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listUserRoles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/inst/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listInstRoles",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/role/assignments/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "startingRole": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listRoleAssignments",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/role/grant",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "expireTimeMs": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "grantRole",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/role/revoke",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "role": Object {
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "revokeRole",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/chat",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "frequencyPenalty": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "messages": Object {
+            "minLength": 1,
+            "schema": Object {
+              "schema": Object {
+                "author": Object {
+                  "optional": true,
+                  "type": "string",
+                },
+                "content": Object {
+                  "options": Array [
+                    Object {
+                      "type": "string",
+                    },
+                    Object {
+                      "schema": Object {
+                        "options": Array [
+                          Object {
+                            "schema": Object {
+                              "text": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          Object {
+                            "schema": Object {
+                              "base64": Object {
+                                "type": "string",
+                              },
+                              "mimeType": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          Object {
+                            "schema": Object {
+                              "url": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                  "type": "union",
+                },
+                "role": Object {
+                  "options": Array [
+                    Object {
+                      "type": "literal",
+                      "value": "system",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "user",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "assistant",
+                    },
+                    Object {
+                      "type": "literal",
+                      "value": "function",
+                    },
+                  ],
+                  "type": "union",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "model": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "presencePenalty": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "stopWords": Object {
+            "maxLength": 4,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "temperature": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "topP": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "aiChat",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/skybox",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "blockadeLabs": Object {
+            "optional": true,
+            "schema": Object {
+              "remixImagineId": Object {
+                "optional": true,
+                "type": "number",
+              },
+              "seed": Object {
+                "optional": true,
+                "type": "number",
+              },
+              "skyboxStyleId": Object {
+                "optional": true,
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "negativePrompt": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createAiSkybox",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/ai/skybox",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "skyboxId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getAiSkybox",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/image",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "cfgScale": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "clipGuidancePreset": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "height": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "model": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "negativePrompt": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "numberOfImages": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+          "sampler": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "seed": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "steps": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "stylePreset": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "width": Object {
+            "optional": true,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createAiImage",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "displayName": Object {
+            "type": "string",
+          },
+          "ownerStudioComId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "PUT",
+        "path": "/api/v2/studios",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comIdConfig": Object {
+            "optional": true,
+            "schema": Object {
+              "allowedStudioCreators": Object {
+                "description": "Who is allowed to create studios in this comId.",
+                "options": Array [
+                  Object {
+                    "type": "literal",
+                    "value": "anyone",
+                  },
+                  Object {
+                    "type": "literal",
+                    "value": "only-members",
+                  },
+                ],
+                "type": "union",
+              },
+            },
+            "type": "object",
+          },
+          "displayName": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "id": Object {
+            "type": "string",
+          },
+          "logoUrl": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "playerConfig": Object {
+            "description": "The configuration that the comId provides which overrides the default player configuration.",
+            "optional": true,
+            "schema": Object {
+              "ab1BootstrapURL": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "allowedBiosOptions": Object {
+                "nullable": true,
+                "optional": true,
+                "schema": Object {
+                  "type": "enum",
+                  "values": Array [
+                    "enter join code",
+                    "join inst",
+                    "static inst",
+                    "local inst",
+                    "local",
+                    "public inst",
+                    "private inst",
+                    "free inst",
+                    "free",
+                    "studio inst",
+                    "studio",
+                    "sign in",
+                    "sign up",
+                    "sign out",
+                  ],
+                },
+                "type": "array",
+              },
+              "arcGisApiKey": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "automaticBiosOption": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "enter join code",
+                  "join inst",
+                  "static inst",
+                  "local inst",
+                  "local",
+                  "public inst",
+                  "private inst",
+                  "free inst",
+                  "free",
+                  "studio inst",
+                  "studio",
+                  "sign in",
+                  "sign up",
+                  "sign out",
+                ],
+              },
+              "defaultBiosOption": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "enum",
+                "values": Array [
+                  "enter join code",
+                  "join inst",
+                  "static inst",
+                  "local inst",
+                  "local",
+                  "public inst",
+                  "private inst",
+                  "free inst",
+                  "free",
+                  "studio inst",
+                  "studio",
+                  "sign in",
+                  "sign up",
+                  "sign out",
+                ],
+              },
+              "jitsiAppName": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+              "what3WordsApiKey": Object {
+                "nullable": true,
+                "optional": true,
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateStudio",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios/requestComId",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "type": "string",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestStudioComId",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listStudios",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/studios/members/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listStudioMembers",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/studios/members",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "addedEmail": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "addedPhoneNumber": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "addedUserId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "role": Object {
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "admin",
+              },
+              Object {
+                "type": "literal",
+                "value": "member",
+              },
+            ],
+            "type": "union",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "addStudioMember",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/studios/members",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "removedUserId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "studioId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "removeStudioMember",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/player/config",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "comId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getPlayerConfig",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/subscriptions",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getSubscriptions",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/subscriptions/manage",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "expectedPrice": Object {
+            "optional": true,
+            "schema": Object {
+              "cost": Object {
+                "type": "number",
+              },
+              "currency": Object {
+                "type": "string",
+              },
+              "interval": Object {
+                "type": "enum",
+                "values": Array [
+                  "month",
+                  "year",
+                  "week",
+                  "day",
+                ],
+              },
+              "intervalLength": Object {
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "subscriptionId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getManageSubscriptionLink",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/records/insts/list",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "listInsts",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "DELETE",
+        "path": "/api/v2/records/insts",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "inst": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordKey": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "deleteInst",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/insts/report",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "automaticReport": Object {
+            "type": "boolean",
+          },
+          "inst": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "reportReason": Object {
+            "options": Array [
+              Object {
+                "type": "literal",
+                "value": "poor-performance",
+              },
+              Object {
+                "type": "literal",
+                "value": "spam",
+              },
+              Object {
+                "type": "literal",
+                "value": "harassment",
+              },
+              Object {
+                "type": "literal",
+                "value": "copyright-infringement",
+              },
+              Object {
+                "type": "literal",
+                "value": "obscene",
+              },
+              Object {
+                "type": "literal",
+                "value": "illegal",
+              },
+              Object {
+                "type": "literal",
+                "value": "other",
+              },
+            ],
+            "type": "union",
+          },
+          "reportReasonText": Object {
+            "type": "string",
+          },
+          "reportedPermalink": Object {
+            "type": "string",
+          },
+          "reportedUrl": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "reportInst",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/instData",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "branch": Object {
+            "defaultValue": "default",
+            "hasDefault": true,
+            "type": "string",
+          },
+          "inst": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getInstData",
+      "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/procedures",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "listProcedures",
+      "origins": true,
+    },
+  ],
+  "success": true,
+}
+`;

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1010,17 +1010,11 @@ Object {
           },
           "sort": Object {
             "optional": true,
-            "options": Array [
-              Object {
-                "type": "literal",
-                "value": "ascending",
-              },
-              Object {
-                "type": "literal",
-                "value": "descending",
-              },
+            "type": "enum",
+            "values": Array [
+              "ascending",
+              "descending",
             ],
-            "type": "union",
           },
         },
         "type": "object",
@@ -3663,17 +3657,11 @@ Object {
           },
           "sort": Object {
             "optional": true,
-            "options": Array [
-              Object {
-                "type": "literal",
-                "value": "ascending",
-              },
-              Object {
-                "type": "literal",
-                "value": "descending",
-              },
+            "type": "enum",
+            "values": Array [
+              "ascending",
+              "descending",
             ],
-            "type": "union",
           },
         },
         "type": "object",

--- a/src/casualos-cli/.gitignore
+++ b/src/casualos-cli/.gitignore
@@ -4,3 +4,4 @@
 !typings/**/*
 docs
 package-lock.json
+dist/

--- a/src/casualos-cli/.gitignore
+++ b/src/casualos-cli/.gitignore
@@ -1,0 +1,6 @@
+*.js
+*.js.map
+*.d.ts
+!typings/**/*
+docs
+package-lock.json

--- a/src/casualos-cli/LICENSE.txt
+++ b/src/casualos-cli/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Casual Simulation, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/casualos-cli/README.md
+++ b/src/casualos-cli/README.md
@@ -1,0 +1,17 @@
+# CasualOS CLI
+
+[![npm (scoped)](https://img.shields.io/npm/v/casualos.svg)](https://www.npmjs.com/package/casualos)
+
+## Installation
+
+Install to your global package directory:
+
+```bash
+$ npm install -g casualos
+```
+
+Execute directly from NPM:
+
+```bash
+$ npx casualos
+```

--- a/src/casualos-cli/README.md
+++ b/src/casualos-cli/README.md
@@ -10,8 +10,109 @@ Install to your global package directory:
 $ npm install -g casualos
 ```
 
-Execute directly from NPM:
+Or, execute directly from NPM:
 
 ```bash
 $ npx casualos
+```
+
+## Usage
+
+```
+Usage: casualos [options] [command]
+
+A CLI for CasualOS
+
+Options:
+  -V, --version                        output the version number
+  -e, --endpoint <url>                 The endpoint to use for queries. Can be used to override the current endpoint.
+  -h, --help                           display help for command
+
+Commands:
+  login                                Login to the CasualOS API
+  logout                               Logout of the CasualOS API
+  set-endpoint [endpoint]              Set the endpoint that is currently in use.
+  status                               Get the status of the current session.
+  query [options] [procedure] [input]  Query the CasualOS API
+  repl [options]                       Start a REPL for the CasualOS API
+  help [command]                       display help for command
+```
+
+### Commands
+
+#### `login`
+
+```
+$ casualos help login
+
+Usage: casualos login [options]
+
+Login to the CasualOS API
+
+Options:
+  -h, --help  display help for command
+```
+
+#### `logout`
+
+```
+$ casualos help logout
+
+Usage: casualos logout [options]
+
+Logout of the CasualOS API
+
+Options:
+  -h, --help  display help for command
+```
+
+#### `set-endpoint`
+
+```
+$ casualos help set-endpoint
+
+Usage: casualos set-endpoint [options] [endpoint]
+
+Set the endpoint that is currently in use.
+
+Arguments:
+  endpoint    The endpoint to use for queries. If omitted, then you will be prompted to enter an endpoint.
+
+Options:
+  -h, --help  display help for command
+```
+
+#### `query`
+
+```
+$ casualos help query
+
+Usage: casualos query [options] [procedure] [input]
+
+Query the CasualOS API
+
+Arguments:
+  procedure        The procedure to execute. If omitted, then you will be prompted to select a procedure.
+  input            The input to the procedure. If specified, then it will be parsed as JSON. If omitted, then you will be prompted to enter the input.
+
+Options:
+  -k, --key <key>  The session key to use for the query. If not specified, then the current session key will be used.
+  -h, --help       display help for command
+```
+
+#### `repl`
+
+```
+$ casualos help repl
+
+Usage: casualos repl [options]
+
+Start a REPL for the CasualOS API
+
+Options:
+  -k, --key <key>  The session key to use for the session. If omitted, then the current session key will be used.
+  -h, --help       display help for command
+
+The CasualOS REPL allows you to interact with the CasualOS API using a Read-Eval-Print Loop (REPL).
+It supports JavaScript and has a special function, query([procedure], [input]), that can be used to query the API.
 ```

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -55,9 +55,14 @@ program
 
 program
     .command('set-endpoint')
+    .argument('[endpoint]', 'The endpoint to use for queries.')
     .description('Set the endpoint that is currently in use.')
-    .action(async () => {
-        await updateEndpoint();
+    .action(async (endpoint) => {
+        if (endpoint) {
+            saveCurrentEndpoint(endpoint);
+        } else {
+            await updateEndpoint();
+        }
     });
 
 program
@@ -487,6 +492,7 @@ async function getEndpoint(endpoint: string) {
         return endpoint;
     }
     let savedEndpoint = getCurrentEndpoint();
+    console.log('saved endpoint', savedEndpoint);
     if (!savedEndpoint) {
         savedEndpoint = await updateEndpoint();
     }
@@ -505,9 +511,13 @@ async function updateEndpoint() {
     });
 
     const savedEndpoint = response.endpoint;
-    config.set('currentEndpoint', savedEndpoint);
-    console.log('Endpoint updated to ' + savedEndpoint);
+    saveCurrentEndpoint(savedEndpoint);
     return savedEndpoint;
+}
+
+function saveCurrentEndpoint(endpoint: string) {
+    config.set('currentEndpoint', endpoint);
+    console.log('Endpoint updated to:', endpoint);
 }
 
 function getHeaders(client: RecordsClient) {

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -273,7 +273,7 @@ async function getOrRefreshSessionKey(endpoint: string) {
 }
 
 function getSessionKey(endpoint: string) {
-    return String(config.get(`${endpoint}:sessionKey`));
+    return convertToString(config.get(`${endpoint}:sessionKey`));
 }
 
 function saveSessionKey(endpoint: string, key: string) {
@@ -494,7 +494,7 @@ async function getEndpoint(endpoint: string) {
 }
 
 function getCurrentEndpoint() {
-    return String(config.get('currentEndpoint'));
+    return convertToString(config.get('currentEndpoint'));
 }
 
 async function updateEndpoint() {
@@ -545,6 +545,13 @@ async function main() {
     } catch (err) {
         console.error(err);
     }
+}
+
+function convertToString(str: unknown) {
+    if (typeof str === 'undefined' || str === null) {
+        return str;
+    }
+    return String(str);
 }
 
 main();

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -31,7 +31,10 @@ program
     .name('casualos')
     .description('A CLI for CasualOS')
     .version('0.0.1')
-    .option('-e, --endpoint <url>', 'The endpoint to use for queries.');
+    .option(
+        '-e, --endpoint <url>',
+        'The endpoint to use for queries. Can be used to override the current endpoint.'
+    );
 
 program
     .command('login')
@@ -55,7 +58,10 @@ program
 
 program
     .command('set-endpoint')
-    .argument('[endpoint]', 'The endpoint to use for queries.')
+    .argument(
+        '[endpoint]',
+        'The endpoint to use for queries. If omitted, then you will be prompted to enter an endpoint.'
+    )
     .description('Set the endpoint that is currently in use.')
     .action(async (endpoint) => {
         if (endpoint) {
@@ -76,9 +82,18 @@ program
 program
     .command('query')
     .description('Query the CasualOS API')
-    .argument('[procedure]', 'The procedure to execute')
-    .argument('[input]', 'The input to the procedure')
-    .option('-k, --key <key>', 'The session key to use for the query.')
+    .argument(
+        '[procedure]',
+        'The procedure to execute. If omitted, then you will be prompted to select a procedure.'
+    )
+    .argument(
+        '[input]',
+        'The input to the procedure. If specified, then it will be parsed as JSON. If omitted, then you will be prompted to enter the input.'
+    )
+    .option(
+        '-k, --key <key>',
+        'The session key to use for the query. If not specified, then the current session key will be used.'
+    )
     .action(async (procedure, input, options) => {
         const opts = program.optsWithGlobals();
         const endpoint = await getEndpoint(opts.endpoint);
@@ -93,7 +108,14 @@ program
 program
     .command('repl')
     .description('Start a REPL for the CasualOS API')
-    .option('-k, --key <key>', 'The session key to use for the query.')
+    .option(
+        '-k, --key <key>',
+        'The session key to use for the session. If omitted, then the current session key will be used.'
+    )
+    .addHelpText(
+        'after',
+        `\nThe CasualOS REPL allows you to interact with the CasualOS API using a Read-Eval-Print Loop (REPL).\nIt supports JavaScript and has a special function, query([procedure], [input]), that can be used to query the API.`
+    )
     .action(async (options) => {
         const opts = program.optsWithGlobals();
         const endpoint = await getEndpoint(opts.endpoint);

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -4,6 +4,14 @@ import {
     RecordsClient,
     createRecordsClient,
 } from '@casual-simulation/aux-records/RecordsClient';
+import type {
+    ArraySchemaMetadata,
+    DiscriminatedUnionSchemaMetadata,
+    EnumSchemaMetadata,
+    ObjectSchemaMetadata,
+    SchemaMetadata,
+    UnionSchemaMetadata,
+} from '../aux-common';
 const program = new Command();
 
 let client: ReturnType<typeof createRecordsClient>;
@@ -38,14 +46,240 @@ program
     .command('query')
     .description('Query the CasualOS API')
     .argument('[procedure]', 'The procedure to execute')
+    .option('-k, --key <key>', 'The session key to use for the query.')
     .action(async (procedure, options) => {
-        const client = await getClient(options.endpoint);
+        const opts = program.optsWithGlobals();
+        const client = await getClient(opts.endpoint);
+        if (options.key) {
+            client.sessionKey = options.key;
+        }
+        const availableOperations = await client.listProcedures({});
         if (!procedure) {
-            // const availableOperations = await client.
+            const response = await prompts({
+                type: 'select',
+                name: 'procedure',
+                message: 'Select the procedure to execute',
+                choices: availableOperations.procedures.map((op) => ({
+                    title: op.name,
+                    value: op.name,
+                })),
+            });
+            procedure = response.procedure;
+        }
+
+        const operation = availableOperations.procedures.find(
+            (p) => p.name === procedure
+        );
+
+        if (!operation) {
+            console.error(`Could not find operation ${procedure}!`);
+            return;
+        }
+
+        console.log('Your selected operation:', operation);
+
+        const input = await askForInputs(operation.inputs, operation.name);
+
+        console.log('Your input:', input);
+
+        const confirm = await prompts({
+            type: 'confirm',
+            name: 'continue',
+            message: 'Do you want to continue?',
+        });
+
+        if (confirm.continue) {
+            const result = await client.callProcedure(operation.name, input, {
+                headers: {
+                    origin: opts.endpoint,
+                },
+            });
+
+            console.log('Result:', result);
+        } else {
+            console.log('Cancelled.');
         }
     });
 
-program.parse();
+async function askForInputs(
+    inputs: SchemaMetadata,
+    name: string
+): Promise<any> {
+    if (inputs) {
+        if (inputs.type === 'object') {
+            return await askForObjectInputs(inputs, name);
+        } else if (inputs.type === 'string') {
+            const response = await prompts({
+                type: 'text',
+                name: 'value',
+                message: `Enter a value for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'number') {
+            const response = await prompts({
+                type: 'number',
+                name: 'value',
+                message: `Enter a number for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'boolean') {
+            const response = await prompts({
+                type: 'toggle',
+                name: 'value',
+                message: `Enable ${name}?`,
+                initial: inputs.defaultValue ?? undefined,
+                active: 'yes',
+                inactive: 'no',
+            });
+
+            return response.value;
+        } else if (inputs.type === 'date') {
+            const response = await prompts({
+                type: 'date',
+                name: 'value',
+                message: `Enter a date for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'literal') {
+            return inputs.value;
+        } else if (inputs.type === 'array') {
+            return await askForArrayInputs(inputs, name);
+        } else if (inputs.type === 'enum') {
+            return await askForEnumInputs(inputs, name);
+        } else if (inputs.type === 'union') {
+            return await askForUnionInputs(inputs, name);
+        }
+    }
+
+    return undefined;
+}
+
+async function askForObjectInputs(
+    inputs: ObjectSchemaMetadata,
+    name: string
+): Promise<any> {
+    const result: any = {};
+    for (let key in inputs.schema) {
+        const prop = inputs.schema[key];
+        const value = await askForInputs(prop, `${name}.${key}`);
+        result[key] = value;
+    }
+    return result;
+}
+
+async function askForArrayInputs(
+    inputs: ArraySchemaMetadata,
+    name: string
+): Promise<any[]> {
+    const result: any[] = [];
+    let length = 0;
+    if (typeof inputs.exactLength === 'number') {
+        length = inputs.exactLength;
+    } else {
+        const response = await prompts({
+            type: 'number',
+            name: 'length',
+            message: `Enter the length of the array for ${name}.`,
+            min: inputs.minLength ?? undefined,
+            max: inputs.maxLength ?? undefined,
+        });
+        length = response.length;
+    }
+
+    for (let i = 0; i < length; i++) {
+        const value = await askForInputs(inputs.schema, `${name}[${i}]`);
+        result.push(value);
+    }
+
+    return result;
+}
+
+async function askForEnumInputs(
+    inputs: EnumSchemaMetadata,
+    name: string
+): Promise<any> {
+    const response = await prompts({
+        type: 'select',
+        name: 'value',
+        message: `Select a value for ${name}.`,
+        choices: inputs.values.map((value) => ({
+            title: value,
+            value: value,
+        })),
+    });
+
+    return response.value;
+}
+
+async function askForUnionInputs(
+    inputs: UnionSchemaMetadata,
+    name: string
+): Promise<any> {
+    if ('discriminator' in inputs) {
+        return await askForDiscriminatedUnionInputs(
+            inputs as DiscriminatedUnionSchemaMetadata,
+            name
+        );
+    } else {
+        const kind = await prompts({
+            type: 'select',
+            name: 'kind',
+            message: `Select a kind for ${name}.`,
+            choices: inputs.options.map((option) => ({
+                title: option.type,
+                description: option.description,
+                value: option,
+            })),
+        });
+
+        return await askForInputs(kind.kind, name);
+    }
+}
+
+async function askForDiscriminatedUnionInputs(
+    inputs: DiscriminatedUnionSchemaMetadata,
+    name: string
+): Promise<any> {
+    const kind = await prompts({
+        type: 'select',
+        name: 'kind',
+        message: `Select a ${inputs.discriminator} for ${name}.`,
+        choices: inputs.options.map((option) => {
+            const prop = option.schema[inputs.discriminator];
+            if (prop.type !== 'literal') {
+                return {
+                    title: option.type,
+                    description: option.description,
+                    value: option,
+                };
+            }
+
+            return {
+                title: prop.value,
+                description: option.description,
+                value: option,
+            };
+        }),
+    });
+
+    return await askForInputs(kind.kind, name);
+}
+
+async function main() {
+    try {
+        await program.parseAsync(process.argv);
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+main();
 
 // async function start() {
 //     const reponse = await prompts({

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -557,9 +557,9 @@ async function main() {
     }
 }
 
-function convertToString(str: unknown) {
+function convertToString(str: unknown): string {
     if (typeof str === 'undefined' || str === null) {
-        return str;
+        return str as string;
     }
     return String(str);
 }

--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -1,0 +1,66 @@
+import prompts from 'prompts';
+import { Command } from 'commander';
+import {
+    RecordsClient,
+    createRecordsClient,
+} from '@casual-simulation/aux-records/RecordsClient';
+const program = new Command();
+
+let client: ReturnType<typeof createRecordsClient>;
+let savedEndpoint: string;
+
+async function getClient(endpoint: string) {
+    if (!endpoint) {
+        if (!savedEndpoint) {
+            const response = await prompts({
+                type: 'text',
+                name: 'endpoint',
+                message: 'Enter the endpoint to use for queries.',
+            });
+
+            savedEndpoint = response.endpoint;
+        }
+        endpoint = savedEndpoint;
+    }
+    if (!client) {
+        client = createRecordsClient(endpoint);
+    }
+    return client;
+}
+
+program
+    .name('casualos')
+    .description('A CLI for CasualOS')
+    .version('0.0.1')
+    .option('-e, --endpoint <url>', 'The endpoint to use for queries.');
+
+program
+    .command('query')
+    .description('Query the CasualOS API')
+    .argument('[procedure]', 'The procedure to execute')
+    .action(async (procedure, options) => {
+        const client = await getClient(options.endpoint);
+        if (!procedure) {
+            // const availableOperations = await client.
+        }
+    });
+
+program.parse();
+
+// async function start() {
+//     const reponse = await prompts({
+//         type: 'select',
+//         name: 'action',
+//         message: 'What would you like to do?',
+//         choices: [
+//             { title: 'Migrate', value: 'migrate' },
+//             { title: 'Collect Responses', value: 'collect' },
+//         ],
+//     });
+
+//     if (reponse.action === 'migrate') {
+//         await migrate();
+//     } else {
+//         await collectAndSaveResponses();
+//     }
+// }

--- a/src/casualos-cli/index.ts
+++ b/src/casualos-cli/index.ts
@@ -1,0 +1,3 @@
+import { RecordsClient } from '@casual-simulation/aux-records/RecordsClient';
+
+export { RecordsClient };

--- a/src/casualos-cli/package.json
+++ b/src/casualos-cli/package.json
@@ -2,14 +2,15 @@
     "name": "casualos",
     "version": "3.2.19",
     "description": "Common library for AUX Vue components and Misc",
-    "main": "index.js",
+    "main": "./dist/index.js",
     "types": "index.d.ts",
-    "module": "index",
+    "module": "./dist/index.js",
     "bin": {
-        "casualos": "./cli.js"
+        "casualos": "./dist/cli.js"
     },
     "scripts": {
-        "start": "node ./cli.js",
+        "start": "node ./dist/cli.js",
+        "build": "node ./script/build-cli.mjs",
         "test": "jest",
         "test:watch": "jest --watchAll"
     },

--- a/src/casualos-cli/package.json
+++ b/src/casualos-cli/package.json
@@ -40,7 +40,8 @@
         "axios": "1.6.2",
         "prompts": "2.4.2",
         "commander": "12.0.0",
-        "conf": "12.0.0"
+        "conf": "12.0.0",
+        "open": "10.1.0"
     },
     "devDependencies": {
         "@types/prompts": "^2.4.9"

--- a/src/casualos-cli/package.json
+++ b/src/casualos-cli/package.json
@@ -10,6 +10,7 @@
     },
     "scripts": {
         "start": "node ./dist/cli.js",
+        "dev": "npm run build && npm start",
         "build": "node ./script/build-cli.mjs",
         "test": "jest",
         "test:watch": "jest --watchAll"
@@ -37,9 +38,12 @@
         "@casual-simulation/aux-common": "^3.2.19",
         "@casual-simulation/aux-records": "^3.2.19",
         "axios": "1.6.2",
-        "@types/prompts": "^2.4.9",
         "prompts": "2.4.2",
-        "commander": "12.0.0"
+        "commander": "12.0.0",
+        "conf": "12.0.0"
+    },
+    "devDependencies": {
+        "@types/prompts": "^2.4.9"
     },
     "files": [
         "/README.md",

--- a/src/casualos-cli/package.json
+++ b/src/casualos-cli/package.json
@@ -1,0 +1,51 @@
+{
+    "name": "casualos",
+    "version": "3.2.19",
+    "description": "Common library for AUX Vue components and Misc",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "module": "index",
+    "bin": {
+        "casualos": "./cli.js"
+    },
+    "scripts": {
+        "start": "node ./cli.js",
+        "test": "jest",
+        "test:watch": "jest --watchAll"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/casual-simulation/casualos.git"
+    },
+    "keywords": [
+        "aux",
+        "so4",
+        "realtime",
+        "crdt"
+    ],
+    "author": "Casual Simulation, Inc.",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/casual-simulation/casualos/issues"
+    },
+    "homepage": "https://github.com/casual-simulation/casualos#readme",
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "@casual-simulation/aux-common": "^3.2.19",
+        "@casual-simulation/aux-records": "^3.2.19",
+        "axios": "1.6.2",
+        "@types/prompts": "^2.4.9",
+        "prompts": "2.4.2",
+        "commander": "12.0.0"
+    },
+    "files": [
+        "/README.md",
+        "/LICENSE.txt",
+        "**/*.js",
+        "**/*.js.map",
+        "**/*.d.ts",
+        "**/*.def"
+    ]
+}

--- a/src/casualos-cli/schema.ts
+++ b/src/casualos-cli/schema.ts
@@ -1,0 +1,179 @@
+import prompts from 'prompts';
+import type {
+    ArraySchemaMetadata,
+    DiscriminatedUnionSchemaMetadata,
+    EnumSchemaMetadata,
+    ObjectSchemaMetadata,
+    SchemaMetadata,
+    UnionSchemaMetadata,
+} from '../aux-common';
+
+export async function askForInputs(
+    inputs: SchemaMetadata,
+    name: string
+): Promise<any> {
+    if (inputs) {
+        if (inputs.type === 'object') {
+            return await askForObjectInputs(inputs, name);
+        } else if (inputs.type === 'string') {
+            const response = await prompts({
+                type: 'text',
+                name: 'value',
+                message: `Enter a value for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'number') {
+            const response = await prompts({
+                type: 'number',
+                name: 'value',
+                message: `Enter a number for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'boolean') {
+            const response = await prompts({
+                type: 'toggle',
+                name: 'value',
+                message: `Enable ${name}?`,
+                initial: inputs.defaultValue ?? undefined,
+                active: 'yes',
+                inactive: 'no',
+            });
+
+            return response.value;
+        } else if (inputs.type === 'date') {
+            const response = await prompts({
+                type: 'date',
+                name: 'value',
+                message: `Enter a date for ${name}.`,
+                initial: inputs.defaultValue ?? undefined,
+            });
+
+            return response.value;
+        } else if (inputs.type === 'literal') {
+            return inputs.value;
+        } else if (inputs.type === 'array') {
+            return await askForArrayInputs(inputs, name);
+        } else if (inputs.type === 'enum') {
+            return await askForEnumInputs(inputs, name);
+        } else if (inputs.type === 'union') {
+            return await askForUnionInputs(inputs, name);
+        }
+    }
+
+    return undefined;
+}
+
+async function askForObjectInputs(
+    inputs: ObjectSchemaMetadata,
+    name: string
+): Promise<any> {
+    const result: any = {};
+    for (let key in inputs.schema) {
+        const prop = inputs.schema[key];
+        const value = await askForInputs(prop, `${name}.${key}`);
+        result[key] = value;
+    }
+    return result;
+}
+
+async function askForArrayInputs(
+    inputs: ArraySchemaMetadata,
+    name: string
+): Promise<any[]> {
+    const result: any[] = [];
+    let length = 0;
+    if (typeof inputs.exactLength === 'number') {
+        length = inputs.exactLength;
+    } else {
+        const response = await prompts({
+            type: 'number',
+            name: 'length',
+            message: `Enter the length of the array for ${name}.`,
+            min: inputs.minLength ?? undefined,
+            max: inputs.maxLength ?? undefined,
+        });
+        length = response.length;
+    }
+
+    for (let i = 0; i < length; i++) {
+        const value = await askForInputs(inputs.schema, `${name}[${i}]`);
+        result.push(value);
+    }
+
+    return result;
+}
+
+async function askForEnumInputs(
+    inputs: EnumSchemaMetadata,
+    name: string
+): Promise<any> {
+    const response = await prompts({
+        type: 'select',
+        name: 'value',
+        message: `Select a value for ${name}.`,
+        choices: inputs.values.map((value) => ({
+            title: value,
+            value: value,
+        })),
+    });
+
+    return response.value;
+}
+
+async function askForUnionInputs(
+    inputs: UnionSchemaMetadata,
+    name: string
+): Promise<any> {
+    if ('discriminator' in inputs) {
+        return await askForDiscriminatedUnionInputs(
+            inputs as DiscriminatedUnionSchemaMetadata,
+            name
+        );
+    } else {
+        const kind = await prompts({
+            type: 'select',
+            name: 'kind',
+            message: `Select a kind for ${name}.`,
+            choices: inputs.options.map((option) => ({
+                title: option.type,
+                description: option.description,
+                value: option,
+            })),
+        });
+
+        return await askForInputs(kind.kind, name);
+    }
+}
+
+async function askForDiscriminatedUnionInputs(
+    inputs: DiscriminatedUnionSchemaMetadata,
+    name: string
+): Promise<any> {
+    const kind = await prompts({
+        type: 'select',
+        name: 'kind',
+        message: `Select a ${inputs.discriminator} for ${name}.`,
+        choices: inputs.options.map((option) => {
+            const prop = option.schema[inputs.discriminator];
+            if (prop.type !== 'literal') {
+                return {
+                    title: option.type,
+                    description: option.description,
+                    value: option,
+                };
+            }
+
+            return {
+                title: prop.value,
+                description: option.description,
+                value: option,
+            };
+        }),
+    });
+
+    return await askForInputs(kind.kind, name);
+}

--- a/src/casualos-cli/script/build-cli.mjs
+++ b/src/casualos-cli/script/build-cli.mjs
@@ -1,0 +1,4 @@
+import { build } from '../../../script/build-helpers.mjs';
+import { createConfigs } from './cli-configs.mjs';
+
+build(createConfigs(false));

--- a/src/casualos-cli/script/clean.mjs
+++ b/src/casualos-cli/script/clean.mjs
@@ -1,0 +1,3 @@
+import { cleanDirectories as cleanServerDirectories } from './cli-configs.mjs';
+
+cleanServerDirectories();

--- a/src/casualos-cli/script/cli-configs.mjs
+++ b/src/casualos-cli/script/cli-configs.mjs
@@ -35,6 +35,7 @@ export function createConfigs(dev, version) {
                     ...developmentVariables,
                 },
                 minify: false,
+                external: ['open'],
             },
         ],
     ];

--- a/src/casualos-cli/script/cli-configs.mjs
+++ b/src/casualos-cli/script/cli-configs.mjs
@@ -1,0 +1,41 @@
+import path from 'path';
+import { paths, cleanDirectory } from '../../../script/build-helpers.mjs';
+import { GIT_HASH, GIT_TAG } from '../../../script/git-stats.mjs';
+
+const src = path.resolve(paths.root, 'src');
+const casualosCli = path.resolve(src, 'casualos-cli');
+const dist = path.resolve(casualosCli, 'dist');
+
+export function cleanDirectories() {
+    cleanDirectory(dist);
+}
+
+export function createConfigs(dev, version) {
+    const versionVariables = {
+        GIT_HASH: JSON.stringify(GIT_HASH),
+        GIT_TAG: JSON.stringify(version ?? GIT_TAG),
+    };
+    const developmentVariables = {
+        DEVELOPMENT: dev ? JSON.stringify(true) : JSON.stringify(false),
+    };
+
+    return [
+        [
+            'CLI',
+            {
+                entryPoints: [
+                    path.resolve(casualosCli, 'index.ts'),
+                    path.resolve(casualosCli, 'cli.ts'),
+                ],
+                outdir: dist,
+                platform: 'node',
+                target: ['node18.18'],
+                define: {
+                    ...versionVariables,
+                    ...developmentVariables,
+                },
+                minify: false,
+            },
+        ],
+    ];
+}

--- a/src/casualos-cli/script/dev-cli.mjs
+++ b/src/casualos-cli/script/dev-cli.mjs
@@ -1,0 +1,6 @@
+import { cleanDirectory, setupWatch } from '../../../script/build-helpers.mjs';
+import { createConfigs, cleanDirectories } from './cli-configs.mjs';
+
+cleanDirectories();
+
+setupWatch([...createConfigs(true, 'v9.9.9-dev:alpha')]);

--- a/src/casualos-cli/tsconfig.json
+++ b/src/casualos-cli/tsconfig.json
@@ -6,9 +6,7 @@
         "declaration": true,
         "declarationMap": true,
         "composite": true,
-        "incremental": true,
-        "module": "Node16",
-        "moduleResolution": "Node16"
+        "incremental": true
     },
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "lib", "**/*.spec.ts"],

--- a/src/casualos-cli/tsconfig.json
+++ b/src/casualos-cli/tsconfig.json
@@ -6,7 +6,9 @@
         "declaration": true,
         "declarationMap": true,
         "composite": true,
-        "incremental": true
+        "incremental": true,
+        "module": "Node16",
+        "moduleResolution": "Node16"
     },
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "lib", "**/*.spec.ts"],

--- a/src/casualos-cli/tsconfig.json
+++ b/src/casualos-cli/tsconfig.json
@@ -10,9 +10,5 @@
     },
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "lib", "**/*.spec.ts"],
-    "references": [
-        { "path": "../aux-vm" },
-        { "path": "../aux-vm-client" },
-        { "path": "../crypto" }
-    ]
+    "references": [{ "path": "../aux-records" }, { "path": "../aux-common" }]
 }

--- a/src/casualos-cli/tsconfig.json
+++ b/src/casualos-cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "outDir": ".",
+        "declaration": true,
+        "declarationMap": true,
+        "composite": true,
+        "incremental": true
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "lib", "**/*.spec.ts"],
+    "references": [
+        { "path": "../aux-vm" },
+        { "path": "../aux-vm-client" },
+        { "path": "../crypto" }
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
         { "path": "./src/rate-limit-redis" },
         { "path": "./src/aux-websocket" },
         { "path": "./src/aux-websocket-aws" },
-        { "path": "./xpexchange/xp-api" }
+        { "path": "./xpexchange/xp-api" },
+        { "path": "./src/casualos-cli" }
     ]
 }


### PR DESCRIPTION
### :rocket: Features

-   Added a command line interface (CLI) for CasualOS.
    -   It is available on NPM as `casualos`, and provides functionality to query the CasualOS backend API.
    -   It currently provides the following operations:
        -   `login` - Authenticates the cilent to a CasualOS backend.
        -   `query` - Queries a CasualOS backend.
        -   `repl` - A Read-eval-print-loop (REPL) that makes interacting with the CasualOS backend via JavaScript really easy.