### PR TITLE
Improve labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
         -   Requesting users require access to the `ai.hume` resource kind and `create` action for the specified record.
 -   Added the `floatingBillboard` option for `labelPosition`.
     -   Like `floating`, but the label background won't have an arrow and the label will always face the camera.
+-   Added the `labelFloatingBackgroundColor` tag to control the color of the background for floating labels.
+    -   Defaults to `white`.
 
 ### :bug: Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
         -   This allows the user to specify which record they want to use for hume.ai access.
         -   Once a studio is configured, requests to one of the Studio's records will return an access token derived from the Studio's configured `apiKey` and `secretKey`.
         -   Requesting users require access to the `ai.hume` resource kind and `create` action for the specified record.
+-   Added the `floatingBillboard` option for `labelPosition`.
+    -   Like `floating`, but the label background won't have an arrow and the label will always face the camera.
 
 ### :bug: Bug Fixes
 
@@ -53,6 +55,7 @@
 -   Fixed an issue where the wrist portals for hands in Meta Quest devices were positioned incorrectly.
 -   Fixed an issue where it was impossible to close the map portal from inside `@onInstJoined`.
 -   Fixed an issue where selecting an option in the BIOS would fail to actually show the selected option.
+-   Fixed an issue where the arrow on floating labels would clip into the bot if the bot had a scale > 1.
 
 ## V3.3.6
 

