### PR TITLE
Add the PRIVO Certification Seal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CasualOS Changelog
 
+## V3.3.6
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   [Casual Simulation is now PRIVO Certified!](https://cert.privo.com/#/companies/casualsimulation)
+    -   The certification seal has been added in various locations to notify users that Casual Simulation, ab1.bot, and publicos.link are [COPPA Safe Harbor Certified](https://www.ftc.gov/enforcement/coppa-safe-harbor-program).
+
 ## V3.3.5
 
 #### Date: 5/31/2024

--- a/policies/default/privacy-policy.md
+++ b/policies/default/privacy-policy.md
@@ -2,7 +2,7 @@
 
 You can find a plain-text version of this privacy policy <a href="/privacy-policy.txt">here</a>.
 
-_Last updated on March 20, 2024_
+_Last updated on June 10, 2024_
 
 Please review this Privacy Policy. When using our products or services the terms of our [Code of Conduct](/code-of-conduct), [Acceptable Use Policy](/acceptable-use-policy) and [Terms of Service](/terms) also apply.
 

--- a/policies/default/privacy-policy.md
+++ b/policies/default/privacy-policy.md
@@ -18,7 +18,8 @@ Please review this Privacy Policy. When using our products or services the terms
 8. [A Note to EU & UK Citizens](#a-note-to-eu--uk-citizens)
 9. [Links From Our Services](#links-from-our-services)
 10. [Security](#security)
-11. [Contact Us](#contact-us)
+11. [COPPA Safe Harbor Certification](#coppa-certification)
+12. [Contact Us](#contact-us)
 
 <h2 id="introduction">Introduction</h2>
 
@@ -120,7 +121,12 @@ We may provide links to third party websites or services from Our Services. You 
 <h2 id="security">Security</h2>
 
 We use generally accepted security measures and safeguards in an attempt to keep the data we collect secure and we require that the service providers we work with agree to do the same.
-These measures and safeguards include limiting access to the data to those persons who need it to complete their work, using a fire-wall protected environment, and storing personal information in secure operating environments. However, no security measure is full proof.
+These measures and safeguards include limiting access to the data to those persons who need it to complete their work, using a fire-wall protected environment, and storing personal information in secure operating environments. However, no security measure is foolproof.
+
+<h2 id="coppa-certification">Kids Privacy Assured by PRIVO: COPPA Safe Harbor Certification</h2>
+
+<a style="float: inline-start; margin-inline-end: 12px; display: inline-block; width: 140px; height: 70px;" target="_blank" href="https://cert.privo.com/#/companies/casualsimulation"><img src="https://privohub.privo.com/files/images/PRIVO_Cert/COPPA.png" alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"></a>
+Casual Simulation Inc is a member of the PRIVO Kids Privacy Assured COPPA safe harbor certification Program (“the Program”). The Program certification applies to the digital properties listed on the certification page that is viewable by clicking on the PRIVO Seal. PRIVO is an independent, third-party organization committed to supporting online services to safeguard children’s personal information collected online. The PRIVO COPPA safe harbor certification Seal posted on this page indicates Casual Simulation Inc has established COPPA compliant privacy practices and has agreed to submit to PRIVO’s oversight and consumer dispute resolution process. If you have questions or concerns about our privacy practices, please contact us at +1 (616) 209-4439 or [hello@casualsimulation.com](mailto:hello@casualsimulation.com). If you have further concerns after you have contacted us, you can contact PRIVO directly at <privacy@privo.com>.
 
 <h2 id="contact-us">Contact Us</h2>
 

--- a/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
+++ b/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
@@ -151,6 +151,7 @@ export class AuthHandler implements AuxAuth {
         return {
             privacyPolicyUrl: this.privacyPolicyUrl,
             termsOfServiceUrl: this.termsOfServiceUrl,
+            codeOfConductUrl: this.codeOfConductUrl,
         };
     }
 
@@ -407,6 +408,7 @@ export class AuthHandler implements AuxAuth {
                 siteName: this.siteName,
                 termsOfServiceUrl: this.termsOfServiceUrl,
                 privacyPolicyUrl: this.privacyPolicyUrl,
+                codeOfConductUrl: this.codeOfConductUrl,
                 supportsSms: this._supportsSms,
                 supportsWebAuthn: this._supportsWebAuthn,
                 errors: errors,
@@ -462,6 +464,7 @@ export class AuthHandler implements AuxAuth {
                 siteName: this.siteName,
                 termsOfServiceUrl: this.termsOfServiceUrl,
                 privacyPolicyUrl: this.privacyPolicyUrl,
+                codeOfConductUrl: this.codeOfConductUrl,
                 supportsSms: this._supportsSms,
                 supportsWebAuthn: this._supportsWebAuthn,
                 errors: errors,
@@ -614,6 +617,7 @@ export class AuthHandler implements AuxAuth {
                 siteName: this.siteName,
                 termsOfServiceUrl: this.termsOfServiceUrl,
                 privacyPolicyUrl: this.privacyPolicyUrl,
+                codeOfConductUrl: this.codeOfConductUrl,
                 errors: errors,
             });
             return;
@@ -747,6 +751,7 @@ export class AuthHandler implements AuxAuth {
             page: 'enter_address',
             termsOfServiceUrl: this.termsOfServiceUrl,
             privacyPolicyUrl: this.privacyPolicyUrl,
+            codeOfConductUrl: this.codeOfConductUrl,
             siteName: this.siteName,
             supportsSms: this._supportsSms,
             supportsWebAuthn: this._supportsWebAuthn,
@@ -850,6 +855,7 @@ export class AuthHandler implements AuxAuth {
                         siteName: this.siteName,
                         termsOfServiceUrl: this.termsOfServiceUrl,
                         privacyPolicyUrl: this.privacyPolicyUrl,
+                        codeOfConductUrl: this.codeOfConductUrl,
                         errors: errors,
                         supportsSms: this._supportsSms,
                         supportsWebAuthn: this._supportsWebAuthn,
@@ -906,6 +912,8 @@ export class AuthHandler implements AuxAuth {
             this._loginUIStatus.next({
                 page: 'has_account',
                 privacyPolicyUrl: this.privacyPolicyUrl,
+                codeOfConductUrl: this.codeOfConductUrl,
+                termsOfServiceUrl: this.termsOfServiceUrl,
             });
 
             const hasAccount = await firstValueFrom(
@@ -966,6 +974,7 @@ export class AuthHandler implements AuxAuth {
             page: 'enter_privo_account_info',
             termsOfServiceUrl: this.termsOfServiceUrl,
             privacyPolicyUrl: this.privacyPolicyUrl,
+            codeOfConductUrl: this.codeOfConductUrl,
             siteName: this.siteName,
             errors: [],
         });
@@ -1000,6 +1009,7 @@ export class AuthHandler implements AuxAuth {
                         page: 'enter_privo_account_info',
                         termsOfServiceUrl: this.termsOfServiceUrl,
                         privacyPolicyUrl: this.privacyPolicyUrl,
+                        codeOfConductUrl: this.codeOfConductUrl,
                         siteName: this.siteName,
                         errors: errors,
                     });
@@ -1015,6 +1025,7 @@ export class AuthHandler implements AuxAuth {
                     page: 'enter_privo_account_info',
                     termsOfServiceUrl: this.termsOfServiceUrl,
                     privacyPolicyUrl: this.privacyPolicyUrl,
+                    codeOfConductUrl: this.codeOfConductUrl,
                     siteName: this.siteName,
                     errors: [
                         {
@@ -1133,6 +1144,10 @@ export class AuthHandler implements AuxAuth {
 
     private get privacyPolicyUrl() {
         return new URL('/privacy-policy', location.origin).href;
+    }
+
+    private get codeOfConductUrl() {
+        return new URL('/code-of-conduct', location.origin).href;
     }
 
     private get _supportsSms() {

--- a/src/aux-server/aux-web/aux-auth/site/AuthApp/AuthApp.ts
+++ b/src/aux-server/aux-web/aux-auth/site/AuthApp/AuthApp.ts
@@ -38,6 +38,7 @@ export default class AuthApp extends Vue {
     logoUrl: string = null;
     displayName: string = null;
     comId: string = null;
+    usePrivoLogin: boolean = false;
 
     get title() {
         return comId ?? location.hostname;
@@ -96,6 +97,7 @@ export default class AuthApp extends Vue {
         this.createRecordStudioId = null;
         this.logoUrl = null;
         this.displayName = null;
+        this.usePrivoLogin = authManager.usePrivoLogin;
         this.allowCreateStudio = authManager.studiosSupported;
         authManager.loginState
             .pipe(distinctUntilChanged())

--- a/src/aux-server/aux-web/aux-auth/site/AuthApp/AuthApp.vue
+++ b/src/aux-server/aux-web/aux-auth/site/AuthApp/AuthApp.vue
@@ -194,6 +194,16 @@
                 <li v-if="comId">
                     <a href="/">Back to {{ hostname }}</a>
                 </li>
+                <li v-if="usePrivoLogin">
+                    <a
+                        style="display: inline-block; width: 140px; height: 70px"
+                        target="_blank"
+                        href="https://cert.privo.com/#/companies/casualsimulation"
+                        ><img
+                            src="https://privohub.privo.com/files/images/PRIVO_Cert/COPPA.png"
+                            alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"
+                    /></a>
+                </li>
             </ul>
         </footer>
     </div>

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
@@ -77,3 +77,8 @@
 .logo {
     max-height: 750px;
 }
+
+.policies-grid {
+    display: flex;
+    margin-top: 14px;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -139,6 +139,7 @@ export default class PlayerHome extends Vue {
     joinCode: string = null;
     privacyPolicyUrl: string = null;
     termsOfServiceUrl: string = null;
+    codeOfConductUrl: string = null;
     logoUrl: string = null;
     logoTitle: string = null;
 
@@ -147,6 +148,10 @@ export default class PlayerHome extends Vue {
     private _loadedStaticInst: boolean = false;
 
     private _simulations: Map<BrowserSimulation, Subscription>;
+
+    get isPrivoCertified() {
+        return appManager.config?.requirePrivoLogin;
+    }
 
     get joinCodeClass() {
         const hasJoinCodeError = this.errors.some((e) => e.for === 'joinCode');
@@ -360,6 +365,7 @@ export default class PlayerHome extends Vue {
         appManager.auth.primary.getPolicyUrls().then((urls) => {
             this.privacyPolicyUrl = urls.privacyPolicyUrl;
             this.termsOfServiceUrl = urls.termsOfServiceUrl;
+            this.codeOfConductUrl = urls.codeOfConductUrl;
         });
     }
 

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -71,12 +71,32 @@
                     </md-select>
                 </md-field>
 
-                <p v-if="privacyPolicyUrl">
-                    <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
-                </p>
-                <p v-if="termsOfServiceUrl">
-                    <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
-                </p>
+                <div class="policies-grid">
+                    <div>
+                        <p v-if="privacyPolicyUrl">
+                            <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
+                        </p>
+                        <p v-if="codeOfConductUrl">
+                            <a target="_blank" :href="codeOfConductUrl">Code of Conduct</a>
+                        </p>
+                        <p v-if="termsOfServiceUrl">
+                            <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
+                        </p>
+                    </div>
+                    <div class="spacer"></div>
+                    <div class="policy-cert" v-if="isPrivoCertified">
+                        <a
+                            style="display: inline-block; width: 70px; height: 70px"
+                            target="_blank"
+                            href="https://cert.privo.com/#/companies/casualsimulation"
+                        >
+                            <img
+                                src="https://privohub.privo.com/files/images/PRIVO_Cert/KPAS_C2V_104_4_72.png"
+                                alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"
+                            />
+                        </a>
+                    </div>
+                </div>
             </md-dialog-content>
             <md-dialog-actions>
                 <md-button v-if="canSignIn()" @click="signIn()">Sign In</md-button>

--- a/src/aux-server/aux-web/shared/vue-components/EnterAccountInfoDialog/EnterAccountInfoDialog.ts
+++ b/src/aux-server/aux-web/shared/vue-components/EnterAccountInfoDialog/EnterAccountInfoDialog.ts
@@ -52,6 +52,10 @@ export default class EnterAccountInfoDialog extends Vue {
         return this.status.privacyPolicyUrl;
     }
 
+    get codeOfConductUrl(): string {
+        return this.status.codeOfConductUrl;
+    }
+
     get loginSiteName(): string {
         return this.status.siteName;
     }

--- a/src/aux-server/aux-web/shared/vue-components/EnterAccountInfoDialog/EnterAccountInfoDialog.vue
+++ b/src/aux-server/aux-web/shared/vue-components/EnterAccountInfoDialog/EnterAccountInfoDialog.vue
@@ -26,9 +26,32 @@
                     </div>
                 </div>
                 <field-errors :field="null" :errors="errors" />
-                <p>
-                    <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
-                </p>
+                <div class="policies-grid">
+                    <div>
+                        <p v-if="privacyPolicyUrl">
+                            <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
+                        </p>
+                        <p v-if="codeOfConductUrl">
+                            <a target="_blank" :href="codeOfConductUrl">Code of Conduct</a>
+                        </p>
+                        <p v-if="termsOfServiceUrl">
+                            <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
+                        </p>
+                    </div>
+                    <div class="spacer"></div>
+                    <div class="policy-cert">
+                        <a
+                            style="display: inline-block; width: 70px; height: 70px"
+                            target="_blank"
+                            href="https://cert.privo.com/#/companies/casualsimulation"
+                        >
+                            <img
+                                src="https://privohub.privo.com/files/images/PRIVO_Cert/KPAS_C2V_104_4_72.png"
+                                alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"
+                            />
+                        </a>
+                    </div>
+                </div>
             </form>
             <form v-else @submit.prevent="register()">
                 <div class="md-layout md-gutter">
@@ -112,9 +135,32 @@
                     </div>
                 </div>
                 <field-errors :field="null" :errors="errors" />
-                <p>
-                    <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
-                </p>
+                <div class="policies-grid" style="margin-top: 24px">
+                    <div>
+                        <p v-if="privacyPolicyUrl">
+                            <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
+                        </p>
+                        <p v-if="codeOfConductUrl">
+                            <a target="_blank" :href="codeOfConductUrl">Code of Conduct</a>
+                        </p>
+                        <p v-if="termsOfServiceUrl">
+                            <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
+                        </p>
+                    </div>
+                    <div class="spacer"></div>
+                    <div class="policy-cert">
+                        <a
+                            style="display: inline-block; width: 70px; height: 70px"
+                            target="_blank"
+                            href="https://cert.privo.com/#/companies/casualsimulation"
+                        >
+                            <img
+                                src="https://privohub.privo.com/files/images/PRIVO_Cert/KPAS_C2V_104_4_72.png"
+                                alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"
+                            />
+                        </a>
+                    </div>
+                </div>
             </form>
         </md-dialog-content>
         <md-dialog-actions>

--- a/src/aux-server/aux-web/shared/vue-components/EnterAddressDialog/EnterAddressDialog.ts
+++ b/src/aux-server/aux-web/shared/vue-components/EnterAddressDialog/EnterAddressDialog.ts
@@ -55,6 +55,10 @@ export default class EnterAddressDialog extends Vue {
         }
     }
 
+    get isPrivoCertified() {
+        return appManager.config.requirePrivoLogin;
+    }
+
     get supportsSms() {
         return !!this.status.supportsSms;
     }
@@ -87,6 +91,10 @@ export default class EnterAddressDialog extends Vue {
 
     get privacyPolicyUrl() {
         return this.status.privacyPolicyUrl;
+    }
+
+    get codeOfConductUrl() {
+        return this.status.codeOfConductUrl;
     }
 
     get formErrors() {

--- a/src/aux-server/aux-web/shared/vue-components/EnterAddressDialog/EnterAddressDialog.vue
+++ b/src/aux-server/aux-web/shared/vue-components/EnterAddressDialog/EnterAddressDialog.vue
@@ -37,9 +37,19 @@
                     </div>
                 </div>
                 <field-errors :field="null" :errors="formErrors" />
-                <p>
-                    <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
-                </p>
+                <div class="policies-grid" style="margin-top: 24px">
+                    <div>
+                        <p v-if="privacyPolicyUrl">
+                            <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
+                        </p>
+                        <p v-if="codeOfConductUrl">
+                            <a target="_blank" :href="codeOfConductUrl">Code of Conduct</a>
+                        </p>
+                        <p v-if="termsOfServiceUrl">
+                            <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
+                        </p>
+                    </div>
+                </div>
             </md-dialog-content>
             <md-dialog-actions>
                 <md-button

--- a/src/aux-server/aux-web/shared/vue-components/HasAccountDialog/HasAccountDialog.ts
+++ b/src/aux-server/aux-web/shared/vue-components/HasAccountDialog/HasAccountDialog.ts
@@ -28,6 +28,14 @@ export default class HasAccountDialog extends Vue {
         return this.status.privacyPolicyUrl;
     }
 
+    get codeOfConductUrl() {
+        return this.status.codeOfConductUrl;
+    }
+
+    get termsOfServiceUrl() {
+        return this.status.termsOfServiceUrl;
+    }
+
     processing: boolean = false;
 
     @Watch('status')

--- a/src/aux-server/aux-web/shared/vue-components/HasAccountDialog/HasAccountDialog.vue
+++ b/src/aux-server/aux-web/shared/vue-components/HasAccountDialog/HasAccountDialog.vue
@@ -14,9 +14,32 @@
                     <p>You are not logged in. What do you want to do?</p>
                 </div>
             </div>
-            <p>
-                <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
-            </p>
+            <div class="policies-grid" style="margin-top: 24px">
+                <div>
+                    <p v-if="privacyPolicyUrl">
+                        <a target="_blank" :href="privacyPolicyUrl">Privacy Policy</a>
+                    </p>
+                    <p v-if="codeOfConductUrl">
+                        <a target="_blank" :href="codeOfConductUrl">Code of Conduct</a>
+                    </p>
+                    <p v-if="termsOfServiceUrl">
+                        <a target="_blank" :href="termsOfServiceUrl">Terms of Service</a>
+                    </p>
+                </div>
+                <div class="spacer"></div>
+                <div class="policy-cert">
+                    <a
+                        style="display: inline-block; width: 70px; height: 70px"
+                        target="_blank"
+                        href="https://cert.privo.com/#/companies/casualsimulation"
+                    >
+                        <img
+                            src="https://privohub.privo.com/files/images/PRIVO_Cert/KPAS_C2V_104_4_72.png"
+                            alt="COPPA Safe Harbor Certification - Kids Privacy Assured by PRIVO"
+                        />
+                    </a>
+                </div>
+            </div>
         </md-dialog-content>
         <md-dialog-actions>
             <md-button type="button" @click="hasAccount(true)" :disabled="processing">

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -621,6 +621,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
             return {
                 privacyPolicyUrl: null,
                 termsOfServiceUrl: null,
+                codeOfConductUrl: null,
             };
         }
         if (!this._initialized) {
@@ -630,6 +631,7 @@ export class AuthEndpointHelper implements AuthHelperInterface {
             return {
                 privacyPolicyUrl: null,
                 termsOfServiceUrl: null,
+                codeOfConductUrl: null,
             };
         }
         return await this._proxy.getPolicyUrls();

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -66,6 +66,11 @@ export interface LoginUIAddressStatus {
     privacyPolicyUrl: string;
 
     /**
+     * The page that should be linked to as the code of conduct.
+     */
+    codeOfConductUrl: string;
+
+    /**
      * The name of the site that is being logged into.
      */
     siteName: string;
@@ -121,6 +126,16 @@ export interface LoginUIHasAccount {
      * The page that should be linked to as the privacy policy.
      */
     privacyPolicyUrl: string;
+
+    /**
+     * The page that should be linked to as the code of conduct.
+     */
+    codeOfConductUrl: string;
+
+    /**
+     * The page that should be linked to as the terms of service.
+     */
+    termsOfServiceUrl: string;
 }
 
 export interface LoginUIPrivoSignUp {
@@ -135,6 +150,11 @@ export interface LoginUIPrivoSignUp {
      * The page that should be linked to as the privacy policy.
      */
     privacyPolicyUrl: string;
+
+    /**
+     * The page that should be linked to as the code of conduct.
+     */
+    codeOfConductUrl: string;
 
     /**
      * The name of the site that is being logged into.
@@ -226,6 +246,7 @@ export type LoginHint = 'sign in' | 'sign up' | null;
 export interface PolicyUrls {
     privacyPolicyUrl: string;
     termsOfServiceUrl: string;
+    codeOfConductUrl: string;
 }
 
 /**


### PR DESCRIPTION
### :rocket: Features

-   [Casual Simulation is now PRIVO Certified!](https://cert.privo.com/#/companies/casualsimulation)
    -   The certification seal has been added in various locations to notify users that Casual Simulation, ab1.bot, and publicos.link are [COPPA Safe Harbor Certified](https://www.ftc.gov/enforcement/coppa-safe-harbor-program).

Closes #482