### PR TITLE
Support specifying a `sessionKey` in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@
         -   `listStudios` for all users
         -   `listStudioMembers` for all studios
         -   `getSubscriptions` for all users and studios
+-   Added the ability to specify user login details in the URL.
+    -   When logged in, CasualOS stores a `sessionKey` and a `connectionKey` in the local storage of their web browser to keep them logged in.
+    -   When the `sessionKey` and `connectionKey` query params are specified in the URL, they will be used instead of the stored ones.
+    -   Additionally, they work for users who are not logged in.
+    -   This makes it possible to give someone a URL that grants them automatic access to an account.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -4325,6 +4325,7 @@ describe('AuthController', () => {
                     allSessionRevokeTimeMs: undefined,
                     currentLoginRequestId: undefined,
                 });
+                nowMock.mockReturnValue(101);
             });
 
             describe('v1 hashes', () => {
@@ -4347,6 +4348,44 @@ describe('AuthController', () => {
                         secretHash: hashPasswordWithSalt(code, sessionId),
                         connectionSecret: code,
                         expireTimeMs: 200,
+                        grantedTimeMs: 100,
+                        previousSessionId: null,
+                        nextSessionId: null,
+                        revokeTimeMs: null,
+                        userId,
+                        ipAddress: '127.0.0.1',
+                    });
+
+                    const result = await controller.validateSessionKey(
+                        sessionKey
+                    );
+
+                    expect(result).toEqual({
+                        success: true,
+                        userId: userId,
+                        sessionId: sessionId,
+                    });
+                });
+
+                it('should allow session keys that dont expire', async () => {
+                    const requestId = 'requestId';
+                    const sessionId = toBase64String('sessionId');
+                    const code = 'code';
+                    const userId = 'myid';
+
+                    const sessionKey = formatV1SessionKey(
+                        userId,
+                        sessionId,
+                        code,
+                        Infinity
+                    );
+
+                    await store.saveSession({
+                        requestId,
+                        sessionId,
+                        secretHash: hashPasswordWithSalt(code, sessionId),
+                        connectionSecret: code,
+                        expireTimeMs: null,
                         grantedTimeMs: 100,
                         previousSessionId: null,
                         nextSessionId: null,
@@ -4576,6 +4615,47 @@ describe('AuthController', () => {
                         ),
                         connectionSecret: code,
                         expireTimeMs: 200,
+                        grantedTimeMs: 100,
+                        previousSessionId: null,
+                        nextSessionId: null,
+                        revokeTimeMs: null,
+                        userId,
+                        ipAddress: '127.0.0.1',
+                    });
+
+                    const result = await controller.validateSessionKey(
+                        sessionKey
+                    );
+
+                    expect(result).toEqual({
+                        success: true,
+                        userId: userId,
+                        sessionId: sessionId,
+                    });
+                });
+
+                it('should allow sessions that dont expire', async () => {
+                    const requestId = 'requestId';
+                    const sessionId = toBase64String('sessionId');
+                    const code = 'code';
+                    const userId = 'myid';
+
+                    const sessionKey = formatV1SessionKey(
+                        userId,
+                        sessionId,
+                        code,
+                        Infinity
+                    );
+
+                    await store.saveSession({
+                        requestId,
+                        sessionId,
+                        secretHash: hashHighEntropyPasswordWithSalt(
+                            code,
+                            sessionId
+                        ),
+                        connectionSecret: code,
+                        expireTimeMs: null,
                         grantedTimeMs: 100,
                         previousSessionId: null,
                         nextSessionId: null,

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -1903,9 +1903,13 @@ export class AuthController {
                 };
             }
 
-            if (now >= session.expireTimeMs) {
+            if (
+                typeof session.expireTimeMs === 'number' &&
+                now >= session.expireTimeMs
+            ) {
                 console.log(
-                    '[AuthController] [validateSessionKey] Session has expired.'
+                    '[AuthController] [validateSessionKey] Session has expired.',
+                    session
                 );
                 return {
                     success: false,

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -734,8 +734,9 @@ export interface AuthSession {
 
     /**
      * The unix timestamp in miliseconds that the session will expire at.
+     * If null, then the session does not expire.
      */
-    expireTimeMs: number;
+    expireTimeMs: number | null;
 
     /**
      * The unix timestamp in miliseconds that the session was revoked at.

--- a/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
+++ b/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
@@ -338,6 +338,16 @@ export class AuthHandler implements AuxAuth {
 
     async openAccountPage(): Promise<void> {
         const url = new URL('/', location.origin);
+        if (
+            authManager.currentSessionKey !== authManager.savedSessionKey &&
+            authManager.currentConnectionKey !== authManager.savedConnectionKey
+        ) {
+            url.searchParams.set('sessionKey', authManager.currentSessionKey);
+            url.searchParams.set(
+                'connectionKey',
+                authManager.currentConnectionKey
+            );
+        }
         window.open(url.href, '_blank');
     }
 

--- a/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
+++ b/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
@@ -1068,6 +1068,12 @@ export class AuthHandler implements AuxAuth {
             clearTimeout(this._refreshTimeout);
         }
         const expiry = this._getTokenExpirationTime(token);
+
+        if (expiry < 0 || !isFinite(expiry)) {
+            console.log('[AuthHandler] Token does not expire.');
+            return;
+        }
+
         const now = Date.now();
         const lifetimeMs = expiry - now;
         const refreshTimeMs = Math.max(lifetimeMs - REFRESH_LIFETIME_MS, 0);

--- a/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
+++ b/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
@@ -109,7 +109,11 @@ export class AuthHandler implements AuxAuth {
     private _loginPromise: Promise<AuthData>;
     private _isLoggingIn: boolean;
 
-    constructor() {
+    constructor(sessionKey?: string, connectionKey?: string) {
+        if (sessionKey && connectionKey) {
+            authManager.useTemporaryKeys(sessionKey, connectionKey);
+        }
+
         this._oauthChannel.addEventListener('message', (event) => {
             if (event.data === 'login') {
                 console.log('[AuthHandler] Got oauth login message.');
@@ -649,8 +653,8 @@ export class AuthHandler implements AuxAuth {
         if (!authManager.userInfoLoaded) {
             await authManager.loadUserInfo();
         }
-        this._token = authManager.savedSessionKey;
-        this._connectionKey = authManager.savedConnectionKey;
+        this._token = authManager.currentSessionKey;
+        this._connectionKey = authManager.currentConnectionKey;
         this._loginData = {
             userId: this._userId ?? authManager.userId,
             avatarUrl: authManager.avatarUrl,

--- a/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
+++ b/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
@@ -551,6 +551,24 @@ export class AuthManager {
         }
     }
 
+    getSessionKeyFromUrl(): string {
+        const params = new URLSearchParams(location.search);
+        if (params.has('sessionKey')) {
+            return params.get('sessionKey');
+        } else {
+            return null;
+        }
+    }
+
+    getConnectionKeyFromUrl(): string {
+        const params = new URLSearchParams(location.search);
+        if (params.has('connectionKey')) {
+            return params.get('connectionKey');
+        } else {
+            return null;
+        }
+    }
+
     private async _revokeSessionKey(sessionKey: string): Promise<void> {
         try {
             const result = await this.client.revokeSession(

--- a/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
+++ b/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
@@ -137,6 +137,9 @@ export class AuthManager {
     private _gitTag: string;
     private _client: ReturnType<typeof createRecordsClient>;
 
+    private _temporarySessionKey: string;
+    private _temporaryConnectionKey: string;
+
     constructor(
         apiEndpoint: string,
         websocketEndpoint: string,
@@ -152,7 +155,7 @@ export class AuthManager {
         this._studiosSupported = ASSUME_STUDIOS_SUPPORTED;
         this._usePrivoLogin = USE_PRIVO_LOGIN;
         this._client = createRecordsClient(this.apiEndpoint);
-        this._client.sessionKey = this.savedSessionKey;
+        this._updateClientSessionKey();
     }
 
     get userId() {
@@ -212,7 +215,9 @@ export class AuthManager {
     }
 
     get userInfoLoaded() {
-        return !!this._userId && !!this.savedSessionKey && !!this._appMetadata;
+        return (
+            !!this._userId && !!this.currentSessionKey && !!this._appMetadata
+        );
     }
 
     get loginState(): Observable<boolean> {
@@ -280,7 +285,7 @@ export class AuthManager {
     }
 
     isLoggedIn(): boolean {
-        const sessionKey = this.savedSessionKey;
+        const sessionKey = this.currentSessionKey;
         if (!sessionKey) {
             return false;
         }
@@ -299,7 +304,7 @@ export class AuthManager {
 
     async loadUserInfo() {
         const [userId, sessionId, sessionSecret, expireTimeMs] =
-            parseSessionKey(this.savedSessionKey);
+            parseSessionKey(this.currentSessionKey);
         this._userId = userId;
         this._sessionId = sessionId;
         this._appMetadata = await this._loadAppMetadata();
@@ -307,8 +312,13 @@ export class AuthManager {
         if (!this._appMetadata) {
             this._userId = null;
             this._sessionId = null;
-            this.savedSessionKey = null;
-            this.savedConnectionKey = null;
+            if (this._temporarySessionKey) {
+                this._temporarySessionKey = null;
+                this._temporaryConnectionKey = null;
+            } else {
+                this.savedSessionKey = null;
+                this.savedConnectionKey = null;
+            }
         } else {
             this._saveAcceptedTerms(true);
             if (this.email) {
@@ -361,6 +371,25 @@ export class AuthManager {
         this.savedSessionKey = result.sessionKey;
         this.savedConnectionKey = result.connectionKey;
         this._userId = result.userId;
+
+        this._temporarySessionKey = null;
+        this._temporaryConnectionKey = null;
+    }
+
+    useTemporaryKeys(sessionKey: string, connectionKey: string) {
+        if (sessionKey && connectionKey) {
+            console.log('[AuthManager] Using temporary keys.');
+            const [userId, sessionId] = parseSessionKey(sessionKey);
+            this._temporarySessionKey = sessionKey;
+            this._temporaryConnectionKey = connectionKey;
+            this._sessionId = sessionId;
+            this._userId = userId;
+            this._updateClientSessionKey();
+        }
+    }
+
+    private _updateClientSessionKey() {
+        this._client.sessionKey = this.currentSessionKey;
     }
 
     async addPasskeyWithWebAuthn(): Promise<
@@ -396,14 +425,18 @@ export class AuthManager {
     }
 
     async logout(revokeSessionKey: boolean = true) {
-        const sessionKey = this.savedSessionKey;
-        if (sessionKey) {
-            this.savedSessionKey = null;
-            if (revokeSessionKey) {
-                await this._revokeSessionKey(sessionKey);
+        if (this.currentSessionKey === this.savedSessionKey) {
+            const sessionKey = this.savedSessionKey;
+            if (sessionKey) {
+                this.savedSessionKey = null;
+                if (revokeSessionKey) {
+                    await this._revokeSessionKey(sessionKey);
+                }
             }
+            this.savedConnectionKey = null;
         }
-        this.savedConnectionKey = null;
+        this._temporaryConnectionKey = null;
+        this._temporarySessionKey = null;
         this._userId = null;
         this._sessionId = null;
         this._appMetadata = null;
@@ -684,6 +717,14 @@ export class AuthManager {
         return localStorage.getItem(ACCEPTED_TERMS_KEY) === 'true';
     }
 
+    get currentSessionKey(): string {
+        return this._temporarySessionKey ?? this.savedSessionKey;
+    }
+
+    get currentConnectionKey(): string {
+        return this._temporaryConnectionKey ?? this.savedConnectionKey;
+    }
+
     get savedSessionKey(): string {
         return localStorage.getItem(SESSION_KEY);
     }
@@ -694,7 +735,7 @@ export class AuthManager {
         } else {
             localStorage.setItem(SESSION_KEY, value);
         }
-        this._client.sessionKey = value;
+        this._updateClientSessionKey();
     }
 
     get savedConnectionKey(): string {
@@ -796,7 +837,7 @@ export class AuthManager {
 
     private _authenticationHeaders(): Record<string, string> {
         return {
-            Authorization: `Bearer ${this.savedSessionKey}`,
+            Authorization: `Bearer ${this.currentSessionKey}`,
         };
     }
 

--- a/src/aux-server/aux-web/aux-auth/site/index.ts
+++ b/src/aux-server/aux-web/aux-auth/site/index.ts
@@ -265,6 +265,13 @@ router.beforeEach((to, from, next) => {
 });
 
 const manager = authManager;
+
+const sessionKeyUrl = authManager.getSessionKeyFromUrl();
+const connectionKeyUrl = authManager.getConnectionKeyFromUrl();
+if (sessionKeyUrl && connectionKeyUrl) {
+    authManager.useTemporaryKeys(sessionKeyUrl, connectionKeyUrl);
+}
+
 let messagePort: MessagePort;
 
 if (window.opener) {

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -796,6 +796,9 @@ export default class PlayerHome extends Vue {
         let changes: BotTags = {};
         let hasChange = false;
         for (let tag of tags) {
+            if (tag === 'sessionKey' || tag === 'connectionKey') {
+                continue;
+            }
             const oldValue = calculateBotValue(calc, bot, tag);
             const newValue = this.query[tag];
             if (newValue !== oldValue) {

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -460,17 +460,42 @@ export class AppManager {
         }
     }
 
+    getSessionKeyFromUrl(): string {
+        const params = new URLSearchParams(location.search);
+        if (params.has('sessionKey')) {
+            return params.get('sessionKey');
+        } else {
+            return null;
+        }
+    }
+
+    getConnectionKeyFromUrl(): string {
+        const params = new URLSearchParams(location.search);
+        if (params.has('connectionKey')) {
+            return params.get('connectionKey');
+        } else {
+            return null;
+        }
+    }
+
     private async _initAuth() {
         let factory: (
             primaryAuthOrigin: string,
-            recordsAuthOrigin: string
+            recordsAuthOrigin: string,
+            sessionKey?: string,
+            connectionKey?: string
         ) => AuthHelperInterface;
+
+        const sessionKey = this.getSessionKeyFromUrl();
+        const connectionKey = this.getConnectionKeyFromUrl();
 
         this._auth = new AuthHelper(
             this.config.authOrigin,
             this.config.recordsOrigin,
             factory,
-            this.config.requirePrivoLogin
+            this.config.requirePrivoLogin,
+            sessionKey,
+            connectionKey
         );
         this._authCoordinator.authHelper = this._auth;
         console.log('[AppManager] Authenticating user in background...');

--- a/src/aux-vm-browser/managers/AuthHelper.ts
+++ b/src/aux-vm-browser/managers/AuthHelper.ts
@@ -12,7 +12,9 @@ export class AuthHelper {
     private _requirePrivoLogin: boolean;
     private _factory: (
         primaryAuthOrigin: string,
-        primaryRecordsOrigin: string
+        primaryRecordsOrigin: string,
+        sessionKey?: string,
+        connectionKey?: string
     ) => AuthHelperInterface;
 
     private _onEndpointDiscovered: Subject<{
@@ -47,19 +49,35 @@ export class AuthHelper {
         primaryRecordsOrigin: string,
         factory?: (
             primaryAuthOrigin: string,
-            primaryRecordsOrigin: string
+            primaryRecordsOrigin: string,
+            sessionKey?: string,
+            connectionKey?: string
         ) => AuthHelperInterface,
-        requirePrivoLogin?: boolean
+        requirePrivoLogin?: boolean,
+        primarySessionKey?: string,
+        primaryConnectionKey?: string
     ) {
         this._factory =
             factory ??
-            ((primaryAuthOrigin, primaryRecordsOrigin) =>
+            ((
+                primaryAuthOrigin,
+                primaryRecordsOrigin,
+                sessionKey,
+                connectionKey
+            ) =>
                 new AuthEndpointHelper(
                     primaryAuthOrigin,
                     primaryRecordsOrigin,
-                    requirePrivoLogin
+                    requirePrivoLogin,
+                    sessionKey,
+                    connectionKey
                 ));
-        this._primary = this._factory(primaryAuthOrigin, primaryRecordsOrigin);
+        this._primary = this._factory(
+            primaryAuthOrigin,
+            primaryRecordsOrigin,
+            primarySessionKey,
+            primaryConnectionKey
+        );
         this._auths = new Map();
         this._loginUIStatus = new Subject();
         this._requirePrivoLogin = requirePrivoLogin ?? false;


### PR DESCRIPTION
### :rocket: Features

-   Added the ability to specify user login details in the URL.
    -   When logged in, CasualOS stores a `sessionKey` and a `connectionKey` in the local storage of their web browser to keep them logged in.
    -   When the `sessionKey` and `connectionKey` query params are specified in the URL, they will be used instead of the stored ones.
    -   Additionally, they work for users who are not logged in.
    -   This makes it possible to give someone a URL that grants them automatic access to an account.

Closes #440 