### PR TITLE
Improve private insts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 -   Fixed an issue where editing a tag may fail if multiple initialization updates for the same bot with different tag values were applied to the inst.
 -   Fixed an issue where different instances of the CasualOS server could try to save an inst at the same time and cause the inst to lose track of its data.
+-   Fixed an issue where CasualOS would always decide to load inst data from Redis instead of the database.
 -   Improved the CasualOS server to discard redundant updates when saving a studio inst. This will greatly help prevent hitting inst size limits in the future.
 
 ## V3.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 ### :bug: Bug Fixes
 
 -   Fixed an issue where editing a tag may fail if multiple initialization updates for the same bot with different tag values were applied to the inst.
+-   Fixed an issue where different instances of the CasualOS server could try to save an inst at the same time and cause the inst to lose track of its data.
+-   Improved the CasualOS server to discard redundant updates when saving a studio inst. This will greatly help prevent hitting inst size limits in the future.
 
 ## V3.3.6
 

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -410,7 +410,9 @@ describe('RecordsServer', () => {
         checkDisplayName: jest.Mock<
             ReturnType<PrivoClientInterface['checkDisplayName']>
         >;
-        revokeToken: jest.Mock<ReturnType<PrivoClientInterface['revokeToken']>>;
+        generateLogoutUrl: jest.Mock<
+            ReturnType<PrivoClientInterface['generateLogoutUrl']>
+        >;
     };
 
     beforeEach(async () => {
@@ -464,7 +466,7 @@ describe('RecordsServer', () => {
             processAuthorizationCallback: jest.fn(),
             checkEmail: jest.fn(),
             checkDisplayName: jest.fn(),
-            revokeToken: jest.fn(),
+            generateLogoutUrl: jest.fn(),
         };
         relyingParty = {
             id: 'relying_party_id',

--- a/src/aux-records/websockets/SplitInstRecordsStore.spec.ts
+++ b/src/aux-records/websockets/SplitInstRecordsStore.spec.ts
@@ -530,6 +530,41 @@ describe('SplitInstRecordsStore', () => {
             });
         });
 
+        it('should return the most recent update from the permanent store when the temp store returns an empty array of updates', async () => {
+            await perm.addUpdates(
+                recordName,
+                instName,
+                branchName,
+                ['test'],
+                4
+            );
+            await temp.addUpdates(recordName, instName, branchName, [], 0);
+
+            const result = await store.getCurrentUpdates(
+                recordName,
+                instName,
+                branchName
+            );
+
+            expect(result).toEqual({
+                updates: ['test'],
+                timestamps: [expect.any(Number)],
+                instSizeInBytes: 4,
+            });
+
+            const tempResult = await temp.getUpdates(
+                recordName,
+                instName,
+                branchName
+            );
+            expect(tempResult).toEqual({
+                updates: ['test'],
+                timestamps: [expect.any(Number)],
+                instSizeInBytes: 4,
+                branchSizeInBytes: 4,
+            });
+        });
+
         it('should return the updates from the temp store', async () => {
             await temp.addUpdates(
                 recordName,

--- a/src/aux-records/websockets/SplitInstRecordsStore.ts
+++ b/src/aux-records/websockets/SplitInstRecordsStore.ts
@@ -148,7 +148,7 @@ export class SplitInstRecordsStore implements InstRecordsStore {
             branch
         );
 
-        if (tempUpdates) {
+        if (tempUpdates && tempUpdates.updates.length > 0) {
             const { branchSizeInBytes, ...result } = tempUpdates;
             return result;
         } else if (!recordName) {

--- a/src/aux-records/websockets/TemporaryInstRecordsStore.ts
+++ b/src/aux-records/websockets/TemporaryInstRecordsStore.ts
@@ -163,6 +163,7 @@ export interface TemporaryInstRecordsStore {
 
     /**
      * Deletes the given number of updates from the beginning of the updates list.
+     * May also set the branch to expire.
      * @param recordName The name of the record.
      * @param inst The name of the inst.
      * @param branch The name of the branch.

--- a/src/aux-records/websockets/TemporaryInstRecordsStore.ts
+++ b/src/aux-records/websockets/TemporaryInstRecordsStore.ts
@@ -211,6 +211,18 @@ export interface TemporaryInstRecordsStore {
     getDirtyBranchGeneration(): Promise<string>;
 
     /**
+     * Aquires a lock with the given ID.
+     * If successful, returns a function that will release the lock when called.
+     * If unsuccessful, returns null.
+     * @param id The id of the lock.
+     * @param timeout The timeout for the lock in miliseconds. If the lock isn't released in this time, it will be automatically released.
+     */
+    aquireLock(
+        id: string,
+        timeout: number
+    ): Promise<(() => Promise<boolean>) | null>;
+
+    /**
      * Marks the given branch as dirty in the current generation.
      * @param branch The branch that should be marked.
      */

--- a/src/aux-records/websockets/WebsocketController.ts
+++ b/src/aux-records/websockets/WebsocketController.ts
@@ -687,7 +687,9 @@ export class WebsocketController {
                     event.inst,
                     event.branch
                 ));
-            const updateSize = sumBy(event.updates, (u) => u.length);
+            const updateSize = sumBy(event.updates, (u) =>
+                Buffer.byteLength(u, 'utf8')
+            );
             const config = await this._config.getSubscriptionConfiguration();
             let features: FeaturesConfiguration = null;
 

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -1278,7 +1278,10 @@ export class PrismaAuthStore implements AuthStore {
             oidProvider: session.oidProvider,
             oidAccessToken: session.oidAccessToken,
             oidIdToken: session.oidIdToken,
-            oidExpiresAtMs: session.oidExpiresAtMs,
+            oidExpiresAtMs:
+                typeof session.oidExpiresAtMs === 'bigint'
+                    ? Number(session.oidExpiresAtMs)
+                    : session.oidExpiresAtMs,
             oidRefreshToken: session.oidRefreshToken,
             oidRequestId: session.oidRequestId,
             oidScope: session.oidScope,

--- a/src/aux-server/aux-backend/redis/RedisLock.ts
+++ b/src/aux-server/aux-backend/redis/RedisLock.ts
@@ -1,0 +1,49 @@
+import { randomBytes } from 'crypto';
+import { RedisClientType, defineScript } from 'redis';
+
+const releaseLock = defineScript({
+    NUMBER_OF_KEYS: 1,
+    SCRIPT: `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`,
+    transformArguments: (key: string, randomValue: number) => [
+        key,
+        randomValue.toString(),
+    ],
+});
+
+/**
+ * Attempts to aquire a lock on the given key.
+ * Returns a function that will release the lock when called.
+ * If the lock could not be aquired, returns null.
+ *
+ * Follows the simple implementation pattern described here:
+ * https://redis.io/docs/latest/develop/use/patterns/distributed-locks/#correct-implementation-with-a-single-instance
+ *
+ * @param redis The redis client.
+ * @param key The key that should be aquired.
+ * @param timeout The timeout for the lock in miliseconds. If the lock isn't released in this time, it will be automatically released.
+ */
+export async function tryAquireLock(
+    redis: RedisClientType,
+    key: string,
+    timeout: number
+): Promise<(() => Promise<boolean>) | null> {
+    const randomValue = randomBytes(32).readInt32LE();
+    await redis.set(key, randomValue, {
+        NX: true,
+        PX: timeout,
+    });
+
+    const value = await redis.get(key);
+
+    if (parseInt(value) === randomValue) {
+        return async () => {
+            const result = await redis.executeScript(releaseLock, [
+                key,
+                randomValue.toString(),
+            ]);
+            return result === 1;
+        };
+    }
+
+    return null;
+}

--- a/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
+++ b/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
@@ -39,7 +39,7 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
      * @param redis The client that should be used.
      * @param dataExpirationSeconds The number of seconds that inst data should be stored for. If null, then the data will not expire.
      * @param dataExpirationMode The expiration mode that should be used for inst data.
-     * @param onlyExpireRecordlessUpdates Whether to only expire updates that are not associated with a record.
+     * @param onlyExpireRecordlessUpdates Whether to only expire updates that are not associated with a record. This will set the expiration for the updates when they are added. All kinds of branches will have an expiration set when trimmed.
      */
     constructor(
         globalNamespace: string,
@@ -75,7 +75,19 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
     async markBranchAsDirty(branch: BranchName): Promise<void> {
         const generation = await this.getDirtyBranchGeneration();
         const key = this._generationKey(generation);
-        await this._redis.sAdd(key, JSON.stringify(branch));
+        if (this._instDataExpirationSeconds) {
+            const multi = this._redis.multi();
+            multi.sAdd(key, JSON.stringify(branch));
+
+            // Always reset the expiration for the branch size
+            // if it is for a private record.
+            // Otherwise, we can follow the expiration mode.
+            const expireMode = this._instDataExpirationMode;
+            this._expireMulti(multi, key, expireMode);
+            await multi.exec();
+        } else {
+            await this._redis.sAdd(key, JSON.stringify(branch));
+        }
     }
 
     @traced(TRACE_NAME, SPAN_OPTIONS)
@@ -273,7 +285,10 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
             this._expireMulti(multi, key, expireMode);
             promise = multi.exec();
         } else {
-            promise = this._redis.rPush(key, finalUpdates);
+            const multi = this._redis.multi();
+            multi.rPush(key, finalUpdates);
+            multi.persist(key);
+            promise = multi.exec();
         }
 
         await Promise.all([
@@ -432,7 +447,27 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
         numToDelete: number
     ): Promise<void> {
         const key = this._getUpdatesKey(recordName, inst, branch);
-        await this._redis.lPopCount(key, numToDelete);
+        if (this._instDataExpirationSeconds) {
+            const multi = this._redis.multi();
+            multi.lPopCount(key, numToDelete);
+
+            // Always reset the expiration for updates if it is for a private record.
+            // Otherwise, we can follow the expiration mode.
+            const expireMode = !recordName
+                ? this._instDataExpirationMode
+                : null;
+            this._expireMulti(multi, key, expireMode);
+            const branchSizeKey = this._getBranchSizeKey(
+                recordName,
+                inst,
+                branch
+            );
+            this._expireMulti(multi, branchSizeKey, expireMode);
+
+            await multi.exec();
+        } else {
+            await this._redis.lPopCount(key, numToDelete);
+        }
     }
 
     @traced(TRACE_NAME, SPAN_OPTIONS)

--- a/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
+++ b/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
@@ -11,6 +11,7 @@ import {
     SEMRESATTRS_SERVICE_NAME,
 } from '@opentelemetry/semantic-conventions';
 import { RedisClientType } from 'redis';
+import { tryAquireLock } from './RedisLock';
 
 const TRACE_NAME = 'RedisTempInstRecordsStore';
 const SPAN_OPTIONS: SpanOptions = {
@@ -53,6 +54,10 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
         this._instDataExpirationSeconds = dataExpirationSeconds;
         this._instDataExpirationMode = dataExpirationMode;
         this._onlyExpireRecordlessUpdates = onlyExpireRecordlessUpdates;
+    }
+
+    aquireLock(id: string, timeout: number): Promise<() => Promise<boolean>> {
+        return tryAquireLock(this._redis, id, timeout);
     }
 
     @traced(TRACE_NAME, SPAN_OPTIONS)

--- a/src/aux-server/aux-backend/redis/RedisWebsocketConnectionStore.ts
+++ b/src/aux-server/aux-backend/redis/RedisWebsocketConnectionStore.ts
@@ -80,6 +80,8 @@ export class RedisWebsocketConnectionStore implements WebsocketConnectionStore {
 
         if (scope === 'updateData') {
             await this._redis.expire(key, this._expireAuthorizationSeconds);
+        } else if (scope === 'token') {
+            this._expire(key);
         }
     }
 

--- a/src/aux-server/aux-backend/schemas/migrations/20240701192238_make_oid_expires_at_ms_a_bigint/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240701192238_make_oid_expires_at_ms_a_bigint/migration.sql
@@ -5,4 +5,4 @@
 
 */
 -- AlterTable
-ALTER TABLE "AuthSession" ALTER COLUMN "oidExpiresAtMs" SET TYPE INT8;
+ALTER TABLE "AuthSession" ALTER COLUMN "oidExpiresAtMs" TYPE INT8;

--- a/src/aux-server/aux-backend/serverless/aws/src/handlers/Records.ts
+++ b/src/aux-server/aux-backend/serverless/aws/src/handlers/Records.ts
@@ -123,5 +123,7 @@ export async function handleRecords(
 
 export async function savePermanentBranches() {
     await builder.ensureInitialized();
-    await websocketController.savePermanentBranches();
+
+    // 15 minute timeout to match the lambda timeout.
+    await websocketController.savePermanentBranches(900 * 1000);
 }

--- a/src/aux-server/aux-backend/serverless/aws/template.yml
+++ b/src/aux-server/aux-backend/serverless/aws/template.yml
@@ -140,7 +140,7 @@ Resources:
             Handler: Records.savePermanentBranches
             CodeUri: dist/handlers
             Runtime: nodejs18.x
-            MemorySize: 512
+            MemorySize: 1024
             Timeout: 900
             Description: A function that periodically saves all the permanent inst branches.
             Policies:


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where different instances of the CasualOS server could try to save an inst at the same time and cause the inst to lose track of its data.
-   Fixed an issue where CasualOS would always decide to load inst data from Redis instead of the database.
-   Improved the CasualOS server to discard redundant updates when saving a studio inst. This will greatly help prevent hitting inst size limits in the future.

Fixes #498 