### PR TITLE
Add `ai.sloyd.generateModel(request)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CasualOS Changelog
 
+## V3.3.7
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Added the ability to generate [Sloyd.ai](https://www.sloyd.ai/) models with `ai.sloyd.generateModel(request)`.
+    -   Requires a valid subscription that has been granted access to the `ai.sloyd` feature.
+    -   `request` is should be an object with the following properties:
+        -   `prompt` - The prompt to use for generating the model.
+        -   `recordName` - The name of the record that the model should be generated in. If omitted, then the user's record will be used by default.
+        -   `outputMimeType` - The MIME Type of the model that should be output. Currently, only `model/gltf+json` and `model/gltf-binary` are supported. If omitted, then `model/gltf+json` will be used.
+        -   `levelOfDetail` - A number between `0.01` and `1` that indicates the level of detail that should be generated for the model. Higher values will generate more detailed models. If omitted, then `0.5` will be used.
+        -   `baseModelId` - The ID of the model that should be edited.
+        -   `thumbnail` - An object that specifies how the thumbnail for the model should be generated. If omitted, then no thumbnail will be created. The object should have the following properties:
+            -   `type` - Should always be `"image/png"`
+            -   `width` - The desired width of the thumbnail in pixels.
+            -   `height` - The desired height of the thumbnail in pixels.
+
 ## V3.3.6
 
 #### Date: 6/14/2024

--- a/src/aux-common/common/PolicyPermissions.ts
+++ b/src/aux-common/common/PolicyPermissions.ts
@@ -22,6 +22,7 @@ export const MARKER_RESOURCE_KIND = 'marker';
 export const ROLE_RESOURCE_KIND = 'role';
 export const INST_RESOURCE_KIND = 'inst';
 export const LOOM_RESOURCE_KIND = 'loom';
+export const SLOYD_RESOURCE_KIND = 'ai.sloyd';
 
 /**
  * The possible types of resources that can be affected by permissions.
@@ -36,7 +37,8 @@ export type ResourceKinds =
     | 'marker'
     | 'role'
     | 'inst'
-    | 'loom';
+    | 'loom'
+    | 'ai.sloyd';
 
 export const READ_ACTION = 'read';
 export const CREATE_ACTION = 'create';
@@ -146,6 +148,14 @@ export type InstActionKinds =
 export type LoomActionKinds = 'create';
 
 /**
+ * The possible types of actions that can be performed on ai.sloyd resources.
+ *
+ * @dochash types/permissions
+ * @docname SloydActionKinds
+ */
+export type SloydActionKinds = 'create';
+
+/**
  * The possible types of permissions that can be added to policies.
  *
  * @dochash types/permissions
@@ -161,7 +171,8 @@ export type AvailablePermissions =
     | MarkerPermission
     | RolePermission
     | InstPermission
-    | LoomPermission;
+    | LoomPermission
+    | SloydPermission;
 
 export const SUBJECT_TYPE_VALIDATION = z.enum(['user', 'inst', 'role']);
 
@@ -216,6 +227,8 @@ export const INST_ACTION_KINDS_VALIDATION = z.enum([
 
 export const LOOM_ACTION_KINDS_VALIDATION = z.enum([CREATE_ACTION]);
 
+export const SLOYD_ACTION_KINDS_VALIDATION = z.enum([CREATE_ACTION]);
+
 export const RESOURCE_KIND_VALIDATION = z.enum([
     DATA_RESOURCE_KIND,
     FILE_RESOURCE_KIND,
@@ -224,6 +237,7 @@ export const RESOURCE_KIND_VALIDATION = z.enum([
     ROLE_RESOURCE_KIND,
     INST_RESOURCE_KIND,
     LOOM_RESOURCE_KIND,
+    SLOYD_RESOURCE_KIND,
 ]);
 
 export const ACTION_KINDS_VALIDATION = z.enum([
@@ -570,6 +584,31 @@ export const LOOM_PERMISSION_VALIDATION = PERMISSION_VALIDATION.extend({
 type ZodLoomPermission = z.infer<typeof LOOM_PERMISSION_VALIDATION>;
 type ZodLoomPermissionAssertion = HasType<ZodLoomPermission, LoomPermission>;
 
+/**
+ * Defines an interface that describes common options for all permissions that affect ai.sloyd resources.
+ *
+ * @dochash types/permissions
+ * @docname SloydPermission
+ */
+export interface SloydPermission extends Permission {
+    /**
+     * The kind of the permission.
+     */
+    resourceKind: 'ai.sloyd';
+
+    /**
+     * The action that is allowed.
+     * If null, then all actions are allowed.
+     */
+    action: SloydActionKinds | null;
+}
+export const SLOYD_PERMISSION_VALIDATION = PERMISSION_VALIDATION.extend({
+    resourceKind: z.literal(SLOYD_RESOURCE_KIND),
+    action: SLOYD_ACTION_KINDS_VALIDATION.nullable(),
+});
+type ZodSloydPermission = z.infer<typeof SLOYD_PERMISSION_VALIDATION>;
+type ZodSloydPermissionAssertion = HasType<ZodSloydPermission, SloydPermission>;
+
 export const AVAILABLE_PERMISSIONS_VALIDATION = z.discriminatedUnion(
     'resourceKind',
     [
@@ -580,6 +619,7 @@ export const AVAILABLE_PERMISSIONS_VALIDATION = z.discriminatedUnion(
         ROLE_PERMISSION_VALIDATION,
         INST_PERMISSION_VALIDATION,
         LOOM_PERMISSION_VALIDATION,
+        SLOYD_PERMISSION_VALIDATION,
     ]
 );
 

--- a/src/aux-records/AIController.spec.ts
+++ b/src/aux-records/AIController.spec.ts
@@ -3018,9 +3018,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
                 name: 'model name',
-                gltfJson: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3059,9 +3059,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'binary-glb',
+                modelMimeType: 'model/gltf-binary',
+                modelData: new Uint8Array([123, 255, 0, 37]),
                 name: 'model name',
-                binary: [123, 255, 0, 37],
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3100,15 +3100,15 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
                 name: 'model name',
-                gltfJson: 'json',
             });
             sloydInterface.editModel.mockResolvedValueOnce({
                 success: true,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3143,7 +3143,7 @@ describe('AIController', () => {
                 interactionId: 'baseModelId',
                 levelOfDetail: 1,
                 prompt: 'test',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
             });
         });
 
@@ -3157,9 +3157,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3202,9 +3202,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3231,16 +3231,16 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
                 userId: null,
                 recordName: userId,
-                outputMimeType: 'model/gltf+json',
                 prompt: 'test',
+                outputMimeType: 'model/gltf+json',
                 levelOfDetail: 1,
             });
 
@@ -3259,9 +3259,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({
@@ -3300,9 +3300,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const permissionResult = await policies.grantMarkerPermission({
@@ -3360,9 +3360,9 @@ describe('AIController', () => {
                 success: true,
                 confidenceScore: 0.5,
                 interactionId: 'modelId',
-                modelOutputType: 'json-gltf',
                 name: 'model name',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
 
             const result = await controller.sloydGenerateModel({

--- a/src/aux-records/AIController.spec.ts
+++ b/src/aux-records/AIController.spec.ts
@@ -3049,6 +3049,7 @@ describe('AIController', () => {
                     createdAtMs: expect.any(Number),
                     name: 'model name',
                     modelData: 'json',
+                    modelsCreated: 1,
                 },
             ]);
         });
@@ -3089,6 +3090,7 @@ describe('AIController', () => {
                     createdAtMs: expect.any(Number),
                     name: 'model name',
                     modelData: fromByteArray(new Uint8Array([123, 255, 0, 37])),
+                    modelsCreated: 1,
                 },
             ]);
         });
@@ -3139,6 +3141,7 @@ describe('AIController', () => {
                     name: 'model name',
                     modelData: 'json',
                     baseModelId: 'baseModelId',
+                    modelsCreated: 1,
                 },
             ]);
 
@@ -3198,6 +3201,7 @@ describe('AIController', () => {
                 createdAtMs: Date.now(),
                 name: 'model name',
                 modelData: 'json',
+                modelsCreated: 1,
             });
 
             sloydInterface.createModel.mockResolvedValueOnce({
@@ -3292,6 +3296,7 @@ describe('AIController', () => {
                     createdAtMs: expect.any(Number),
                     name: 'model name',
                     modelData: 'json',
+                    modelsCreated: 1,
                 },
             ]);
         });
@@ -3351,6 +3356,7 @@ describe('AIController', () => {
                     createdAtMs: expect.any(Number),
                     name: 'model name',
                     modelData: 'json',
+                    modelsCreated: 1,
                 },
             ]);
         });

--- a/src/aux-records/AIController.spec.ts
+++ b/src/aux-records/AIController.spec.ts
@@ -3106,10 +3106,8 @@ describe('AIController', () => {
             });
             sloydInterface.editModel.mockResolvedValueOnce({
                 success: true,
-                confidenceScore: 0.5,
                 interactionId: 'modelId',
                 modelOutputType: 'json-gltf',
-                name: 'model name',
                 gltfJson: 'json',
             });
 
@@ -3126,8 +3124,6 @@ describe('AIController', () => {
                 success: true,
                 modelId: 'modelId',
                 mimeType: 'model/gltf+json',
-                confidence: 0.5,
-                name: 'model name',
                 modelData: 'json',
             });
 
@@ -3135,10 +3131,8 @@ describe('AIController', () => {
                 {
                     modelId: 'modelId',
                     mimeType: 'model/gltf+json',
-                    confidence: 0.5,
                     userId: userId,
                     createdAtMs: expect.any(Number),
-                    name: 'model name',
                     modelData: 'json',
                     baseModelId: 'baseModelId',
                     modelsCreated: 1,

--- a/src/aux-records/AIController.spec.ts
+++ b/src/aux-records/AIController.spec.ts
@@ -29,6 +29,10 @@ import {
 import { merge } from 'lodash';
 import { unwind } from '../js-interpreter/InterpreterUtils';
 import { AIHumeInterfaceGetAccessTokenResult } from './AIHumeInterface';
+import {
+    AISloydInterfaceCreateModelRequest,
+    AISloydInterfaceCreateModelResponse,
+} from './AISloydInterface';
 
 console.log = jest.fn();
 
@@ -73,6 +77,12 @@ describe('AIController', () => {
             []
         >;
     };
+    let sloydInterface: {
+        createModel: jest.Mock<
+            Promise<AISloydInterfaceCreateModelResponse>,
+            [AISloydInterfaceCreateModelRequest]
+        >;
+    };
     let userId: string;
     let userSubscriptionTier: string;
     let store: MemoryStore;
@@ -97,6 +107,9 @@ describe('AIController', () => {
         };
         humeInterface = {
             getAccessToken: jest.fn(),
+        };
+        sloydInterface = {
+            createModel: jest.fn(),
         };
         store = new MemoryStore({
             subscriptions: null,
@@ -154,6 +167,9 @@ describe('AIController', () => {
             },
             hume: {
                 interface: humeInterface,
+            },
+            sloyd: {
+                interface: sloydInterface,
             },
             metrics: store,
             config: store,

--- a/src/aux-records/AIController.ts
+++ b/src/aux-records/AIController.ts
@@ -1168,6 +1168,10 @@ export class AIController {
                 };
             }
 
+            console.log(
+                `[AIController] [sloydGenerateModel] [maxModelsPerPeriod: ${features.maxModelsPerPeriod} totalModelsInCurrentPeriod: ${metrics.totalModelsInCurrentPeriod}]`
+            );
+
             if (
                 typeof features.maxModelsPerPeriod === 'number' &&
                 metrics.totalModelsInCurrentPeriod >=
@@ -1183,10 +1187,7 @@ export class AIController {
             const result = await (request.baseModelId
                 ? this._sloydInterface.editModel({
                       prompt: request.prompt,
-                      modelOutputType:
-                          request.outputMimeType === 'model/gltf+json'
-                              ? 'json-gltf'
-                              : 'binary-glb',
+                      modelMimeType: request.outputMimeType,
                       levelOfDetail: request.levelOfDetail,
                       thumbnailPreviewExportType: request.thumbnail?.type,
                       thumbnailPreviewSizeX: request.thumbnail?.width,
@@ -1195,10 +1196,7 @@ export class AIController {
                   })
                 : this._sloydInterface.createModel({
                       prompt: request.prompt,
-                      modelOutputType:
-                          request.outputMimeType === 'model/gltf+json'
-                              ? 'json-gltf'
-                              : 'binary-glb',
+                      modelMimeType: request.outputMimeType,
                       levelOfDetail: request.levelOfDetail,
                       thumbnailPreviewExportType: request.thumbnail?.type,
                       thumbnailPreviewSizeX: request.thumbnail?.width,
@@ -1212,14 +1210,11 @@ export class AIController {
             const response: AISloydGenerateModelSuccess = {
                 success: true,
                 modelId: result.interactionId,
-                mimeType:
-                    result.modelOutputType === 'json-gltf'
-                        ? 'model/gltf+json'
-                        : 'model/gltf-binary',
+                mimeType: request.outputMimeType,
                 modelData:
-                    result.modelOutputType === 'json-gltf'
-                        ? result.gltfJson
-                        : fromByteArray(new Uint8Array(result.binary)),
+                    typeof result.modelData === 'string'
+                        ? result.modelData
+                        : fromByteArray(result.modelData),
                 thumbnailBase64: result.previewImage,
             };
 

--- a/src/aux-records/AIController.ts
+++ b/src/aux-records/AIController.ts
@@ -1651,10 +1651,22 @@ export interface AISloydGenerateModelRequest {
     };
 }
 
+/**
+ * The response to a request to generate a model using the Sloyd AI interface.
+ *
+ * @dochash types/ai
+ * @docname AISloydGenerateModelResponse
+ */
 export type AISloydGenerateModelResponse =
     | AISloydGenerateModelSuccess
     | AISloydGenerateModelFailure;
 
+/**
+ * A successful response to a request to generate a model using the Sloyd AI interface.
+ *
+ * @dochash types/ai
+ * @docname AISloydGenerateModelSuccess
+ */
 export interface AISloydGenerateModelSuccess {
     success: true;
 
@@ -1691,8 +1703,18 @@ export interface AISloydGenerateModelSuccess {
     thumbnailBase64?: string;
 }
 
+/**
+ * A failed response to a request to generate a model using the Sloyd AI interface.
+ *
+ * @dochash types/ai
+ * @docname AISloydGenerateModelFailure
+ */
 export interface AISloydGenerateModelFailure {
     success: false;
+
+    /**
+     * The error code.
+     */
     errorCode:
         | ServerError
         | NotLoggedInError
@@ -1703,7 +1725,14 @@ export interface AISloydGenerateModelFailure {
         | NotAuthorizedError
         | AuthorizeSubjectFailure['errorCode']
         | AISloydInterfaceCreateModelFailure['errorCode'];
+
+    /**
+     * The error message.
+     */
     errorMessage: string;
 
+    /**
+     * The reason why the request was denied.
+     */
     reason?: DenialReason;
 }

--- a/src/aux-records/AISloydInterface.ts
+++ b/src/aux-records/AISloydInterface.ts
@@ -30,7 +30,7 @@ export interface AISloydInterfaceCreateModelRequest {
     /**
      * The type of model to create.
      */
-    modelOutputType: 'binary-glb' | 'json-gltf';
+    modelMimeType: SloydModelMimeTypes;
 
     /**
      * The level of detail to use for the model.
@@ -74,16 +74,9 @@ export interface AISloydInterfaceCreateModelSuccess {
     name: string;
 
     /**
-     * The binary data of the model.
-     * Only provided if the modelOutputType is 'binary-glb'.
+     * The generated data of the model.
      */
-    binary?: number[];
-
-    /**
-     * The GLTF JSON data.
-     * Only provided if the modelOutputType is 'json-gltf'.
-     */
-    gltfJson?: string;
+    modelData: string | Uint8Array;
 
     /**
      * A score indicating how confident the AI is that the returned object matches the text prompt.
@@ -94,7 +87,7 @@ export interface AISloydInterfaceCreateModelSuccess {
     /**
      * The type of model to create.
      */
-    modelOutputType: 'binary-glb' | 'json-gltf';
+    modelMimeType: SloydModelMimeTypes;
 
     /**
      * The base64 encoded thumbnail preview image.
@@ -116,6 +109,8 @@ export interface AISloydInterfaceCreateModelFailure {
     errorMessage: string;
 }
 
+export type SloydModelMimeTypes = 'model/gltf+json' | 'model/gltf-binary';
+
 /**
  * The request to edit a model in Sloyd.
  */
@@ -133,7 +128,7 @@ export interface AISloydInterfaceEditModelRequest {
     /**
      * The type of model to create.
      */
-    modelOutputType: 'binary-glb' | 'json-gltf';
+    modelMimeType: SloydModelMimeTypes;
 
     /**
      * The level of detail to use for the model.
@@ -172,21 +167,14 @@ export interface AISloydInterfaceEditModelSuccess {
     interactionId: string;
 
     /**
-     * The binary data of the model.
-     * Only provided if the modelOutputType is 'binary-glb'.
+     * The model data.
      */
-    binary?: number[];
-
-    /**
-     * The GLTF JSON data.
-     * Only provided if the modelOutputType is 'json-gltf'.
-     */
-    gltfJson?: string;
+    modelData: string | Uint8Array;
 
     /**
      * The type of model to create.
      */
-    modelOutputType: 'binary-glb' | 'json-gltf';
+    modelMimeType: SloydModelMimeTypes;
 
     /**
      * The base64 encoded thumbnail preview image.

--- a/src/aux-records/AISloydInterface.ts
+++ b/src/aux-records/AISloydInterface.ts
@@ -1,0 +1,109 @@
+import { ServerError } from '@casual-simulation/aux-common';
+
+export interface AISloydInterface {
+    /**
+     * Attempts to create a new model in Sloyd.
+     * @param request The request to create the model.
+     */
+    createModel(
+        request: AISloydInterfaceCreateModelRequest
+    ): Promise<AISloydInterfaceCreateModelResponse>;
+}
+
+/**
+ * The request to create a model in Sloyd.
+ */
+export interface AISloydInterfaceCreateModelRequest {
+    /**
+     * The prompt to use for the model.
+     */
+    prompt: string;
+
+    /**
+     * The type of model to create.
+     */
+    modelOutputType: 'binary-glb' | 'json-gltf';
+
+    /**
+     * The level of detail to use for the model.
+     * This is a number between 0.01 and 1.
+     * Defaults to 0.5.
+     */
+    levelOfDetail?: number;
+
+    /**
+     * The type of thumbnail preview to create for the model.
+     * If not provided, no thumbnail preview will be created.
+     */
+    thumbnailPreviewExportType?: 'image/png';
+
+    /**
+     * The width of the thumbnail preview to create.
+     */
+    thumbnailPreviewSizeX?: number;
+
+    /**
+     * The height of the thumbnail preview to create.
+     */
+    thumbnailPreviewSizeY?: number;
+}
+
+export type AISloydInterfaceCreateModelResponse =
+    | AISloydInterfaceCreateModelSuccess
+    | AISloydInterfaceCreateModelFailure;
+
+export interface AISloydInterfaceCreateModelSuccess {
+    success: true;
+
+    /**
+     * A reference to the generated model.
+     */
+    interactionId: string;
+
+    /**
+     * A basic name for the object.
+     */
+    name: string;
+
+    /**
+     * The binary data of the model.
+     * Only provided if the modelOutputType is 'binary-glb'.
+     */
+    binary?: number[];
+
+    /**
+     * The GLTF JSON data.
+     * Only provided if the modelOutputType is 'json-gltf'.
+     */
+    gltfJson?: string;
+
+    /**
+     * A score indicating how confident the AI is that the returned object matches the text prompt.
+     * See [Using Confidence Score](https://doc.clickup.com/20484704/p/h/kh4k0-8035/ed114594b2af381).
+     */
+    confidenceScore: number;
+
+    /**
+     * The type of model to create.
+     */
+    modelOutputType: 'binary-glb' | 'json-gltf';
+
+    /**
+     * The base64 encoded thumbnail preview image.
+     */
+    previewImage?: string;
+}
+
+export interface AISloydInterfaceCreateModelFailure {
+    success: false;
+
+    /**
+     * The error code for the failure.
+     */
+    errorCode: ServerError;
+
+    /**
+     * The error message for the failure.
+     */
+    errorMessage: string;
+}

--- a/src/aux-records/AISloydInterface.ts
+++ b/src/aux-records/AISloydInterface.ts
@@ -172,11 +172,6 @@ export interface AISloydInterfaceEditModelSuccess {
     interactionId: string;
 
     /**
-     * A basic name for the object.
-     */
-    name: string;
-
-    /**
      * The binary data of the model.
      * Only provided if the modelOutputType is 'binary-glb'.
      */
@@ -187,12 +182,6 @@ export interface AISloydInterfaceEditModelSuccess {
      * Only provided if the modelOutputType is 'json-gltf'.
      */
     gltfJson?: string;
-
-    /**
-     * A score indicating how confident the AI is that the returned object matches the text prompt.
-     * See [Using Confidence Score](https://doc.clickup.com/20484704/p/h/kh4k0-8035/ed114594b2af381).
-     */
-    confidenceScore: number;
 
     /**
      * The type of model to create.

--- a/src/aux-records/AISloydInterface.ts
+++ b/src/aux-records/AISloydInterface.ts
@@ -8,6 +8,14 @@ export interface AISloydInterface {
     createModel(
         request: AISloydInterfaceCreateModelRequest
     ): Promise<AISloydInterfaceCreateModelResponse>;
+
+    /**
+     * Attempts to edit a model in Sloyd.
+     * @param request The request to edit the model.
+     */
+    editModel(
+        request: AISloydInterfaceEditModelRequest
+    ): Promise<AISloydInterfaceEditModelResponse>;
 }
 
 /**
@@ -95,6 +103,109 @@ export interface AISloydInterfaceCreateModelSuccess {
 }
 
 export interface AISloydInterfaceCreateModelFailure {
+    success: false;
+
+    /**
+     * The error code for the failure.
+     */
+    errorCode: ServerError;
+
+    /**
+     * The error message for the failure.
+     */
+    errorMessage: string;
+}
+
+/**
+ * The request to edit a model in Sloyd.
+ */
+export interface AISloydInterfaceEditModelRequest {
+    /**
+     * The interaction ID of the model to edit.
+     */
+    interactionId: string;
+
+    /**
+     * The prompt to use for the model.
+     */
+    prompt: string;
+
+    /**
+     * The type of model to create.
+     */
+    modelOutputType: 'binary-glb' | 'json-gltf';
+
+    /**
+     * The level of detail to use for the model.
+     * This is a number between 0.01 and 1.
+     * Defaults to 0.5.
+     */
+    levelOfDetail?: number;
+
+    /**
+     * The type of thumbnail preview to create for the model.
+     * If not provided, no thumbnail preview will be created.
+     */
+    thumbnailPreviewExportType?: 'image/png';
+
+    /**
+     * The width of the thumbnail preview to create.
+     */
+    thumbnailPreviewSizeX?: number;
+
+    /**
+     * The height of the thumbnail preview to create.
+     */
+    thumbnailPreviewSizeY?: number;
+}
+
+export type AISloydInterfaceEditModelResponse =
+    | AISloydInterfaceEditModelSuccess
+    | AISloydInterfaceEditModelFailure;
+
+export interface AISloydInterfaceEditModelSuccess {
+    success: true;
+
+    /**
+     * A reference to the generated model.
+     */
+    interactionId: string;
+
+    /**
+     * A basic name for the object.
+     */
+    name: string;
+
+    /**
+     * The binary data of the model.
+     * Only provided if the modelOutputType is 'binary-glb'.
+     */
+    binary?: number[];
+
+    /**
+     * The GLTF JSON data.
+     * Only provided if the modelOutputType is 'json-gltf'.
+     */
+    gltfJson?: string;
+
+    /**
+     * A score indicating how confident the AI is that the returned object matches the text prompt.
+     * See [Using Confidence Score](https://doc.clickup.com/20484704/p/h/kh4k0-8035/ed114594b2af381).
+     */
+    confidenceScore: number;
+
+    /**
+     * The type of model to create.
+     */
+    modelOutputType: 'binary-glb' | 'json-gltf';
+
+    /**
+     * The base64 encoded thumbnail preview image.
+     */
+    previewImage?: string;
+}
+
+export interface AISloydInterfaceEditModelFailure {
     success: false;
 
     /**

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -112,6 +112,8 @@ import {
     AIImageSubscriptionMetrics,
     AISkyboxSubscriptionMetrics,
     InstSubscriptionMetrics,
+    AISloydMetrics,
+    AISloydSubscriptionMetrics,
 } from './MetricsStore';
 import { ConfigurationStore } from './ConfigurationStore';
 import { SubscriptionConfiguration } from './SubscriptionConfiguration';
@@ -178,6 +180,7 @@ export class MemoryStore
     private _aiChatMetrics: AIChatMetrics[] = [];
     private _aiImageMetrics: AIImageMetrics[] = [];
     private _aiSkyboxMetrics: AISkyboxMetrics[] = [];
+    private _aiSloydMetrics: AISloydMetrics[] = [];
 
     private _dataBuckets: Map<string, Map<string, RecordData>> = new Map();
     private _eventBuckets: Map<string, Map<string, EventData>> = new Map();
@@ -230,6 +233,10 @@ export class MemoryStore
             }[];
         };
     };
+
+    get aiSloydMetrics(): AISloydMetrics[] {
+        return this._aiSloydMetrics;
+    }
 
     get users(): AuthUser[] {
         return this._users;
@@ -2709,6 +2716,58 @@ export class MemoryStore
             ...info,
             totalInsts,
         };
+    }
+
+    async getSubscriptionAiSloydMetrics(
+        filter: SubscriptionFilter
+    ): Promise<AISloydSubscriptionMetrics> {
+        const info = await this._getSubscriptionMetrics(filter);
+        const metrics = filter.ownerId
+            ? this._aiSloydMetrics.filter(
+                  (m) =>
+                      m.userId === filter.ownerId &&
+                      (!info.currentPeriodStartMs ||
+                          (m.createdAtMs >= info.currentPeriodStartMs &&
+                              m.createdAtMs < info.currentPeriodEndMs))
+              )
+            : this._aiSloydMetrics.filter(
+                  (m) =>
+                      m.studioId === filter.studioId &&
+                      (!info.currentPeriodStartMs ||
+                          (m.createdAtMs >= info.currentPeriodStartMs &&
+                              m.createdAtMs < info.currentPeriodEndMs))
+              );
+
+        const totalModels = metrics.length;
+        return {
+            ...info,
+            totalModelsInCurrentPeriod: totalModels,
+        };
+    }
+
+    async getSubscriptionAiSloydMetricsByRecordName(
+        recordName: string
+    ): Promise<AISloydSubscriptionMetrics> {
+        const info = await this._getSubscriptionInfo(recordName);
+
+        let totalModels = 0;
+        for (let metric of this._aiSloydMetrics) {
+            if (
+                metric.userId === info.ownerId ||
+                metric.studioId === info.studioId
+            ) {
+                totalModels += 1;
+            }
+        }
+
+        return {
+            ...info,
+            totalModelsInCurrentPeriod: totalModels,
+        };
+    }
+
+    async recordSloydMetrics(metrics: AISloydMetrics): Promise<void> {
+        this._aiSloydMetrics.push(metrics);
     }
 
     async recordChatMetrics(metrics: AIChatMetrics): Promise<void> {

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -2738,7 +2738,10 @@ export class MemoryStore
                               m.createdAtMs < info.currentPeriodEndMs))
               );
 
-        const totalModels = metrics.length;
+        let totalModels = 0;
+        for (let m of metrics) {
+            totalModels += m.modelsCreated;
+        }
         return {
             ...info,
             totalModelsInCurrentPeriod: totalModels,
@@ -2756,7 +2759,7 @@ export class MemoryStore
                 metric.userId === info.ownerId ||
                 metric.studioId === info.studioId
             ) {
-                totalModels += 1;
+                totalModels += metric.modelsCreated;
             }
         }
 

--- a/src/aux-records/MetricsStore.ts
+++ b/src/aux-records/MetricsStore.ts
@@ -336,7 +336,17 @@ export interface AISloydMetrics {
     thumbnailBase64?: string;
 
     /**
+     * The ID of the model that the created model is based on.
+     */
+    baseModelId?: string;
+
+    /**
      * The unix time in miliseconds of when the metrics were created.
      */
     createdAtMs: number;
+
+    /**
+     * The number of models that were created in this metric.
+     */
+    modelsCreated: number;
 }

--- a/src/aux-records/MetricsStore.ts
+++ b/src/aux-records/MetricsStore.ts
@@ -82,14 +82,6 @@ export interface MetricsStore {
     ): Promise<AISloydSubscriptionMetrics>;
 
     /**
-     * Gets the subscription metrics for sloyd.ai for the given record.
-     * @param recordName The name of the record.
-     */
-    getSubscriptionAiSloydMetricsByRecordName(
-        recordName: string
-    ): Promise<AISloydSubscriptionMetrics>;
-
-    /**
      * Records the given sloyd.ai metrics.
      * @param metrics The metrics to record.
      */
@@ -311,12 +303,12 @@ export interface AISloydMetrics {
     /**
      * The name of the model that was created.
      */
-    name: string;
+    name?: string;
 
     /**
      * The confidence of the AI in the created model.
      */
-    confidence: number;
+    confidence?: number;
 
     /**
      * The MIME type of the model.

--- a/src/aux-records/MetricsStore.ts
+++ b/src/aux-records/MetricsStore.ts
@@ -82,6 +82,14 @@ export interface MetricsStore {
     ): Promise<AISloydSubscriptionMetrics>;
 
     /**
+     * Gets the subscription metrics for sloyd.ai for the given record.
+     * @param recordName The name of the record.
+     */
+    getSubscriptionAiSloydMetricsByRecordName(
+        recordName: string
+    ): Promise<AISloydSubscriptionMetrics>;
+
+    /**
      * Records the given sloyd.ai metrics.
      * @param metrics The metrics to record.
      */
@@ -280,7 +288,7 @@ export interface AISloydSubscriptionMetrics extends SubscriptionMetrics {
     /**
      * The total number of sloyd.ai items that have been created for the current period.
      */
-    totalSloydItemsInCurrentPeriod: number;
+    totalModelsInCurrentPeriod: number;
 }
 
 export interface AISloydMetrics {
@@ -326,4 +334,9 @@ export interface AISloydMetrics {
      * The base64 encoded thumbnail of the model.
      */
     thumbnailBase64?: string;
+
+    /**
+     * The unix time in miliseconds of when the metrics were created.
+     */
+    createdAtMs: number;
 }

--- a/src/aux-records/MetricsStore.ts
+++ b/src/aux-records/MetricsStore.ts
@@ -74,6 +74,20 @@ export interface MetricsStore {
     recordSkyboxMetrics(metrics: AISkyboxMetrics): Promise<void>;
 
     /**
+     * Gets the subscription metrics for sloyd.ai for the given user/studio.
+     * @param filter The filter.
+     */
+    getSubscriptionAiSloydMetrics(
+        filter: SubscriptionFilter
+    ): Promise<AISloydSubscriptionMetrics>;
+
+    /**
+     * Records the given sloyd.ai metrics.
+     * @param metrics The metrics to record.
+     */
+    recordSloydMetrics(metrics: AISloydMetrics): Promise<void>;
+
+    /**
      * Gets the inst metrics for the given user/studio.
      * @param filter The filter.
      */
@@ -260,4 +274,56 @@ export interface AISkyboxMetrics {
      * The unix time in miliseconds of when the metrics were created.
      */
     createdAtMs: number;
+}
+
+export interface AISloydSubscriptionMetrics extends SubscriptionMetrics {
+    /**
+     * The total number of sloyd.ai items that have been created for the current period.
+     */
+    totalSloydItemsInCurrentPeriod: number;
+}
+
+export interface AISloydMetrics {
+    /**
+     * The ID of the user that the metrics are for.
+     */
+    userId?: string;
+
+    /**
+     * The ID of the studio that the metrics are for.
+     */
+    studioId?: string;
+
+    /**
+     * The ID of the model that was created.
+     * ("interactionId" in the sloyd interface)
+     */
+    modelId: string;
+
+    /**
+     * The name of the model that was created.
+     */
+    name: string;
+
+    /**
+     * The confidence of the AI in the created model.
+     */
+    confidence: number;
+
+    /**
+     * The MIME type of the model.
+     */
+    mimeType: string;
+
+    /**
+     * The data for the model.
+     * If the mimeType is "model/gltf+json", then this will be a JSON string.
+     * If the mimeType is "model/gltf-binary", then this will be a base64 encoded string.
+     */
+    modelData: string;
+
+    /**
+     * The base64 encoded thumbnail of the model.
+     */
+    thumbnailBase64?: string;
 }

--- a/src/aux-records/PolicyController.spec.ts
+++ b/src/aux-records/PolicyController.spec.ts
@@ -2542,6 +2542,7 @@ describe('PolicyController', () => {
             ['marker'],
             ['role'],
             ['loom'],
+            ['ai.sloyd'],
         ];
 
         // Admins can perform all actions on all resources
@@ -3388,6 +3389,7 @@ describe('PolicyController', () => {
                 ],
             ],
             ['loom', [['create', 'resourceId']]],
+            ['ai.sloyd', [['create', 'resourceId']]],
         ];
 
         const recordKeySubjectTypeDenialCases: [SubjectType, string][] = [
@@ -3884,6 +3886,7 @@ describe('PolicyController', () => {
                     ['increment', 'resourceId'],
                 ],
             ],
+            ['ai.sloyd', [['create', 'resourceId']]],
         ];
 
         describe.each(studioMemberResourceKindDenialCases)(

--- a/src/aux-records/PolicyController.ts
+++ b/src/aux-records/PolicyController.ts
@@ -3069,7 +3069,7 @@ export interface AuthorizeSubjectRequest {
     /**
      * The markers that are applied to the resource.
      */
-    markers: string[];
+    markers: string[] | null;
 }
 
 export type AuthorizeSubjectsResult =

--- a/src/aux-records/PolicyController.ts
+++ b/src/aux-records/PolicyController.ts
@@ -2386,12 +2386,43 @@ export interface ConstructAuthorizationContextFailure {
 }
 
 export interface AuthorizationContext {
+    /**
+     * The result of validating the record key if one was provided.
+     * Null if a record key was not provided.
+     */
     recordKeyResult: ValidatePublicRecordKeyResult | null;
+
+    /**
+     * Whether a record key was provided.
+     */
     recordKeyProvided: boolean;
+
+    /**
+     * The name of the record.
+     */
     recordName: string;
+
+    /**
+     * The ID of the user that owns the record.
+     * Null if the record is owned by a studio.
+     */
     recordOwnerId: string;
+
+    /**
+     * The ID of the studio that owns the record.
+     * Null if the record is owned by a user.
+     */
     recordStudioId: string;
+
+    /**
+     * The list of members that are assigned to the studio.
+     * Null if the record is owned by a user.
+     */
     recordStudioMembers?: ListedStudioAssignment[];
+
+    /**
+     * The subject policy that is used for the record key.
+     */
     subjectPolicy: PublicRecordKeyPolicy;
 
     /**

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -12833,6 +12833,68 @@ describe('RecordsServer', () => {
             });
         });
 
+        it('should use the user record if no record name is specified', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/ai/sloyd/model`,
+                    JSON.stringify({
+                        prompt: 'a blue sky',
+                        outputMimeType: 'model/gltf+json',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    modelId: 'model-1',
+                    mimeType: 'model/gltf+json',
+                    confidence: 0.5,
+                    name: 'model-1',
+                    modelData: 'json',
+                },
+                headers: apiCorsHeaders,
+            });
+
+            expect(sloydInterface.createModel).toHaveBeenCalledWith({
+                prompt: 'a blue sky',
+                modelOutputType: 'json-gltf',
+            });
+        });
+
+        it('should default outputMimeType to gltf+json', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/ai/sloyd/model`,
+                    JSON.stringify({
+                        recordName: userId,
+                        prompt: 'a blue sky',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    modelId: 'model-1',
+                    mimeType: 'model/gltf+json',
+                    confidence: 0.5,
+                    name: 'model-1',
+                    modelData: 'json',
+                },
+                headers: apiCorsHeaders,
+            });
+
+            expect(sloydInterface.createModel).toHaveBeenCalledWith({
+                prompt: 'a blue sky',
+                modelOutputType: 'json-gltf',
+            });
+        });
+
         it('should be able to include additional options', async () => {
             const result = await server.handleHttpRequest(
                 httpPost(

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -12788,16 +12788,15 @@ describe('RecordsServer', () => {
                 name: 'model-1',
                 confidenceScore: 0.5,
                 interactionId: 'model-1',
-                modelOutputType: 'json-gltf',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
             sloydInterface.editModel.mockResolvedValueOnce({
                 success: true,
-                name: 'model-2',
-                confidenceScore: 0.5,
+                // confidenceScore: 0.5,
                 interactionId: 'model-2',
-                modelOutputType: 'json-gltf',
-                gltfJson: 'json',
+                modelMimeType: 'model/gltf+json',
+                modelData: 'json',
             });
         });
 
@@ -12829,7 +12828,7 @@ describe('RecordsServer', () => {
 
             expect(sloydInterface.createModel).toHaveBeenCalledWith({
                 prompt: 'a blue sky',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
             });
         });
 
@@ -12860,7 +12859,7 @@ describe('RecordsServer', () => {
 
             expect(sloydInterface.createModel).toHaveBeenCalledWith({
                 prompt: 'a blue sky',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
             });
         });
 
@@ -12891,7 +12890,7 @@ describe('RecordsServer', () => {
 
             expect(sloydInterface.createModel).toHaveBeenCalledWith({
                 prompt: 'a blue sky',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
             });
         });
 
@@ -12921,8 +12920,6 @@ describe('RecordsServer', () => {
                     success: true,
                     modelId: 'model-2',
                     mimeType: 'model/gltf+json',
-                    confidence: 0.5,
-                    name: 'model-2',
                     modelData: 'json',
                 },
                 headers: apiCorsHeaders,
@@ -12931,7 +12928,7 @@ describe('RecordsServer', () => {
             expect(sloydInterface.editModel).toHaveBeenCalledWith({
                 interactionId: 'model-5',
                 prompt: 'a blue sky',
-                modelOutputType: 'json-gltf',
+                modelMimeType: 'model/gltf+json',
                 levelOfDetail: 1,
                 thumbnailPreviewExportType: 'image/png',
                 thumbnailPreviewSizeX: 64,

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -138,6 +138,12 @@ import { z } from 'zod';
 import { AIHumeInterfaceGetAccessTokenResult } from './AIHumeInterface';
 import * as jose from 'jose';
 import { LoomController } from './LoomController';
+import {
+    AISloydInterfaceCreateModelRequest,
+    AISloydInterfaceCreateModelResponse,
+    AISloydInterfaceEditModelRequest,
+    AISloydInterfaceEditModelResponse,
+} from './AISloydInterface';
 
 jest.mock('@simplewebauthn/server');
 let verifyRegistrationResponseMock: jest.Mock<
@@ -339,6 +345,16 @@ describe('RecordsServer', () => {
     };
     let humeInterface: {
         getAccessToken: jest.Mock<Promise<AIHumeInterfaceGetAccessTokenResult>>;
+    };
+    let sloydInterface: {
+        createModel: jest.Mock<
+            Promise<AISloydInterfaceCreateModelResponse>,
+            [AISloydInterfaceCreateModelRequest]
+        >;
+        editModel: jest.Mock<
+            Promise<AISloydInterfaceEditModelResponse>,
+            [AISloydInterfaceEditModelRequest]
+        >;
     };
 
     let stripe: StripeInterface;
@@ -591,6 +607,10 @@ describe('RecordsServer', () => {
         humeInterface = {
             getAccessToken: jest.fn(),
         };
+        sloydInterface = {
+            createModel: jest.fn(),
+            editModel: jest.fn(),
+        };
         aiController = new AIController({
             chat: {
                 interfaces: {
@@ -639,9 +659,13 @@ describe('RecordsServer', () => {
             hume: {
                 interface: humeInterface,
             },
+            sloyd: {
+                interface: sloydInterface,
+            },
             config: store,
             metrics: store,
             policies: store,
+            policyController: policyController,
         });
         moderationController = new ModerationController(store, store, store);
         loomController = new LoomController({
@@ -12723,7 +12747,7 @@ describe('RecordsServer', () => {
             });
         });
 
-        it('should return a not_supported result if the server has a null AI controller', async () => {
+        it('should be able to retrive a token that can be used to access Hume', async () => {
             const result = await server.handleHttpRequest(
                 httpGet(`/api/v2/ai/hume/token`, apiHeaders)
             );
@@ -12748,6 +12772,140 @@ describe('RecordsServer', () => {
         );
         testAuthorization(() => httpGet(`/api/v2/ai/hume/token`, apiHeaders));
         testRateLimit(() => httpGet(`/api/v2/ai/hume/token`, apiHeaders));
+    });
+
+    describe('POST /api/v2/ai/sloyd/model', () => {
+        beforeEach(async () => {
+            const u = await store.findUser(userId);
+            await store.saveUser({
+                ...u,
+                subscriptionId: 'sub_id',
+                subscriptionStatus: 'active',
+            });
+
+            sloydInterface.createModel.mockResolvedValueOnce({
+                success: true,
+                name: 'model-1',
+                confidenceScore: 0.5,
+                interactionId: 'model-1',
+                modelOutputType: 'json-gltf',
+                gltfJson: 'json',
+            });
+            sloydInterface.editModel.mockResolvedValueOnce({
+                success: true,
+                name: 'model-2',
+                confidenceScore: 0.5,
+                interactionId: 'model-2',
+                modelOutputType: 'json-gltf',
+                gltfJson: 'json',
+            });
+        });
+
+        it('should be able to call the sloyd interface to create a model', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/ai/sloyd/model`,
+                    JSON.stringify({
+                        recordName: userId,
+                        prompt: 'a blue sky',
+                        outputMimeType: 'model/gltf+json',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    modelId: 'model-1',
+                    mimeType: 'model/gltf+json',
+                    confidence: 0.5,
+                    name: 'model-1',
+                    modelData: 'json',
+                },
+                headers: apiCorsHeaders,
+            });
+
+            expect(sloydInterface.createModel).toHaveBeenCalledWith({
+                prompt: 'a blue sky',
+                modelOutputType: 'json-gltf',
+            });
+        });
+
+        it('should be able to include additional options', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/ai/sloyd/model`,
+                    JSON.stringify({
+                        recordName: userId,
+                        prompt: 'a blue sky',
+                        outputMimeType: 'model/gltf+json',
+                        levelOfDetail: 1,
+                        thumbnail: {
+                            type: 'image/png',
+                            width: 64,
+                            height: 64,
+                        },
+                        baseModelId: 'model-5',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    modelId: 'model-2',
+                    mimeType: 'model/gltf+json',
+                    confidence: 0.5,
+                    name: 'model-2',
+                    modelData: 'json',
+                },
+                headers: apiCorsHeaders,
+            });
+
+            expect(sloydInterface.editModel).toHaveBeenCalledWith({
+                interactionId: 'model-5',
+                prompt: 'a blue sky',
+                modelOutputType: 'json-gltf',
+                levelOfDetail: 1,
+                thumbnailPreviewExportType: 'image/png',
+                thumbnailPreviewSizeX: 64,
+                thumbnailPreviewSizeY: 64,
+            });
+        });
+
+        testOrigin('POST', `/api/v2/ai/sloyd/model`, () =>
+            JSON.stringify({
+                recordName: userId,
+                prompt: 'a blue sky',
+                outputMimeType: 'model/gltf+json',
+            })
+        );
+        testAuthorization(() =>
+            httpPost(
+                `/api/v2/ai/sloyd/model`,
+                JSON.stringify({
+                    recordName: userId,
+                    prompt: 'a blue sky',
+                    outputMimeType: 'model/gltf+json',
+                }),
+                apiHeaders
+            )
+        );
+        testRateLimit(() =>
+            httpPost(
+                `/api/v2/ai/sloyd/model`,
+                JSON.stringify({
+                    recordName: userId,
+                    prompt: 'a blue sky',
+                    outputMimeType: 'model/gltf+json',
+                }),
+                apiHeaders
+            )
+        );
     });
 
     describe('GET /api/v2/loom/token', () => {

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -2321,11 +2321,10 @@ export class RecordsServer {
                 .http('POST', '/api/v2/ai/sloyd/model')
                 .inputs(
                     z.object({
-                        recordName: RECORD_NAME_VALIDATION,
-                        outputMimeType: z.enum([
-                            'model/gltf+json',
-                            'model/gltf-binary',
-                        ]),
+                        recordName: RECORD_NAME_VALIDATION.optional(),
+                        outputMimeType: z
+                            .enum(['model/gltf+json', 'model/gltf-binary'])
+                            .default('model/gltf+json'),
                         prompt: z.string().min(1),
                         levelOfDetail: z.number().min(0.01).max(1).optional(),
                         baseModelId: z.string().optional(),
@@ -2369,7 +2368,8 @@ export class RecordsServer {
                         const result =
                             await this._aiController.sloydGenerateModel({
                                 userId: sessionKeyValidation.userId,
-                                recordName,
+                                recordName:
+                                    recordName ?? sessionKeyValidation.userId,
                                 outputMimeType,
                                 prompt,
                                 levelOfDetail,

--- a/src/aux-records/SloydInterface.ts
+++ b/src/aux-records/SloydInterface.ts
@@ -7,6 +7,7 @@ import {
     AISloydInterfaceEditModelResponse,
 } from './AISloydInterface';
 import axios from 'axios';
+import { handleAxiosErrors } from 'Utils';
 
 export interface SloydOptions {
     clientId: string;
@@ -25,89 +26,101 @@ export class SloydInterface implements AISloydInterface {
     async createModel(
         request: AISloydInterfaceCreateModelRequest
     ): Promise<AISloydInterfaceCreateModelResponse> {
-        const result = await axios.post('https://api.sloyd.ai/create', {
-            ClientId: this._clientId,
-            ClientSecret: this._clientSecret,
-            Prompt: request.prompt,
-            ModelOutputType:
-                request.modelOutputType === 'binary-glb'
-                    ? 1
-                    : request.modelOutputType === 'json-gltf'
-                    ? 4
-                    : 4,
-            LOD: request.levelOfDetail,
-            ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
-            ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
-            ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
-        });
+        try {
+            const result = await axios.post('https://api.sloyd.ai/create', {
+                ClientId: this._clientId,
+                ClientSecret: this._clientSecret,
+                Prompt: request.prompt,
+                ModelOutputType:
+                    request.modelOutputType === 'binary-glb'
+                        ? 1
+                        : request.modelOutputType === 'json-gltf'
+                        ? 4
+                        : 4,
+                LOD: request.levelOfDetail,
+                ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
+                ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
+                ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
+            });
 
-        const schema = z.object({
-            InteractionId: z.string(),
-            Name: z.string(),
-            ConfidenceScore: z.number(),
-            ModelOutputType: z.number(),
-            Binary: z.array(z.number()).optional().nullable(),
-            GLTFJson: z.object({}).passthrough().optional().nullable(),
-        });
+            const schema = z.object({
+                InteractionId: z.string(),
+                Name: z.string(),
+                ConfidenceScore: z.number(),
+                ModelOutputType: z.number(),
+                Binary: z.array(z.number()).optional().nullable(),
+                GLTFJson: z.object({}).passthrough().optional().nullable(),
+            });
 
-        const data = schema.parse(result.data);
+            const data = schema.parse(result.data);
 
-        return {
-            success: true,
-            interactionId: data.InteractionId,
-            name: data.Name,
-            confidenceScore: data.ConfidenceScore,
-            modelOutputType:
-                data.ModelOutputType === 1
-                    ? 'binary-glb'
-                    : data.ModelOutputType === 4
-                    ? 'json-gltf'
-                    : 'json-gltf',
-            binary: data.Binary,
-            gltfJson: data.GLTFJson ? JSON.stringify(data.GLTFJson) : undefined,
-        };
+            return {
+                success: true,
+                interactionId: data.InteractionId,
+                name: data.Name,
+                confidenceScore: data.ConfidenceScore,
+                modelOutputType:
+                    data.ModelOutputType === 1
+                        ? 'binary-glb'
+                        : data.ModelOutputType === 4
+                        ? 'json-gltf'
+                        : 'json-gltf',
+                binary: data.Binary,
+                gltfJson: data.GLTFJson
+                    ? JSON.stringify(data.GLTFJson)
+                    : undefined,
+            };
+        } catch (err) {
+            handleAxiosErrors(err);
+        }
     }
 
     async editModel(
         request: AISloydInterfaceEditModelRequest
     ): Promise<AISloydInterfaceEditModelResponse> {
-        const result = await axios.post('https://api.sloyd.ai/edit', {
-            ClientId: this._clientId,
-            ClientSecret: this._clientSecret,
-            InteractionId: request.interactionId,
-            Prompt: request.prompt,
-            ModelOutputType:
-                request.modelOutputType === 'binary-glb'
-                    ? 1
-                    : request.modelOutputType === 'json-gltf'
-                    ? 4
-                    : 4,
-            LOD: request.levelOfDetail,
-            ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
-            ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
-            ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
-        });
+        try {
+            const result = await axios.post('https://api.sloyd.ai/edit', {
+                ClientId: this._clientId,
+                ClientSecret: this._clientSecret,
+                InteractionId: request.interactionId,
+                Prompt: request.prompt,
+                ModelOutputType:
+                    request.modelOutputType === 'binary-glb'
+                        ? 1
+                        : request.modelOutputType === 'json-gltf'
+                        ? 4
+                        : 4,
+                LOD: request.levelOfDetail,
+                ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
+                ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
+                ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
+            });
 
-        const schema = z.object({
-            InteractionId: z.string(),
-            ModelOutputType: z.number(),
-            Binary: z.array(z.number()).optional().nullable(),
-            GLTFJson: z.object({}).passthrough().optional().nullable(),
-        });
+            const schema = z.object({
+                InteractionId: z.string(),
+                ModelOutputType: z.number(),
+                Binary: z.array(z.number()).optional().nullable(),
+                GLTFJson: z.object({}).passthrough().optional().nullable(),
+            });
 
-        const data = schema.parse(result.data);
+            const data = schema.parse(result.data);
 
-        return {
-            success: true,
-            interactionId: data.InteractionId,
-            modelOutputType:
-                data.ModelOutputType === 1
-                    ? 'binary-glb'
-                    : data.ModelOutputType === 4
-                    ? 'json-gltf'
-                    : 'json-gltf',
-            binary: data.Binary,
-            gltfJson: data.GLTFJson ? JSON.stringify(data.GLTFJson) : undefined,
-        };
+            return {
+                success: true,
+                interactionId: data.InteractionId,
+                modelOutputType:
+                    data.ModelOutputType === 1
+                        ? 'binary-glb'
+                        : data.ModelOutputType === 4
+                        ? 'json-gltf'
+                        : 'json-gltf',
+                binary: data.Binary,
+                gltfJson: data.GLTFJson
+                    ? JSON.stringify(data.GLTFJson)
+                    : undefined,
+            };
+        } catch (err) {
+            handleAxiosErrors(err);
+        }
     }
 }

--- a/src/aux-records/SloydInterface.ts
+++ b/src/aux-records/SloydInterface.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import {
+    AISloydInterface,
+    AISloydInterfaceCreateModelRequest,
+    AISloydInterfaceCreateModelResponse,
+    AISloydInterfaceEditModelRequest,
+    AISloydInterfaceEditModelResponse,
+} from './AISloydInterface';
+import axios from 'axios';
+
+export interface SloydOptions {
+    clientId: string;
+    clientSecret: string;
+}
+
+export class SloydInterface implements AISloydInterface {
+    private _clientId: string;
+    private _clientSecret: string;
+
+    constructor(options: SloydOptions) {
+        this._clientId = options.clientId;
+        this._clientSecret = options.clientSecret;
+    }
+
+    async createModel(
+        request: AISloydInterfaceCreateModelRequest
+    ): Promise<AISloydInterfaceCreateModelResponse> {
+        const result = await axios.post('https://api.sloyd.ai/create', {
+            ClientId: this._clientId,
+            ClientSecret: this._clientSecret,
+            Prompt: request.prompt,
+            ModelOutputType:
+                request.modelOutputType === 'binary-glb'
+                    ? 1
+                    : request.modelOutputType === 'json-gltf'
+                    ? 4
+                    : 4,
+            LOD: request.levelOfDetail,
+            ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
+            ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
+            ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
+        });
+
+        const schema = z.object({
+            InteractionId: z.string(),
+            Name: z.string(),
+            ConfidenceScore: z.number(),
+            ModelOutputType: z.number(),
+            Binary: z.array(z.number()).optional().nullable(),
+            GLTFJson: z.object({}).passthrough().optional().nullable(),
+        });
+
+        const data = schema.parse(result.data);
+
+        return {
+            success: true,
+            interactionId: data.InteractionId,
+            name: data.Name,
+            confidenceScore: data.ConfidenceScore,
+            modelOutputType:
+                data.ModelOutputType === 1
+                    ? 'binary-glb'
+                    : data.ModelOutputType === 4
+                    ? 'json-gltf'
+                    : 'json-gltf',
+            binary: data.Binary,
+            gltfJson: data.GLTFJson ? JSON.stringify(data.GLTFJson) : undefined,
+        };
+    }
+
+    async editModel(
+        request: AISloydInterfaceEditModelRequest
+    ): Promise<AISloydInterfaceEditModelResponse> {
+        const result = await axios.post('https://api.sloyd.ai/edit', {
+            ClientId: this._clientId,
+            ClientSecret: this._clientSecret,
+            InteractionId: request.interactionId,
+            Prompt: request.prompt,
+            ModelOutputType:
+                request.modelOutputType === 'binary-glb'
+                    ? 1
+                    : request.modelOutputType === 'json-gltf'
+                    ? 4
+                    : 4,
+            LOD: request.levelOfDetail,
+            ThumbnailPreviewExportType: request.thumbnailPreviewExportType,
+            ThumbnailPreviewSizeX: request.thumbnailPreviewSizeX,
+            ThumbnailPreviewSizeY: request.thumbnailPreviewSizeY,
+        });
+
+        const schema = z.object({
+            InteractionId: z.string(),
+            ModelOutputType: z.number(),
+            Binary: z.array(z.number()).optional().nullable(),
+            GLTFJson: z.object({}).passthrough().optional().nullable(),
+        });
+
+        const data = schema.parse(result.data);
+
+        return {
+            success: true,
+            interactionId: data.InteractionId,
+            modelOutputType:
+                data.ModelOutputType === 1
+                    ? 'binary-glb'
+                    : data.ModelOutputType === 4
+                    ? 'json-gltf'
+                    : 'json-gltf',
+            binary: data.Binary,
+            gltfJson: data.GLTFJson ? JSON.stringify(data.GLTFJson) : undefined,
+        };
+    }
+}

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -949,6 +949,9 @@ export function allowAllFeatures(): FeaturesConfiguration {
             hume: {
                 allowed: true,
             },
+            sloyd: {
+                allowed: true,
+            },
         },
         data: {
             allowed: true,

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -188,21 +188,29 @@ export const subscriptionFeaturesSchema = z.object({
             .default({
                 allowed: false,
             }),
-        sloyd: z.object({
-            allowed: z
-                .boolean()
-                .describe(
-                    'Whether Sloyd AI features are allowed for the subscription. If false, then every request to generate Sloyd AI will be rejected.'
-                ),
-            maxModelsPerPeriod: z
-                .number()
-                .describe(
-                    'The maximum number of models that can be generated per subscription period. If omitted, then there is no limit.'
-                )
-                .positive()
-                .int()
-                .optional(),
-        }),
+        sloyd: z
+            .object({
+                allowed: z
+                    .boolean()
+                    .describe(
+                        'Whether Sloyd AI features are allowed for the subscription. If false, then every request to generate Sloyd AI will be rejected.'
+                    ),
+                maxModelsPerPeriod: z
+                    .number()
+                    .describe(
+                        'The maximum number of models that can be generated per subscription period. If omitted, then there is no limit.'
+                    )
+                    .positive()
+                    .int()
+                    .optional(),
+            })
+            .describe(
+                'The configuration for Sloyd AI features for the subscription. Defaults to not allowed if omitted.'
+            )
+            .optional()
+            .default({
+                allowed: false,
+            }),
     }),
     insts: z.object({
         allowed: z

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1507,6 +1507,46 @@ Object {
                 },
                 "type": "object",
               },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "type": "enum",
+                    "values": Array [
+                      "create",
+                    ],
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "ai.sloyd",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "user",
+                      "inst",
+                      "role",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
             ],
             "type": "union",
           },
@@ -1573,6 +1613,7 @@ Object {
               "role",
               "inst",
               "loom",
+              "ai.sloyd",
             ],
           },
         },
@@ -2151,6 +2192,56 @@ Object {
         "type": "object",
       },
       "name": "getHumeAccessToken",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/sloyd/model",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "baseModelId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "levelOfDetail": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "outputMimeType": Object {
+            "type": "enum",
+            "values": Array [
+              "model/gltf+json",
+              "model/gltf-binary",
+            ],
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "thumbnail": Object {
+            "optional": true,
+            "schema": Object {
+              "height": Object {
+                "type": "number",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "image/png",
+              },
+              "width": Object {
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createSloydModel",
       "origins": "api",
     },
     Object {
@@ -4272,6 +4363,46 @@ Object {
                 },
                 "type": "object",
               },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "type": "enum",
+                    "values": Array [
+                      "create",
+                    ],
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "ai.sloyd",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "user",
+                      "inst",
+                      "role",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
             ],
             "type": "union",
           },
@@ -4338,6 +4469,7 @@ Object {
               "role",
               "inst",
               "loom",
+              "ai.sloyd",
             ],
           },
         },
@@ -4916,6 +5048,56 @@ Object {
         "type": "object",
       },
       "name": "getHumeAccessToken",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/ai/sloyd/model",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "baseModelId": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "levelOfDetail": Object {
+            "optional": true,
+            "type": "number",
+          },
+          "outputMimeType": Object {
+            "type": "enum",
+            "values": Array [
+              "model/gltf+json",
+              "model/gltf-binary",
+            ],
+          },
+          "prompt": Object {
+            "type": "string",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+          "thumbnail": Object {
+            "optional": true,
+            "schema": Object {
+              "height": Object {
+                "type": "number",
+              },
+              "type": Object {
+                "type": "literal",
+                "value": "image/png",
+              },
+              "width": Object {
+                "type": "number",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "type": "object",
+      },
+      "name": "createSloydModel",
       "origins": "api",
     },
     Object {

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -2210,6 +2210,8 @@ Object {
             "type": "number",
           },
           "outputMimeType": Object {
+            "defaultValue": "model/gltf+json",
+            "hasDefault": true,
             "type": "enum",
             "values": Array [
               "model/gltf+json",
@@ -2220,6 +2222,7 @@ Object {
             "type": "string",
           },
           "recordName": Object {
+            "optional": true,
             "type": "string",
           },
           "thumbnail": Object {
@@ -5066,6 +5069,8 @@ Object {
             "type": "number",
           },
           "outputMimeType": Object {
+            "defaultValue": "model/gltf+json",
+            "hasDefault": true,
             "type": "enum",
             "values": Array [
               "model/gltf+json",
@@ -5076,6 +5081,7 @@ Object {
             "type": "string",
           },
           "recordName": Object {
+            "optional": true,
             "type": "string",
           },
           "thumbnail": Object {

--- a/src/aux-records/__snapshots__/SubscriptionConfiguration.spec.ts.snap
+++ b/src/aux-records/__snapshots__/SubscriptionConfiguration.spec.ts.snap
@@ -15,6 +15,9 @@ Object {
     "skyboxes": Object {
       "allowed": true,
     },
+    "sloyd": Object {
+      "allowed": true,
+    },
   },
   "data": Object {
     "allowed": true,

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -182,6 +182,7 @@ import {
     listDataRecordByMarker,
     aiChatStream,
     aiHumeGetAccessToken,
+    aiSloydGenerateModel,
 } from './RecordsEvents';
 import {
     DEFAULT_BRANCH_NAME,
@@ -3504,6 +3505,24 @@ describe('AuxLibrary', () => {
             it('should emit a AIGetHumeAccessTokenAction', () => {
                 const promise: any = library.api.ai.hume.getAccessToken();
                 const expected = aiHumeGetAccessToken({}, context.tasks.size);
+
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('ai.sloyd.generateModel()', () => {
+            it('should emit a AISloydGenerateModelAction', () => {
+                const promise: any = library.api.ai.sloyd.generateModel({
+                    prompt: 'this is a test',
+                });
+                const expected = aiSloydGenerateModel(
+                    {
+                        prompt: 'this is a test',
+                    },
+                    undefined,
+                    context.tasks.size
+                );
 
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -3520,7 +3520,7 @@ describe('AuxLibrary', () => {
                     {
                         prompt: 'this is a test',
                     },
-                    undefined,
+                    {},
                     context.tasks.size
                 );
 

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -300,6 +300,8 @@ import {
     ListDataOptions,
     listDataRecordByMarker,
     aiHumeGetAccessToken,
+    AISloydGenerateModelOptions,
+    aiSloydGenerateModel,
 } from './RecordsEvents';
 import {
     sortBy,
@@ -431,6 +433,7 @@ import {
     AIGenerateImageResponse,
     AIGenerateImageSuccess,
     AIHumeGetAccessTokenResult,
+    AISloydGenerateModelResponse,
 } from '@casual-simulation/aux-records/AIController';
 import {
     RuntimeActions,
@@ -2994,6 +2997,10 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                     getAccessToken: getHumeAccessToken,
                 },
 
+                sloyd: {
+                    generateModel: generateSloydModel,
+                },
+
                 stream: {
                     chat: chatStream,
                 },
@@ -5375,6 +5382,36 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function getHumeAccessToken(): Promise<AIHumeGetAccessTokenResult> {
         const task = context.createTask();
         const action = aiHumeGetAccessToken({}, task.taskId);
+        const final = addAsyncResultAction(task, action);
+        (final as any)[ORIGINAL_OBJECT] = action;
+        return final;
+    }
+
+    /**
+     * Generates a new 3D model using [sloyd.ai](https://www.sloyd.ai/).
+     * @param request The options for the 3D model.
+     * @param options The options for the request.
+     *
+     * @example Generate a chair model using Sloyd
+     * const model = await ai.sloyd.generateModel({
+     *     prompt: 'a chair'
+     * });
+     *
+     * @example Generate a chair using a studio subscription
+     * const model = await ai.sloyd.generateModel({
+     *     recordName: 'studioID',
+     *     prompt: 'a chair'
+     * });
+     *
+     * @dochash actions/ai
+     * @docname ai.sloyd.generateModel
+     */
+    function generateSloydModel(
+        request: AISloydGenerateModelOptions,
+        options?: RecordActionOptions
+    ): Promise<AISloydGenerateModelResponse> {
+        const task = context.createTask();
+        const action = aiSloydGenerateModel(request, options, task.taskId);
         const final = addAsyncResultAction(task, action);
         (final as any)[ORIGINAL_OBJECT] = action;
         return final;

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -5408,7 +5408,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      */
     function generateSloydModel(
         request: AISloydGenerateModelOptions,
-        options?: RecordActionOptions
+        options: RecordActionOptions = {}
     ): Promise<AISloydGenerateModelResponse> {
         const task = context.createTask();
         const action = aiSloydGenerateModel(request, options, task.taskId);

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -9969,6 +9969,7 @@ export interface StopFormAnimationOptions {
     duration: number;
 }
 
+
 /**
  * Defines an interface that represents a single chat message in a conversation with an AI.
  *
@@ -10336,9 +10337,145 @@ export interface AIHumeGetAccessTokenFailure {
         | NotLoggedInError
         | NotSupportedError
         | NotAuthorizedError
-        | 'hume_api_error'
+        | 'hume_api_error';
     errorMessage: string;
 }
+
+
+/**
+ * The response to a request to generate a model using the Sloyd AI interface.
+ * 
+ * @dochash types/ai
+ * @docname AISloydGenerateModelResponse
+ */
+export type AISloydGenerateModelResponse =
+    | AISloydGenerateModelSuccess
+    | AISloydGenerateModelFailure;
+
+/**
+ * A successful response to a request to generate a model using the Sloyd AI interface.
+ * 
+ * @dochash types/ai
+ * @docname AISloydGenerateModelSuccess
+ */
+export interface AISloydGenerateModelSuccess {
+    success: true;
+
+    /**
+     * The ID of the model that was created.
+     */
+    modelId: string;
+
+    /**
+     * The name of the model.
+     */
+    name: string;
+
+    /**
+     * The confidence of the AI in the created model.
+     */
+    confidence: number;
+
+    /**
+     * The MIME type of the model.
+     */
+    mimeType: 'model/gltf+json' | 'model/gltf-binary';
+
+    /**
+     * The data for the model.
+     * If the mimeType is "model/gltf+json", then this will be a JSON string.
+     * If the mimeType is "model/gltf-binary", then this will be a base64 encoded string.
+     */
+    modelData: string;
+
+    /**
+     * The base64 encoded thumbnail of the model.
+     */
+    thumbnailBase64?: string;
+}
+
+/**
+ * A failed response to a request to generate a model using the Sloyd AI interface.
+ * 
+ * @dochash types/ai
+ * @docname AISloydGenerateModelFailure
+ */
+export interface AISloydGenerateModelFailure {
+    success: false;
+
+    /**
+     * The error code.
+     */
+    errorCode:
+        | ServerError
+        | NotLoggedInError
+        | NotSupportedError
+        | NotAuthorizedError;
+
+    /**
+     * The error message.
+     */
+    errorMessage: string;
+}
+
+
+/**
+ * The options for generating a model using Sloyd AI.
+ * 
+ * @dochash types/ai
+ * @docname AISloydGenerateModelOptions
+ */
+export interface AISloydGenerateModelOptions {
+    /**
+     * The name of the record that should be used.
+     * If omitted, then the ID of the user will be used.
+     */
+    recordName?: string | null;
+
+    /**
+     * The prompt to use for the model.
+     */
+    prompt: string;
+
+    /**
+     * The MIME type that should be used for the model.
+     * If omitted, then "model/gltf+json" will be used.
+     */
+    outputMimeType?: 'model/gltf+json' | 'model/gltf-binary';
+
+    /**
+     * The level of detail that should be used.
+     */
+    levelOfDetail?: number;
+
+    /**
+     * The ID of the model that the new model should be based on.
+     */
+    baseModelId?: string;
+
+    /**
+     * The options for the thumbnail for the model.
+     * If omitted, then no thumbnail will be generated.
+     */
+    thumbnail?: {
+        /**
+         * The type of the thumbnail.
+         * Currently only "image/png" is supported.
+         */
+        type: 'image/png';
+
+        /**
+         * The desired width of the thumbnail in pixels.
+         */
+        width: number;
+
+        /**
+         * The desired height of the thumbnail in pixels.
+         */
+        height: number;
+    }
+}
+
 
 interface Ai {
     /**
@@ -10646,6 +10783,15 @@ interface Ai {
          * @docname ai.hume.getAccessToken
          */
         getAccessToken(): Promise<AIHumeGetAccessTokenResult>;
+    }
+
+    sloyd: {
+        /**
+         * Generates a new 3D model using [sloyd.ai](https://www.sloyd.ai/).
+         * @param request The options for the 3D model.
+         * @param options The options for the request.
+         */
+        generateModel(request: AISloydGenerateModelOptions, options?: RecordActionOptions): Promise<AISloydGenerateModelResponse>;
     }
 
     stream: {

--- a/src/aux-runtime/runtime/RecordsEvents.ts
+++ b/src/aux-runtime/runtime/RecordsEvents.ts
@@ -27,6 +27,7 @@ export type RecordsAsyncActions =
     | AIGenerateImageAction
     | AIGenerateSkyboxAction
     | AIHumeGetAccessTokenAction
+    | AISloydGenerateModelAction
     | ListUserStudiosAction
     | GetPublicRecordKeyAction
     | GrantRecordPermissionAction
@@ -278,6 +279,72 @@ export interface AIGenerateImageOptions {
  */
 export interface AIHumeGetAccessTokenAction extends RecordsAction {
     type: 'ai_hume_get_access_token';
+}
+
+/**
+ * An event that is used to generate a model using Sloyd AI.
+ */
+export interface AISloydGenerateModelAction
+    extends RecordsAction,
+        AISloydGenerateModelOptions {
+    type: 'ai_sloyd_generate_model';
+}
+
+/**
+ * The options for generating a model using Sloyd AI.
+ *
+ * @dochash types/ai
+ * @docname AISloydGenerateModelOptions
+ */
+export interface AISloydGenerateModelOptions {
+    /**
+     * The name of the record that should be used.
+     * If omitted, then the ID of the user will be used.
+     */
+    recordName?: string | null;
+
+    /**
+     * The prompt to use for the model.
+     */
+    prompt: string;
+
+    /**
+     * The MIME type that should be used for the model.
+     * If omitted, then "model/gltf+json" will be used.
+     */
+    outputMimeType?: 'model/gltf+json' | 'model/gltf-binary';
+
+    /**
+     * The level of detail that should be used.
+     */
+    levelOfDetail?: number;
+
+    /**
+     * The ID of the model that the new model should be based on.
+     */
+    baseModelId?: string;
+
+    /**
+     * The options for the thumbnail for the model.
+     * If omitted, then no thumbnail will be generated.
+     */
+    thumbnail?: {
+        /**
+         * The type of the thumbnail.
+         * Currently only "image/png" is supported.
+         */
+        type: 'image/png';
+
+        /**
+         * The desired width of the thumbnail in pixels.
+         */
+        width: number;
+
+        /**
+         * The desired height of the thumbnail in pixels.
+         */
+        height: number;
+    };
 }
 
 /**
@@ -1126,6 +1193,25 @@ export function aiHumeGetAccessToken(
     return {
         type: 'ai_hume_get_access_token',
         options: options ?? {},
+        taskId,
+    };
+}
+
+/**
+ * Creates a new AISloydGenerateModelAction.
+ * @param parameters The parameters for the action.
+ * @param options The options for the action.
+ * @param taskId The ID of the async task.
+ */
+export function aiSloydGenerateModel(
+    parameters: AISloydGenerateModelOptions,
+    options?: RecordActionOptions,
+    taskId?: number | string
+): AISloydGenerateModelAction {
+    return {
+        type: 'ai_sloyd_generate_model',
+        ...parameters,
+        options,
         taskId,
     };
 }

--- a/src/aux-runtime/runtime/RecordsEvents.ts
+++ b/src/aux-runtime/runtime/RecordsEvents.ts
@@ -316,6 +316,9 @@ export interface AISloydGenerateModelOptions {
 
     /**
      * The level of detail that should be used.
+     * Higher values will result in more detailed models.
+     * Should be between `0.01` and `1`.
+     * Defaults to `0.5`.
      */
     levelOfDetail?: number;
 

--- a/src/aux-server/aux-backend/mongo/MongoDBMetricsStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBMetricsStore.ts
@@ -5,6 +5,8 @@ import {
     AIImageSubscriptionMetrics,
     AISkyboxMetrics,
     AISkyboxSubscriptionMetrics,
+    AISloydMetrics,
+    AISloydSubscriptionMetrics,
     ConfigurationStore,
     DataSubscriptionMetrics,
     EventSubscriptionMetrics,
@@ -61,6 +63,22 @@ export class MongoDBMetricsStore implements MetricsStore {
         this._imageMetrics = this._db.collection(IMAGE_METRICS_COLLECTION);
         this._skyboxMetrics = this._db.collection(SKYBOX_METRICS_COLLECTION);
         this._config = configStore;
+    }
+
+    getSubscriptionAiSloydMetrics(
+        filter: SubscriptionFilter
+    ): Promise<AISloydSubscriptionMetrics> {
+        throw new Error('Method not implemented.');
+    }
+
+    getSubscriptionAiSloydMetricsByRecordName(
+        recordName: string
+    ): Promise<AISloydSubscriptionMetrics> {
+        throw new Error('Method not implemented.');
+    }
+
+    recordSloydMetrics(metrics: AISloydMetrics): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 
     getSubscriptionInstMetrics(

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -72,6 +72,7 @@ model User {
     aiChatMetrics AiChatMetrics[]
     aiImageMetrics AiImageMetrics[]
     aiSkyboxMetrics AiSkyboxMetrics[]
+    aiSloydMetrics AiSloydMetrics[]
 
     instReports UserInstReport[]
     comIdRequests StudioComIdRequest[]
@@ -270,6 +271,7 @@ model Studio {
     aiChatMetrics AiChatMetrics[]
     aiImageMetrics AiImageMetrics[]
     aiSkyboxMetrics AiSkyboxMetrics[]
+    aiSloydMetrics AiSloydMetrics[]
 
     childStudios Studio[] @relation("OwnerStudio")
     comIdRequests StudioComIdRequest[]
@@ -794,6 +796,26 @@ model AiSkyboxMetrics {
 
     studioId String?
     studio Studio? @relation(fields: [studioId], references: [id], onDelete: Cascade, map: "AiSkyboxMetrics_studioId_fkey1")
+}
+
+model AiSloydMetrics {
+    id String @id @db.Uuid
+
+    modelsCreated Int
+    name String?
+    confidence Float?
+    mimeType String
+    modelData String
+    thumbnailBase64 String?
+    baseModelId String?
+
+    createdAt DateTime @default(now())
+
+    userId String?
+    user User? @relation(fields: [userId], references: [id], onDelete: Cascade, map: "AiSloydMetrics_userId_fkey1")
+
+    studioId String?
+    studio Studio? @relation(fields: [studioId], references: [id], onDelete: Cascade, map: "AiSloydMetrics_studioId_fkey1")
 }
 
 model PrivoClientCredentials {

--- a/src/aux-server/aux-backend/schemas/migrations/20240621213154_add_sloyd/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240621213154_add_sloyd/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "AiSloydMetrics" (
+    "id" UUID NOT NULL,
+    "modelsCreated" INT4 NOT NULL,
+    "name" STRING NOT NULL,
+    "confidence" FLOAT8 NOT NULL,
+    "mimeType" STRING NOT NULL,
+    "modelData" STRING NOT NULL,
+    "thumbnailBase64" STRING,
+    "baseModelId" STRING,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" STRING,
+    "studioId" STRING,
+
+    CONSTRAINT "AiSloydMetrics_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "AiSloydMetrics" ADD CONSTRAINT "AiSloydMetrics_userId_fkey1" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiSloydMetrics" ADD CONSTRAINT "AiSloydMetrics_studioId_fkey1" FOREIGN KEY ("studioId") REFERENCES "Studio"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/aux-server/aux-backend/schemas/migrations/20240621215232_make_sloyd_metrics_name_confidence_optional/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240621215232_make_sloyd_metrics_name_confidence_optional/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "AiSloydMetrics" ALTER COLUMN "name" DROP NOT NULL;
+ALTER TABLE "AiSloydMetrics" ALTER COLUMN "confidence" DROP NOT NULL;

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -42,6 +42,7 @@ import {
     revokeRecordPermission,
     aiChatStream,
     aiHumeGetAccessToken,
+    aiSloydGenerateModel,
 } from '@casual-simulation/aux-runtime';
 import { Subject, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -8081,6 +8082,91 @@ describe('RecordsManager', () => {
                     asyncResult(1, {
                         success: true,
                         accessToken: 'token',
+                    }),
+                ]);
+                expect(authMock.isAuthenticated).toBeCalled();
+                expect(authMock.authenticate).not.toBeCalled();
+                expect(authMock.getAuthToken).toBeCalled();
+            });
+        });
+
+        describe('ai_sloyd_generate_model', () => {
+            let fetch: jest.Mock<
+                Promise<{
+                    status: number;
+                    headers?: Headers;
+                    json?: () => Promise<any>;
+                    text?: () => Promise<string>;
+                    body?: ReadableStream;
+                }>
+            >;
+
+            const originalFetch = globalThis.fetch;
+
+            beforeEach(() => {
+                authMock.getRecordKeyPolicy.mockResolvedValue('subjectfull');
+                require('axios').__reset();
+                fetch = globalThis.fetch = jest.fn();
+            });
+
+            afterAll(() => {
+                globalThis.fetch = originalFetch;
+            });
+
+            it('should make a GET request to /api/v3/callProcedure', async () => {
+                fetch.mockResolvedValueOnce({
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        confidenceScore: 0.5,
+                        interactionId: 'modelId',
+                        modelOutputType: 'json-gltf',
+                        name: 'model name',
+                        gltfJson: 'json',
+                    }),
+                });
+
+                authMock.isAuthenticated.mockResolvedValueOnce(true);
+                authMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    aiSloydGenerateModel(
+                        {
+                            prompt: 'the prompt',
+                        },
+                        {},
+                        1
+                    ),
+                ]);
+
+                await waitAsync();
+
+                expect(fetch).toHaveBeenCalledWith(
+                    'http://localhost:3002/api/v3/callProcedure',
+                    {
+                        method: 'POST',
+                        body: JSON.stringify({
+                            procedure: 'createSloydModel',
+                            input: {
+                                prompt: 'the prompt',
+                            },
+                        }),
+                        headers: expect.objectContaining({
+                            Authorization: 'Bearer authToken',
+                        }),
+                    }
+                );
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        confidenceScore: 0.5,
+                        interactionId: 'modelId',
+                        modelOutputType: 'json-gltf',
+                        name: 'model name',
+                        gltfJson: 'json',
                     }),
                 ]);
                 expect(authMock.isAuthenticated).toBeCalled();


### PR DESCRIPTION
### :rocket: Features

-   Added the ability to generate [Sloyd.ai](https://www.sloyd.ai/) models with `ai.sloyd.generateModel(request)`.
    -   Requires a valid subscription that has been granted access to the `ai.sloyd` feature.
    -   `request` is should be an object with the following properties:
        -   `prompt` - The prompt to use for generating the model.
        -   `recordName` - The name of the record that the model should be generated in. If omitted, then the user's record will be used by default.
        -   `outputMimeType` - The MIME Type of the model that should be output. Currently, only `model/gltf+json` and `model/gltf-binary` are supported. If omitted, then `model/gltf+json` will be used.
        -   `levelOfDetail` - A number between `0.01` and `1` that indicates the level of detail that should be generated for the model. Higher values will generate more detailed models. If omitted, then `0.5` will be used.
        -   `baseModelId` - The ID of the model that should be edited.
        -   `thumbnail` - An object that specifies how the thumbnail for the model should be generated. If omitted, then no thumbnail will be created. The object should have the following properties:
            -   `type` - Should always be `"image/png"`
            -   `width` - The desired width of the thumbnail in pixels.
            -   `height` - The desired height of the thumbnail in pixels.

Closes #475 