### PR TITLE
Allow Studios to configure their own Hume API Key and Secret Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,16 @@
             -   `type` - Should always be `"image/png"`
             -   `width` - The desired width of the thumbnail in pixels.
             -   `height` - The desired height of the thumbnail in pixels.
+    -   Requesting users require access to the `ai.sloyd` resource kind and `create` action for the specified record.
 -   Tags added to bots through the `systemPortal` will now be added to the "tags" section instead of the "pinned tags" section.
 -   Improved the [CasualOS CLI](https://www.npmjs.com/package/casualos) to be able to generate and validate server configs.
 -   Improved `portalZoomableMax` and `portalZoomableMin` to be supported for `perspective` portal camera types.
+-   Improved Hume AI features to support Studios.
+    -   The `ai.hume` features now determine whether a Studio can configure their own Hume `apiKey` and `secretKey`.
+    -   `ai.hume.getAccessToken(recordName)` now accepts a record name.
+        -   This allows the user to specify which record they want to use for hume.ai access.
+        -   Once a studio is configured, requests to one of the Studio's records will return an access token derived from the Studio's configured `apiKey` and `secretKey`.
+        -   Requesting users require access to the `ai.hume` resource kind and `create` action for the specified record.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-common/common/PolicyPermissions.ts
+++ b/src/aux-common/common/PolicyPermissions.ts
@@ -23,6 +23,7 @@ export const ROLE_RESOURCE_KIND = 'role';
 export const INST_RESOURCE_KIND = 'inst';
 export const LOOM_RESOURCE_KIND = 'loom';
 export const SLOYD_RESOURCE_KIND = 'ai.sloyd';
+export const HUME_RESOURCE_KIND = 'ai.hume';
 
 /**
  * The possible types of resources that can be affected by permissions.
@@ -38,7 +39,8 @@ export type ResourceKinds =
     | 'role'
     | 'inst'
     | 'loom'
-    | 'ai.sloyd';
+    | 'ai.sloyd'
+    | 'ai.hume';
 
 export const READ_ACTION = 'read';
 export const CREATE_ACTION = 'create';
@@ -156,6 +158,14 @@ export type LoomActionKinds = 'create';
 export type SloydActionKinds = 'create';
 
 /**
+ * The possible types of actions that can be performed on ai.hume resources.
+ *
+ * @dochash types/permissions
+ * @docname HumeActionKinds
+ */
+export type HumeActionKinds = 'create';
+
+/**
  * The possible types of permissions that can be added to policies.
  *
  * @dochash types/permissions
@@ -229,6 +239,8 @@ export const LOOM_ACTION_KINDS_VALIDATION = z.enum([CREATE_ACTION]);
 
 export const SLOYD_ACTION_KINDS_VALIDATION = z.enum([CREATE_ACTION]);
 
+export const HUME_ACTION_KINDS_VALIDATION = z.enum([CREATE_ACTION]);
+
 export const RESOURCE_KIND_VALIDATION = z.enum([
     DATA_RESOURCE_KIND,
     FILE_RESOURCE_KIND,
@@ -238,6 +250,7 @@ export const RESOURCE_KIND_VALIDATION = z.enum([
     INST_RESOURCE_KIND,
     LOOM_RESOURCE_KIND,
     SLOYD_RESOURCE_KIND,
+    HUME_RESOURCE_KIND,
 ]);
 
 export const ACTION_KINDS_VALIDATION = z.enum([
@@ -609,6 +622,31 @@ export const SLOYD_PERMISSION_VALIDATION = PERMISSION_VALIDATION.extend({
 type ZodSloydPermission = z.infer<typeof SLOYD_PERMISSION_VALIDATION>;
 type ZodSloydPermissionAssertion = HasType<ZodSloydPermission, SloydPermission>;
 
+/**
+ * Defines an interface that describes common options for all permissions that affect ai.hume resources.
+ *
+ * @dochash types/permissions
+ * @docname HumePermission
+ */
+export interface HumePermission extends Permission {
+    /**
+     * The kind of the permission.
+     */
+    resourceKind: 'ai.hume';
+
+    /**
+     * The action that is allowed.
+     * If null, then all actions are allowed.
+     */
+    action: HumeActionKinds | null;
+}
+export const HUME_PERMISSION_VALIDATION = PERMISSION_VALIDATION.extend({
+    resourceKind: z.literal(HUME_RESOURCE_KIND),
+    action: HUME_ACTION_KINDS_VALIDATION.nullable(),
+});
+type ZodHumePermission = z.infer<typeof HUME_PERMISSION_VALIDATION>;
+type ZodHumePermissionAssertion = HasType<ZodHumePermission, HumePermission>;
+
 export const AVAILABLE_PERMISSIONS_VALIDATION = z.discriminatedUnion(
     'resourceKind',
     [
@@ -620,6 +658,7 @@ export const AVAILABLE_PERMISSIONS_VALIDATION = z.discriminatedUnion(
         INST_PERMISSION_VALIDATION,
         LOOM_PERMISSION_VALIDATION,
         SLOYD_PERMISSION_VALIDATION,
+        HUME_PERMISSION_VALIDATION,
     ]
 );
 

--- a/src/aux-common/common/PolicyPermissions.ts
+++ b/src/aux-common/common/PolicyPermissions.ts
@@ -182,7 +182,8 @@ export type AvailablePermissions =
     | RolePermission
     | InstPermission
     | LoomPermission
-    | SloydPermission;
+    | SloydPermission
+    | HumePermission;
 
 export const SUBJECT_TYPE_VALIDATION = z.enum(['user', 'inst', 'role']);
 

--- a/src/aux-records/AIHumeInterface.ts
+++ b/src/aux-records/AIHumeInterface.ts
@@ -7,21 +7,20 @@ import { z } from 'zod';
 export interface AIHumeInterface {
     /**
      * Generates an access token that can be used to access the Hume API.
+     * @param request The request that contains the API key and secret key.
      */
-    getAccessToken(): Promise<AIHumeInterfaceGetAccessTokenResult>;
+    getAccessToken(
+        request: AIHumeInterfaceGetAccessTokenRequest
+    ): Promise<AIHumeInterfaceGetAccessTokenResult>;
 }
 
 export class HumeInterface implements AIHumeInterface {
-    private _apiKey: string;
-    private _secretKey: string;
+    constructor() {}
 
-    constructor(apiKey: string, secretKey: string) {
-        this._apiKey = apiKey;
-        this._secretKey = secretKey;
-    }
-
-    async getAccessToken(): Promise<AIHumeInterfaceGetAccessTokenResult> {
-        const authString = `${this._apiKey}:${this._secretKey}`;
+    async getAccessToken(
+        request: AIHumeInterfaceGetAccessTokenRequest
+    ): Promise<AIHumeInterfaceGetAccessTokenResult> {
+        const authString = `${request.apiKey}:${request.secretKey}`;
         const encodedAuthString = Buffer.from(authString).toString('base64');
 
         const response = await fetch('https://api.hume.ai/oauth2-cc/token', {
@@ -79,6 +78,14 @@ export class HumeInterface implements AIHumeInterface {
             tokenType: result.data.token_type,
         };
     }
+}
+
+export interface AIHumeInterfaceGetAccessTokenRequest {
+    /**
+     * The API key that should be used for the request.
+     */
+    apiKey: string;
+    secretKey: string;
 }
 
 export type AIHumeInterfaceGetAccessTokenResult =

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -32,6 +32,7 @@ import {
     StoreListedStudio,
     StudioComIdRequest,
     LoomConfig,
+    HumeConfig,
 } from './RecordsStore';
 import { v4 as uuid } from 'uuid';
 import {
@@ -203,6 +204,7 @@ export class MemoryStore
     private _resourcePermissionAssignments: ResourcePermissionAssignment[] = [];
     private _markerPermissionAssignments: MarkerPermissionAssignment[] = [];
     private _studioLoomConfigs: Map<string, LoomConfig> = new Map();
+    private _studioHumeConfigs: Map<string, HumeConfig> = new Map();
 
     // TODO: Support global permissions
     // private _globalPermissionAssignments: GlobalPermissionAssignment[] = [];
@@ -750,6 +752,17 @@ export class MemoryStore
         config: LoomConfig
     ): Promise<void> {
         this._studioLoomConfigs.set(studioId, config);
+    }
+
+    async getStudioHumeConfig(studioId: string): Promise<HumeConfig | null> {
+        return this._studioHumeConfigs.get(studioId) ?? null;
+    }
+
+    async updateStudioHumeConfig(
+        studioId: string,
+        config: HumeConfig
+    ): Promise<void> {
+        this._studioHumeConfigs.set(studioId, config);
     }
 
     async getUserPrivacyFeatures(userId: string): Promise<PrivacyFeatures> {

--- a/src/aux-records/PolicyController.spec.ts
+++ b/src/aux-records/PolicyController.spec.ts
@@ -2543,6 +2543,7 @@ describe('PolicyController', () => {
             ['role'],
             ['loom'],
             ['ai.sloyd'],
+            ['ai.hume'],
         ];
 
         // Admins can perform all actions on all resources
@@ -3390,6 +3391,7 @@ describe('PolicyController', () => {
             ],
             ['loom', [['create', 'resourceId']]],
             ['ai.sloyd', [['create', 'resourceId']]],
+            ['ai.hume', [['create', 'resourceId']]],
         ];
 
         const recordKeySubjectTypeDenialCases: [SubjectType, string][] = [
@@ -3887,6 +3889,7 @@ describe('PolicyController', () => {
                 ],
             ],
             ['ai.sloyd', [['create', 'resourceId']]],
+            ['ai.hume', [['create', 'resourceId']]],
         ];
 
         describe.each(studioMemberResourceKindDenialCases)(

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -2518,6 +2518,44 @@ describe('RecordsController', () => {
             });
         });
 
+        it('should be able to update the hume config', async () => {
+            await store.updateStudio({
+                id: 'studioId',
+                displayName: 'studio',
+                subscriptionId: 'sub1',
+                subscriptionStatus: 'active',
+            });
+
+            const result = await manager.updateStudio({
+                userId: 'userId',
+                studio: {
+                    id: 'studioId',
+                    humeConfig: {
+                        apiKey: 'apiKey',
+                        secretKey: 'secretKey',
+                    },
+                },
+            });
+
+            expect(result).toEqual({
+                success: true,
+            });
+
+            const studio = await store.getStudioById('studioId');
+            expect(studio).toEqual({
+                id: 'studioId',
+                displayName: 'studio',
+                subscriptionId: 'sub1',
+                subscriptionStatus: 'active',
+            });
+
+            const humeConfig = await store.getStudioHumeConfig('studioId');
+            expect(humeConfig).toEqual({
+                apiKey: 'apiKey',
+                secretKey: 'secretKey',
+            });
+        });
+
         it('should do nothing if no updates are provided', async () => {
             await store.updateStudio({
                 id: 'studioId',
@@ -2650,6 +2688,9 @@ describe('RecordsController', () => {
                     loomFeatures: {
                         allowed: false,
                     },
+                    humeFeatures: {
+                        allowed: false,
+                    },
                 },
             });
         });
@@ -2702,6 +2743,9 @@ describe('RecordsController', () => {
                     loomFeatures: {
                         allowed: false,
                     },
+                    humeFeatures: {
+                        allowed: false,
+                    },
                 },
             });
         });
@@ -2751,6 +2795,9 @@ describe('RecordsController', () => {
                     },
                     loomFeatures: {
                         allowed: true,
+                    },
+                    humeFeatures: {
+                        allowed: false,
                     },
                 },
             });
@@ -2807,8 +2854,125 @@ describe('RecordsController', () => {
                     loomFeatures: {
                         allowed: true,
                     },
+                    humeFeatures: {
+                        allowed: false,
+                    },
                     loomConfig: {
                         appId: 'appId',
+                    },
+                },
+            });
+        });
+
+        it('should include the configured hume features', async () => {
+            store.subscriptionConfiguration = merge(
+                createTestSubConfiguration(),
+                {
+                    subscriptions: [
+                        {
+                            id: 'sub1',
+                            eligibleProducts: [],
+                            product: '',
+                            featureList: [],
+                            tier: 'tier1',
+                        },
+                    ],
+                    tiers: {
+                        tier1: {
+                            features: merge(allowAllFeatures(), {
+                                hume: {
+                                    allowed: true,
+                                },
+                            } as Partial<FeaturesConfiguration>),
+                        },
+                    },
+                } as Partial<SubscriptionConfiguration>
+            );
+
+            const result = await manager.getStudio('studioId', 'userId');
+
+            expect(result).toEqual({
+                success: true,
+                studio: {
+                    id: 'studioId',
+                    displayName: 'studio',
+                    logoUrl: 'https://example.com/logo.png',
+                    comId: 'comId1',
+                    comIdConfig: {
+                        allowedStudioCreators: 'anyone',
+                    },
+                    playerConfig: {
+                        ab1BootstrapURL: 'https://example.com/ab1',
+                    },
+                    comIdFeatures: {
+                        allowed: false,
+                    },
+                    loomFeatures: {
+                        allowed: false,
+                    },
+                    humeFeatures: {
+                        allowed: true,
+                    },
+                },
+            });
+        });
+
+        it('should include the hume config if hume features are allowed', async () => {
+            store.subscriptionConfiguration = merge(
+                createTestSubConfiguration(),
+                {
+                    subscriptions: [
+                        {
+                            id: 'sub1',
+                            eligibleProducts: [],
+                            product: '',
+                            featureList: [],
+                            tier: 'tier1',
+                        },
+                    ],
+                    tiers: {
+                        tier1: {
+                            features: merge(allowAllFeatures(), {
+                                hume: {
+                                    allowed: true,
+                                },
+                            } as Partial<FeaturesConfiguration>),
+                        },
+                    },
+                } as Partial<SubscriptionConfiguration>
+            );
+
+            await store.updateStudioHumeConfig('studioId', {
+                apiKey: 'apiKey',
+                secretKey: 'secretKey',
+            });
+
+            const result = await manager.getStudio('studioId', 'userId');
+
+            expect(result).toEqual({
+                success: true,
+                studio: {
+                    id: 'studioId',
+                    displayName: 'studio',
+                    logoUrl: 'https://example.com/logo.png',
+                    comId: 'comId1',
+                    comIdConfig: {
+                        allowedStudioCreators: 'anyone',
+                    },
+                    playerConfig: {
+                        ab1BootstrapURL: 'https://example.com/ab1',
+                    },
+                    comIdFeatures: {
+                        allowed: false,
+                    },
+                    loomFeatures: {
+                        allowed: false,
+                    },
+                    humeFeatures: {
+                        allowed: true,
+                    },
+                    humeConfig: {
+                        apiKey: 'apiKey',
                     },
                 },
             });

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -2689,7 +2689,7 @@ describe('RecordsController', () => {
                         allowed: false,
                     },
                     humeFeatures: {
-                        allowed: false,
+                        allowed: true,
                     },
                 },
             });
