### PR TITLE
Add the `superUser` role

### DIFF
--- a/src/aux-common/rpc/GenericRPCInterface.ts
+++ b/src/aux-common/rpc/GenericRPCInterface.ts
@@ -208,6 +208,9 @@ class ProcBuilder
 }
 
 export interface ProceduresMetadata {
+    /**
+     * The list of procedures.
+     */
     procedures: ProcedureMetadata[];
 }
 

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -6933,6 +6933,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -6976,6 +6977,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -7004,6 +7006,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -7043,6 +7046,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -7082,6 +7086,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -7123,6 +7128,7 @@ describe('AuthController', () => {
                     allowAI: true,
                     allowPublicInsts: true,
                 },
+                role: 'none',
             });
         });
 
@@ -7301,6 +7307,7 @@ describe('AuthController', () => {
                         allowAI: false,
                         allowPublicInsts: true,
                     },
+                    role: 'none',
                 });
 
                 expect(privoClientMock.getUserInfo).toHaveBeenCalledWith(
@@ -7371,6 +7378,7 @@ describe('AuthController', () => {
                         allowAI: true,
                         allowPublicInsts: false,
                     },
+                    role: 'none',
                 });
 
                 expect(privoClientMock.getUserInfo).toHaveBeenCalledWith(
@@ -7469,6 +7477,7 @@ describe('AuthController', () => {
                         allowAI: true,
                         allowPublicInsts: true,
                     },
+                    role: 'none',
                 });
 
                 expect(privoClientMock.getUserInfo).toHaveBeenCalledWith(
@@ -7567,6 +7576,7 @@ describe('AuthController', () => {
                         allowAI: true,
                         allowPublicInsts: true,
                     },
+                    role: 'none',
                 });
 
                 expect(privoClientMock.getUserInfo).toHaveBeenCalledWith(
@@ -7631,6 +7641,33 @@ describe('AuthController', () => {
                 });
             });
 
