### PR TITLE
Feature/pressing enter while tag is focused in system portal triggers new tag dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Improve support for environments that do no support local storage or indexedDB.
 -   Added the `ai.hume.getAccessToken()` function to allow retrieving an access token for a [Hume.ai](https://www.hume.ai/) session.
     -   Requires that `humeai` be specified in the server configuration with an `apiKey` and `secretKey` and that the user has a subscription with `ai.hume.allowed` set to true in the subscription tier features.
+-   Pressing `Enter` while a tag is focused in the system portal now triggers the "New Tag" dialog.
 
 ## V3.3.4
 

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.vue
@@ -276,7 +276,11 @@
                         @pointermove="onSliderPointerMove"
                         @pointerup="onSliderPointerUp"
                     ></div>
-                    <div class="tags" v-if="selectedPane === 'bots' && hasSelection">
+                    <div
+                        class="tags"
+                        v-if="selectedPane === 'bots' && hasSelection"
+                        @keyup.enter="openNewTag"
+                    >
                         <div class="tags-list">
                             <div @click="toggleTags()" class="tags-toggle">
                                 <md-icon>{{


### PR DESCRIPTION
fixes #470 