--- a/docs/docs/components.jsx
+++ b/docs/docs/components.jsx
@@ -405,6 +405,10 @@ export const LabelAnchorValues = ({}) => (<React.Fragment>
   <PossibleValueCode value='floating'>
      Floating above the bot.
   </PossibleValueCode>
+  <PossibleValueCode value='floatingBillboard'>
+     Floating above the bot and billboarded to face the camera.
+     Like floating, but the label background won't have an arrow and the label will always face the camera.
+  </PossibleValueCode>
 </React.Fragment>)
 
 export const Badges = ({children}) => (

--- a/docs/docs/components.jsx
+++ b/docs/docs/components.jsx
@@ -146,6 +146,7 @@ export const tagMap = {
     labelAlignment: 'tags/visualization',
     labelFontAddress: 'tags/visualization',
     labelWordWrapMode: 'tags/visualization',
+    labelFloatingBackgroundColor: 'tags/visualization',
     scale: 'tags/visualization',
     scaleX: 'tags/visualization',
     scaleY: 'tags/visualization',

--- a/docs/docs/tags/visualization.mdx
+++ b/docs/docs/tags/visualization.mdx
@@ -375,6 +375,23 @@ The word wrapping mode that the label should use. Useful for automatically fitti
   </PossibleValue>
 </PossibleValuesTable>
 
+### `labelFloatingBackgroundColor`
+
+The background color of the floating label.
+Only works when <TagLink tag='labelPosition'/> is set to `floating` or `floatingBillboard`.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='white'>
+    (default)
+  </PossibleValueCode>
+  <AnyColorValues/>
+  <PossibleValueCode value='clear'>
+    The background will be invisible.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `scale`
 
 <Badges>

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -2696,6 +2696,7 @@ export const KNOWN_TAGS: string[] = [
     'labelAlignment',
     'labelWordWrapMode',
     'labelFontAddress',
+    'labelFloatingBackgroundColor',
     'listening',
     'scale',
     'scaleX',

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -999,7 +999,8 @@ export type BotLabelAnchor =
     | 'back'
     | 'left'
     | 'right'
-    | 'floating';
+    | 'floating'
+    | 'floatingBillboard';
 
 /**
  * Defines the possible label alignment types.

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -1940,6 +1940,7 @@ export function getBotTagAnchor(
     if (
         anchor === 'back' ||
         anchor === 'floating' ||
+        anchor === 'floatingBillboard' ||
         anchor === 'front' ||
         anchor === 'left' ||
         anchor === 'right' ||
@@ -1948,6 +1949,14 @@ export function getBotTagAnchor(
         return anchor;
     }
     return DEFAULT_LABEL_ANCHOR;
+}
+
+/**
+ * Determines whether the given anchor is a floating anchor.
+ * @param anchor The anchor to check.
+ */
+export function isFloatingAnchor(anchor: BotLabelAnchor) {
+    return anchor === 'floating' || anchor === 'floatingBillboard';
 }
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -2826,6 +2826,7 @@ export function botCalculationContextTests(
             ['left', 'left'],
             ['right', 'right'],
             ['floating', 'floating'],
+            ['floatingBillboard', 'floatingBillboard'],
             ['abc', 'top'],
         ];
 

--- a/src/aux-server/aux-web/shared/scene/Text3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Text3D.ts
@@ -19,6 +19,7 @@ import {
     BotLabelAnchor,
     BotLabelAlignment,
     BotLabelWordWrap,
+    isFloatingAnchor,
 } from '@casual-simulation/aux-common';
 import { DebugObjectManager } from './debugobjectmanager/DebugObjectManager';
 import { Text as TextMesh } from 'troika-three-text';
@@ -44,6 +45,7 @@ export class Text3D extends Object3D {
 
     public static readonly extraSpace: number = 0.001;
     public static readonly floatingExtraSpace: number = 0.4;
+    public static readonly floatingBillboardExtraSpace: number = 0.2;
 
     /**
      * Number chosen by expirementation to place 5-6 characters on a bot.
@@ -288,12 +290,19 @@ export class Text3D extends Object3D {
      * @param scale The scale of the text mesh. (default is 0.004)
      */
     public setScale(scale: number): boolean {
-        if (this.scale.x !== scale) {
-            this.scale.setScalar(scale);
+        if (this._mesh.scale.x !== scale) {
+            this._mesh.scale.setScalar(scale);
             this.updateBoundingBox();
         }
 
         return false;
+    }
+
+    /**
+     * Gets the scale of the text.
+     */
+    public getScale(): Vector3 {
+        return this._mesh.scale;
     }
 
     /**
@@ -514,6 +523,7 @@ export class Text3D extends Object3D {
         this._mesh.overflowWrap = other._mesh.overflowWrap;
         this._mesh.color = other._mesh.color;
         this._mesh.rotation.copy(other._mesh.rotation);
+        this._mesh.scale.copy(other._mesh.scale);
         this._anchor = other._anchor;
         this._unprocessedText = other._unprocessedText;
         this.currentWidth = other.currentWidth;

--- a/src/aux-server/aux-web/shared/scene/Text3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Text3D.ts
@@ -474,7 +474,7 @@ export class Text3D extends Object3D {
         }
         this._anchor = anchor;
 
-        if (anchor === 'floating') {
+        if (isFloatingAnchor(anchor)) {
             this._mesh.anchorY = 'bottom';
         } else {
             this._mesh.anchorY = 'middle';
@@ -587,8 +587,8 @@ export class Text3D extends Object3D {
 
         const positionMultiplier = 0.5;
 
-        if (anchor === 'floating') {
-            let [pos, anchor] = Text3D._positionOffset(
+        if (isFloatingAnchor(anchor)) {
+            let [pos, textAnchor] = Text3D._positionOffset(
                 targetCenter,
                 targetSize,
                 'x',
@@ -599,11 +599,13 @@ export class Text3D extends Object3D {
                     targetCenter.y,
                     targetCenter.z +
                         targetSize.z * positionMultiplier +
-                        Text3D.floatingExtraSpace
+                        (anchor === 'floatingBillboard'
+                            ? Text3D.floatingBillboardExtraSpace
+                            : Text3D.floatingExtraSpace)
                 )
             );
 
-            return [pos, new Euler(ThreeMath.degToRad(90), 0, 0), anchor];
+            return [pos, new Euler(ThreeMath.degToRad(90), 0, 0), textAnchor];
         } else if (anchor === 'front') {
             let [pos, anchor] = Text3D._positionOffset(
                 targetCenter,

--- a/src/aux-server/aux-web/shared/scene/WordBubble3D.ts
+++ b/src/aux-server/aux-web/shared/scene/WordBubble3D.ts
@@ -46,12 +46,12 @@ export class WordBubble3D extends Object3D {
 
     /**
      * Update the world bubble.
-     * @param arrowPosition The position that the arrow point should start at. Should be relative to the bot.
+     * @param arrowPosition The position that the arrow point should start at. Should be relative to the bot. If null, then no arrow will be drawn.
      * @param labelPosition The position that the label is at. Should be relative to the bot.
      * @param labelSize The size of the label.
      */
     public update(
-        arrowPosition: Vector3,
+        arrowPosition: Vector3 | null,
         labelPosition: Vector3,
         labelSize: Vector2
     ): void {
@@ -59,7 +59,7 @@ export class WordBubble3D extends Object3D {
     }
 
     public regenerateMesh(
-        arrowPosition: Vector3,
+        arrowPosition: Vector3 | null,
         labelPosition: Vector3,
         labelSize: Vector2
     ) {
@@ -70,36 +70,60 @@ export class WordBubble3D extends Object3D {
 
         let halfWidth = sizeWithPadding.x / 2;
 
-        // Get local space conversion of min, max, and arrowPoint.
-        const arrowPointLocal = arrowPosition.clone();
-
-        const minPanel = new Vector3(
-            -halfWidth,
-            arrowPointLocal.y,
-            labelPosition.z
-        );
-        const maxPanel = new Vector3(
-            halfWidth,
-            arrowPointLocal.y,
-            labelPosition.z + labelSize.y
-        );
-
-        // Clamp arrow width to the size of the box if the box is smaller than the defualt arrow width.
-        const arrowWidthPct = 0.3;
-        const boxWidth = maxPanel.x - minPanel.x;
-        const arrowWidth = boxWidth * arrowWidthPct;
-
-        // Generate base word bubble mesh.
         let shape = new Shape();
+        if (arrowPosition) {
+            // Get local space conversion of min, max, and arrowPoint.
+            const arrowPointLocal = arrowPosition.clone();
 
-        // Sharp corners.
-        shape.moveTo(arrowPointLocal.x, arrowPointLocal.z);
-        shape.lineTo(-arrowWidth / 2 + arrowPointLocal.x, minPanel.z);
-        shape.lineTo(minPanel.x, minPanel.z);
-        shape.lineTo(minPanel.x, maxPanel.z);
-        shape.lineTo(maxPanel.x, maxPanel.z);
-        shape.lineTo(maxPanel.x, minPanel.z);
-        shape.lineTo(arrowWidth / 2 + arrowPointLocal.x, minPanel.z);
+            const minPanel = new Vector3(
+                -halfWidth,
+                arrowPointLocal.y,
+                labelPosition.z
+            );
+            const maxPanel = new Vector3(
+                halfWidth,
+                arrowPointLocal.y,
+                labelPosition.z + labelSize.y
+            );
+
+            // Clamp arrow width to the size of the box if the box is smaller than the defualt arrow width.
+            const arrowWidthPct = 0.3;
+            const boxWidth = maxPanel.x - minPanel.x;
+            const arrowWidth = boxWidth * arrowWidthPct;
+
+            // Sharp corners.
+            shape.moveTo(arrowPointLocal.x, arrowPointLocal.z);
+            shape.lineTo(-arrowWidth / 2 + arrowPointLocal.x, minPanel.z);
+            shape.lineTo(minPanel.x, minPanel.z);
+            shape.lineTo(minPanel.x, maxPanel.z);
+            shape.lineTo(maxPanel.x, maxPanel.z);
+            shape.lineTo(maxPanel.x, minPanel.z);
+            shape.lineTo(arrowWidth / 2 + arrowPointLocal.x, minPanel.z);
+        } else {
+            const minPanel = new Vector2(-halfWidth, labelPosition.z);
+
+            const maxPanel = new Vector2(
+                halfWidth,
+                labelPosition.z + labelSize.y
+            );
+
+            // Draw rectangle
+
+            // Bottom left corner
+            shape.moveTo(minPanel.x, minPanel.y);
+
+            // Line to top left corner
+            shape.lineTo(minPanel.x, maxPanel.y);
+
+            // Line to top right corner
+            shape.lineTo(maxPanel.x, maxPanel.y);
+
+            // Line to bottom right corner
+            shape.lineTo(maxPanel.x, minPanel.y);
+
+            // Line to bottom left corner
+            shape.lineTo(minPanel.x, minPanel.y);
+        }
 
         // Dispose of old geometry.
         if (this._shapeGeometry) {
@@ -120,7 +144,7 @@ export class WordBubble3D extends Object3D {
         }
 
         // Nudge the shape mesh back so that meshes that we encapsulated can render 'on top'.
-        this._shapeMesh.position.set(0, arrowPointLocal.y + 0.01, 0);
+        this._shapeMesh.position.set(0, arrowPosition?.y ?? 0 + 0.01, 0);
         this._shapeMesh.rotation.set(ThreeMath.degToRad(90), 0, 0);
 
         this.updateMatrixWorld(true);

--- a/src/aux-server/aux-web/shared/scene/WordBubble3D.ts
+++ b/src/aux-server/aux-web/shared/scene/WordBubble3D.ts
@@ -12,7 +12,7 @@ import {
     ShapeBufferGeometry,
 } from '@casual-simulation/three';
 import { merge } from '@casual-simulation/aux-common/utils';
-import { setLayerMask, buildSRGBColor } from './SceneUtils';
+import { setLayerMask, buildSRGBColor, setColor } from './SceneUtils';
 import { Text3D } from './Text3D';
 
 export class WordBubble3D extends Object3D {
@@ -21,6 +21,10 @@ export class WordBubble3D extends Object3D {
     private _shapeMesh: Mesh;
 
     private _options: WordBubbleOptions;
+
+    get mesh() {
+        return this._shapeMesh;
+    }
 
     constructor(opt?: WordBubbleOptions) {
         super();

--- a/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
@@ -2,6 +2,8 @@ import { AuxBot3DDecorator, AuxBot3DDecoratorBase } from '../AuxBot3DDecorator';
 import { AuxBot3D } from '../AuxBot3D';
 import {
     BotCalculationContext,
+    calculateBotValue,
+    calculateStringTagValue,
     getBotLabelAnchor,
     isFloatingAnchor,
 } from '@casual-simulation/aux-common';
@@ -12,6 +14,7 @@ import {
     convertToBox2,
     objectUpwardRay,
     objectWorldDirectionRay,
+    setColor,
 } from '../SceneUtils';
 import {
     Scene,
@@ -85,6 +88,13 @@ export class WordBubbleDecorator extends AuxBot3DDecoratorBase {
             this.wordBubble.visible = false;
             return;
         }
+
+        const color = calculateBotValue(
+            calc,
+            this.bot3D.bot,
+            'auxLabelFloatingBackgroundColor'
+        );
+        setColor(this.wordBubble.mesh, color);
 
         let arrowPoint: Vector3 | null;
 

--- a/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/WordBubbleDecorator.ts
@@ -82,7 +82,7 @@ export class WordBubbleDecorator extends AuxBot3DDecoratorBase {
 
         let arrowPoint = new Vector3(0, 0, 0);
 
-        arrowPoint.z += this.bot3D.gridScale;
+        arrowPoint.z += this.bot3D.boundingBox.max.z;
 
         let elementsBoundingBox: Vector2 = this._label.getSize();
         let labelPosition: Vector3 = this._label.text3D.position;


### PR DESCRIPTION
### :rocket: Features

-   Added the `floatingBillboard` option for `labelPosition`.
    -   Like `floating`, but the label background won't have an arrow and the label will always face the camera.
-   Added the `labelFloatingBackgroundColor` tag to control the color of the background for floating labels.
    -   Defaults to `white`.

### :bug: Bug Fixes

-   Fixed an issue where the arrow on floating labels would clip into the bot if the bot had a scale > 1.

Closes #503 