### PR TITLE
Feature/hume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### :rocket: Features
 
 -   Improve support for environments that do no support local storage or indexedDB.
+-   Added the `ai.hume.getAccessToken()` function to allow retrieving an access token for a [Hume.ai](https://www.hume.ai/) session.
+    -   Requires that `humeai` be specified in the server configuration with an `apiKey` and `secretKey` and that the user has a subscription with `ai.hume.allowed` set to true in the subscription tier features.
 
 ## V3.3.4
 

--- a/src/aux-common/rpc/ErrorCodes.spec.ts
+++ b/src/aux-common/rpc/ErrorCodes.spec.ts
@@ -80,6 +80,7 @@ describe('getStatusCode()', () => {
         ['invalid_connection_state', 500] as const,
         ['user_already_exists', 400] as const,
         ['session_is_not_revokable', 400] as const,
+        ['hume_api_error', 500] as const,
     ];
 
     it.each(cases)('should map error code %s to %s', (code, expectedStatus) => {

--- a/src/aux-common/rpc/ErrorCodes.ts
+++ b/src/aux-common/rpc/ErrorCodes.ts
@@ -70,7 +70,8 @@ export type KnownErrorCodes =
     | 'not_found'
     | 'invalid_connection_state'
     | 'user_already_exists'
-    | 'session_is_not_revokable';
+    | 'session_is_not_revokable'
+    | 'hume_api_error';
 
 /**
  * Gets the status code that should be used for the given response.
@@ -176,6 +177,8 @@ export function getStatusCode(
             return 500;
         } else if (response.errorCode === 'user_already_exists') {
             return 400;
+        } else if (response.errorCode === 'hume_api_error') {
+            return 500;
         } else {
             return 400;
         }

--- a/src/aux-records/AIHumeInterface.ts
+++ b/src/aux-records/AIHumeInterface.ts
@@ -1,0 +1,115 @@
+import { ServerError } from '@casual-simulation/aux-common';
+import { z } from 'zod';
+
+/**
+ * Defines an interface that is able to be used to provide [hume.ai](https://www.hume.ai/) features for a server.
+ */
+export interface AIHumeInterface {
+    /**
+     * Generates an access token that can be used to access the Hume API.
+     */
+    getAccessToken(): Promise<AIHumeInterfaceGetAccessTokenResult>;
+}
+
+export class HumeInterface implements AIHumeInterface {
+    private _apiKey: string;
+    private _secretKey: string;
+
+    constructor(apiKey: string, secretKey: string) {
+        this._apiKey = apiKey;
+        this._secretKey = secretKey;
+    }
+
+    async getAccessToken(): Promise<AIHumeInterfaceGetAccessTokenResult> {
+        const authString = `${this._apiKey}:${this._secretKey}`;
+        const encodedAuthString = Buffer.from(authString).toString('base64');
+
+        const response = await fetch('https://api.hume.ai/oauth2-cc/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Authorization: `Basic ${encodedAuthString}`,
+            },
+            body: new URLSearchParams({
+                grant_type: 'client_credentials',
+            }).toString(),
+            cache: 'no-cache',
+        });
+
+        if (!response.ok) {
+            const data = await response.text();
+            console.error(
+                `[HumeInterface] Failed to get access token from Hume. Status: ${response.status} Data:`,
+                data
+            );
+            return {
+                success: false,
+                errorCode: 'hume_api_error',
+                errorMessage: `Failed to get access token from Hume.`,
+            };
+        }
+
+        const data = await response.json();
+        const schema = z.object({
+            access_token: z.string(),
+            expires_in: z.number(),
+            issued_at: z.number(),
+            token_type: z.literal('Bearer'),
+        });
+
+        const result = schema.safeParse(data);
+
+        if (!result.success) {
+            console.error(
+                `[HumeInterface] Failed to parse access token data from Hume. Data:`,
+                data
+            );
+            return {
+                success: false,
+                errorCode: 'hume_api_error',
+                errorMessage: `Failed to parse access token data from Hume.`,
+            };
+        }
+
+        return {
+            success: true,
+            accessToken: result.data.access_token,
+            expiresIn: result.data.expires_in,
+            issuedAt: result.data.issued_at,
+            tokenType: result.data.token_type,
+        };
+    }
+}
+
+export type AIHumeInterfaceGetAccessTokenResult =
+    | AIHumeInterfaceGetAccessTokenSuccess
+    | AIHumeInterfaceGetAccessTokenFailure;
+
+export interface AIHumeInterfaceGetAccessTokenSuccess {
+    success: true;
+    /**
+     * The access token that was generated.
+     */
+    accessToken: string;
+
+    /**
+     * The number of seconds that the token expires in.
+     */
+    expiresIn: number;
+
+    /**
+     * The unix time in seconds that the token was issued at.
+     */
+    issuedAt: number;
+
+    /**
+     * The type of token that was generated.
+     */
+    tokenType: 'Bearer';
+}
+
+export interface AIHumeInterfaceGetAccessTokenFailure {
+    success: false;
+    errorCode: ServerError | 'hume_api_error';
+    errorMessage: string;
+}

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -2278,6 +2278,34 @@ export class RecordsServer {
                     }
                 ),
 
+            getHumeAccessToken: procedure()
+                .origins('api')
+                .http('GET', '/api/v2/ai/hume/token')
+                .inputs(z.object({}))
+                .handler(async (_, context) => {
+                    if (!this._aiController) {
+                        return AI_NOT_SUPPORTED_RESULT;
+                    }
+
+                    const sessionKeyValidation = await this._validateSessionKey(
+                        context.sessionKey
+                    );
+                    if (sessionKeyValidation.success === false) {
+                        if (
+                            sessionKeyValidation.errorCode === 'no_session_key'
+                        ) {
+                            return NOT_LOGGED_IN_RESULT;
+                        }
+                        return sessionKeyValidation;
+                    }
+
+                    const result = await this._aiController.getHumeAccessToken({
+                        userId: sessionKeyValidation.userId,
+                    });
+
+                    return result;
+                }),
+
             getStudio: procedure()
                 .origins('account')
                 .http('GET', '/api/v2/studios')

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -172,6 +172,21 @@ export const subscriptionFeaturesSchema = z.object({
                 .positive()
                 .optional(),
         }),
+        hume: z
+            .object({
+                allowed: z
+                    .boolean()
+                    .describe(
+                        'Whether Hume AI features are allowed for the subscription. If false, then every request to generate Hume AI will be rejected.'
+                    ),
+            })
+            .describe(
+                'The configuration for Hume AI features for the subscription. Defaults to not allowed if omitted.'
+            )
+            .optional()
+            .default({
+                allowed: false,
+            }),
     }),
     insts: z.object({
         allowed: z
@@ -749,6 +764,11 @@ export interface AIFeaturesConfiguration {
      * The configuration for AI skybox features.
      */
     skyboxes: AISkyboxFeaturesConfiguration;
+
+    /**
+     * The configuration for Hume AI features.
+     */
+    hume?: AIHumeFeaturesConfiguration;
 }
 
 export interface AIChatFeaturesConfiguration {
@@ -804,6 +824,13 @@ export interface AISkyboxFeaturesConfiguration {
      * If not specified, then there is no limit.
      */
     maxSkyboxesPerPeriod?: number;
+}
+
+export interface AIHumeFeaturesConfiguration {
+    /**
+     * Whether Hume AI features are allowed.
+     */
+    allowed: boolean;
 }
 
 export interface InstsFeaturesConfiguration {
@@ -863,6 +890,9 @@ export function allowAllFeatures(): FeaturesConfiguration {
             skyboxes: {
                 allowed: true,
             },
+            hume: {
+                allowed: true,
+            },
         },
         data: {
             allowed: true,
@@ -902,6 +932,29 @@ export function getComIdFeatures(
             // allowCustomComId: false,
         }
     );
+}
+
+/**
+ * Gets the Hume AI features that are allowed for the given subscription.
+ * If hume ai features are not configured, then they are not allowed.
+ * @param config The configuration. If null, then all default features are allowed.
+ * @param subscriptionStatus The status of the subscription.
+ * @param subscriptionId The ID of the subscription.
+ * @param type The type of the user.
+ */
+export function getHumeAiFeatures(
+    config: SubscriptionConfiguration,
+    subscriptionStatus: string,
+    subscriptionId: string,
+    type: 'user' | 'studio'
+): AIHumeFeaturesConfiguration {
+    const features = getSubscriptionFeatures(
+        config,
+        subscriptionStatus,
+        subscriptionId,
+        type
+    );
+    return features.ai.hume ?? { allowed: false };
 }
 
 /**

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -2268,6 +2268,18 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/ai/hume/token",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "getHumeAccessToken",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/studios",
       },
       "inputs": Object {
@@ -5109,6 +5121,18 @@ Object {
         "type": "object",
       },
       "name": "createAiImage",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/ai/hume/token",
+      },
+      "inputs": Object {
+        "schema": Object {},
+        "type": "object",
+      },
+      "name": "getHumeAccessToken",
       "origins": "api",
     },
     Object {

--- a/src/aux-records/__snapshots__/SubscriptionConfiguration.spec.ts.snap
+++ b/src/aux-records/__snapshots__/SubscriptionConfiguration.spec.ts.snap
@@ -6,6 +6,9 @@ Object {
     "chat": Object {
       "allowed": true,
     },
+    "hume": Object {
+      "allowed": true,
+    },
     "images": Object {
       "allowed": true,
     },

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -178,6 +178,7 @@ import {
     listUserStudios,
     listDataRecordByMarker,
     aiChatStream,
+    aiHumeGetAccessToken,
 } from './RecordsEvents';
 import {
     DEFAULT_BRANCH_NAME,
@@ -3493,6 +3494,16 @@ describe('AuxLibrary', () => {
                         },
                     ],
                 });
+            });
+        });
+
+        describe('ai.hume.getAccessToken()', () => {
+            it('should emit a AIGetHumeAccessTokenAction', () => {
+                const promise: any = library.api.ai.hume.getAccessToken();
+                const expected = aiHumeGetAccessToken({}, context.tasks.size);
+
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
             });
         });
 

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -293,6 +293,7 @@ import {
     recordFile as calcRecordFile,
     ListDataOptions,
     listDataRecordByMarker,
+    aiHumeGetAccessToken,
 } from './RecordsEvents';
 import {
     sortBy,
@@ -423,6 +424,7 @@ import { CasualOSError } from './CasualOSError';
 import {
     AIGenerateImageResponse,
     AIGenerateImageSuccess,
+    AIHumeGetAccessTokenResult,
 } from '@casual-simulation/aux-records/AIController';
 import {
     RuntimeActions,
@@ -2982,6 +2984,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 chat,
                 generateSkybox,
                 generateImage,
+                hume: {
+                    getAccessToken: getHumeAccessToken,
+                },
 
                 stream: {
                     chat: chatStream,
@@ -5341,6 +5346,24 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 }
             }
         );
+        (final as any)[ORIGINAL_OBJECT] = action;
+        return final;
+    }
+
+    /**
+     * Gets an access token for the Hume AI API.
+     * Returns a promise that resolves with the access token.
+     *
+     * @example Get an access token for the Hume AI API.
+     * const accessToken = await ai.hume.getAccessToken();
+     *
+     * @dochash actions/ai
+     * @docname ai.hume.getAccessToken
+     */
+    function getHumeAccessToken(): Promise<AIHumeGetAccessTokenResult> {
+        const task = context.createTask();
+        const action = aiHumeGetAccessToken({}, task.taskId);
+        const final = addAsyncResultAction(task, action);
         (final as any)[ORIGINAL_OBJECT] = action;
         return final;
     }

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -10296,6 +10296,45 @@ export interface AIGeneratedImage {
     seed?: number;
 }
 
+
+export type AIHumeGetAccessTokenResult =
+    | AIHumeGetAccessTokenSuccess
+    | AIHumeGetAccessTokenFailure;
+
+export interface AIHumeGetAccessTokenSuccess {
+    success: true;
+    /**
+     * The access token that was generated.
+     */
+    accessToken: string;
+    /**
+     * The number of seconds that the access token is valid for.
+     */
+    expiresIn: number;
+
+    /**
+     * The unix time in seconds that the token was issued at.
+     */
+    issuedAt: number;
+
+    /**
+     * The type of the token. Always "Bearer" for now.
+     */
+    tokenType: 'Bearer';
+}
+
+export interface AIHumeGetAccessTokenFailure {
+    success: false;
+
+    errorCode:
+        | ServerError
+        | NotLoggedInError
+        | NotSupportedError
+        | NotAuthorizedError
+        | 'hume_api_error'
+    errorMessage: string;
+}
+
 interface Ai {
     /**
      * Sends a chat message to the AI.
@@ -10589,6 +10628,20 @@ interface Ai {
         negativePrompt?: string | RecordActionOptions,
         options?: RecordActionOptions
     ): Promise<string | AIGenerateImageSuccess>;
+
+    hume: {
+        /**
+         * Gets an access token for the Hume AI API.
+         * Returns a promise that resolves with the access token.
+         * 
+         * @example Get an access token for the Hume AI API.
+         * const accessToken = await ai.hume.getAccessToken();
+         *
+         * @dochash actions/ai
+         * @docname ai.hume.getAccessToken
+         */
+        getAccessToken(): Promise<AIHumeGetAccessTokenResult>;
+    }
 
     stream: {
         /**

--- a/src/aux-runtime/runtime/RecordsEvents.ts
+++ b/src/aux-runtime/runtime/RecordsEvents.ts
@@ -26,6 +26,7 @@ export type RecordsAsyncActions =
     | AIChatStreamAction
     | AIGenerateImageAction
     | AIGenerateSkyboxAction
+    | AIHumeGetAccessTokenAction
     | ListUserStudiosAction
     | GetPublicRecordKeyAction
     | GrantRecordPermissionAction
@@ -270,6 +271,13 @@ export interface AIGenerateImageOptions {
      * The style preset that should be used to guide the image model torwards a specific style.
      */
     stylePreset?: string;
+}
+
+/**
+ * An event that is used to generate an image using AI.
+ */
+export interface AIHumeGetAccessTokenAction extends RecordsAction {
+    type: 'ai_hume_get_access_token';
 }
 
 /**
@@ -1101,6 +1109,22 @@ export function aiGenerateImage(
     return {
         type: 'ai_generate_image',
         ...parameters,
+        options: options ?? {},
+        taskId,
+    };
+}
+
+/**
+ * Creates a new AIHumeGetAccessTokenAction.
+ * @param options The options for the action.
+ * @param taskId The ID of the async task.
+ */
+export function aiHumeGetAccessToken(
+    options?: RecordActionOptions,
+    taskId?: number | string
+): AIHumeGetAccessTokenAction {
+    return {
+        type: 'ai_hume_get_access_token',
         options: options ?? {},
         taskId,
     };

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -140,7 +140,6 @@ import {
 import xpApiPlugins from '../../../../xpexchange/xp-api/*.server.plugin.ts';
 // @ts-ignore
 import casualWareApiPlugins from '../../../../extensions/casualos-casualware/casualware-api/*.server.plugin.ts';
-import { nodeModuleNameResolver } from 'typescript';
 import { HumeInterface } from '@casual-simulation/aux-records/AIHumeInterface';
 
 const automaticPlugins: ServerPlugin[] = [


### PR DESCRIPTION
### :rocket: Features

-   Added the `ai.hume.getAccessToken()` function to allow retrieving an access token for a [Hume.ai](https://www.hume.ai/) session.
    -   Requires that `humeai` be specified in the server configuration with an `apiKey` and `secretKey` and that the user has a subscription with `ai.hume.allowed` set to true in the subscription tier features.

Closes #474 