### PR TITLE
Add the ability to manually assign subscriptions to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
     -   When the `sessionKey` and `connectionKey` query params are specified in the URL, they will be used instead of the stored ones.
     -   Additionally, they work for users who are not logged in.
     -   This makes it possible to give someone a URL that grants them automatic access to an account.
+-   Added the `updateSubscription` operation (`POST /api/v2/subscriptions/update`) to allow super users to grant a subscription to users or studios.
+    -   Currently, it can only be used to grant/revoke simple non-stripe subscriptions. If the user already has a stripe subscription, then the function will refuse to make changes.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -1076,13 +1076,16 @@ export interface UpdateSubscriptionInfoRequest {
 
     /**
      * The ID of the subscription in Stripe's database.
+     * If null, then the subscription is not associated with a stripe subscription.
      */
-    stripeSubscriptionId: string;
+    stripeSubscriptionId: string | null;
 
     /**
      * The ID of the stripe customer.
+     * If null, then the subscription is not associated with a stripe customer.
+     * Note that if the user already has a customer ID, and null is provided, then the customer ID will not be updated.
      */
-    stripeCustomerId: string;
+    stripeCustomerId: string | null;
 
     /**
      * The unix time in miliseconds that the current subscription period started at.

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -1513,9 +1513,11 @@ export class MemoryStore
     ): Promise<void> {
         if (request.userId) {
             const user = await this.findUser(request.userId);
-            let subscription = await this.getSubscriptionByStripeSubscriptionId(
-                request.stripeSubscriptionId
-            );
+            let subscription = request.stripeSubscriptionId
+                ? await this.getSubscriptionByStripeSubscriptionId(
+                      request.stripeSubscriptionId
+                  )
+                : null;
 
             if (subscription) {
                 await this.saveSubscription({
@@ -1527,7 +1529,7 @@ export class MemoryStore
                     currentPeriodEndMs: request.currentPeriodEndMs,
                     currentPeriodStartMs: request.currentPeriodStartMs,
                 });
-            } else {
+            } else if (request.stripeSubscriptionId) {
                 subscription = {
                     id: uuid(),
                     userId: user.id,
@@ -1547,16 +1549,19 @@ export class MemoryStore
                 ...user,
                 subscriptionId: request.subscriptionId,
                 subscriptionStatus: request.subscriptionStatus,
-                stripeCustomerId: request.stripeCustomerId,
+                stripeCustomerId:
+                    request.stripeCustomerId ?? user.stripeCustomerId,
                 subscriptionPeriodStartMs: request.currentPeriodStartMs,
                 subscriptionPeriodEndMs: request.currentPeriodEndMs,
-                subscriptionInfoId: subscription.id,
+                subscriptionInfoId: subscription?.id ?? null,
             });
         } else if (request.studioId) {
             const studio = await this.getStudioById(request.studioId);
-            let subscription = await this.getSubscriptionByStripeSubscriptionId(
-                request.stripeSubscriptionId
-            );
+            let subscription = request.stripeSubscriptionId
+                ? await this.getSubscriptionByStripeSubscriptionId(
+                      request.stripeSubscriptionId
+                  )
+                : null;
 
             if (subscription) {
                 await this.saveSubscription({
@@ -1568,7 +1573,7 @@ export class MemoryStore
                     currentPeriodEndMs: request.currentPeriodEndMs,
                     currentPeriodStartMs: request.currentPeriodStartMs,
                 });
-            } else {
+            } else if (request.stripeSubscriptionId) {
                 subscription = {
                     id: uuid(),
                     userId: null,
@@ -1588,10 +1593,11 @@ export class MemoryStore
                 ...studio,
                 subscriptionId: request.subscriptionId,
                 subscriptionStatus: request.subscriptionStatus,
-                stripeCustomerId: request.stripeCustomerId,
+                stripeCustomerId:
+                    request.stripeCustomerId ?? studio.stripeCustomerId,
                 subscriptionPeriodStartMs: request.currentPeriodStartMs,
                 subscriptionPeriodEndMs: request.currentPeriodEndMs,
-                subscriptionInfoId: subscription.id,
+                subscriptionInfoId: subscription?.id,
             });
         }
     }

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -1597,7 +1597,7 @@ export class MemoryStore
                     request.stripeCustomerId ?? studio.stripeCustomerId,
                 subscriptionPeriodStartMs: request.currentPeriodStartMs,
                 subscriptionPeriodEndMs: request.currentPeriodEndMs,
-                subscriptionInfoId: subscription?.id,
+                subscriptionInfoId: subscription?.id ?? null,
             });
         }
     }

--- a/src/aux-records/SubscriptionConfiguration.spec.ts
+++ b/src/aux-records/SubscriptionConfiguration.spec.ts
@@ -400,6 +400,32 @@ describe('getSubscriptionFeatures()', () => {
                 );
                 expect(features === config.tiers.beta.features).toBe(true);
             });
+
+            it('should return the default features if the subscription has expired', () => {
+                const features = getSubscriptionFeatures(
+                    config,
+                    status,
+                    'subId',
+                    'user',
+                    1000, // start
+                    2000, // end
+                    2001 // now
+                );
+                expect(features === config.defaultFeatures.user).toBe(true);
+            });
+
+            it('should return the features for the subscription if it is still active', () => {
+                const features = getSubscriptionFeatures(
+                    config,
+                    status,
+                    'subId',
+                    'user',
+                    1000, // start
+                    2000, // end
+                    1500 // now
+                );
+                expect(features === config.tiers.beta.features).toBe(true);
+            });
         } else {
             it('should return the default features for the user', () => {
                 const features = getSubscriptionFeatures(

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -911,12 +911,18 @@ export function getComIdFeatures(
  * @param subscriptionStatus The status of the subscription.
  * @param subscriptionId The ID of the subscription.
  * @param type The type of the user.
+ * @param periodStartMs The start of the subscription period in unix time in miliseconds. If omitted, then the period won't be checked.
+ * @param periodEndMs The end of the subscription period in unix time in miliseconds. If omitted, then the period won't be checked.
+ * @param nowMs The current time in milliseconds.
  */
 export function getSubscriptionFeatures(
     config: SubscriptionConfiguration,
     subscriptionStatus: string,
     subscriptionId: string,
-    type: 'user' | 'studio'
+    type: 'user' | 'studio',
+    periodStartMs?: number,
+    periodEndMs?: number,
+    nowMs: number = Date.now()
 ): FeaturesConfiguration {
     if (!config) {
         return allowAllFeatures();
@@ -925,7 +931,14 @@ export function getSubscriptionFeatures(
         const roleSubscriptions = config.subscriptions.filter((s) =>
             subscriptionMatchesRole(s, type)
         );
-        if (isActiveSubscription(subscriptionStatus)) {
+        if (
+            isActiveSubscription(
+                subscriptionStatus,
+                periodStartMs,
+                periodEndMs,
+                nowMs
+            )
+        ) {
             const sub = roleSubscriptions.find((s) => s.id === subscriptionId);
             const tier = sub?.tier;
             const features = tier ? config.tiers[tier]?.features : null;

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -9,6 +9,7 @@ import {
     AuthStore,
     AuthUser,
     UpdateSubscriptionPeriodRequest,
+    UserRole,
 } from './AuthStore';
 import {
     STRIPE_EVENT_INVOICE_PAID_SCHEMA,
@@ -17,7 +18,11 @@ import {
     StripeInterface,
     StripeInvoice,
 } from './StripeInterface';
-import { ServerError } from '@casual-simulation/aux-common/Errors';
+import {
+    NotAuthorizedError,
+    NotLoggedInError,
+    ServerError,
+} from '@casual-simulation/aux-common/Errors';
 import { isActiveSubscription, JsonParseResult, tryParseJson } from './Utils';
 import { SubscriptionConfiguration } from './SubscriptionConfiguration';
 import { ListedStudioAssignment, RecordsStore, Studio } from './RecordsStore';
@@ -240,6 +245,94 @@ export class SubscriptionController {
         } catch (err) {
             console.error(
                 '[SubscriptionController] An error occurred while getting subscription status:',
+                err
+            );
+            return {
+                success: false,
+                errorCode: 'server_error',
+                errorMessage: 'A server error occurred.',
+            };
+        }
+    }
+
+    /**
+     * Attempts to update the subscription for the given user.
+     * @param request The request to update the subscription.
+     */
+    async updateSubscription(
+        request: UpdateSubscriptionRequest
+    ): Promise<UpdateSubscriptionResult> {
+        try {
+            if (!request.currentUserId) {
+                return {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage:
+                        'You must be logged in to update a subscription.',
+                };
+            }
+
+            if (!isSuperUserRole(request.currentUserRole)) {
+                return {
+                    success: false,
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You are not authorized to perform this action.',
+                };
+            }
+
+            console.log(
+                `[SubscriptionController] [updateSubscription currentUserId: ${request.currentUserId}, userId: ${request.userId}, subscriptionId: ${request.subscriptionId}, subscriptionStatus: ${request.subscriptionStatus}] Updating subscription.`
+            );
+
+            const user = await this._authStore.findUser(request.userId);
+
+            if (!user) {
+                return {
+                    success: false,
+                    errorCode: 'user_not_found',
+                    errorMessage: 'The user could not be found.',
+                };
+            }
+
+            if (
+                user.subscriptionInfoId &&
+                isActiveSubscription(
+                    user.subscriptionStatus,
+                    user.subscriptionPeriodStartMs,
+                    user.subscriptionPeriodEndMs
+                )
+            ) {
+                return {
+                    success: false,
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'The user already has an active stripe subscription. Currently, this operation only supports updating the subscription of a user who does not have an active stripe subscription.',
+                };
+            }
+
+            await this._authStore.updateSubscriptionInfo({
+                userId: request.userId,
+                subscriptionId: request.subscriptionId,
+                subscriptionStatus: request.subscriptionId
+                    ? request.subscriptionStatus
+                    : null,
+                currentPeriodStartMs: request.subscriptionId
+                    ? request.subscriptionPeriodStartMs
+                    : null,
+                currentPeriodEndMs: request.subscriptionId
+                    ? request.subscriptionPeriodEndMs
+                    : null,
+                stripeCustomerId: null,
+                stripeSubscriptionId: null,
+            });
+
+            return {
+                success: true,
+            };
+        } catch (err) {
+            console.error(
+                '[SubscriptionController] An error occurred while updating a subscription:',
                 err
             );
             return {
@@ -1335,5 +1428,64 @@ export interface HandleStripeWebhookSuccess {
 export interface HandleStripeWebhookFailure {
     success: false;
     errorCode: ServerError | 'invalid_request' | 'not_supported';
+    errorMessage: string;
+}
+
+export interface UpdateSubscriptionRequest {
+    /**
+     * The role of the user that is currently logged in.
+     */
+    currentUserRole: UserRole | undefined | null;
+
+    /**
+     * The ID of the user that is currently logged in.
+     */
+    currentUserId: string;
+
+    /**
+     * The ID of the user whose subscription should be updated.
+     */
+    userId: string;
+
+    /**
+     * The ID of the subscription that the user should have.
+     * If null, then the subscription will be removed from the user.
+     */
+    subscriptionId: string | null;
+
+    /**
+     * The status of the subscription.
+     */
+    subscriptionStatus: SubscriptionStatus['statusCode'] | null;
+
+    /**
+     * The unix time in miliseconds that the subscription period starts.
+     * If null, then the subscription does not have a start date. This means that the subscription has already started.
+     */
+    subscriptionPeriodStartMs: number | null;
+
+    /**
+     * The unix time in miliseconds that the subscription period ends.
+     * If null, then the subscription does not have an end date. This means that the subscription will never end.
+     */
+    subscriptionPeriodEndMs: number | null;
+}
+
+export type UpdateSubscriptionResult =
+    | UpdateSubscriptionSuccess
+    | UpdateSubscriptionFailure;
+
+export interface UpdateSubscriptionSuccess {
+    success: true;
+}
+
+export interface UpdateSubscriptionFailure {
+    success: false;
+    errorCode:
+        | ServerError
+        | NotLoggedInError
+        | NotAuthorizedError
+        | 'user_not_found'
+        | 'invalid_request';
     errorMessage: string;
 }

--- a/src/aux-records/Utils.spec.ts
+++ b/src/aux-records/Utils.spec.ts
@@ -559,8 +559,18 @@ describe('isActiveSubscription()', () => {
         [undefined as any, false] as const,
     ];
 
-    it.each(statusTypes)('should map %s to %s', (status, expected) => {
-        expect(isActiveSubscription(status)).toBe(expected);
+    describe.each(statusTypes)('%s', (status, expected) => {
+        it(expected ? 'return true' : 'return false', () => {
+            expect(isActiveSubscription(status)).toBe(expected);
+        });
+
+        it('should be able to take a subscription period into account', () => {
+            expect(isActiveSubscription(status, 100, 200, 99)).toBe(false);
+            expect(isActiveSubscription(status, 100, 200, 100)).toBe(expected);
+            expect(isActiveSubscription(status, 100, 200, 105)).toBe(expected);
+            expect(isActiveSubscription(status, 100, 200, 200)).toBe(expected);
+            expect(isActiveSubscription(status, 100, 200, 201)).toBe(false);
+        });
     });
 });
 

--- a/src/aux-records/Utils.ts
+++ b/src/aux-records/Utils.ts
@@ -399,9 +399,21 @@ export function tryDecodeUriComponent(component: string): string | null {
 /**
  * Determines whether the given subscription status should be treated as an active subscription.
  * @param status The status.
+ * @param periodStartMs The start of the subscription period in unix time in miliseconds. If omitted, then the period won't be checked.
+ * @param periodEndMs The end of the subscription period in unix time in miliseconds. If omitted, then the period won't be checked.
+ * @param nowMs The current time in unix time in miliseconds.
  */
-export function isActiveSubscription(status: string): boolean {
-    return status === 'active' || status === 'trialing';
+export function isActiveSubscription(
+    status: string,
+    periodStartMs?: number,
+    periodEndMs?: number,
+    nowMs: number = Date.now()
+): boolean {
+    const active = status === 'active' || status === 'trialing';
+    if (active && periodStartMs && periodEndMs) {
+        return nowMs >= periodStartMs && nowMs <= periodEndMs;
+    }
+    return active;
 }
 
 /**

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -2519,6 +2519,54 @@ Object {
     },
     Object {
       "http": Object {
+        "method": "POST",
+        "path": "/api/v2/subscriptions/update",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "subscriptionId": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "subscriptionPeriodEndMs": Object {
+            "nullable": true,
+            "type": "number",
+          },
+          "subscriptionPeriodStartMs": Object {
+            "nullable": true,
+            "type": "number",
+          },
+          "subscriptionStatus": Object {
+            "nullable": true,
+            "type": "enum",
+            "values": Array [
+              "active",
+              "canceled",
+              "ended",
+              "past_due",
+              "unpaid",
+              "incomplete",
+              "incomplete_expired",
+              "trialing",
+              "paused",
+            ],
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateSubscription",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
         "method": "GET",
         "path": "/api/v2/records/insts/list",
       },
@@ -5186,6 +5234,54 @@ Object {
         "type": "object",
       },
       "name": "getManageSubscriptionLink",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/subscriptions/update",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "studioId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "subscriptionId": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "subscriptionPeriodEndMs": Object {
+            "nullable": true,
+            "type": "number",
+          },
+          "subscriptionPeriodStartMs": Object {
+            "nullable": true,
+            "type": "number",
+          },
+          "subscriptionStatus": Object {
+            "nullable": true,
+            "type": "enum",
+            "values": Array [
+              "active",
+              "canceled",
+              "ended",
+              "past_due",
+              "unpaid",
+              "incomplete",
+              "incomplete_expired",
+              "trialing",
+              "paused",
+            ],
+          },
+          "userId": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "updateSubscription",
       "origins": "account",
     },
     Object {

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -949,7 +949,7 @@ export class PrismaAuthStore implements AuthStore {
                     },
                 };
             } else {
-                updateData.subscriptionInfo = null;
+                updateData.subscriptionInfoId = null;
             }
 
             await this._client.user.update({
@@ -994,7 +994,7 @@ export class PrismaAuthStore implements AuthStore {
                     },
                 };
             } else {
-                updateData.subscriptionInfo = null;
+                updateData.subscriptionInfoId = null;
             }
 
             await this._client.studio.update({

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -914,78 +914,94 @@ export class PrismaAuthStore implements AuthStore {
         const periodStart = convertToDate(request.currentPeriodStartMs);
         const periodEnd = convertToDate(request.currentPeriodEndMs);
         if (request.userId) {
+            const updateData: Prisma.UserUpdateArgs<any>['data'] = {
+                subscriptionId: request.subscriptionId,
+                subscriptionStatus: request.subscriptionStatus,
+                subscriptionPeriodStart: periodStart,
+                subscriptionPeriodEnd: periodEnd,
+            };
+
+            if (request.stripeCustomerId) {
+                updateData.stripeCustomerId = request.stripeCustomerId;
+            }
+
+            if (request.stripeSubscriptionId) {
+                updateData.subscriptionInfo = {
+                    upsert: {
+                        create: {
+                            id: uuid(),
+                            userId: request.userId,
+                            subscriptionId: request.subscriptionId,
+                            subscriptionStatus: request.subscriptionStatus,
+                            stripeCustomerId: request.stripeCustomerId,
+                            stripeSubscriptionId: request.stripeSubscriptionId,
+                            currentPeriodStart: periodStart,
+                            currentPeriodEnd: periodEnd,
+                        },
+                        update: {
+                            subscriptionId: request.subscriptionId,
+                            subscriptionStatus: request.subscriptionStatus,
+                            stripeCustomerId: request.stripeCustomerId,
+                            stripeSubscriptionId: request.stripeSubscriptionId,
+                            currentPeriodStart: periodStart,
+                            currentPeriodEnd: periodEnd,
+                        },
+                    },
+                };
+            } else {
+                updateData.subscriptionInfo = null;
+            }
+
             await this._client.user.update({
                 where: {
                     id: request.userId,
                 },
-                data: {
-                    subscriptionId: request.subscriptionId,
-                    subscriptionStatus: request.subscriptionStatus,
-                    stripeCustomerId: request.stripeCustomerId,
-                    subscriptionPeriodStart: periodStart,
-                    subscriptionPeriodEnd: periodEnd,
-                    subscriptionInfo: {
-                        upsert: {
-                            create: {
-                                id: uuid(),
-                                userId: request.userId,
-                                subscriptionId: request.subscriptionId,
-                                subscriptionStatus: request.subscriptionStatus,
-                                stripeCustomerId: request.stripeCustomerId,
-                                stripeSubscriptionId:
-                                    request.stripeSubscriptionId,
-                                currentPeriodStart: periodStart,
-                                currentPeriodEnd: periodEnd,
-                            },
-                            update: {
-                                subscriptionId: request.subscriptionId,
-                                subscriptionStatus: request.subscriptionStatus,
-                                stripeCustomerId: request.stripeCustomerId,
-                                stripeSubscriptionId:
-                                    request.stripeSubscriptionId,
-                                currentPeriodStart: periodStart,
-                                currentPeriodEnd: periodEnd,
-                            },
-                        },
-                    },
-                },
+                data: updateData,
             });
         } else if (request.studioId) {
+            const updateData: Prisma.StudioUpdateArgs<any>['data'] = {
+                subscriptionId: request.subscriptionId,
+                subscriptionStatus: request.subscriptionStatus,
+                subscriptionPeriodStart: periodStart,
+                subscriptionPeriodEnd: periodEnd,
+            };
+
+            if (request.stripeCustomerId) {
+                updateData.stripeCustomerId = request.stripeCustomerId;
+            }
+
+            if (request.stripeSubscriptionId) {
+                updateData.subscriptionInfo = {
+                    upsert: {
+                        create: {
+                            id: uuid(),
+                            studioId: request.studioId,
+                            subscriptionId: request.subscriptionId,
+                            subscriptionStatus: request.subscriptionStatus,
+                            stripeCustomerId: request.stripeCustomerId,
+                            stripeSubscriptionId: request.stripeSubscriptionId,
+                            currentPeriodStart: periodStart,
+                            currentPeriodEnd: periodEnd,
+                        },
+                        update: {
+                            subscriptionId: request.subscriptionId,
+                            subscriptionStatus: request.subscriptionStatus,
+                            stripeCustomerId: request.stripeCustomerId,
+                            stripeSubscriptionId: request.stripeSubscriptionId,
+                            currentPeriodStart: periodStart,
+                            currentPeriodEnd: periodEnd,
+                        },
+                    },
+                };
+            } else {
+                updateData.subscriptionInfo = null;
+            }
+
             await this._client.studio.update({
                 where: {
                     id: request.studioId,
                 },
-                data: {
-                    subscriptionId: request.subscriptionId,
-                    subscriptionStatus: request.subscriptionStatus,
-                    stripeCustomerId: request.stripeCustomerId,
-                    subscriptionPeriodStart: periodStart,
-                    subscriptionPeriodEnd: periodEnd,
-                    subscriptionInfo: {
-                        upsert: {
-                            create: {
-                                id: uuid(),
-                                studioId: request.studioId,
-                                subscriptionId: request.subscriptionId,
-                                subscriptionStatus: request.subscriptionStatus,
-                                stripeCustomerId: request.stripeCustomerId,
-                                stripeSubscriptionId:
-                                    request.stripeSubscriptionId,
-                                currentPeriodStart: periodStart,
-                                currentPeriodEnd: periodEnd,
-                            },
-                            update: {
-                                subscriptionId: request.subscriptionId,
-                                subscriptionStatus: request.subscriptionStatus,
-                                stripeCustomerId: request.stripeCustomerId,
-                                stripeSubscriptionId:
-                                    request.stripeSubscriptionId,
-                                currentPeriodStart: periodStart,
-                                currentPeriodEnd: periodEnd,
-                            },
-                        },
-                    },
-                },
+                data: updateData,
             });
         }
     }


### PR DESCRIPTION
### :rocket: Features

-   Added the `updateSubscription` operation (`POST /api/v2/subscriptions/update`) to allow super users to grant a subscription to users or studios.
    -   Currently, it can only be used to grant/revoke simple non-stripe subscriptions. If the user already has a stripe subscription, then the function will refuse to make changes.