### PR TITLE
Add several camera utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
 -   Added the ability to create accounts that are not associated with an email or phone number.
     -   These accounts are also issued a session key that cannot be revoked and does not expire.
     -   They will mostly be used for one-time subscriptions and machine users.
+-   Added several functions to make working with screen coordinates easier.
+    -   `os.calculateViewportCoordinatesFromPosition(portal, position)` - Calculates the viewport coordinates from the given 3D position in the portal.
+        -   `portal` is the portal that the request is from (one of `grid`, `miniGrid`, `map`, or `miniMap`).
+        -   `position` is the 3D position in the portal.
+        -   Viewport coordinates locate a specific point on the image that the camera produces. `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+    -   `os.calculateViewportCoordinatesFromScreenCoordinates(portal, coordinates)` - Calculates the viewport coordinates from the given 2D screen position.
+        -   `portal` is the portal that the request is for (one of `grid`, `miniGrid`, `map`, or `miniMap`).
+        -   `position` is the 2D position on the screen.
+    -   `os.calculateScreenCoordinatesFromViewportCoordinates(portal, coordinates)` - Calculates the screen coordinates from the given 2D viewport coordinates.
+        -   `portal` is the portal that the request is for (one of `grid`, `miniGrid`, `map`, or `miniMap`).
+        -   `position` is the 2D viewport coordinates that the screen coordinates should be found for.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -174,7 +174,8 @@ export type AsyncActions =
     | EnableCollaborationAction
     | GetRecordsEndpointAction
     | ShowAccountInfoAction
-    | LDrawCountBuildStepsAction;
+    | LDrawCountBuildStepsAction
+    | CalculateViewportCoordinatesFromPositionAction;
 
 export type RemoteBotActions =
     | GetRemoteCountAction
@@ -3150,6 +3151,27 @@ export interface CalculateRayFromCameraAction extends AsyncAction {
 }
 
 /**
+ * Defines an event that calculates the 2D viewport coordinates from the given 3D position.
+ *
+ * @dochash types/os/portals
+ * @docname CalculateViewportCoordinatesFromPositionAction
+ */
+export interface CalculateViewportCoordinatesFromPositionAction
+    extends AsyncAction {
+    type: 'calculate_viewport_coordinates_from_position';
+
+    /**
+     * The portal that the ray should be calculated for.
+     */
+    portal: CameraPortal;
+
+    /**
+     * The 3D position that the viewport coordinates should be calculated for.
+     */
+    position: Point3D;
+}
+
+/**
  * Defines an event that requests the pre-caching of a GLTF mesh.
  *
  * @dochash types/os/portals
@@ -5171,6 +5193,25 @@ export function calculateRayFromCamera(
         type: 'calculate_camera_ray',
         portal,
         viewportCoordinates,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new CalculateViewportCoordinatesFromPositionAction.
+ * @param portal The portal that the ray should be calcualted for.
+ * @param position The 3D position that the ray should be calculated for.
+ * @param taskId The ID of the task.
+ */
+export function calculateViewportCoordinatesFromPosition(
+    portal: CameraPortal,
+    position: Point3D,
+    taskId?: number | string
+): CalculateViewportCoordinatesFromPositionAction {
+    return {
+        type: 'calculate_viewport_coordinates_from_position',
+        portal,
+        position,
         taskId,
     };
 }

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -175,7 +175,9 @@ export type AsyncActions =
     | GetRecordsEndpointAction
     | ShowAccountInfoAction
     | LDrawCountBuildStepsAction
-    | CalculateViewportCoordinatesFromPositionAction;
+    | CalculateViewportCoordinatesFromPositionAction
+    | CalculateScreenCoordinatesFromViewportCoordinatesAction
+    | CalculateViewportCoordinatesFromScreenCoordinatesAction;
 
 export type RemoteBotActions =
     | GetRemoteCountAction
@@ -3172,6 +3174,48 @@ export interface CalculateViewportCoordinatesFromPositionAction
 }
 
 /**
+ * Defines an event that calculates the 2D screen coordinates from the given 2D viewport coordinates.
+ *
+ * @dochash types/os/portals
+ * @docname CalculateScreenCoordinatesFromViewportCoordinatesAction
+ */
+export interface CalculateScreenCoordinatesFromViewportCoordinatesAction
+    extends AsyncAction {
+    type: 'calculate_screen_coordinates_from_viewport_coordinates';
+
+    /**
+     * The portal that the ray should be calculated for.
+     */
+    portal: CameraPortal;
+
+    /**
+     * The 2D position that the screen coordinates should be calculated for.
+     */
+    coordinates: Point2D;
+}
+
+/**
+ * Defines an event that calculates the 2D viewport coordinates from the given 2D screen coordinates.
+ *
+ * @dochash types/os/portals
+ * @docname CalculateViewportCoordinatesFromScreenCoordinatesAction
+ */
+export interface CalculateViewportCoordinatesFromScreenCoordinatesAction
+    extends AsyncAction {
+    type: 'calculate_viewport_coordinates_from_screen_coordinates';
+
+    /**
+     * The portal that the ray should be calculated for.
+     */
+    portal: CameraPortal;
+
+    /**
+     * The 2D position that the viewport coordinates should be calculated for.
+     */
+    coordinates: Point2D;
+}
+
+/**
  * Defines an event that requests the pre-caching of a GLTF mesh.
  *
  * @dochash types/os/portals
@@ -5212,6 +5256,44 @@ export function calculateViewportCoordinatesFromPosition(
         type: 'calculate_viewport_coordinates_from_position',
         portal,
         position,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new CalculateScreenCoordinatesFromViewportCoordinatesAction.
+ * @param portal The portal that the ray should be calcualted for.
+ * @param coordinates The 2D position that the coordinates should be calculated for.
+ * @param taskId The ID of the task.
+ */
+export function calculateScreenCoordinatesFromViewportCoordinates(
+    portal: CameraPortal,
+    coordinates: Point2D,
+    taskId?: number | string
+): CalculateScreenCoordinatesFromViewportCoordinatesAction {
+    return {
+        type: 'calculate_screen_coordinates_from_viewport_coordinates',
+        portal,
+        coordinates,
+        taskId,
+    };
+}
+
+/**
+ * Creates a new CalculateViewportCoordinatesFromScreenCoordinatesAction.
+ * @param portal The portal that the ray should be calcualted for.
+ * @param coordinates The 2D position that the coordinates should be calculated for.
+ * @param taskId The ID of the task.
+ */
+export function calculateViewportCoordinatesFromScreenCoordinates(
+    portal: CameraPortal,
+    coordinates: Point2D,
+    taskId?: number | string
+): CalculateViewportCoordinatesFromScreenCoordinatesAction {
+    return {
+        type: 'calculate_viewport_coordinates_from_screen_coordinates',
+        portal,
+        coordinates,
         taskId,
     };
 }

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -140,6 +140,8 @@ import {
     ldrawCountAddressBuildSteps,
     ldrawCountTextBuildSteps,
     calculateViewportCoordinatesFromPosition,
+    calculateScreenCoordinatesFromViewportCoordinates,
+    calculateViewportCoordinatesFromScreenCoordinates,
 } from '@casual-simulation/aux-common/bots';
 import { types } from 'util';
 import { attachRuntime, detachRuntime } from './RuntimeEvents';
@@ -7491,6 +7493,48 @@ describe('AuxLibrary', () => {
                     },
                     context.tasks.size
                 );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.calculateScreenCoordinatesFromViewportCoordinates()', () => {
+            it('should emit a CalculateScreenCoordinatesFromViewportCoordinates', () => {
+                const promise: any =
+                    library.api.os.calculateScreenCoordinatesFromViewportCoordinates(
+                        'grid',
+                        new Vector2(1, 2)
+                    );
+                const expected =
+                    calculateScreenCoordinatesFromViewportCoordinates(
+                        'grid',
+                        {
+                            x: 1,
+                            y: 2,
+                        },
+                        context.tasks.size
+                    );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.calculateViewportCoordinatesFromScreenCoordinates()', () => {
+            it('should emit a CalculateViewportCoordinatesFromScreenCoordinates', () => {
+                const promise: any =
+                    library.api.os.calculateViewportCoordinatesFromScreenCoordinates(
+                        'grid',
+                        new Vector2(1, 2)
+                    );
+                const expected =
+                    calculateViewportCoordinatesFromScreenCoordinates(
+                        'grid',
+                        {
+                            x: 1,
+                            y: 2,
+                        },
+                        context.tasks.size
+                    );
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -139,6 +139,7 @@ import {
     getRecordsEndpoint,
     ldrawCountAddressBuildSteps,
     ldrawCountTextBuildSteps,
+    calculateViewportCoordinatesFromPosition,
 } from '@casual-simulation/aux-common/bots';
 import { types } from 'util';
 import { attachRuntime, detachRuntime } from './RuntimeEvents';
@@ -7447,6 +7448,46 @@ describe('AuxLibrary', () => {
                     {
                         x: 1,
                         y: 2,
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.calculateViewportCoordinatesFromPosition()', () => {
+            it('should emit a CalculateViewportCoordinatesFromPositionAction', () => {
+                const promise: any =
+                    library.api.os.calculateViewportCoordinatesFromPosition(
+                        'grid',
+                        new Vector3(1, 2, 3)
+                    );
+                const expected = calculateViewportCoordinatesFromPosition(
+                    'grid',
+                    {
+                        x: 1,
+                        y: 2,
+                        z: 3,
+                    },
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should default each coordinate to 0 if not specified', () => {
+                const promise: any =
+                    library.api.os.calculateViewportCoordinatesFromPosition(
+                        'grid',
+                        {} as any
+                    );
+                const expected = calculateViewportCoordinatesFromPosition(
+                    'grid',
+                    {
+                        x: 0,
+                        y: 0,
+                        z: 0,
                     },
                     context.tasks.size
                 );

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -237,6 +237,9 @@ import {
     ldrawCountAddressBuildSteps as calcLdrawCountAddressBuildSteps,
     ldrawCountTextBuildSteps as calcLdrawCountTextBuildSteps,
     calculateViewportCoordinatesFromPosition as calcCalculateViewportCoordinatesFromPosition,
+    calculateScreenCoordinatesFromViewportCoordinates as calcCalculateScreenCoordinatesFromViewportCoordinates,
+    calculateViewportCoordinatesFromScreenCoordinates as calcCalculateViewportCoordinatesFromScreenCoordinates,
+    Point2D,
 } from '@casual-simulation/aux-common/bots';
 import {
     AIChatOptions,
@@ -3237,6 +3240,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 raycast,
                 calculateRayFromCamera,
                 calculateViewportCoordinatesFromPosition,
+                calculateScreenCoordinatesFromViewportCoordinates,
+                calculateViewportCoordinatesFromScreenCoordinates,
                 bufferFormAddressGLTF,
                 startFormAnimation,
                 stopFormAnimation,
@@ -9732,6 +9737,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * );
      * const viewportPosition = await os.calculateViewportCoordinatesFromPosition("grid", botPosition);
      * os.toast(viewportPosition);
+     *
+     * @dochash actions/os/portals
+     * @docname os.calculateViewportCoordinatesFromPosition
+     * @docgroup 10-raycast
      */
     function calculateViewportCoordinatesFromPosition(
         portal: 'grid' | 'miniGrid' | 'map' | 'miniMap',
@@ -9741,6 +9750,76 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const event = calcCalculateViewportCoordinatesFromPosition(
             portal,
             { x: position.x || 0, y: position.y || 0, z: position.z || 0 },
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Calculates the screen coordinates that the given viewport coordinates map to on the screen.
+     * Returns a promise that resolves with the calculated screen coordinates.
+     *
+     * Screen coordinates are in pixels and are relative to the top-left corner of the screen.
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     *
+     * @param portal the name of the portal that should be tested.
+     * @param coordinates the 2D viewport coordinates that should be converted to screen coordinates.
+     *
+     * @example Calculate the screen coordinates at the center of grid portal screen
+     * const screenCoordinates = await os.calculateScreenCoordinatesFromViewportCoordinates('grid', new Vector2(0, 0));
+     * os.toast(screenCoordinates);
+     *
+     * @dochash actions/os/portals
+     * @docname os.calculateScreenCoordinatesFromViewportCoordinates
+     * @docgroup 10-raycast
+     */
+    function calculateScreenCoordinatesFromViewportCoordinates(
+        portal: 'grid' | 'miniGrid' | 'map' | 'miniMap',
+        coordinates: Point2D
+    ): Promise<Vector2> {
+        const task = context.createTask();
+        const event = calcCalculateScreenCoordinatesFromViewportCoordinates(
+            portal,
+            {
+                x: coordinates.x || 0,
+                y: coordinates.y || 0,
+            },
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Calculates the viewport coordinates that the given screen coordinates map to on the camera.
+     * Returns a promise that resolves with the calculated viewport coordinates.
+     *
+     * Screen coordinates are in pixels and are relative to the top-left corner of the screen.
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     *
+     * @param portal the name of the portal that should be tested.
+     * @param coordinates the 2D screen coordinates that should be converted to viewport coordinates.
+     *
+     * @example Calculate the viewport coordinates at (0,0) on the screen
+     * const viewportCoordinates = await os.calculateViewportCoordinatesFromScreenCoordinates('grid', new Vector2(0, 0));
+     * os.toast(viewportCoordinates);
+     *
+     * @dochash actions/os/portals
+     * @docname os.calculateViewportCoordinatesFromScreenCoordinates
+     * @docgroup 10-raycast
+     */
+    function calculateViewportCoordinatesFromScreenCoordinates(
+        portal: 'grid' | 'miniGrid' | 'map' | 'miniMap',
+        coordinates: Point2D
+    ): Promise<Vector2> {
+        const task = context.createTask();
+        const event = calcCalculateViewportCoordinatesFromScreenCoordinates(
+            portal,
+            {
+                x: coordinates.x || 0,
+                y: coordinates.y || 0,
+            },
             task.taskId
         );
         return addAsyncAction(task, event);

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -236,6 +236,7 @@ import {
     getRecordsEndpoint as calcGetRecordsEndpoint,
     ldrawCountAddressBuildSteps as calcLdrawCountAddressBuildSteps,
     ldrawCountTextBuildSteps as calcLdrawCountTextBuildSteps,
+    calculateViewportCoordinatesFromPosition as calcCalculateViewportCoordinatesFromPosition,
 } from '@casual-simulation/aux-common/bots';
 import {
     AIChatOptions,
@@ -3235,6 +3236,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 raycastFromCamera,
                 raycast,
                 calculateRayFromCamera,
+                calculateViewportCoordinatesFromPosition,
                 bufferFormAddressGLTF,
                 startFormAnimation,
                 stopFormAnimation,
@@ -9705,6 +9707,40 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         const event = calcCalculateRayFromCamera(
             portal,
             { x: viewportCoordinates.x, y: viewportCoordinates.y },
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Calculates the viewport coordinates that the given position would be projected to in the camera of the given portal.
+     * Returns a promise that resolves with the calculated viewport coordinates.
+     *
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     *
+     * This function is useful for converting a position in the portal to a position on the camera viewport (screen position, but the location is not in pixels).
+     *
+     * @param portal the name of the portal that should be tested.
+     * @param position the 3D position that should be projected to the viewport.
+     *
+     * @example Calculate the viewport coordinates of the current bot in the home dimension in the grid portal
+     * const botPosition = new Vector3(
+     *   thisBot.homeX,
+     *   thisBot.homeY,
+     *   thisBot.homeZ
+     * );
+     * const viewportPosition = await os.calculateViewportCoordinatesFromPosition("grid", botPosition);
+     * os.toast(viewportPosition);
+     */
+    function calculateViewportCoordinatesFromPosition(
+        portal: 'grid' | 'miniGrid' | 'map' | 'miniMap',
+        position: Vector3
+    ): Promise<Vector2> {
+        const task = context.createTask();
+        const event = calcCalculateViewportCoordinatesFromPosition(
+            portal,
+            { x: position.x || 0, y: position.y || 0, z: position.z || 0 },
             task.taskId
         );
         return addAsyncAction(task, event);

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -12078,6 +12078,29 @@ interface Os {
     calculateRayFromCamera(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', viewportCoordinates: Vector2): Promise<RaycastRay>;
 
     /**
+     * Calculates the viewport coordinates that the given position would be projected to in the camera of the given portal.
+     * Returns a promise that resolves with the calculated viewport coordinates.
+     * 
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     * 
+     * This function is useful for converting a position in the portal to a position on the camera viewport (screen position, but the location is not in pixels).
+     * 
+     * @param portal the name of the portal that should be tested.
+     * @param position the 3D position that should be projected to the viewport.
+     * 
+     * @example Calculate the viewport coordinates of the current bot in the home dimension in the grid portal
+     * const botPosition = new Vector3(
+     *   thisBot.homeX,
+     *   thisBot.homeY,
+     *   thisBot.homeZ
+     * );
+     * const viewportPosition = await os.calculateViewportCoordinatesFromPosition("grid", botPosition);
+     * os.toast(viewportPosition);
+     */
+    calculateViewportCoordinatesFromPosition(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', position: Vector3): Promise<Vector2>;
+
+    /**
      * Requests that the given address be pre-cached so that it is available for use on a bot.
      * Returns a promise that resolves once the address has been cached.
      * @param address The address that should be cached.

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -12101,6 +12101,48 @@ interface Os {
     calculateViewportCoordinatesFromPosition(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', position: Vector3): Promise<Vector2>;
 
     /**
+     * Calculates the screen coordinates that the given viewport coordinates map to on the screen.
+     * Returns a promise that resolves with the calculated screen coordinates.
+     * 
+     * Screen coordinates are in pixels and are relative to the top-left corner of the screen.
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     * 
+     * @param portal the name of the portal that should be tested.
+     * @param coordinates the 2D viewport coordinates that should be converted to screen coordinates.
+     * 
+     * @example Calculate the screen coordinates at the center of grid portal screen
+     * const screenCoordinates = await os.calculateScreenCoordinatesFromViewportCoordinates('grid', new Vector2(0, 0));
+     * os.toast(screenCoordinates);
+     * 
+     * @dochash actions/os/portals
+     * @docname os.calculateScreenCoordinatesFromViewportCoordinates
+     * @docgroup 10-raycast
+     */
+    calculateScreenCoordinatesFromViewportCoordinates(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', coordinates: Vector2): Promise<Vector2>;
+
+    /**
+     * Calculates the viewport coordinates that the given screen coordinates map to on the camera.
+     * Returns a promise that resolves with the calculated viewport coordinates.
+     * 
+     * Screen coordinates are in pixels and are relative to the top-left corner of the screen.
+     * Viewport coordinates locate a specific point on the image that the camera produces.
+     * `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
+     * 
+     * @param portal the name of the portal that should be tested.
+     * @param coordinates the 2D screen coordinates that should be converted to viewport coordinates.
+     * 
+     * @example Calculate the viewport coordinates at (0,0) on the screen
+     * const viewportCoordinates = await os.calculateViewportCoordinatesFromScreenCoordinates('grid', new Vector2(0, 0));
+     * os.toast(viewportCoordinates);
+     * 
+     * @dochash actions/os/portals
+     * @docname os.calculateViewportCoordinatesFromScreenCoordinates
+     * @docgroup 10-raycast
+     */
+    calculateViewportCoordinatesFromScreenCoordinates(portal: 'grid' | 'miniGrid' | 'map' | 'miniMap', coordinates: Vector2): Promise<Vector2>;
+
+    /**
      * Requests that the given address be pre-cached so that it is available for use on a bot.
      * Returns a promise that resolves once the address has been cached.
      * @param address The address that should be cached.


### PR DESCRIPTION
### :rocket: Features
-   Added several functions to make working with screen coordinates easier.
    -   `os.calculateViewportCoordinatesFromPosition(portal, position)` - Calculates the viewport coordinates from the given 3D position in the portal.
        -   `portal` is the portal that the request is from (one of `grid`, `miniGrid`, `map`, or `miniMap`).
        -   `position` is the 3D position in the portal.
        -   Viewport coordinates locate a specific point on the image that the camera produces. `(X: 0, Y: 0)` represents the center of the camera while `(X: -1, Y: -1)` represents the lower left corner and `(X: 1, Y: 1)` represents the upper right corner.
    -   `os.calculateViewportCoordinatesFromScreenCoordinates(portal, coordinates)` - Calculates the viewport coordinates from the given 2D screen position.
        -   `portal` is the portal that the request is for (one of `grid`, `miniGrid`, `map`, or `miniMap`).
        -   `position` is the 2D position on the screen.
    -   `os.calculateScreenCoordinatesFromViewportCoordinates(portal, coordinates)` - Calculates the screen coordinates from the given 2D viewport coordinates.
        -   `portal` is the portal that the request is for (one of `grid`, `miniGrid`, `map`, or `miniMap`).
        -   `position` is the 2D viewport coordinates that the screen coordinates should be found for.

Closes #426 
Closes #427 