### PR TITLE
Add zoom limits for perspective cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
             -   `height` - The desired height of the thumbnail in pixels.
 -   Tags added to bots through the `systemPortal` will now be added to the "tags" section instead of the "pinned tags" section.
 -   Improved the [CasualOS CLI](https://www.npmjs.com/package/casualos) to be able to generate and validate server configs.
+-   Improved `portalZoomableMax` and `portalZoomableMin` to be supported for `perspective` portal camera types.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/tags/portal-bot.mdx
+++ b/docs/docs/tags/portal-bot.mdx
@@ -312,8 +312,17 @@ For the mapPortal and miniMapPortal, the value is measured in meters.
 
 #### Possible values are:
 <PossibleValuesTable>
+  <PossibleValueCode value='0.4'>
+    (Default for grid portals with <TagLink tag='portalCameraType'>orthographic camera types</TagLink>)
+  </PossibleValueCode>
+  <PossibleValueCode value='0'>
+    (Default for grid portals with <TagLink tag='portalCameraType'>perspective camera types</TagLink>)
+  </PossibleValueCode>
+  <PossibleValueCode value='-Infinity'>
+    (Default for map portals)
+  </PossibleValueCode>
   <PossibleValue value='Any Number > 0'>
-    Minimum value that the camera zoom to. (Default is 0.4 for the grid portals and -Infinity for the map portals)
+    Minimum value that the camera zoom to.
   </PossibleValue>
 </PossibleValuesTable>
 
@@ -330,8 +339,17 @@ For the mapPortal and miniMapPortal, the value is measured in meters.
 
 #### Possible values are:
 <PossibleValuesTable>
+<PossibleValueCode value='80'>
+    (Default for grid portals with <TagLink tag='portalCameraType'>orthographic camera types</TagLink>)
+  </PossibleValueCode>
+  <PossibleValueCode value='Infinity'>
+    (Default for grid portals with <TagLink tag='portalCameraType'>perspective camera types</TagLink>)
+  </PossibleValueCode>
+  <PossibleValueCode value='EARTH_RADIUS * 4'>
+    (Default for map portals)
+  </PossibleValueCode>
   <PossibleValue value='Any Number > 0'>
-    Maximum value that the camera can zoom to. (Default is 80 for the grid portals and EARTH_RADIUS * 4 for the map portals)
+    Maximum value that the camera can zoom to.
   </PossibleValue>
 </PossibleValuesTable>
 

--- a/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerGame.ts
@@ -4,6 +4,8 @@ import {
     CameraRig,
     CameraType,
     createCameraRig,
+    Perspective_MaxZoom,
+    Perspective_MinZoom,
     resizeCameraRig,
 } from '../../shared/scene/CameraRigFactory';
 import {
@@ -24,6 +26,7 @@ import {
     SphereGeometry,
     MeshBasicMaterial,
     Group,
+    PerspectiveCamera,
 } from '@casual-simulation/three';
 import { PlayerPageSimulation3D } from './PlayerPageSimulation3D';
 import { MiniSimulation3D } from './MiniSimulation3D';
@@ -326,6 +329,22 @@ export class PlayerGame extends Game {
             this.playerSimulations,
             'zoomMax',
             Orthographic_MaxZoom
+        );
+    }
+
+    getPerspectiveZoomMin(): number {
+        return this._getSimulationValue(
+            this.playerSimulations,
+            'zoomMin',
+            Perspective_MinZoom
+        );
+    }
+
+    getPerspectiveZoomMax(): number {
+        return this._getSimulationValue(
+            this.playerSimulations,
+            'zoomMax',
+            Perspective_MaxZoom
         );
     }
 
@@ -2108,8 +2127,19 @@ export class PlayerGame extends Game {
             mainControls.controls.enableRotate = this.getRotatable();
             mainControls.controls.enableZoom = this.getZoomable();
 
-            mainControls.controls.minZoom = this.getZoomMin();
-            mainControls.controls.maxZoom = this.getZoomMax();
+            if (mainControls.rig.mainCamera instanceof PerspectiveCamera) {
+                mainControls.controls.minDistance =
+                    this.getPerspectiveZoomMin();
+                mainControls.controls.maxDistance =
+                    this.getPerspectiveZoomMax();
+                mainControls.controls.minZoom = Orthographic_MinZoom;
+                mainControls.controls.maxZoom = Orthographic_MaxZoom;
+            } else {
+                mainControls.controls.minDistance = Perspective_MinZoom;
+                mainControls.controls.maxDistance = Perspective_MaxZoom;
+                mainControls.controls.minZoom = this.getZoomMin();
+                mainControls.controls.maxZoom = this.getZoomMax();
+            }
 
             mainControls.controls.minPanX = this.getPanMinX();
             mainControls.controls.maxPanX = this.getPanMaxX();

--- a/src/aux-server/aux-web/shared/interaction/CameraControls.ts
+++ b/src/aux-server/aux-web/shared/interaction/CameraControls.ts
@@ -1335,17 +1335,17 @@ export class CameraControls {
 
             this.spherical.radius *= this.scale;
 
-            if (!this.usingImmersiveControls) {
-                if (this._camera instanceof PerspectiveCamera) {
-                    this.sphereRadiusSetter = this.spherical.radius;
-                }
-            }
-
             // restrict radius to be between desired limits
             this.spherical.radius = Math.max(
                 this.minDistance,
                 Math.min(this.maxDistance, this.spherical.radius)
             );
+
+            if (!this.usingImmersiveControls) {
+                if (this._camera instanceof PerspectiveCamera) {
+                    this.sphereRadiusSetter = this.spherical.radius;
+                }
+            }
 
             // move target to panned location
             this.target.add(this.panOffset);

--- a/src/aux-server/aux-web/shared/scene/CameraRigFactory.ts
+++ b/src/aux-server/aux-web/shared/scene/CameraRigFactory.ts
@@ -20,6 +20,8 @@ export const Perspective_FOV: number = 60;
 export const Perspective_NearClip: number = 0.1;
 export const Perspective_FarClip: number = 20000;
 export const Perspective_DefaultPosition = { x: 5, y: 5, z: 5 };
+export const Perspective_MinZoom: number = 0;
+export const Perspective_MaxZoom: number = Infinity;
 
 export declare type CameraType = 'perspective' | 'orthographic';
 


### PR DESCRIPTION
### :rocket: Features
-   Improved `portalZoomableMax` and `portalZoomableMin` to be supported for `perspective` portal camera types.

Closes #459