### PR TITLE
Implement `os.capturePortalScreenshot()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CasualOS Changelog
 
+## V3.3.4
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Added the `os.capturePortalScreenshot()` function.
+    -   This function can be used to get a screenshot of the gridPortal.
+-   Made `systemPortal` panel resizable.
+
 ## V3.3.3
 
 #### Date: 5/9/2024
@@ -8,7 +18,6 @@
 
 -   Improved server deployments to support the same configuration options as serverless deployments.
 -   Updated `livekit-client` to `v2.1.3`.
--   Made `systemPortal` panel resizable.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -178,7 +178,8 @@ export type AsyncActions =
     | LDrawCountBuildStepsAction
     | CalculateViewportCoordinatesFromPositionAction
     | CalculateScreenCoordinatesFromViewportCoordinatesAction
-    | CalculateViewportCoordinatesFromScreenCoordinatesAction;
+    | CalculateViewportCoordinatesFromScreenCoordinatesAction
+    | CapturePortalScreenshotAction;
 
 export type RemoteBotActions =
     | GetRemoteCountAction
@@ -3341,6 +3342,18 @@ export interface CalculateViewportCoordinatesFromScreenCoordinatesAction
 }
 
 /**
+ * Defines an event that captures a screenshot from the given portal.
+ */
+export interface CapturePortalScreenshotAction extends AsyncAction {
+    type: 'capture_portal_screenshot';
+
+    /**
+     * The portal that should be captured.
+     */
+    portal: CameraPortal;
+}
+
+/**
  * Defines an event that requests the pre-caching of a GLTF mesh.
  *
  * @dochash types/os/portals
@@ -5591,6 +5604,22 @@ export function getRecordsEndpoint(
 ): GetRecordsEndpointAction {
     return {
         type: 'get_records_endpoint',
+        taskId,
+    };
+}
+
+/**
+ * Creates a CapturePortalScreenshotAction.
+ * @param portal The portal that the screenshot should be captured from.
+ * @param taskId The ID of the task.
+ */
+export function capturePortalScreenshot(
+    portal: CameraPortal,
+    taskId?: number | string
+): CapturePortalScreenshotAction {
+    return {
+        type: 'capture_portal_screenshot',
+        portal,
         taskId,
     };
 }

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -142,6 +142,7 @@ import {
     calculateViewportCoordinatesFromPosition,
     calculateScreenCoordinatesFromViewportCoordinates,
     calculateViewportCoordinatesFromScreenCoordinates,
+    capturePortalScreenshot,
 } from '@casual-simulation/aux-common/bots';
 import { types } from 'util';
 import { attachRuntime, detachRuntime } from './RuntimeEvents';
@@ -4195,6 +4196,29 @@ describe('AuxLibrary', () => {
                     false,
                     false,
                     undefined,
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.capturePortalScreenshot()', () => {
+            it('should emit a CapturePortalScreenshotAction', () => {
+                const action: any = library.api.os.capturePortalScreenshot();
+                const expected = capturePortalScreenshot(
+                    'grid',
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept the given portal', () => {
+                const action: any =
+                    library.api.os.capturePortalScreenshot('mini');
+                const expected = capturePortalScreenshot(
+                    'mini',
                     context.tasks.size
                 );
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -4213,17 +4213,6 @@ describe('AuxLibrary', () => {
                 expect(action[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
             });
-
-            it('should accept the given portal', () => {
-                const action: any =
-                    library.api.os.capturePortalScreenshot('mini');
-                const expected = capturePortalScreenshot(
-                    'mini',
-                    context.tasks.size
-                );
-                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
-                expect(context.actions).toEqual([expected]);
-            });
         });
 
         describe('os.localTime', () => {

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -243,6 +243,8 @@ import {
     calculateScreenCoordinatesFromViewportCoordinates as calcCalculateScreenCoordinatesFromViewportCoordinates,
     calculateViewportCoordinatesFromScreenCoordinates as calcCalculateViewportCoordinatesFromScreenCoordinates,
     Point2D,
+    CameraPortal,
+    capturePortalScreenshot as calcCapturePortalScreenshot,
 } from '@casual-simulation/aux-common/bots';
 import {
     AIChatOptions,
@@ -3043,6 +3045,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 openPhotoCamera,
                 capturePhoto,
                 closePhotoCamera,
+
+                capturePortalScreenshot,
 
                 /**
                  * Gets the device-local time as the number of miliseconds since midnight January 1st, 1970 UTC-0 (i.e. the Unix Epoch). This is what your device's clock thinks the current time is.
@@ -6533,6 +6537,29 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             undefined,
             task.taskId
         );
+        return addAsyncAction(task, action);
+    }
+
+    /**
+     * Captures a screenshot (i.e. photo/picture) from the grid portal.
+     *
+     * Returns a promise that resolves with the captured photo.
+     *
+     * @param portal the portal to capture the screenshot from. Defaults to the grid portal.
+     *
+     * @example Capture a screenshot from the grid portal.
+     * const screenshot = await os.capturePortalScreenshot();
+     *
+     * @example Display a screenshot from the grid portal on a bot.
+     * const screenshot = await os.capturePortalScreenshot();
+     * masks.formAddress = bytes.toBase64Url(await screenshot.data.arrayBuffer());
+     *
+     * @dochash actions/os/portals
+     * @docname os.capturePortalScreenshot
+     */
+    function capturePortalScreenshot(): Promise<Photo> {
+        const task = context.createTask();
+        const action = calcCapturePortalScreenshot('grid', task.taskId);
         return addAsyncAction(task, action);
     }
 

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -11168,6 +11168,21 @@ interface Os {
     capturePhoto(options?: OpenPhotoCameraOptions): Promise<Photo>;
 
     /**
+     * Captures a screenshot (i.e. photo/picture) from the grid portal.
+     * 
+     * Returns a promise that resolves with the captured photo.
+     * 
+     * @param portal the portal to capture the screenshot from. Defaults to the grid portal.
+     * 
+     * @example Capture a screenshot from the grid portal.
+     * const screenshot = await os.capturePortalScreenshot();
+     * 
+     * @dochash actions/os/portals
+     * @docname os.capturePortalScreenshot
+     */
+    capturePortalScreenshot(): Promise<Photo>;
+
+    /**
      * Shows the given barcode.
      * @param code The code that should be shown.
      * @param format The format that the barcode should be shown in.


### PR DESCRIPTION
### :rocket: Features

-   Added the `os.capturePortalScreenshot()` function.
    -   This function can be used to get a screenshot of the gridPortal.

Closes #464