### PR TITLE
Fix hand mesh positioning in XR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 -   Fixed an issue where CasualOS would always decide to load inst data from Redis instead of the database.
 -   Improved the CasualOS server to discard redundant updates when saving a studio inst. This will greatly help prevent hitting inst size limits in the future.
 -   Fixed an issue where `@onSpaceMaxSizeReached` would not be called when an inst ran out of space.
+-   Fixed an issue where meshes for hands in XR don't follow the camera when `cameraPositionOffset` is changed.
+-   Fixed an issue where the wrist portals for hands in Meta Quest devices were positioned incorrectly.
 
 ## V3.3.6
 

--- a/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
@@ -33,17 +33,17 @@ const wristOffsets = {
     generic_hand_right: {
         positionOffset: new Vector3(0.1, 0.05, -0.05),
         rotationOffset: new Euler(
-            -90 * ThreeMath.DEG2RAD,
-            0 * ThreeMath.DEG2RAD,
+            -120 * ThreeMath.DEG2RAD,
+            90 * ThreeMath.DEG2RAD,
             -90 * ThreeMath.DEG2RAD
         ),
     },
     generic_hand_left: {
         positionOffset: new Vector3(-0.1, 0.05, -0.05),
         rotationOffset: new Euler(
-            -90 * ThreeMath.DEG2RAD,
-            0 * ThreeMath.DEG2RAD,
-            90 * ThreeMath.DEG2RAD
+            -120 * ThreeMath.DEG2RAD,
+            90 * ThreeMath.DEG2RAD,
+            -90 * ThreeMath.DEG2RAD
         ),
     },
     generic_controller_right: {


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where meshes for hands in XR don't follow the camera when `cameraPositionOffset` is changed.
-   Fixed an issue where the wrist portals for hands in Meta Quest devices were positioned incorrectly.

Fixes #461 