+            it('should include the role of the user', async () => {
+                const result = await controller.getUserInfo({
+                    userId: superUserId,
+                    sessionKey: superUserSessionKey,
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    userId: superUserId,
+                    email: null,
+                    phoneNumber: null,
+                    name: null,
+                    avatarUrl: null,
+                    avatarPortraitUrl: null,
+                    hasActiveSubscription: false,
+                    subscriptionTier: null,
+                    displayName: null,
+                    privacyFeatures: {
+                        publishData: true,
+                        allowPublicData: true,
+                        allowAI: true,
+                        allowPublicInsts: true,
+                    },
+                    role: 'superUser',
+                });
+            });
+
             it('should allow super users to get other users info', async () => {
                 const result = await controller.getUserInfo({
                     userId,
@@ -7654,6 +7691,7 @@ describe('AuthController', () => {
                         allowAI: true,
                         allowPublicInsts: true,
                     },
+                    role: 'none',
                 });
             });
         });

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -2435,7 +2435,10 @@ export class AuthController {
             const keyResult = await this.validateSessionKey(request.sessionKey);
             if (keyResult.success === false) {
                 return keyResult;
-            } else if (keyResult.userId !== request.userId) {
+            } else if (
+                !isSuperUserRole(keyResult.role) &&
+                keyResult.userId !== request.userId
+            ) {
                 return {
                     success: false,
                     errorCode: 'invalid_key',

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -2596,6 +2596,7 @@ export class AuthController {
                 hasActiveSubscription: hasActiveSubscription,
                 subscriptionTier: tier ?? null,
                 privacyFeatures: privacyFeatures,
+                role: result.role ?? 'none',
             };
         } catch (err) {
             console.error(
@@ -3757,6 +3758,11 @@ export interface GetUserInfoSuccess {
      * The privacy-related features that the user has enabled.
      */
     privacyFeatures: PrivacyFeatures;
+
+    /**
+     * The role that the user has in the system.
+     */
+    role: UserRole;
 }
 
 export interface GetUserInfoFailure {

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -212,13 +212,12 @@ export class AuthController {
         request: CreateAccountRequest
     ): Promise<CreateAccountResult> {
         try {
-            const user = await this._store.findUser(request.userId);
-
-            if (!user) {
+            if (!isSuperUserRole(request.userRole)) {
                 return {
                     success: false,
-                    errorCode: 'not_logged_in',
-                    errorMessage: 'The user is not logged in.',
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You are not authorized to perform this action.',
                 };
             }
 
@@ -3164,9 +3163,9 @@ export interface PrivoSignUpRequestFailure {
 
 export interface CreateAccountRequest {
     /**
-     * The ID of the logged in user.
+     * The role of the logged in user.
      */
-    userId: string;
+    userRole: UserRole;
 
     /**
      * The IP Address that the request is being made from.

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -8,6 +8,7 @@ import {
     AuthUser,
     AuthUserAuthenticator,
     SaveNewUserFailure,
+    UserRole,
 } from './AuthStore';
 import {
     NotAuthorizedError,
@@ -35,6 +36,7 @@ import {
     formatV1ConnectionKey,
     formatV1OpenAiKey,
     formatV1SessionKey,
+    isSuperUserRole,
     parseSessionKey,
     randomCode,
     verifyConnectionToken,
@@ -1961,6 +1963,7 @@ export class AuthController {
                 subscriptionId: subscriptionId ?? undefined,
                 subscriptionTier: subscriptionTier ?? undefined,
                 privacyFeatures: userInfo.privacyFeatures,
+                role: userInfo.role,
             };
         } catch (err) {
             console.error(
@@ -2509,7 +2512,10 @@ export class AuthController {
             const keyResult = await this.validateSessionKey(request.sessionKey);
             if (keyResult.success === false) {
                 return keyResult;
-            } else if (keyResult.userId !== request.userId) {
+            } else if (
+                !isSuperUserRole(keyResult.role) &&
+                keyResult.userId !== request.userId
+            ) {
                 console.log(
                     '[AuthController] [getUserInfo] Request User ID doesnt match session key User ID!'
                 );
@@ -3393,6 +3399,11 @@ export interface ValidateSessionKeySuccess {
      * If null or omitted, then all features are enabled.
      */
     privacyFeatures?: PrivacyFeatures;
+
+    /**
+     * The role of the user.
+     */
+    role?: UserRole;
 }
 
 export interface ValidateSessionKeyFailure {

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -5,7 +5,6 @@ import {
     AuthenticatorTransportFuture,
     CredentialDeviceType,
 } from '@simplewebauthn/types';
-import { AttestationFormat } from '@simplewebauthn/server/script/helpers/decodeAttestationObject';
 
 /**
  * Defines an interface that represents an auth store.

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -462,7 +462,20 @@ export interface AuthUser {
      * If null or omitted, then the user has access to all features.
      */
     privacyFeatures?: PrivacyFeatures | null;
+
+    /**
+     * The role that the user has been assigned in the system.
+     */
+    role?: 'none' | 'superUser';
 }
+
+/**
+ * Defines an interface that represents the role that a user can have.
+ *
+ * - "none" means that the user has no special permissions.
+ * - "superUser" means that the user has additional permissions that only special users should have.
+ */
+export type UserRole = 'none' | 'superUser';
 
 export interface AuthUserAuthenticator {
     /**

--- a/src/aux-records/AuthUtils.spec.ts
+++ b/src/aux-records/AuthUtils.spec.ts
@@ -10,6 +10,7 @@ import {
     parseConnectionKey,
     generateV1ConnectionToken,
     verifyConnectionToken,
+    isSuperUserRole,
 } from './AuthUtils';
 import {
     toBase64String,
@@ -553,5 +554,17 @@ describe('parseConnectionToken()', () => {
                 expect.any(String),
             ]);
         });
+    });
+});
+
+describe('isSuperUserRole()', () => {
+    it('should return true if the given user has the super user role', () => {
+        expect(isSuperUserRole('superUser')).toBe(true);
+    });
+
+    it('should return false if the given user does not have the super user role', () => {
+        expect(isSuperUserRole('none')).toBe(false);
+        expect(isSuperUserRole(null)).toBe(false);
+        expect(isSuperUserRole(undefined)).toBe(false);
     });
 });

--- a/src/aux-records/AuthUtils.ts
+++ b/src/aux-records/AuthUtils.ts
@@ -8,6 +8,7 @@ import {
 } from '@casual-simulation/aux-common';
 import { sha256, hmac } from 'hash.js';
 import { fromByteArray, toByteArray } from 'base64-js';
+import type { UserRole } from './AuthStore';
 
 /**
  * The number of characters that random codes should contain.
@@ -378,4 +379,12 @@ export function verifyConnectionToken(
     } catch {
         return false;
     }
+}
+
+/**
+ * Determines whether the given role is a super user role.
+ * @param role The role to check.
+ */
+export function isSuperUserRole(role: UserRole): boolean {
+    return role === 'superUser';
 }

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -3158,9 +3158,19 @@ describe('RecordsController', () => {
                 isPrimaryContact: false,
                 role: 'member',
             });
+
+            await store.saveNewUser({
+                id: 'superUserId',
+                name: null,
+                email: 'su@example.com',
+                phoneNumber: null,
+                allSessionRevokeTimeMs: null,
+                currentLoginRequestId: null,
+                role: 'superUser',
+            });
         });
 
-        it('should list the users in the studio that the user has access to', async () => {
+        it('should list the users in the studio that the admin has access to', async () => {
             const result = await manager.listStudioMembers(studioId, 'userId');
 
             expect(result).toEqual({
@@ -3206,7 +3216,7 @@ describe('RecordsController', () => {
             });
         });
 
-        it('should list the users in the studio that the user has access to', async () => {
+        it('should list the users in the studio that the member has access to', async () => {
             const result = await manager.listStudioMembers(studioId, 'userId3');
 
             expect(result).toEqual({
@@ -3240,6 +3250,55 @@ describe('RecordsController', () => {
                         user: {
                             id: 'userId3',
                             name: 'test user 3',
+                        },
+                    },
+                ],
+            });
+        });
+
+        it('should list the users in the studio if the user is a super user', async () => {
+            const result = await manager.listStudioMembers(
+                studioId,
+                'superUserId'
+            );
+
+            expect(result).toEqual({
+                success: true,
+                members: [
+                    {
+                        studioId,
+                        userId: 'userId',
+                        isPrimaryContact: true,
+                        role: 'admin',
+                        user: {
+                            id: 'userId',
+                            name: 'test user',
+                            email: 'test@example.com',
+                            phoneNumber: null,
+                        },
+                    },
+                    {
+                        studioId,
+                        userId: 'userId2',
+                        isPrimaryContact: true,
+                        role: 'member',
+                        user: {
+                            id: 'userId2',
+                            name: 'test user 2',
+                            email: 'test2@example.com',
+                            phoneNumber: null,
+                        },
+                    },
+                    {
+                        studioId,
+                        userId: 'userId3',
+                        isPrimaryContact: false,
+                        role: 'member',
+                        user: {
+                            id: 'userId3',
+                            name: 'test user 3',
+                            email: null,
+                            phoneNumber: '555',
                         },
                     },
                 ],

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -1978,6 +1978,42 @@ describe('RecordsController', () => {
                 ],
             });
         });
+
+        it('should return all records owned by the studio if the user is a super user', async () => {
+            await store.removeStudioAssignment('studioId', 'userId');
+
+            const user = await store.findUser('userId');
+            await store.saveUser({
+                ...user,
+                role: 'superUser',
+            });
+
+            const result = await manager.listStudioRecords(
+                'studioId',
+                'userId'
+            );
+
+            expect(result).toEqual({
+                success: true,
+                records: [
+                    {
+                        name: 'record1',
+                        ownerId: null,
+                        studioId: 'studioId',
+                    },
+                    {
+                        name: 'record2',
+                        ownerId: null,
+                        studioId: 'studioId',
+                    },
+                    {
+                        name: 'record3',
+                        ownerId: null,
+                        studioId: 'studioId',
+                    },
+                ],
+            });
+        });
     });
 
     describe('createStudio()', () => {

--- a/src/aux-records/RecordsController.ts
+++ b/src/aux-records/RecordsController.ts
@@ -1290,16 +1290,24 @@ export class RecordsController {
 
             const userAssignment = members.find((m) => m.userId === userId);
 
+            let role: StudioAssignmentRole;
             if (!userAssignment) {
-                return {
-                    success: false,
-                    errorCode: 'not_authorized',
-                    errorMessage:
-                        'You are not authorized to access this studio.',
-                };
+                const user = await this._auth.findUser(userId);
+                if (!isSuperUserRole(user?.role)) {
+                    return {
+                        success: false,
+                        errorCode: 'not_authorized',
+                        errorMessage:
+                            'You are not authorized to access this studio.',
+                    };
+                } else {
+                    role = 'admin';
+                }
+            } else {
+                role = userAssignment.role;
             }
 
-            if (userAssignment.role === 'admin') {
+            if (role === 'admin') {
                 return {
                     success: true,
                     members: members.map((m) => ({

--- a/src/aux-records/RecordsController.ts
+++ b/src/aux-records/RecordsController.ts
@@ -40,6 +40,7 @@ import {
 import { ComIdConfig, ComIdPlayerConfig } from './ComIdConfig';
 import { isActiveSubscription } from './Utils';
 import { NotificationMessenger } from './NotificationMessenger';
+import { isSuperUserRole } from './AuthUtils';
 
 export interface RecordsControllerConfig {
     store: RecordsStore;
@@ -845,6 +846,18 @@ export class RecordsController {
                     errorMessage: 'This operation is not supported.',
                 };
             }
+
+            const user = await this._auth.findUser(userId);
+            if (isSuperUserRole(user?.role)) {
+                const records = await this._store.listRecordsByStudioId(
+                    studioId
+                );
+                return {
+                    success: true,
+                    records,
+                };
+            }
+
             const records = await this._store.listRecordsByStudioIdAndUserId(
                 studioId,
                 userId

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -911,6 +911,38 @@ describe('RecordsServer', () => {
             });
         });
 
+        it('should support procedures', async () => {
+            const result = await server.handleHttpRequest(
+                procedureRequest(
+                    'getUserInfo',
+                    {
+                        userId,
+                    },
+                    authenticatedHeaders
+                )
+            );
+
+            expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    email: 'test@example.com',
+                    phoneNumber: null,
+                    hasActiveSubscription: false,
+                    subscriptionTier: null,
+                    privacyFeatures: {
+                        publishData: true,
+                        allowPublicData: true,
+                        allowAI: true,
+                        allowPublicInsts: true,
+                    },
+                    displayName: null,
+                    role: 'none',
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
         testRateLimit('GET', `/api/{userId:${userId}}/metadata`);
     });
 

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -1902,6 +1902,14 @@ describe('RecordsServer', () => {
     });
 
     describe('POST /api/v2/createAccount', () => {
+        beforeEach(async () => {
+            const user = await store.findUser(userId);
+            await store.saveUser({
+                ...user,
+                role: 'superUser',
+            });
+        });
+
         it('should create a new account', async () => {
             const result = await server.handleHttpRequest(
                 httpPost(
@@ -1909,6 +1917,24 @@ describe('RecordsServer', () => {
                     JSON.stringify({}),
                     authenticatedHeaders
                 )
+            );
+
+            expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    userId: expect.any(String),
+                    expireTimeMs: null,
+                    connectionKey: expect.any(String),
+                    sessionKey: expect.any(String),
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        it('should support procedures', async () => {
+            const result = await server.handleHttpRequest(
+                procedureRequest('createAccount', {}, authenticatedHeaders)
             );
 
             expectResponseBodyToEqual(result, {

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -718,6 +718,7 @@ describe('RecordsServer', () => {
                         allowPublicInsts: true,
                     },
                     displayName: null,
+                    role: 'none',
                 },
                 headers: accountCorsHeaders,
             });
@@ -790,6 +791,7 @@ describe('RecordsServer', () => {
                         allowPublicInsts: true,
                     },
                     displayName: null,
+                    role: 'none',
                 },
                 headers: accountCorsHeaders,
             });

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -1184,6 +1184,83 @@ describe('RecordsServer', () => {
             });
         });
 
+        it('should return the list of subscriptions if the current user is a super user', async () => {
+            const owner = await store.findUser(ownerId);
+            await store.saveUser({
+                ...owner,
+                role: 'superUser',
+            });
+
+            stripeMock.listActiveSubscriptionsForCustomer.mockResolvedValueOnce(
+                {
+                    subscriptions: [
+                        {
+                            id: 'subscription_id',
+                            status: 'active',
+                            start_date: 123,
+                            ended_at: null,
+                            cancel_at: null,
+                            canceled_at: null,
+                            current_period_start: 456,
+                            current_period_end: 999,
+                            items: [
+                                {
+                                    id: 'item_id',
+                                    price: {
+                                        id: 'price_id',
+                                        interval: 'month',
+                                        interval_count: 1,
+                                        currency: 'usd',
+                                        unit_amount: 123,
+
+                                        product: {
+                                            id: 'product_id',
+                                            name: 'Product Name',
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                }
+            );
+
+            const result = await server.handleHttpRequest(
+                httpGet(`/api/{userId:${userId}}/subscription`, {
+                    ...authenticatedHeaders,
+                    authorization: `Bearer ${ownerSessionKey}`,
+                })
+            );
+
+            expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    publishableKey: 'publishable_key',
+                    subscriptions: [
+                        {
+                            active: true,
+                            statusCode: 'active',
+                            productName: 'Product Name',
+                            startDate: 123,
+                            endedDate: null,
+                            cancelDate: null,
+                            canceledDate: null,
+                            currentPeriodStart: 456,
+                            currentPeriodEnd: 999,
+                            renewalInterval: 'month',
+                            intervalLength: 1,
+                            intervalCost: 123,
+                            currency: 'usd',
+                            featureList: ['Feature 1', 'Feature 2'],
+                        },
+                    ],
+                    purchasableSubscriptions: [],
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
         it('should return a list of purchasable subscriptions for the user', async () => {
             stripeMock.listActiveSubscriptionsForCustomer.mockResolvedValueOnce(
                 {
@@ -13781,6 +13858,83 @@ describe('RecordsServer', () => {
                     headers: accountCorsHeaders,
                 });
             });
+
+            it('should allow super users to get subscription info for any user', async () => {
+                const owner = await store.findUser(ownerId);
+                await store.saveUser({
+                    ...owner,
+                    role: 'superUser',
+                });
+
+                stripeMock.listActiveSubscriptionsForCustomer.mockResolvedValueOnce(
+                    {
+                        subscriptions: [
+                            {
+                                id: 'subscription_id',
+                                status: 'active',
+                                start_date: 123,
+                                ended_at: null,
+                                cancel_at: null,
+                                canceled_at: null,
+                                current_period_start: 456,
+                                current_period_end: 999,
+                                items: [
+                                    {
+                                        id: 'item_id',
+                                        price: {
+                                            id: 'price_id',
+                                            interval: 'month',
+                                            interval_count: 1,
+                                            currency: 'usd',
+                                            unit_amount: 123,
+
+                                            product: {
+                                                id: 'product_id',
+                                                name: 'Product Name',
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                );
+
+                const result = await server.handleHttpRequest(
+                    httpGet(`/api/v2/subscriptions?userId=${userId}`, {
+                        ...authenticatedHeaders,
+                        authorization: `Bearer ${ownerSessionKey}`,
+                    })
+                );
+
+                expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                        publishableKey: 'publishable_key',
+                        subscriptions: [
+                            {
+                                active: true,
+                                statusCode: 'active',
+                                productName: 'Product Name',
+                                startDate: 123,
+                                endedDate: null,
+                                cancelDate: null,
+                                canceledDate: null,
+                                currentPeriodStart: 456,
+                                currentPeriodEnd: 999,
+                                renewalInterval: 'month',
+                                intervalLength: 1,
+                                intervalCost: 123,
+                                currency: 'usd',
+                                featureList: ['Feature 1', 'Feature 2'],
+                            },
+                        ],
+                        purchasableSubscriptions: [],
+                    },
+                    headers: accountCorsHeaders,
+                });
+            });
         });
 
         describe('?studioId', () => {
@@ -14068,6 +14222,83 @@ describe('RecordsServer', () => {
                         errorMessage:
                             'The given session key is invalid. It must be a correctly formatted string.',
                     }),
+                    headers: accountCorsHeaders,
+                });
+            });
+
+            it('should allow super users to get subscription info for any studio', async () => {
+                const owner = await store.findUser(ownerId);
+                await store.saveUser({
+                    ...owner,
+                    role: 'superUser',
+                });
+
+                stripeMock.listActiveSubscriptionsForCustomer.mockResolvedValueOnce(
+                    {
+                        subscriptions: [
+                            {
+                                id: 'subscription_id',
+                                status: 'active',
+                                start_date: 123,
+                                ended_at: null,
+                                cancel_at: null,
+                                canceled_at: null,
+                                current_period_start: 456,
+                                current_period_end: 999,
+                                items: [
+                                    {
+                                        id: 'item_id',
+                                        price: {
+                                            id: 'price_id',
+                                            interval: 'month',
+                                            interval_count: 1,
+                                            currency: 'usd',
+                                            unit_amount: 123,
+
+                                            product: {
+                                                id: 'product_id',
+                                                name: 'Product Name',
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                );
+
+                const result = await server.handleHttpRequest(
+                    httpGet(`/api/v2/subscriptions?studioId=${studioId}`, {
+                        ...authenticatedHeaders,
+                        authorization: `Bearer ${ownerSessionKey}`,
+                    })
+                );
+
+                expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                        publishableKey: 'publishable_key',
+                        subscriptions: [
+                            {
+                                active: true,
+                                statusCode: 'active',
+                                productName: 'Product Name',
+                                startDate: 123,
+                                endedDate: null,
+                                cancelDate: null,
+                                canceledDate: null,
+                                currentPeriodStart: 456,
+                                currentPeriodEnd: 999,
+                                renewalInterval: 'month',
+                                intervalLength: 1,
+                                intervalCost: 123,
+                                currency: 'usd',
+                                featureList: ['Feature 1', 'Feature 2'],
+                            },
+                        ],
+                        purchasableSubscriptions: [],
+                    },
                     headers: accountCorsHeaders,
                 });
             });

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -12931,6 +12931,152 @@ describe('RecordsServer', () => {
                     headers: apiCorsHeaders,
                 });
             });
+
+            describe('?userId', () => {
+                beforeEach(async () => {
+                    const owner = await store.findUser(ownerId);
+                    await store.saveUser({
+                        ...owner,
+                        role: 'superUser',
+                    });
+                });
+
+                it('should list the studios that the user has access to if the current user is a super user', async () => {
+                    const result = await server.handleHttpRequest(
+                        httpGet(
+                            `/api/v2/studios/list?userId=${userId}&comId=${'comId1'}`,
+                            {
+                                authorization: `Bearer ${ownerSessionKey}`,
+                                origin: apiOrigin,
+                            }
+                        )
+                    );
+
+                    expectResponseBodyToEqual(result, {
+                        statusCode: 200,
+                        body: {
+                            success: true,
+                            studios: [
+                                {
+                                    studioId: 'studioId2',
+                                    displayName: 'studio 2',
+                                    role: 'admin',
+                                    isPrimaryContact: true,
+                                    subscriptionTier: null,
+                                    ownerStudioComId: 'comId1',
+                                },
+                                {
+                                    studioId: 'studioId3',
+                                    displayName: 'studio 3',
+                                    role: 'member',
+                                    isPrimaryContact: true,
+                                    subscriptionTier: null,
+                                    ownerStudioComId: 'comId1',
+                                },
+                            ],
+                        },
+                        headers: apiCorsHeaders,
+                    });
+                });
+
+                it('should return a 403 if the user is not a super user', async () => {
+                    const owner = await store.findUser(ownerId);
+                    await store.saveUser({
+                        ...owner,
+                        role: 'none',
+                    });
+
+                    const result = await server.handleHttpRequest(
+                        httpGet(
+                            `/api/v2/studios/list?userId=${userId}&comId=${'comId1'}`,
+                            {
+                                authorization: `Bearer ${ownerSessionKey}`,
+                                origin: apiOrigin,
+                            }
+                        )
+                    );
+
+                    expectResponseBodyToEqual(result, {
+                        statusCode: 403,
+                        body: {
+                            success: false,
+                            errorCode: 'not_authorized',
+                            errorMessage:
+                                'You are not authorized to perform this action.',
+                        },
+                        headers: apiCorsHeaders,
+                    });
+                });
+            });
+        });
+
+        describe('?userId', () => {
+            beforeEach(async () => {
+                const owner = await store.findUser(ownerId);
+                await store.saveUser({
+                    ...owner,
+                    role: 'superUser',
+                });
+            });
+
+            it('should list the studios that the user has access to if the current user is a super user', async () => {
+                const result = await server.handleHttpRequest(
+                    httpGet(`/api/v2/studios/list?userId=${userId}`, {
+                        authorization: `Bearer ${ownerSessionKey}`,
+                        origin: apiOrigin,
+                    })
+                );
+
+                expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                        studios: [
+                            {
+                                studioId: 'studioId2',
+                                displayName: 'studio 2',
+                                role: 'admin',
+                                isPrimaryContact: true,
+                                subscriptionTier: null,
+                            },
+                            {
+                                studioId: 'studioId3',
+                                displayName: 'studio 3',
+                                role: 'member',
+                                isPrimaryContact: true,
+                                subscriptionTier: null,
+                            },
+                        ],
+                    },
+                    headers: apiCorsHeaders,
+                });
+            });
+
+            it('should return a 403 if the user is not a super user', async () => {
+                const owner = await store.findUser(ownerId);
+                await store.saveUser({
+                    ...owner,
+                    role: 'none',
+                });
+
+                const result = await server.handleHttpRequest(
+                    httpGet(`/api/v2/studios/list?userId=${userId}`, {
+                        authorization: `Bearer ${ownerSessionKey}`,
+                        origin: apiOrigin,
+                    })
+                );
+
+                expectResponseBodyToEqual(result, {
+                    statusCode: 403,
+                    body: {
+                        success: false,
+                        errorCode: 'not_authorized',
+                        errorMessage:
+                            'You are not authorized to perform this action.',
+                    },
+                    headers: apiCorsHeaders,
+                });
+            });
         });
 
         testAuthorization(() => httpGet('/api/v2/studios/list', apiHeaders));

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -73,6 +73,9 @@ import {
 import { ModerationController } from './ModerationController';
 import { COM_ID_CONFIG_SCHEMA, COM_ID_PLAYER_CONFIG } from './ComIdConfig';
 
+declare const GIT_TAG: string;
+declare const GIT_HASH: string;
+
 export const NOT_LOGGED_IN_RESULT = {
     success: false as const,
     errorCode: 'not_logged_in' as const,
@@ -602,7 +605,7 @@ export class RecordsServer {
                     }
 
                     const result = await this._auth.createAccount({
-                        userId: validation.userId,
+                        userRole: validation.role,
                         ipAddress: context.ipAddress,
                     });
 
@@ -2894,7 +2897,14 @@ export class RecordsServer {
                 .handler(async ({}, context) => {
                     const procedures = this._procedures;
                     const metadata = getProcedureMetadata(procedures);
-                    return { success: true, ...metadata };
+                    return {
+                        success: true,
+                        ...metadata,
+                        version:
+                            typeof GIT_TAG === 'string' ? GIT_TAG : undefined,
+                        versionHash:
+                            typeof GIT_HASH === 'string' ? GIT_HASH : undefined,
+                    };
                 }),
         };
     }

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -619,10 +619,11 @@ export class RecordsServer {
                     z
                         .object({
                             expireTimeMs: z.coerce.number().int().optional(),
+                            userId: z.string().optional(),
                         })
                         .default({})
                 )
-                .handler(async ({ expireTimeMs }, context) => {
+                .handler(async ({ expireTimeMs, userId }, context) => {
                     const sessionKey = context.sessionKey;
 
                     if (!sessionKey) {
@@ -635,10 +636,10 @@ export class RecordsServer {
                         return UNACCEPTABLE_SESSION_KEY;
                     }
 
-                    const [userId] = parsed;
+                    const [sessionKeyUserId] = parsed;
 
                     const result = await this._auth.listSessions({
-                        userId,
+                        userId: userId ?? sessionKeyUserId,
                         sessionKey,
                         expireTimeMs,
                     });

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -6291,6 +6291,7 @@ export class RecordsServer {
             subscriptionTier: result.subscriptionTier,
             privacyFeatures: result.privacyFeatures,
             displayName: result.displayName,
+            role: result.role,
         });
     }
 

--- a/src/aux-records/TestUtils.ts
+++ b/src/aux-records/TestUtils.ts
@@ -91,7 +91,7 @@ export function createTestControllers(
 }
 
 export async function createTestUser(
-    { auth, authMessenger, records }: TestServices,
+    { auth, authMessenger }: Pick<TestServices, 'auth' | 'authMessenger'>,
     emailAddress: string = 'test@example.com'
 ) {
     const loginRequest = await auth.requestLogin({

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -2344,6 +2344,10 @@ Object {
             "optional": true,
             "type": "string",
           },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
         },
         "type": "object",
       },
@@ -5008,6 +5012,10 @@ Object {
         "schema": Object {
           "comId": Object {
             "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
             "optional": true,
             "type": "string",
           },

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -4,6 +4,18 @@ exports[`RecordsServer GET /api/v2/procedures should return the list of procedur
 Object {
   "procedures": Array [
     Object {
+      "inputs": Object {
+        "schema": Object {
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getUserInfo",
+      "origins": "account",
+    },
+    Object {
       "http": Object {
         "method": "POST",
         "path": "/api/v2/email/valid",
@@ -2650,6 +2662,18 @@ Object {
 exports[`RecordsServer GET /api/v2/procedures should support procedures 1`] = `
 Object {
   "procedures": Array [
+    Object {
+      "inputs": Object {
+        "schema": Object {
+          "userId": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getUserInfo",
+      "origins": "account",
+    },
     Object {
       "http": Object {
         "method": "POST",

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1121,6 +1121,10 @@ Object {
             "optional": true,
             "type": "string",
           },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
         },
         "type": "object",
       },
@@ -3781,6 +3785,10 @@ Object {
       "inputs": Object {
         "schema": Object {
           "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "userId": Object {
             "optional": true,
             "type": "string",
           },

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -76,6 +76,10 @@ Object {
             "optional": true,
             "type": "number",
           },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
         },
         "type": "object",
       },
@@ -2734,6 +2738,10 @@ Object {
           "expireTimeMs": Object {
             "optional": true,
             "type": "number",
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
           },
         },
         "type": "object",

--- a/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
@@ -31,6 +31,7 @@ import {
     SaveNewUserResult,
     UpdateSubscriptionInfoRequest,
     UpdateSubscriptionPeriodRequest,
+    UserRole,
 } from '@casual-simulation/aux-records/AuthStore';
 import { Db, Collection, FilterQuery } from 'mongodb';
 import { v4 as uuid } from 'uuid';
@@ -496,6 +497,7 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
                     banReason: user.banReason,
                     privoServiceId: user.privoServiceId,
                     privoParentServiceId: user.privoParentServiceId,
+                    role: user.role,
                 },
             },
             {
@@ -539,6 +541,7 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
             banReason: user.banReason,
             privoServiceId: user.privoServiceId,
             privoParentServiceId: user.privoParentServiceId,
+            role: user.role,
         });
 
         return {
@@ -1395,6 +1398,7 @@ export interface MongoDBAuthUser {
     privoParentServiceId?: string;
 
     privacyFeatures?: PrivacyFeatures;
+    role?: UserRole;
 }
 
 export interface MongoDBUserAuthenticator extends AuthUserAuthenticator {

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -16,6 +16,7 @@ import {
     SaveNewUserResult,
     UpdateSubscriptionInfoRequest,
     UpdateSubscriptionPeriodRequest,
+    UserRole,
 } from '@casual-simulation/aux-records/AuthStore';
 import {
     LoginRequest,
@@ -181,6 +182,7 @@ export class PrismaAuthStore implements AuthStore {
             allowPublicData: user.privacyFeatures?.allowPublicData ?? true,
             allowAI: user.privacyFeatures?.allowAI ?? true,
             allowPublicInsts: user.privacyFeatures?.allowPublicInsts ?? true,
+            role: user.role,
         };
 
         await this._client.user.upsert({
@@ -222,6 +224,7 @@ export class PrismaAuthStore implements AuthStore {
                 allowAI: user.privacyFeatures?.allowAI ?? true,
                 allowPublicInsts:
                     user.privacyFeatures?.allowPublicInsts ?? true,
+                role: user.role,
             };
 
             if (!!user.currentLoginRequestId) {
@@ -1173,6 +1176,7 @@ export class PrismaAuthStore implements AuthStore {
                 subscriptionPeriodStartMs: convertToMillis(
                     user.subscriptionPeriodStart
                 ),
+                role: user.role as UserRole,
             };
         }
         return null;

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -46,6 +46,8 @@ model User {
     allowAI Boolean?
     allowPublicInsts Boolean?
 
+    role String?
+
     loginRequests LoginRequest[]
     webauthnLoginRequests WebAuthnLoginRequest[]
     sessions AuthSession[]

--- a/src/aux-server/aux-backend/schemas/migrations/20240408180450_add_user_roles/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240408180450_add_user_roles/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" STRING;


### PR DESCRIPTION
### :rocket: Features
-   Added the `superUser` user role.
    -   This is internal to CasualOS and is not related to roles that control access to record data.
    -   There are currently only two roles: `none`, and `superUser`.
    -   Currently, roles have to be assigned manually through the database. There is not API to grant a user the `superUser` role.
    -   All users default to the `none` role.
    -   When assigned the `superUser` role, a user has access to some operations that they would not normally have access to, including:
        -   `getUserInfo` for all users
        -   `createAccount`
        -   `listSessions` for all users
        -   `listRecords` for all users and studios
        -   `listStudios` for all users
        -   `listStudioMembers` for all studios
        -   `getSubscriptions` for all users and studios
- Made the `createAccount` procedure only allow super users.

Closes #436 