### PR TITLE
Expose several properties from `HTMLVideoElement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 ### :rocket: Features
 
 -   Added `classifyImages()` function.
+-   Exposed the following properties from `HTMLVideoElement`:
+    -   `currentTime`
+    -   `ended`
+    -   `paused`
+    -   `muted`
+    -   `volume`
+    -   `playbackRate`
+    -   Note that these properties are only updated when an event is received from the element. (e.g. `currentTime` will be exposed if you are listening to `onTimeUpdate`)
 
 ### :bug: Bug Fixes
 

--- a/src/aux-vm/portals/HtmlAppBackend.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.ts
@@ -33,7 +33,18 @@ export const TARGET_INPUT_PROPERTIES = ['value', 'checked'];
  */
 export const ELEMENT_SPECIFIC_PROPERTIES: { [nodeName: string]: string[] } = {
     IMG: ['width', 'height', 'naturalWidth', 'naturalHeight', 'currentSrc'],
-    VIDEO: ['videoWidth', 'videoHeight', 'duration', 'currentSrc'],
+    VIDEO: [
+        'videoWidth',
+        'videoHeight',
+        'duration',
+        'currentSrc',
+        'currentTime',
+        'ended',
+        'paused',
+        'muted',
+        'volume',
+        'playbackRate',
+    ],
     SECTION: ['scrollTop', 'offsetHeight'],
     CANVAS: ['height', 'width'],
 };


### PR DESCRIPTION
### :rocket: Features

-   Exposed the following properties from `HTMLVideoElement`:
    -   `currentTime`
    -   `ended`
    -   `paused`
    -   `muted`
    -   `volume`
    -   `playbackRate`
    -   Note that these properties are only updated when an event is received from the element. (e.g. `currentTime` will be exposed if you are listening to `onTimeUpdate`)

Closes #456 