### PR TITLE
Update the BIOS Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 -   Fixed an issue where meshes for hands in XR don't follow the camera when `cameraPositionOffset` is changed.
 -   Fixed an issue where the wrist portals for hands in Meta Quest devices were positioned incorrectly.
 -   Fixed an issue where it was impossible to close the map portal from inside `@onInstJoined`.
+-   Fixed an issue where selecting an option in the BIOS would fail to actually show the selected option.
 
 ## V3.3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
 -   Tags added to bots through the `systemPortal` will now be added to the "tags" section instead of the "pinned tags" section.
 -   Improved the [CasualOS CLI](https://www.npmjs.com/package/casualos) to be able to generate and validate server configs.
 -   Improved `portalZoomableMax` and `portalZoomableMin` to be supported for `perspective` portal camera types.
+-   The default BIOS options have been updated:
+    -   `enter join code`
+    -   `local`
+    -   `studio`
+    -   `free`
+    -   `sign in`
+    -   `sign up`
+    -   `sign out`
 
 ### :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   Tags added to bots through the `systemPortal` will now be added to the "tags" section instead of the "pinned tags" section.
 -   Improved the [CasualOS CLI](https://www.npmjs.com/package/casualos) to be able to generate and validate server configs.
 -   Improved `portalZoomableMax` and `portalZoomableMin` to be supported for `perspective` portal camera types.
+-   Updated the BIOS dialog with various visual improvements.
 -   The default BIOS options have been updated:
     -   `enter join code`
     -   `local`

--- a/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
+++ b/src/aux-server/aux-web/aux-auth/iframe/AuthHandler.ts
@@ -73,6 +73,8 @@ declare let ENABLE_SMS_AUTHENTICATION: boolean;
 
 const REFRESH_LIFETIME_MS = 1000 * 60 * 60 * 24 * 7; // 1 week
 
+const CURRENT_PROTOCOL_VERSION = 11;
+
 /**
  * Defines a class that implements the backend for an AuxAuth instance.
  */
@@ -325,7 +327,7 @@ export class AuthHandler implements AuxAuth {
     }
 
     async getProtocolVersion() {
-        return 10;
+        return CURRENT_PROTOCOL_VERSION;
     }
 
     async getRecordsOrigin(): Promise<string> {
@@ -341,6 +343,11 @@ export class AuthHandler implements AuxAuth {
     }
 
     async openAccountPage(): Promise<void> {
+        const url = await this.getAccountPage();
+        window.open(url, '_blank');
+    }
+
+    async getAccountPage(): Promise<string> {
         const url = new URL('/', location.origin);
         if (
             authManager.currentSessionKey !== authManager.savedSessionKey &&
@@ -352,7 +359,7 @@ export class AuthHandler implements AuxAuth {
                 authManager.currentConnectionKey
             );
         }
-        window.open(url.href, '_blank');
+        return url.href;
     }
 
     async addLoginStatusCallback(

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
@@ -61,10 +61,6 @@
     max-width: 240px;
 }
 
-.bios-selection-field {
-    margin-bottom: 4px;
-}
-
 .spacer {
     flex: 1 1 auto;
 }

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.css
@@ -78,3 +78,8 @@
     display: flex;
     margin-top: 14px;
 }
+
+.bios-title {
+    display: flex;
+    align-items: center;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -206,6 +206,18 @@ export default class PlayerHome extends Vue {
         }
     }
 
+    get biosSelectionOptions() {
+        if (!this.biosOptions) {
+            return [];
+        }
+        return this.biosOptions.filter(
+            (option) =>
+                option !== 'sign in' &&
+                option !== 'sign up' &&
+                option !== 'sign out'
+        );
+    }
+
     hasOptionDescription(option: BiosOption): boolean {
         if (
             isPrivateInst(option) ||

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -473,6 +473,10 @@ export default class PlayerHome extends Vue {
         await appManager.auth.primary.cancelLogin();
     }
 
+    async showAccountInfo() {
+        await appManager.authCoordinator.showAccountInfo(null);
+    }
+
     private _loadStaticInst(instSelection: string) {
         const update: Dictionary<string | string[]> = {};
         const inst =

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -102,13 +102,25 @@ const BiosOptionComponent = MdOption.extend({
                     '.md-list-item-text > span'
                 );
                 if (queryResult) {
-                    return queryResult.textContent;
+                    return queryResult.textContent.trim();
                 }
-                return el.textContent;
+                return el.textContent.trim();
             }
             const slot = this.$slots.default;
             const slotText = slot ? slot[0]?.text?.trim() : '';
             return slotText ?? '';
+        },
+    },
+});
+
+const MdSelect = Vue.component('MdSelect');
+const BiosSelectComponent = MdSelect.extend({
+    methods: {
+        setFieldContent() {
+            // Overrides the default MdSelect#setFieldContent method
+            // to ensure that it actually works for the BIOS selection dialog.
+            // For some reason, the default version doesn't work because of the multiple-line item description issue.
+            this.MdSelect.label = this.localValue;
         },
     },
 });
@@ -118,6 +130,7 @@ const BiosOptionComponent = MdOption.extend({
         'game-view': PlayerGameView,
         'field-errors': FieldErrors,
         'bios-option': BiosOptionComponent,
+        'bios-select': BiosSelectComponent,
     },
 })
 export default class PlayerHome extends Vue {

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -175,6 +175,18 @@ export default class PlayerHome extends Vue {
         return appManager.simulationManager.primary;
     }
 
+    get canLoad() {
+        if (this.biosSelection) {
+            if (isJoinCode(this.biosSelection)) {
+                return !!this.joinCode;
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+
     get startButtonLabel() {
         if (
             isPublicInst(this.biosSelection) ||

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -190,7 +190,7 @@ export default class PlayerHome extends Vue {
         ) {
             return 'Continue';
         } else {
-            return 'Start';
+            return 'Load';
         }
     }
 

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -575,10 +575,10 @@ export default class PlayerHome extends Vue {
         const authenticated = await appManager.auth.primary.isAuthenticated();
         return (
             appManager.config.allowedBiosOptions ?? [
-                'join inst',
-                'local inst',
-                'studio inst',
-                'free inst',
+                'enter join code',
+                'local',
+                'studio',
+                'free',
                 'sign in',
                 'sign up',
                 'sign out',

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -40,11 +40,6 @@
                         >
                     </bios-select>
                 </md-field>
-                <span
-                    class="selection-bios-description"
-                    v-if="hasOptionDescription(biosSelection)"
-                    >{{ getOptionDescription(biosSelection) }}</span
-                >
 
                 <md-field v-if="isJoinCode(biosSelection)" :class="joinCodeClass">
                     <label for="joinCode">joinCode=</label>

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -13,7 +13,7 @@
             :md-close-on-esc="false"
             :md-click-outside-to-close="false"
         >
-            <md-dialog-title :class="{ 'logo-title': !!logoUrl }">
+            <md-dialog-title class="bios-title" :class="{ 'logo-title': !!logoUrl }">
                 <img
                     v-if="logoUrl"
                     :src="logoUrl"
@@ -22,6 +22,11 @@
                     :title="logoTitle"
                 />
                 <span v-else>BIOS</span>
+                <span class="spacer"></span>
+                <md-button v-if="canSignOut()" class="md-icon-button" @click="showAccountInfo()">
+                    <md-icon>perm_identity</md-icon>
+                    <md-tooltip md-direction="bottom">Account Info</md-tooltip>
+                </md-button>
             </md-dialog-title>
             <md-dialog-content>
                 <md-field class="bios-selection-field">

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -102,6 +102,7 @@
                     @click="
                         executeBiosOption(biosSelection, recordSelection, instSelection, joinCode)
                     "
+                    :disabled="!canLoad"
                     >{{ startButtonLabel }}</md-button
                 >
             </md-dialog-actions>

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -25,7 +25,7 @@
             </md-dialog-title>
             <md-dialog-content>
                 <md-field class="bios-selection-field">
-                    <label for="biosOption">bios=</label>
+                    <label for="biosOption">inst type</label>
                     <bios-select v-model="biosSelection" name="biosOption" id="biosOption">
                         <bios-option
                             v-for="option in biosSelectionOptions"
@@ -42,7 +42,7 @@
                 </md-field>
 
                 <md-field v-if="isJoinCode(biosSelection)" :class="joinCodeClass">
-                    <label for="joinCode">joinCode=</label>
+                    <label for="joinCode">join code</label>
                     <md-input name="joinCode" id="joinCode" v-model="joinCode" />
                     <field-errors field="joinCode" :errors="errors" />
                 </md-field>
@@ -56,9 +56,9 @@
                     </md-select>
                 </md-field> -->
                 <md-field v-if="instOptions.length > 0">
-                    <label for="instOption">staticInst=</label>
+                    <label for="instOption">inst</label>
                     <md-select v-model="instSelection" name="instOption" id="instOption">
-                        <md-option value="new-inst">(new inst)</md-option>
+                        <md-option value="new-inst">+new</md-option>
                         <md-option v-for="option in instOptions" :key="option" :value="option">{{
                             option
                         }}</md-option>

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -28,7 +28,7 @@
                     <label for="biosOption">bios=</label>
                     <bios-select v-model="biosSelection" name="biosOption" id="biosOption">
                         <bios-option
-                            v-for="option in biosOptions"
+                            v-for="option in biosSelectionOptions"
                             :key="option"
                             ref="biosOptions"
                             :value="option"

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -26,20 +26,19 @@
             <md-dialog-content>
                 <md-field class="bios-selection-field">
                     <label for="biosOption">bios=</label>
-                    <md-select v-model="biosSelection" name="biosOption" id="biosOption">
+                    <bios-select v-model="biosSelection" name="biosOption" id="biosOption">
                         <bios-option
                             v-for="option in biosOptions"
                             :key="option"
                             ref="biosOptions"
                             :value="option"
                             :class="{ 'double-line': hasOptionDescription(option) }"
-                        >
-                            <span>{{ option }}</span>
-                            <span v-if="hasOptionDescription(option)">{{
+                            ><span>{{ option }}</span
+                            ><span v-if="hasOptionDescription(option)">{{
                                 getOptionDescription(option)
-                            }}</span>
-                        </bios-option>
-                    </md-select>
+                            }}</span></bios-option
+                        >
+                    </bios-select>
                 </md-field>
                 <span
                     class="selection-bios-description"

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
@@ -153,20 +153,16 @@ export default class AuthUI extends Vue {
     }
 
     async openAccountDashboard() {
-        if (this._simId) {
-            const simId = this._simId;
-            this.closeAccountInfo();
-            await appManager.authCoordinator.openAccountDashboard(simId);
-        }
+        const simId = this._simId;
+        this.closeAccountInfo();
+        await appManager.authCoordinator.openAccountDashboard(simId);
     }
 
     async logout() {
-        if (this._simId) {
-            const simId = this._simId;
-            this.closeAccountInfo();
-            await appManager.authCoordinator.logout(simId);
-            location.reload();
-        }
+        const simId = this._simId;
+        this.closeAccountInfo();
+        await appManager.authCoordinator.logout(simId);
+        location.reload();
     }
 
     async changeLogin() {

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.ts
@@ -50,6 +50,8 @@ export default class AuthUI extends Vue {
     expireTimeMs: number = 0;
     grantPermissionLevel: 'full-access' | 'read-only' = 'full-access';
 
+    reportInstVisible: boolean = false;
+
     private _simId: string = null;
     private _origin: string = null;
 
@@ -94,6 +96,18 @@ export default class AuthUI extends Vue {
                 this.showAccountInfo = true;
                 this.loginStatus = e.loginStatus;
                 this._simId = e.simulationId;
+
+                this.reportInstVisible = false;
+                if (this._simId) {
+                    const sim = appManager.simulationManager.simulations.get(
+                        this._simId
+                    );
+                    if (sim) {
+                        if (!sim.origin.isStatic) {
+                            this.reportInstVisible = true;
+                        }
+                    }
+                }
             })
         );
         this._sub.add(

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
@@ -60,11 +60,10 @@
                 </div>
             </md-dialog-content>
             <md-dialog-actions>
-                <md-button class="md-primary" @click="openAccountDashboard()"
-                    >Manage Account</md-button
                 <md-button v-if="reportInstVisible" @click="showReportInst()"
                     >Report Inst</md-button
                 >
+                <md-button @click="openAccountDashboard()">Manage Account</md-button>
                 <md-button @click="logout()">Sign Out</md-button>
             </md-dialog-actions>
         </md-dialog>

--- a/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
+++ b/src/aux-server/aux-web/shared/vue-components/AuthUI/AuthUI.vue
@@ -60,9 +60,10 @@
                 </div>
             </md-dialog-content>
             <md-dialog-actions>
-                <md-button @click="showReportInst()">Report Inst</md-button>
                 <md-button class="md-primary" @click="openAccountDashboard()"
                     >Manage Account</md-button
+                <md-button v-if="reportInstVisible" @click="showReportInst()"
+                    >Report Inst</md-button
                 >
                 <md-button @click="logout()">Sign Out</md-button>
             </md-dialog-actions>

--- a/src/aux-vm-browser/managers/AuthCoordinator.ts
+++ b/src/aux-vm-browser/managers/AuthCoordinator.ts
@@ -609,6 +609,10 @@ export interface MissingPermissionEvent {
 }
 
 export interface ShowAccountInfoEvent {
+    /**
+     * The ID of the simulation that the account info should be shown for.
+     * If null, then the account info should be shown for the default auth endpoint.
+     */
     simulationId: string;
     loginStatus: LoginStatus;
 }

--- a/src/aux-vm-browser/managers/AuthCoordinator.ts
+++ b/src/aux-vm-browser/managers/AuthCoordinator.ts
@@ -141,6 +141,8 @@ export class AuthCoordinator<TSim extends BrowserSimulation>
         const sim = this._simulationManager.simulations.get(simId);
         if (sim) {
             await sim.auth.primary.openAccountPage();
+        } else {
+            await this.authHelper?.primary.openAccountPage();
         }
     }
 
@@ -148,6 +150,8 @@ export class AuthCoordinator<TSim extends BrowserSimulation>
         const sim = this._simulationManager.simulations.get(simId);
         if (sim) {
             await sim.auth.primary.logout();
+        } else {
+            await this.authHelper?.primary.logout();
         }
     }
 
@@ -167,6 +171,15 @@ export class AuthCoordinator<TSim extends BrowserSimulation>
             if (status) {
                 this._onShowAccountInfo.next({
                     simulationId: sim.id,
+                    loginStatus: status,
+                });
+            }
+        } else if (this.authHelper) {
+            const endpoint = this.authHelper.primary;
+            const status = endpoint.currentLoginStatus;
+            if (status) {
+                this._onShowAccountInfo.next({
+                    simulationId: null,
                     loginStatus: status,
                 });
             }

--- a/src/aux-vm-browser/managers/AuthEndpointHelper.ts
+++ b/src/aux-vm-browser/managers/AuthEndpointHelper.ts
@@ -441,7 +441,18 @@ export class AuthEndpointHelper implements AuthHelperInterface {
         if (this._protocolVersion < 2) {
             return;
         }
-        return await this._proxy.openAccountPage();
+
+        if (this._protocolVersion >= 11) {
+            const newTab = window.open('/loading-oauth.html', '_blank');
+
+            const url = await this._proxy.getAccountPage();
+
+            if (newTab && !newTab.closed) {
+                newTab.location = url;
+            }
+        } else {
+            return await this._proxy.openAccountPage();
+        }
     }
 
     async setUseCustomUI(useCustomUI: boolean) {

--- a/src/aux-vm/auth/AuxAuth.ts
+++ b/src/aux-vm/auth/AuxAuth.ts
@@ -300,6 +300,12 @@ export interface AuxAuth {
     openAccountPage(): Promise<void>;
 
     /**
+     * Gets the link to the account page.
+     * Only supported on protocol version 11 or more.
+     */
+    getAccountPage(): Promise<string>;
+
+    /**
      * Adds the given function as a callback for login status information.
      * Only supported on protocol version 2 or more.
      * @param callback The function that should be called when the login status changes.


### PR DESCRIPTION
### :rocket: Features
-   Updated the BIOS dialog with various visual improvements.
-   The default BIOS options have been updated:
    -   `enter join code`
    -   `local`
    -   `studio`
    -   `free`
    -   `sign in`
    -   `sign up`
    -   `sign out`

### :bug: Bug Fixes
-   Fixed an issue where selecting an option in the BIOS would fail to actually show the selected option.

Closes #505 