@@ -2744,7 +2744,7 @@ describe('RecordsController', () => {
                         allowed: false,
                     },
                     humeFeatures: {
-                        allowed: false,
+                        allowed: true,
                     },
                 },
             });
@@ -2797,7 +2797,7 @@ describe('RecordsController', () => {
                         allowed: true,
                     },
                     humeFeatures: {
-                        allowed: false,
+                        allowed: true,
                     },
                 },
             });
@@ -2855,7 +2855,7 @@ describe('RecordsController', () => {
                         allowed: true,
                     },
                     humeFeatures: {
-                        allowed: false,
+                        allowed: true,
                     },
                     loomConfig: {
                         appId: 'appId',

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -24,7 +24,11 @@ import {
     SubscriptionController,
 } from './SubscriptionController';
 import { ZodError, z } from 'zod';
-import { LOOM_CONFIG, PublicRecordKeyPolicy } from './RecordsStore';
+import {
+    HUME_CONFIG,
+    LOOM_CONFIG,
+    PublicRecordKeyPolicy,
+} from './RecordsStore';
 import { RateLimitController } from './RateLimitController';
 import {
     AVAILABLE_PERMISSIONS_VALIDATION,
@@ -2319,8 +2323,12 @@ export class RecordsServer {
             getHumeAccessToken: procedure()
                 .origins('api')
                 .http('GET', '/api/v2/ai/hume/token')
-                .inputs(z.object({}))
-                .handler(async (_, context) => {
+                .inputs(
+                    z.object({
+                        recordName: RECORD_NAME_VALIDATION.optional(),
+                    })
+                )
+                .handler(async ({ recordName }, context) => {
                     if (!this._aiController) {
                         return AI_NOT_SUPPORTED_RESULT;
                     }
@@ -2339,6 +2347,7 @@ export class RecordsServer {
 
                     const result = await this._aiController.getHumeAccessToken({
                         userId: sessionKeyValidation.userId,
+                        recordName,
                     });
 
                     return result;
@@ -2536,6 +2545,7 @@ export class RecordsServer {
                         comIdConfig: COM_ID_CONFIG_SCHEMA.optional(),
                         playerConfig: COM_ID_PLAYER_CONFIG.optional(),
                         loomConfig: LOOM_CONFIG.optional(),
+                        humeConfig: HUME_CONFIG.optional(),
                     })
                 )
                 .handler(
@@ -2547,6 +2557,7 @@ export class RecordsServer {
                             comIdConfig,
                             playerConfig,
                             loomConfig,
+                            humeConfig,
                         },
                         context
                     ) => {
@@ -2571,6 +2582,7 @@ export class RecordsServer {
                                 comIdConfig,
                                 playerConfig,
                                 loomConfig,
+                                humeConfig,
                             },
                         });
                         return result;

--- a/src/aux-records/RecordsStore.ts
+++ b/src/aux-records/RecordsStore.ts
@@ -193,6 +193,20 @@ export interface RecordsStore {
      * @param config The config that should be updated for the studio.
      */
     updateStudioLoomConfig(studioId: string, config: LoomConfig): Promise<void>;
+
+    /**
+     * Gets the hume config for the studio with the given ID.
+     * Returns null if the studio does not have a hume config.
+     * @param studioId The ID of the studio.
+     */
+    getStudioHumeConfig(studioId: string): Promise<HumeConfig | null>;
+
+    /**
+     * Updates the hume config for the studio with the given ID.
+     * @param studioId The ID of the studio that should be updated.
+     * @param config The config that should be updated for the studio.
+     */
+    updateStudioHumeConfig(studioId: string, config: HumeConfig): Promise<void>;
 }
 
 export interface CountRecordsFilter {
@@ -336,10 +350,23 @@ export type LoomConfig = z.infer<typeof LOOM_CONFIG>;
 
 export const LOOM_CONFIG = z
     .object({
-        appId: z.string().describe('The ID of the loom app.'),
-        privateKey: z.string().describe('The private key for the loom app.'),
+        appId: z.string().describe('The ID of the loom app.').max(100),
+        privateKey: z
+            .string()
+            .describe('The private key for the loom app.')
+            .max(100),
     })
     .describe('The configuration that can be used by studios to setup loom.');
+
+export const HUME_CONFIG = z.object({
+    apiKey: z.string().describe('The API key for the Hume service.').max(100),
+    secretKey: z
+        .string()
+        .describe('The secret key for the Hume service.')
+        .max(100),
+});
+
+export type HumeConfig = z.infer<typeof HUME_CONFIG>;
 
 /**
  * Defines the list of possible studio roles that a user can be assigned.

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -712,6 +712,11 @@ export interface FeaturesConfiguration {
      * The configuration for loom features.
      */
     loom?: StudioLoomFeaturesConfiguration;
+
+    // /**
+    //  * The configuration for studio hume features.
+    //  */
+    // hume?: StudioHumeFeaturesConfiguration;
 }
 
 export interface RecordFeaturesConfiguration {

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1547,6 +1547,46 @@ Object {
                 },
                 "type": "object",
               },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "type": "enum",
+                    "values": Array [
+                      "create",
+                    ],
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "ai.hume",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "user",
+                      "inst",
+                      "role",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
             ],
             "type": "union",
           },
@@ -1614,6 +1654,7 @@ Object {
               "inst",
               "loom",
               "ai.sloyd",
+              "ai.hume",
             ],
           },
         },
@@ -2188,7 +2229,12 @@ Object {
         "path": "/api/v2/ai/hume/token",
       },
       "inputs": Object {
-        "schema": Object {},
+        "schema": Object {
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
         "type": "object",
       },
       "name": "getHumeAccessToken",
@@ -2330,6 +2376,20 @@ Object {
           "displayName": Object {
             "optional": true,
             "type": "string",
+          },
+          "humeConfig": Object {
+            "optional": true,
+            "schema": Object {
+              "apiKey": Object {
+                "description": "The API key for the Hume service.",
+                "type": "string",
+              },
+              "secretKey": Object {
+                "description": "The secret key for the Hume service.",
+                "type": "string",
+              },
+            },
+            "type": "object",
           },
           "id": Object {
             "type": "string",
@@ -4406,6 +4466,46 @@ Object {
                 },
                 "type": "object",
               },
+              Object {
+                "schema": Object {
+                  "action": Object {
+                    "nullable": true,
+                    "type": "enum",
+                    "values": Array [
+                      "create",
+                    ],
+                  },
+                  "expireTimeMs": Object {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "marker": Object {
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceId": Object {
+                    "nullable": true,
+                    "optional": true,
+                    "type": "string",
+                  },
+                  "resourceKind": Object {
+                    "type": "literal",
+                    "value": "ai.hume",
+                  },
+                  "subjectId": Object {
+                    "type": "string",
+                  },
+                  "subjectType": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "user",
+                      "inst",
+                      "role",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
             ],
             "type": "union",
           },
@@ -4473,6 +4573,7 @@ Object {
               "inst",
               "loom",
               "ai.sloyd",
+              "ai.hume",
             ],
           },
         },
@@ -5047,7 +5148,12 @@ Object {
         "path": "/api/v2/ai/hume/token",
       },
       "inputs": Object {
-        "schema": Object {},
+        "schema": Object {
+          "recordName": Object {
+            "optional": true,
+            "type": "string",
+          },
+        },
         "type": "object",
       },
       "name": "getHumeAccessToken",
@@ -5189,6 +5295,20 @@ Object {
           "displayName": Object {
             "optional": true,
             "type": "string",
+          },
+          "humeConfig": Object {
+            "optional": true,
+            "schema": Object {
+              "apiKey": Object {
+                "description": "The API key for the Hume service.",
+                "type": "string",
+              },
+              "secretKey": Object {
+                "description": "The secret key for the Hume service.",
+                "type": "string",
+              },
+            },
+            "type": "object",
           },
           "id": Object {
             "type": "string",

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -3504,7 +3504,24 @@ describe('AuxLibrary', () => {
         describe('ai.hume.getAccessToken()', () => {
             it('should emit a AIGetHumeAccessTokenAction', () => {
                 const promise: any = library.api.ai.hume.getAccessToken();
-                const expected = aiHumeGetAccessToken({}, context.tasks.size);
+                const expected = aiHumeGetAccessToken(
+                    undefined,
+                    {},
+                    context.tasks.size
+                );
+
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should be able to include the record name', () => {
+                const promise: any =
+                    library.api.ai.hume.getAccessToken('recordName');
+                const expected = aiHumeGetAccessToken(
+                    'recordName',
+                    {},
+                    context.tasks.size
+                );
 
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -5373,15 +5373,22 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * Gets an access token for the Hume AI API.
      * Returns a promise that resolves with the access token.
      *
+     * @param recordName The name of the record that the access token should be generated for. If omitted, then the user's player studio record will be used.
+     *
      * @example Get an access token for the Hume AI API.
      * const accessToken = await ai.hume.getAccessToken();
+     *
+     * @example Get an access token for the Hume AI API for the given record.
+     * const accessToken = await ai.hume.getAccessToken('recordName');
      *
      * @dochash actions/ai
      * @docname ai.hume.getAccessToken
      */
-    function getHumeAccessToken(): Promise<AIHumeGetAccessTokenResult> {
+    function getHumeAccessToken(
+        recordName?: string
+    ): Promise<AIHumeGetAccessTokenResult> {
         const task = context.createTask();
-        const action = aiHumeGetAccessToken({}, task.taskId);
+        const action = aiHumeGetAccessToken(recordName, {}, task.taskId);
         const final = addAsyncResultAction(task, action);
         (final as any)[ORIGINAL_OBJECT] = action;
         return final;

--- a/src/aux-runtime/runtime/RecordsEvents.ts
+++ b/src/aux-runtime/runtime/RecordsEvents.ts
@@ -279,6 +279,11 @@ export interface AIGenerateImageOptions {
  */
 export interface AIHumeGetAccessTokenAction extends RecordsAction {
     type: 'ai_hume_get_access_token';
+
+    /**
+     * The name of the record that the access token should be retrieved for.
+     */
+    recordName?: string;
 }
 
 /**
@@ -1190,11 +1195,13 @@ export function aiGenerateImage(
  * @param taskId The ID of the async task.
  */
 export function aiHumeGetAccessToken(
+    recordName?: string,
     options?: RecordActionOptions,
     taskId?: number | string
 ): AIHumeGetAccessTokenAction {
     return {
         type: 'ai_hume_get_access_token',
+        recordName,
         options: options ?? {},
         taskId,
     };

--- a/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
@@ -13,6 +13,7 @@ import {
     ListedRecord,
     StoreListedStudio,
     StudioComIdRequest,
+    HumeConfig,
 } from '@casual-simulation/aux-records';
 import {
     AddressType,
@@ -111,6 +112,17 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
             db.collection<MongoDBWebAuthnLoginRequest>(
                 WEB_AUTHN_LOGIN_REQUESTS_COLLECTION_NAME
             );
+    }
+
+    getStudioHumeConfig(studioId: string): Promise<HumeConfig | null> {
+        throw new Error('Method not implemented.');
+    }
+
+    updateStudioHumeConfig(
+        studioId: string,
+        config: HumeConfig
+    ): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 
     getStudioLoomConfig(

--- a/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
@@ -19,6 +19,8 @@ import {
     StudioComIdRequest,
     LoomConfig,
     LOOM_CONFIG,
+    HumeConfig,
+    HUME_CONFIG,
 } from '@casual-simulation/aux-records';
 import { PrismaClient, Prisma } from './generated';
 import { convertToDate, convertToMillis } from './Utils';
@@ -31,6 +33,37 @@ export class PrismaRecordsStore implements RecordsStore {
 
     constructor(client: PrismaClient) {
         this._client = client;
+    }
+
+    async getStudioHumeConfig(studioId: string): Promise<HumeConfig | null> {
+        const studio = await this._client.studio.findUnique({
+            where: {
+                id: studioId,
+            },
+            select: {
+                humeConfig: true,
+            },
+        });
+
+        if (!studio) {
+            return null;
+        }
+
+        return zodParseConfig(studio.humeConfig, HUME_CONFIG);
+    }
+
+    async updateStudioHumeConfig(
+        studioId: string,
+        config: HumeConfig
+    ): Promise<void> {
+        await this._client.studio.update({
+            where: {
+                id: studioId,
+            },
+            data: {
+                humeConfig: config,
+            },
+        });
     }
 
     @traced(TRACE_NAME)

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -257,6 +257,9 @@ model Studio {
     // The loom app id and private key for this studio.
     loomConfig Json?
 
+    // The hume apiKey and secretKey for this studio.
+    humeConfig Json?
+
     records Record[]
     assignments StudioAssignment[]
 

--- a/src/aux-server/aux-backend/schemas/migrations/20240715154333_add_hume_config_to_studio/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20240715154333_add_hume_config_to_studio/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Studio" ADD COLUMN     "humeConfig" JSONB;

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -1176,6 +1176,7 @@ export class ServerBuilder implements SubscriptionLike {
             metrics: this._metricsStore,
             policies: this._policyStore,
             policyController: null,
+            records: this._recordsStore,
         };
 
         if (this._openAIChatInterface && options.ai.chat) {
@@ -1230,14 +1231,22 @@ export class ServerBuilder implements SubscriptionLike {
             };
         }
         if (options.humeai) {
+            console.log('[ServerBuilder] Using Hume AI with API Key.');
+            this._aiConfiguration.hume = {
+                interface: new HumeInterface(),
+                config: {
+                    apiKey: options.humeai.apiKey,
+                    secretKey: options.humeai.secretKey,
+                },
+            };
+        } else {
             console.log('[ServerBuilder] Using Hume AI.');
             this._aiConfiguration.hume = {
-                interface: new HumeInterface(
-                    options.humeai.apiKey,
-                    options.humeai.secretKey
-                ),
+                interface: new HumeInterface(),
+                config: null,
             };
         }
+
         if (options.sloydai) {
             console.log('[ServerBuilder] Using Sloyd AI.');
             this._aiConfiguration.sloyd = {

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
@@ -6,6 +6,7 @@ import { authManager } from '../../shared/index';
 import { SvgIcon } from '@casual-simulation/aux-components';
 import AuthSubscription from '../AuthSubscription/AuthSubscription';
 import {
+    AIHumeFeaturesConfiguration,
     AllowedStudioCreators,
     FormError,
     ListedStudioMember,
@@ -66,6 +67,9 @@ export default class AuthStudio extends Vue {
     loomFeatures: StudioLoomFeaturesConfiguration = {
         allowed: false,
     };
+    humeFeatures: AIHumeFeaturesConfiguration = {
+        allowed: false,
+    };
 
     originalAllowedStudioCreators: AllowedStudioCreators = 'anyone';
     allowedStudioCreators: AllowedStudioCreators = 'anyone';
@@ -95,6 +99,10 @@ export default class AuthStudio extends Vue {
     loomPublicAppId: string = null;
     loomPrivateKey: string = null;
 
+    originalHumeApiKey: string = null;
+    humeApiKey: string = null;
+    humeSecretKey: string = null;
+
     isLoadingInfo: boolean = false;
     isSavingStudio: boolean = false;
 
@@ -103,6 +111,7 @@ export default class AuthStudio extends Vue {
     showUpdateStudioInfo: boolean = false;
     showRequestComId: boolean = false;
     showUpdateLoomConfig: boolean = false;
+    showUpdateHumeConfig: boolean = false;
 
     errors: FormError[] = [];
 
@@ -193,6 +202,18 @@ export default class AuthStudio extends Vue {
 
     get loomPrivateKeyFieldClass() {
         return this.errors.some((e) => e.for === 'loomConfig.privateKey')
+            ? 'md-invalid'
+            : '';
+    }
+
+    get humeApiKeyFieldClass() {
+        return this.errors.some((e) => e.for === 'humeConfig.apiKey')
+            ? 'md-invalid'
+            : '';
+    }
+
+    get humeSecretKeyFieldClass() {
+        return this.errors.some((e) => e.for === 'humeConfig.secretKey')
             ? 'md-invalid'
             : '';
     }
@@ -333,11 +354,23 @@ export default class AuthStudio extends Vue {
                 hasUpdate = true;
             }
 
+            if (
+                this.humeSecretKey ||
+                this.humeApiKey !== this.originalHumeApiKey
+            ) {
+                update.humeConfig = {
+                    apiKey: this.humeApiKey || null,
+                    secretKey: this.humeSecretKey || null,
+                };
+                hasUpdate = true;
+            }
+
             if (!hasUpdate) {
                 this.showUpdateComIdConfig = false;
                 this.showUpdatePlayerConfig = false;
                 this.showUpdateStudioInfo = false;
                 this.showUpdateLoomConfig = false;
+                this.showUpdateHumeConfig = false;
                 return;
             }
             const result = await authManager.client.updateStudio(update);
@@ -369,6 +402,7 @@ export default class AuthStudio extends Vue {
                 this.showUpdatePlayerConfig = false;
                 this.showUpdateStudioInfo = false;
                 this.showUpdateLoomConfig = false;
+                this.showUpdateHumeConfig = false;
             }
         } finally {
             this.isSavingStudio = false;
@@ -384,6 +418,7 @@ export default class AuthStudio extends Vue {
         this.showUpdatePlayerConfig = false;
         this.showUpdateStudioInfo = false;
         this.showUpdateLoomConfig = false;
+        this.showUpdateHumeConfig = false;
     }
 
     private async _loadPageInfo() {
@@ -406,6 +441,7 @@ export default class AuthStudio extends Vue {
                 this.ownerStudioComId = result.studio.ownerStudioComId;
                 this.comIdFeatures = result.studio.comIdFeatures;
                 this.loomFeatures = result.studio.loomFeatures;
+                this.humeFeatures = result.studio.humeFeatures;
                 this.originalAllowedStudioCreators =
                     this.allowedStudioCreators =
                         result.studio.comIdConfig?.allowedStudioCreators ??
@@ -426,7 +462,10 @@ export default class AuthStudio extends Vue {
                     result.studio.playerConfig?.what3WordsApiKey ?? null;
                 this.originalLoomPublicAppId = this.loomPublicAppId =
                     result.studio.loomConfig?.appId ?? null;
+                this.originalHumeApiKey = this.humeApiKey =
+                    result.studio.humeConfig?.apiKey ?? null;
                 this.loomPrivateKey = null;
+                this.humeSecretKey = null;
             }
         } finally {
             this.isLoadingInfo = false;
@@ -536,6 +575,10 @@ export default class AuthStudio extends Vue {
 
     updateLoomConfig() {
         this.showUpdateLoomConfig = true;
+    }
+
+    updateHumeConfig() {
+        this.showUpdateHumeConfig = true;
     }
 
     // TODO: Support uploading logos

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
@@ -226,6 +226,10 @@ export default class AuthStudio extends Vue {
         return this.loomFeatures?.allowed;
     }
 
+    get allowHume() {
+        return this.humeFeatures?.allowed;
+    }
+
     get hasStudioChange() {
         return (
             this.displayName !== this.originalDisplayName ||
@@ -397,6 +401,8 @@ export default class AuthStudio extends Vue {
                 this.originalWhat3WordsApiKey = this.what3WordsApiKey;
                 this.originalLoomPublicAppId = this.loomPublicAppId;
                 this.loomPrivateKey = null;
+                this.originalHumeApiKey = this.humeApiKey;
+                this.humeSecretKey = null;
 
                 this.showUpdateComIdConfig = false;
                 this.showUpdatePlayerConfig = false;

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
@@ -164,12 +164,12 @@
                 </md-table-row>
                 <md-table-row v-if="allowHume" @click="updateHumeConfig()">
                     <md-tooltip>The API key that used to access Hume.</md-tooltip>
-                    <md-table-cell>loom.apiKey</md-table-cell>
+                    <md-table-cell>hume.apiKey</md-table-cell>
                     <md-table-cell>{{ originalHumeApiKey || '(not set)' }}</md-table-cell>
                 </md-table-row>
                 <md-table-row v-if="allowHume" @click="updateHumeConfig()">
                     <md-tooltip>The Secret API key that used to access Hume.</md-tooltip>
-                    <md-table-cell>loom.secretKey</md-table-cell>
+                    <md-table-cell>hume.secretKey</md-table-cell>
                     <md-table-cell>{{ '(secret)' }}</md-table-cell>
                 </md-table-row>
             </md-table>
@@ -445,7 +445,7 @@
                 </md-field>
                 <md-field :class="humeSecretKeyFieldClass">
                     <label for="humeSecretKey">Hume Secret Key</label>
-                    <md-textarea id="humeSecretKey" v-model="humeSecretKey"></md-textarea>
+                    <md-input id="humeSecretKey" v-model="humeSecretKey" type="text"></md-input>
                     <field-errors field="humeConfig.secretKey" :errors="errors" />
                 </md-field>
                 <field-errors :field="null" :errors="errors" />

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
@@ -162,6 +162,16 @@
                     <md-table-cell>loom.privateKey</md-table-cell>
                     <md-table-cell>{{ '(secret)' }}</md-table-cell>
                 </md-table-row>
+                <md-table-row v-if="allowHume" @click="updateHumeConfig()">
+                    <md-tooltip>The API key that used to access Hume.</md-tooltip>
+                    <md-table-cell>loom.apiKey</md-table-cell>
+                    <md-table-cell>{{ originalHumeApiKey || '(not set)' }}</md-table-cell>
+                </md-table-row>
+                <md-table-row v-if="allowHume" @click="updateHumeConfig()">
+                    <md-tooltip>The Secret API key that used to access Hume.</md-tooltip>
+                    <md-table-cell>loom.secretKey</md-table-cell>
+                    <md-table-cell>{{ '(secret)' }}</md-table-cell>
+                </md-table-row>
             </md-table>
         </div>
 
@@ -408,6 +418,35 @@
                     <label for="loomPrivateKey">Loom Private Key</label>
                     <md-textarea id="loomPrivateKey" v-model="loomPrivateKey"></md-textarea>
                     <field-errors field="loomPrivateKey" :errors="errors" />
+                </md-field>
+                <field-errors :field="null" :errors="errors" />
+            </md-dialog-content>
+            <md-dialog-actions>
+                <md-button class="md-primary" @click="saveStudio()">
+                    <md-progress-spinner
+                        md-mode="indeterminate"
+                        :md-diameter="20"
+                        :md-stroke="2"
+                        v-if="isSavingStudio"
+                    >
+                    </md-progress-spinner>
+                    <span v-else>Save</span>
+                </md-button>
+            </md-dialog-actions>
+        </md-dialog>
+
+        <md-dialog :md-active.sync="showUpdateHumeConfig" @md-closed="cancelUpdateStudio()">
+            <md-dialog-title> Update Hume Config</md-dialog-title>
+            <md-dialog-content>
+                <md-field :class="humeApiKeyFieldClass">
+                    <label for="humeApiKey">Loom Public App ID</label>
+                    <md-input id="humeApiKey" v-model="humeApiKey" type="text"></md-input>
+                    <field-errors field="humeConfig.apiKey" :errors="errors" />
+                </md-field>
+                <md-field :class="humeSecretKeyFieldClass">
+                    <label for="humeSecretKey">Hume Secret Key</label>
+                    <md-textarea id="humeSecretKey" v-model="humeSecretKey"></md-textarea>
+                    <field-errors field="humeConfig.secretKey" :errors="errors" />
                 </md-field>
                 <field-errors :field="null" :errors="errors" />
             </md-dialog-content>

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -8058,7 +8058,7 @@ describe('RecordsManager', () => {
                 authMock.isAuthenticated.mockResolvedValueOnce(true);
                 authMock.getAuthToken.mockResolvedValueOnce('authToken');
 
-                records.handleEvents([aiHumeGetAccessToken({}, 1)]);
+                records.handleEvents([aiHumeGetAccessToken(undefined, {}, 1)]);
 
                 await waitAsync();
 
@@ -8069,6 +8069,53 @@ describe('RecordsManager', () => {
                         body: JSON.stringify({
                             procedure: 'getHumeAccessToken',
                             input: {},
+                        }),
+                        headers: expect.objectContaining({
+                            Authorization: 'Bearer authToken',
+                        }),
+                    }
+                );
+
+                await waitAsync();
+
+                expect(vm.events).toEqual([
+                    asyncResult(1, {
+                        success: true,
+                        accessToken: 'token',
+                    }),
+                ]);
+                expect(authMock.isAuthenticated).toBeCalled();
+                expect(authMock.authenticate).not.toBeCalled();
+                expect(authMock.getAuthToken).toBeCalled();
+            });
+
+            it('should include the record name', async () => {
+                fetch.mockResolvedValueOnce({
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        accessToken: 'token',
+                    }),
+                });
+
+                authMock.isAuthenticated.mockResolvedValueOnce(true);
+                authMock.getAuthToken.mockResolvedValueOnce('authToken');
+
+                records.handleEvents([
+                    aiHumeGetAccessToken('recordName', {}, 1),
+                ]);
+
+                await waitAsync();
+
+                expect(fetch).toHaveBeenCalledWith(
+                    'http://localhost:3002/api/v3/callProcedure',
+                    {
+                        method: 'POST',
+                        body: JSON.stringify({
+                            procedure: 'getHumeAccessToken',
+                            input: {
+                                recordName: 'recordName',
+                            },
                         }),
                         headers: expect.objectContaining({
                             Authorization: 'Bearer authToken',

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -1905,7 +1905,9 @@ export class RecordsManager {
             }
 
             const result = await this._client.getHumeAccessToken(
-                {},
+                {
+                    recordName: event.recordName,
+                },
                 {
                     endpoint: await info.auth.getRecordsOrigin(),
                     sessionKey: info.token,


### PR DESCRIPTION
-   Improved Hume AI features to support Studios.
    -   The `ai.hume` features now determine whether a Studio can configure their own Hume `apiKey` and `secretKey`.
    -   `ai.hume.getAccessToken(recordName)` now accepts a record name.
        -   This allows the user to specify which record they want to use for hume.ai access.
        -   Once a studio is configured, requests to one of the Studio's records will return an access token derived from the Studio's configured `apiKey` and `secretKey`.
        -   Requesting users require access to the `ai.hume` resource kind and `create` action for the specified record.

Closes #493 