### PR TITLE
Add the ability to respond to right-click and middle-click in listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
     -   Like `floating`, but the label background won't have an arrow and the label will always face the camera.
 -   Added the `labelFloatingBackgroundColor` tag to control the color of the background for floating labels.
     -   Defaults to `white`.
+-   Improved `@onClick`, `@onAnyBotClicked`, `@onGridClick`, `@onPointerEnter`, `@onPointerExit`, `@onPointerDown`, `@onPointerUp`, `@onAnyBotPointerEnter`, `@onAnyBotPointerExit`, `@onAnyBotPointerDown`, and `@onAnyBotPointerUp` to include the ID of the button that was pressed.
+    -   For each of these listeners, `that.buttonId` will be either `"left"`, `"right"`, `"middle"`, or `null`.
+    -   This means that you can now determine which button was pressed (if any) and respond accordingly.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/tags/listen.mdx
+++ b/docs/docs/tags/listen.mdx
@@ -87,9 +87,45 @@ A whisper that is sent to the bot that was clicked.
 #### Arguments:
 ```typescript
 let that: {
-  face: 'left' | 'right' | 'front' | 'back' | 'top' | 'bottom',
-  dimension: string,
-  uv: Vector2
+  /**
+   * The face of the bot that was clicked.
+   */
+  face: 'left' | 'right' | 'front' | 'back' | 'top' | 'bottom';
+  
+  /**
+   * The dimension that the bot was clicked in.
+  */
+  dimension: string;
+
+  /**
+   * The UV Coordinates that were clicked on the bot.
+   */
+  uv: Vector2;
+
+  /**
+   * The modality that was used to click the bot.
+   * 
+   * - `mouse` - The mouse was used to click the bot.
+   * - `touch` - A touch screen was used to click the bot.
+   * - `controller` - A XR controller was used to click the bot.
+   * - `finger` - A finger was used to click the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -113,8 +149,40 @@ A whisper that is sent to a bot when the mouse cursor starts to hover over it.
 #### Arguments:
 ```typescript
 let that: {
-  bot: Bot,
-  dimension: string
+  /**
+   * The bot that the pointer hovered.
+   */
+  bot: Bot;
+  
+  /**
+   * The dimension that the bot was hovered in.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to hover over the bot.
+   * 
+   * - `mouse` - The mouse was used to hover over the bot.
+   * - `touch` - A touch screen was used to hover over the bot.
+   * - `controller` - A XR controller was used to hover over the bot.
+   * - `finger` - A finger was used to hover over the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to hover over the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to hover over the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to hover over the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -125,8 +193,40 @@ A whisper that is sent to a bot when the mouse cursor stops hovering over it.
 #### Arguments:
 ```typescript
 let that: {
-  bot: Bot,
-  dimension: string
+  /**
+   * The bot that the pointer hovered.
+   */
+  bot: Bot;
+  
+  /**
+   * The dimension that the bot was hovered in.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to hover over the bot.
+   * 
+   * - `mouse` - The mouse was used to hover over the bot.
+   * - `touch` - A touch screen was used to hover over the bot.
+   * - `controller` - A XR controller was used to hover over the bot.
+   * - `finger` - A finger was used to hover over the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to hover over the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to hover over the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to hover over the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -137,8 +237,40 @@ A whipser that is sent to a bot when the user starts clicking it.
 #### Arguments:
 ```typescript
 let that: {
-  bot: Bot,
-  dimension: string
+  /**
+   * The bot that the pointer started clicking.
+   */
+  bot: Bot;
+  
+  /**
+   * The dimension that the bot was clicked in.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to click the bot.
+   * 
+   * - `mouse` - The mouse was used to click the bot.
+   * - `touch` - A touch screen was used to click the bot.
+   * - `controller` - A XR controller was used to click the bot.
+   * - `finger` - A finger was used to click the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -149,8 +281,40 @@ A whisper that is sent to a bot when the user stops clicking it.
 #### Arguments:
 ```typescript
 let that: {
-  bot: Bot,
-  dimension: string
+  /**
+   * The bot that the pointer stopped clicking.
+   */
+  bot: Bot;
+  
+  /**
+   * The dimension that the bot was clicked in.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to click the bot.
+   * 
+   * - `mouse` - The mouse was used to click the bot.
+   * - `touch` - A touch screen was used to click the bot.
+   * - `controller` - A XR controller was used to click the bot.
+   * - `finger` - A finger was used to click the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -573,10 +737,50 @@ A shout that is sent to all bots when a bot is clicked.
 #### Arguments:
 ```typescript
 let that: {
-  bot: Bot,
-  face: 'left' | 'right' | 'front' | 'back' | 'top' | 'bottom',
-  dimension: string,
-  uv: Vector2
+  /**
+   * The bot that was clicked.
+   */
+  bot: Bot;
+
+  /**
+   * The face of the bot that was clicked.
+   */
+  face: 'left' | 'right' | 'front' | 'back' | 'top' | 'bottom';
+  
+  /**
+   * The dimension that the bot was clicked in.
+   */
+  dimension: string;
+
+  /**
+   * The UV Coordinates that were clicked on the bot.
+   */
+  uv: Vector2;
+
+  /**
+   * The modality that was used to click the bot.
+   * 
+   * - `mouse` - The mouse was used to click the bot.
+   * - `touch` - A touch screen was used to click the bot.
+   * - `controller` - A XR controller was used to click the bot.
+   * - `finger` - A finger was used to click the bot in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the bot.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the bot.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the bot.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -695,11 +899,43 @@ A shout that is sent to all bots when the user clicks on empty space.
 #### Arguments:
 ```typescript
 let that: {
+  /**
+   * The position within the dimension that was clicked.
+   */
   position: {
     x: number,
     y: number
-  },
-  dimension: string
+  };
+
+  /**
+   * The dimension that the grid was clicked on.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to click the grid.
+   * 
+   * - `mouse` - The mouse was used to click the grid.
+   * - `touch` - A touch screen was used to click the grid.
+   * - `controller` - A XR controller was used to click the grid.
+   * - `finger` - A finger was used to click the grid in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the grid.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the grid.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the grid.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -710,11 +946,43 @@ A shout that is sent to all bots when the user starts clicking on empty space.
 #### Arguments:
 ```typescript
 let that: {
+  /**
+   * The position within the dimension that was clicked.
+   */
   position: {
     x: number,
     y: number
-  },
-  dimension: string
+  };
+
+  /**
+   * The dimension that the grid was clicked on.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to click the grid.
+   * 
+   * - `mouse` - The mouse was used to click the grid.
+   * - `touch` - A touch screen was used to click the grid.
+   * - `controller` - A XR controller was used to click the grid.
+   * - `finger` - A finger was used to click the grid in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the grid.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the grid.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the grid.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 
@@ -725,11 +993,43 @@ A shout that is sent to all bots when the user stops clicking on empty space.
 #### Arguments:
 ```typescript
 let that: {
+  /**
+   * The position within the dimension that was clicked.
+   */
   position: {
     x: number,
     y: number
-  },
-  dimension: string
+  };
+
+  /**
+   * The dimension that the grid was clicked on.
+   */
+  dimension: string;
+
+  /**
+   * The modality that was used to click the grid.
+   * 
+   * - `mouse` - The mouse was used to click the grid.
+   * - `touch` - A touch screen was used to click the grid.
+   * - `controller` - A XR controller was used to click the grid.
+   * - `finger` - A finger was used to click the grid in XR.
+   */
+  modality: 'mouse' | 'touch' | 'controller' | 'finger';
+
+  /**
+   * For "finger" modalities, which hand was used to click the grid.
+   */
+  hand: 'left' | 'right';
+
+  /**
+   * For "finger" modalities, which finger was used to click the grid.
+   */
+  finger: 'index' | 'middle' | 'ring' | 'pinky' | 'thumb' | 'unknown';
+
+  /**
+   * For "mouse" modalities, which button was used to click the grid.
+   */
+  buttonId: 'left' | 'middle' | 'right';
 };
 ```
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1,6 +1,7 @@
 import { type } from 'os';
 import { TagEditOp } from './AuxStateHelpers';
 import { BotModule, BotModuleResult } from './BotModule';
+import { Point2D } from './BotEvents';
 
 export type PartialBot = Partial<Bot>;
 
@@ -2908,7 +2909,8 @@ export function onClickArg(
     uv: string,
     modality: string,
     hand: string,
-    finger: string
+    finger: string,
+    buttonId: string
 ) {
     return {
         face,
@@ -2917,6 +2919,7 @@ export function onClickArg(
         modality,
         hand,
         finger,
+        buttonId,
     };
 }
 
@@ -2927,11 +2930,30 @@ export function onAnyClickArg(
     uv: string,
     modality: string,
     hand: string,
-    finger: string
+    finger: string,
+    buttonId: string
 ) {
     return {
-        ...onClickArg(face, dimension, uv, modality, hand, finger),
+        ...onClickArg(face, dimension, uv, modality, hand, finger, buttonId),
         bot,
+    };
+}
+
+export function onGridClickArg(
+    position: Point2D,
+    dimension: string,
+    modality: string,
+    hand: string,
+    finger: string,
+    buttonId: string
+) {
+    return {
+        position,
+        dimension,
+        modality,
+        hand,
+        finger,
+        buttonId,
     };
 }
 
@@ -3039,7 +3061,8 @@ export function onPointerEnterExitArg(
     dimension: string,
     modality: string,
     hand: string,
-    finger: string
+    finger: string,
+    buttonId: string
 ) {
     return {
         bot,
@@ -3047,13 +3070,25 @@ export function onPointerEnterExitArg(
         modality,
         hand,
         finger,
+        buttonId,
     };
 }
 
-export function onPointerUpDownArg(bot: Bot, dimension: string) {
+export function onPointerUpDownArg(
+    bot: Bot,
+    dimension: string,
+    modality: string,
+    hand: string,
+    finger: string,
+    buttonId: string
+) {
     return {
         bot,
         dimension,
+        modality,
+        hand,
+        finger,
+        buttonId,
     };
 }
 

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -52,7 +52,11 @@ import { DimensionItem } from '../DimensionItem';
 import { first } from '@casual-simulation/aux-common';
 import { safeParseURL } from '../PlayerUtils';
 import PieProgress from '../../shared/vue-components/PieProgress/PieProgress';
-import { formatModalityButtonId, Input } from '../../shared/scene/Input';
+import {
+    formatModalityButtonId,
+    getModalityKey,
+    Input,
+} from '../../shared/scene/Input';
 import { SvgIcon } from '@casual-simulation/aux-components';
 import { Subscription } from 'rxjs';
 import { BotManager } from '@casual-simulation/aux-vm-browser';
@@ -223,7 +227,14 @@ export default class MenuBot extends Vue {
         const simulation = _simulation(this.item);
         const dimension = first(this.item.dimensions.values());
         const buttonId = formatModalityButtonId(event?.button);
-        let arg = onPointerUpDownArg(this.item.bot, dimension, buttonId);
+        let arg = onPointerUpDownArg(
+            this.item.bot,
+            dimension,
+            'mouse',
+            null,
+            null,
+            buttonId
+        );
         simulation.helper.transaction(
             ...simulation.helper.actions([
                 {
@@ -318,7 +329,14 @@ export default class MenuBot extends Vue {
             const simulation = _simulation(this.item);
             const dimension = first(this.item.dimensions.values());
             const buttonId = formatModalityButtonId(event?.button);
-            let arg = onPointerUpDownArg(this.item.bot, dimension, buttonId);
+            let arg = onPointerUpDownArg(
+                this.item.bot,
+                dimension,
+                'mouse',
+                null,
+                null,
+                buttonId
+            );
             simulation.helper.transaction(
                 ...simulation.helper.actions([
                     {

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -52,7 +52,7 @@ import { DimensionItem } from '../DimensionItem';
 import { first } from '@casual-simulation/aux-common';
 import { safeParseURL } from '../PlayerUtils';
 import PieProgress from '../../shared/vue-components/PieProgress/PieProgress';
-import { Input } from '../../shared/scene/Input';
+import { formatModalityButtonId, Input } from '../../shared/scene/Input';
 import { SvgIcon } from '@casual-simulation/aux-components';
 import { Subscription } from 'rxjs';
 import { BotManager } from '@casual-simulation/aux-vm-browser';
@@ -193,13 +193,14 @@ export default class MenuBot extends Vue {
         }
     }
 
-    async click() {
+    async click(event?: MouseEvent) {
         const simulation = _simulation(this.item);
         const dimension = first(this.item.dimensions.values());
+        const buttonId = formatModalityButtonId(event?.button);
         simulation.helper.action(
             CLICK_ACTION_NAME,
             [this.item.bot],
-            onClickArg(null, dimension, null, 'mouse', null, null)
+            onClickArg(null, dimension, null, 'mouse', null, null, buttonId)
         );
         simulation.helper.action(
             ANY_CLICK_ACTION_NAME,
@@ -211,17 +212,18 @@ export default class MenuBot extends Vue {
                 null,
                 'mouse',
                 null,
-                null
+                null,
+                buttonId
             )
         );
     }
 
-    async mouseDown() {
+    async mouseDown(event?: MouseEvent) {
         this._down = true;
-
         const simulation = _simulation(this.item);
         const dimension = first(this.item.dimensions.values());
-        let arg = onPointerUpDownArg(this.item.bot, dimension);
+        const buttonId = formatModalityButtonId(event?.button);
+        let arg = onPointerUpDownArg(this.item.bot, dimension, buttonId);
         simulation.helper.transaction(
             ...simulation.helper.actions([
                 {
@@ -238,10 +240,11 @@ export default class MenuBot extends Vue {
         );
     }
 
-    async mouseEnter() {
+    async mouseEnter(event?: MouseEvent) {
         this._hover = true;
         const simulation = _simulation(this.item);
         const dimension = first(this.item.dimensions.values());
+        const buttonId = formatModalityButtonId(event?.button);
         simulation.helper.transaction(
             ...simulation.helper.actions([
                 {
@@ -252,7 +255,8 @@ export default class MenuBot extends Vue {
                         dimension,
                         'mouse',
                         null,
-                        null
+                        null,
+                        buttonId
                     ),
                 },
                 {
@@ -263,18 +267,20 @@ export default class MenuBot extends Vue {
                         dimension,
                         'mouse',
                         null,
-                        null
+                        null,
+                        buttonId
                     ),
                 },
             ])
         );
     }
 
-    async mouseLeave() {
+    async mouseLeave(event?: MouseEvent) {
         if (this._hover === true) {
             this._hover = false;
             const simulation = _simulation(this.item);
             const dimension = first(this.item.dimensions.values());
+            const buttonId = formatModalityButtonId(event?.button);
             simulation.helper.transaction(
                 ...simulation.helper.actions([
                     {
@@ -285,7 +291,8 @@ export default class MenuBot extends Vue {
                             dimension,
                             'mouse',
                             null,
-                            null
+                            null,
+                            buttonId
                         ),
                     },
                     {
@@ -296,7 +303,8 @@ export default class MenuBot extends Vue {
                             dimension,
                             'mouse',
                             null,
-                            null
+                            null,
+                            buttonId
                         ),
                     },
                 ])
@@ -304,12 +312,13 @@ export default class MenuBot extends Vue {
         }
     }
 
-    async mouseUp() {
+    async mouseUp(event?: MouseEvent) {
         if (this._down === true) {
             this._down = false;
             const simulation = _simulation(this.item);
             const dimension = first(this.item.dimensions.values());
-            let arg = onPointerUpDownArg(this.item.bot, dimension);
+            const buttonId = formatModalityButtonId(event?.button);
+            let arg = onPointerUpDownArg(this.item.bot, dimension, buttonId);
             simulation.helper.transaction(
                 ...simulation.helper.actions([
                     {

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -41,10 +41,10 @@
         :class="{ active: selected, 'no-hover': hoverStyle === 'none' }"
         :style="style"
         :md-ripple="hoverStyle !== 'none'"
-        @click="click()"
-        @mousedown="mouseDown()"
-        @mouseenter="mouseEnter()"
-        @mouseleave="mouseLeave()"
+        @click="click"
+        @mousedown="mouseDown"
+        @mouseenter="mouseEnter"
+        @mouseleave="mouseLeave"
     >
         <div
             class="menu-bot-content"

--- a/src/aux-server/aux-web/aux-player/MenuPortalConfig.ts
+++ b/src/aux-server/aux-web/aux-player/MenuPortalConfig.ts
@@ -69,7 +69,7 @@ export class MenuPortalConfig implements SubscriptionLike {
         this._simulation.helper.action(
             CLICK_ACTION_NAME,
             [this._configBot],
-            onClickArg(null, dimension, null, 'mouse', null, null)
+            onClickArg(null, dimension, null, 'mouse', null, null, null)
         );
     }
 

--- a/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerBotClickOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerBotClickOperation.ts
@@ -31,6 +31,7 @@ import {
     InputModality,
     getModalityHand,
     getModalityFinger,
+    getModalityButtonId,
 } from '../../../shared/scene/Input';
 import { MapSimulation3D } from '../../scene/MapSimulation3D';
 import { Block } from 'three-mesh-ui';
@@ -72,6 +73,7 @@ export class PlayerBotClickOperation extends BaseBotClickOperation {
         const uv = !!this._hit?.uv
             ? `${VECTOR_TAG_PREFIX}${this._hit.uv.x},${this._hit.uv.y}`
             : null;
+
         this.simulation.helper.action(
             CLICK_ACTION_NAME,
             [this._bot],
@@ -81,7 +83,8 @@ export class PlayerBotClickOperation extends BaseBotClickOperation {
                 uv,
                 this._inputModality.type,
                 getModalityHand(this._inputModality),
-                getModalityFinger(this._inputModality)
+                getModalityFinger(this._inputModality),
+                getModalityButtonId(this._inputModality)
             )
         );
 
@@ -95,7 +98,8 @@ export class PlayerBotClickOperation extends BaseBotClickOperation {
                 uv,
                 this._inputModality.type,
                 getModalityHand(this._inputModality),
-                getModalityFinger(this._inputModality)
+                getModalityFinger(this._inputModality),
+                getModalityButtonId(this._inputModality)
             )
         );
 

--- a/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerEmptyClickOperation.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/ClickOperation/PlayerEmptyClickOperation.ts
@@ -1,4 +1,12 @@
-import { Input, InputMethod } from '../../../shared/scene/Input';
+import {
+    getModalityButtonId,
+    getModalityFinger,
+    getModalityHand,
+    getModalityKey,
+    Input,
+    InputMethod,
+    InputModality,
+} from '../../../shared/scene/Input';
 import { Ray } from '@casual-simulation/three';
 import { appManager } from '../../../shared/AppManager';
 import { PlayerInteractionManager } from '../PlayerInteractionManager';
@@ -13,6 +21,7 @@ import {
     ON_GRID_CLICK_ACTION_NAME,
     ON_GRID_DOWN_ACTION_NAME,
     ON_GRID_UP_ACTION_NAME,
+    onGridClickArg,
 } from '@casual-simulation/aux-common';
 import { objectForwardRay } from '../../../shared/scene/SceneUtils';
 import { Simulation } from '@casual-simulation/aux-vm';
@@ -32,9 +41,10 @@ export class PlayerEmptyClickOperation extends BaseEmptyClickOperation {
     constructor(
         game: PlayerGame,
         interaction: PlayerInteractionManager,
-        inputMethod: InputMethod
+        inputMethod: InputMethod,
+        inputModality: InputModality
     ) {
-        super(game, interaction, inputMethod);
+        super(game, interaction, inputMethod, inputModality);
         this._game = game;
         this._interaction = interaction;
     }
@@ -97,10 +107,17 @@ export class PlayerEmptyClickOperation extends BaseEmptyClickOperation {
                 };
             }
 
-            sendAction(sim.simulation, {
-                dimension: inputDimension,
-                position: position,
-            });
+            sendAction(
+                sim.simulation,
+                onGridClickArg(
+                    position,
+                    inputDimension,
+                    getModalityKey(this._inputModality),
+                    getModalityHand(this._inputModality),
+                    getModalityFinger(this._inputModality),
+                    getModalityButtonId(this._inputModality)
+                )
+            );
         };
 
         // If we're in VR, then send the empty click to the PlayerPageSimulation

--- a/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
+++ b/src/aux-server/aux-web/aux-player/interaction/PlayerInteractionManager.ts
@@ -60,6 +60,8 @@ import {
     InputModality,
     getModalityHand,
     getModalityFinger,
+    getModalityButtonId,
+    getModalityKey,
 } from '../../shared/scene/Input';
 import { appManager } from '../../shared/AppManager';
 import { Simulation } from '@casual-simulation/aux-vm';
@@ -305,7 +307,8 @@ export class PlayerInteractionManager extends BaseInteractionManager {
             dimension,
             modality.type,
             getModalityHand(modality),
-            getModalityFinger(modality)
+            getModalityFinger(modality),
+            getModalityButtonId(modality)
         );
         const actions = simulation.helper.actions([
             {
@@ -334,7 +337,8 @@ export class PlayerInteractionManager extends BaseInteractionManager {
             dimension,
             modality.type,
             getModalityHand(modality),
-            getModalityFinger(modality)
+            getModalityFinger(modality),
+            getModalityButtonId(modality)
         );
         const actions = simulation.helper.actions([
             {
@@ -389,7 +393,11 @@ export class PlayerInteractionManager extends BaseInteractionManager {
         if (modality.type !== 'finger') {
             let arg = onPointerUpDownArg(
                 bot,
-                [...bot3D.dimensionGroup.dimensions.values()][0]
+                [...bot3D.dimensionGroup.dimensions.values()][0],
+                getModalityKey(modality),
+                getModalityHand(modality),
+                getModalityFinger(modality),
+                getModalityButtonId(modality)
             );
             simulation.helper.transaction(
                 ...simulation.helper.actions([
@@ -425,7 +433,11 @@ export class PlayerInteractionManager extends BaseInteractionManager {
         if (modality.type !== 'finger') {
             let arg = onPointerUpDownArg(
                 bot,
-                [...bot3D.dimensionGroup.dimensions.values()][0]
+                [...bot3D.dimensionGroup.dimensions.values()][0],
+                getModalityKey(modality),
+                getModalityHand(modality),
+                getModalityFinger(modality),
+                getModalityButtonId(modality)
             );
             simulation.helper.transaction(
                 ...simulation.helper.actions([
@@ -476,8 +488,16 @@ export class PlayerInteractionManager extends BaseInteractionManager {
         simulation.helper.transaction(...actions);
     }
 
-    createEmptyClickOperation(inputMethod: InputMethod): IOperation {
-        return new PlayerEmptyClickOperation(this._game, this, inputMethod);
+    createEmptyClickOperation(
+        inputMethod: InputMethod,
+        inputModality: InputModality
+    ): IOperation {
+        return new PlayerEmptyClickOperation(
+            this._game,
+            this,
+            inputMethod,
+            inputModality
+        );
     }
 
     createHtmlElementClickOperation(element: HTMLElement): IOperation {

--- a/src/aux-server/aux-web/shared/MonacoHelpers.ts
+++ b/src/aux-server/aux-web/shared/MonacoHelpers.ts
@@ -366,7 +366,15 @@ export function watchSimulation(
             };
             simulation.helper.transaction(
                 action(CLICK_ACTION_NAME, [botId], simulation.helper.userId, {
-                    ...onClickArg(null, dimension, null, null, null, null),
+                    ...onClickArg(
+                        null,
+                        dimension,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
                     ...extraArgs,
                 }),
                 action(ANY_CLICK_ACTION_NAME, null, simulation.helper.userId, {
@@ -374,6 +382,7 @@ export function watchSimulation(
                         null,
                         dimension,
                         bot,
+                        null,
                         null,
                         null,
                         null,
@@ -639,6 +648,7 @@ function registerEditorActionsForSimulation(simulation: Simulation) {
                                         null,
                                         null,
                                         null,
+                                        null,
                                         null
                                     )
                                 ),
@@ -650,6 +660,7 @@ function registerEditorActionsForSimulation(simulation: Simulation) {
                                         null,
                                         EDITOR_CODE_BUTTON_DIMENSION,
                                         bot,
+                                        null,
                                         null,
                                         null,
                                         null,
@@ -980,6 +991,7 @@ export function watchEditor(
                                         null,
                                         null,
                                         null,
+                                        null,
                                         null
                                     ),
                                     ...extraArgs,
@@ -994,6 +1006,7 @@ export function watchEditor(
                                         null,
                                         dimension,
                                         bot,
+                                        null,
                                         null,
                                         null,
                                         null,

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseClickOperation.ts
@@ -3,6 +3,7 @@ import {
     ControllerData,
     InputMethod,
     InputModality,
+    MouseOrTouchInputMethod,
 } from '../../../shared/scene/Input';
 import {
     Vector2,
@@ -142,7 +143,9 @@ export abstract class BaseClickOperation implements IOperation {
                       )
                     : DragThresholdPassed(
                           this._startScreenPos,
-                          this.game.getInput().getMouseScreenPos()
+                          this.game.getInput().getMouseScreenPos(),
+                          (this._inputMethod as MouseOrTouchInputMethod)
+                              .buttonId ?? 0
                       );
 
                 if (dragThresholdPassed) {

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/BaseEmptyClickOperation.ts
@@ -2,6 +2,8 @@ import {
     Input,
     InputMethod,
     ControllerData,
+    InputModality,
+    MouseOrTouchInputMethod,
 } from '../../../shared/scene/Input';
 import { Vector2, Object3D } from '@casual-simulation/three';
 import { IOperation } from '../../../shared/interaction/IOperation';
@@ -29,6 +31,8 @@ export abstract class BaseEmptyClickOperation implements IOperation {
 
     protected _startScreenPos: Vector2;
     protected _startVRControllerPose: Object3D;
+    protected _inputModality: InputModality;
+    protected _inputMethod: InputMethod;
 
     get simulation() {
         return appManager.simulationManager.primary;
@@ -37,12 +41,15 @@ export abstract class BaseEmptyClickOperation implements IOperation {
     constructor(
         game: Game,
         interaction: BaseInteractionManager,
-        inputMethod: InputMethod
+        inputMethod: InputMethod,
+        inputModality: InputModality
     ) {
         this._game = game;
         this._interaction = interaction;
         this._controller =
             inputMethod.type === 'controller' ? inputMethod.controller : null;
+        this._inputMethod = inputMethod;
+        this._inputModality = inputModality;
 
         if (this._controller) {
             // Store the pose of the vr controller when the click occured.
@@ -66,7 +73,9 @@ export abstract class BaseEmptyClickOperation implements IOperation {
         const input = this._game.getInput();
         const buttonHeld: boolean = this._controller
             ? input.getControllerPrimaryButtonHeld(this._controller)
-            : input.getMouseButtonHeld(0);
+            : input.getMouseButtonHeld(
+                  (this._inputMethod as MouseOrTouchInputMethod).buttonId ?? 0
+              );
 
         if (!buttonHeld) {
             let dragThresholdPassed: boolean = this._controller
@@ -76,7 +85,9 @@ export abstract class BaseEmptyClickOperation implements IOperation {
                   )
                 : DragThresholdPassed(
                       this._startScreenPos,
-                      this._game.getInput().getMouseScreenPos()
+                      this._game.getInput().getMouseScreenPos(),
+                      (this._inputMethod as MouseOrTouchInputMethod).buttonId ??
+                          0
                   );
 
             if (!dragThresholdPassed) {

--- a/src/aux-server/aux-web/shared/interaction/ClickOperation/ClickOperationUtils.ts
+++ b/src/aux-server/aux-web/shared/interaction/ClickOperation/ClickOperationUtils.ts
@@ -1,6 +1,8 @@
 import { Vector2, Object3D, Sphere } from '@casual-simulation/three';
+import { MouseButtonId } from '../../scene/Input';
 
 export const DragThreshold: number = 0.03;
+export const MiddleDragThreshold: number = 0.001;
 export const VRDragAngleThreshold: number = 0.06;
 export const VRDragPosThreshold: number = 0.03;
 
@@ -10,10 +12,15 @@ export const MaxFingerClickTimeMs = 3000;
 
 export function DragThresholdPassed(
     startScreenPos: Vector2,
-    curScreenPos: Vector2
+    curScreenPos: Vector2,
+    buttonId: number
 ): boolean {
     const distance = curScreenPos.distanceTo(startScreenPos);
-    return distance >= DragThreshold;
+    if (buttonId === MouseButtonId.Middle) {
+        return distance >= MiddleDragThreshold;
+    } else {
+        return distance >= DragThreshold;
+    }
 }
 
 export function VRDragThresholdPassed(

--- a/src/aux-server/aux-web/shared/scene/Input.ts
+++ b/src/aux-server/aux-web/shared/scene/Input.ts
@@ -2752,6 +2752,11 @@ export interface ControllerInputMethod {
 export interface MouseOrTouchInputMethod {
     type: 'mouse_or_touch';
     identifier: string;
+    /**
+     * The ID of the mouse button that is being used.
+     * If null, then the button ID is not known.
+     */
+    buttonId: number;
 }
 
 export type InputModality =
@@ -2762,6 +2767,12 @@ export type InputModality =
 
 export interface MouseInputModality {
     type: 'mouse';
+
+    /**
+     * The ID of the button.
+     * Null if the button ID is not known or a button is not pressed.
+     */
+    buttonId: 'left' | 'right' | 'middle';
 }
 
 export interface TouchInputModality {
@@ -2780,13 +2791,38 @@ export interface FingerInputModality {
     pose: Sphere;
 }
 
+export function modalityForInputMethod(
+    method: InputMethod,
+    currentInputType: InputType
+): InputModality {
+    if (method.type === 'mouse_or_touch') {
+        if (currentInputType === InputType.Mouse) {
+            return {
+                type: 'mouse',
+                buttonId: formatModalityButtonId(method.buttonId),
+            };
+        } else {
+            return {
+                type: 'touch',
+            };
+        }
+    } else if (method.type === 'controller') {
+        return {
+            type: 'controller',
+            hand: method.controller.inputSource.handedness,
+        };
+    }
+
+    return null;
+}
+
 /**
  * Gets the identifier for the given input modality.
  * @param modality
  */
 export function getModalityKey(modality: InputModality): string {
     if (modality.type === 'mouse') {
-        return 'mouse';
+        return `mouse`;
     } else if (modality.type === 'controller') {
         return 'controller';
     } else if (modality.type === 'finger') {
@@ -2841,6 +2877,29 @@ export function getModalityFinger(modality: InputModality): string {
         return modality.finger;
     } else {
         return null;
+    }
+}
+
+export function getModalityButtonId(modality: InputModality) {
+    if (modality.type === 'mouse') {
+        return modality.buttonId;
+    } else {
+        return null;
+    }
+}
+
+export function formatModalityButtonId(
+    buttonId: number
+): MouseInputModality['buttonId'] {
+    switch (buttonId) {
+        case MouseButtonId.Left:
+            return 'left';
+        case MouseButtonId.Middle:
+            return 'middle';
+        case MouseButtonId.Right:
+            return 'right';
+        default:
+            return null;
     }
 }
 

--- a/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
+++ b/src/aux-server/aux-web/shared/vue-components/BotSheet/BotSheet.ts
@@ -316,6 +316,7 @@ export default class BotSheet extends Vue {
                             null,
                             'mouse',
                             null,
+                            null,
                             null
                         )
                     );

--- a/src/aux-server/aux-web/shared/vue-components/CodeToolsPortal/CodeToolsPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/CodeToolsPortal/CodeToolsPortal.ts
@@ -77,7 +77,15 @@ export default class CodeToolsPortal extends Vue {
                         CLICK_ACTION_NAME,
                         [bot.id],
                         sim.helper.userId,
-                        onClickArg(null, tool.dimension, null, null, null, null)
+                        onClickArg(
+                            null,
+                            tool.dimension,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        )
                     ),
                     action(
                         ANY_CLICK_ACTION_NAME,
@@ -87,6 +95,7 @@ export default class CodeToolsPortal extends Vue {
                             null,
                             tool.dimension,
                             bot,
+                            null,
                             null,
                             null,
                             null,

--- a/src/aux-server/aux-web/shared/vue-components/IdePortal/IdePortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/IdePortal/IdePortal.ts
@@ -319,7 +319,7 @@ export default class IdePortal extends Vue {
             const result = await this._simulation.helper.shout(
                 CLICK_ACTION_NAME,
                 [this._currentConfig.configBot],
-                onClickArg(null, null, null, 'mouse', null, null)
+                onClickArg(null, null, null, 'mouse', null, null, null)
             );
 
             if (result.results.length <= 0) {

--- a/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/SystemPortal/SystemPortal.ts
@@ -1381,7 +1381,7 @@ export default class SystemPortal extends Vue {
                 const result = await sim.helper.shout(
                     CLICK_ACTION_NAME,
                     [this._currentConfig.configBot],
-                    onClickArg(null, null, null, 'mouse', null, null)
+                    onClickArg(null, null, null, 'mouse', null, null, null)
                 );
                 if (result.results.length <= 0) {
                     this._exitPortal(sim);

--- a/src/aux-server/aux-web/shared/vue-components/TagPortal/TagPortalConfig.ts
+++ b/src/aux-server/aux-web/shared/vue-components/TagPortal/TagPortalConfig.ts
@@ -96,7 +96,7 @@ export class TagPortalConfig implements SubscriptionLike {
         this._simulation.helper.action(
             CLICK_ACTION_NAME,
             [this._configBot],
-            onClickArg(null, dimension, null, 'mouse', null, null)
+            onClickArg(null, dimension, null, 'mouse', null, null, null)
         );
     }
 


### PR DESCRIPTION
### :rocket: Features
-   Improved `@onClick`, `@onAnyBotClicked`, `@onGridClick`, `@onPointerEnter`, `@onPointerExit`, `@onPointerDown`, `@onPointerUp`, `@onAnyBotPointerEnter`, `@onAnyBotPointerExit`, `@onAnyBotPointerDown`, and `@onAnyBotPointerUp` to include the ID of the button that was pressed.
    -   For each of these listeners, `that.buttonId` will be either `"left"`, `"right"`, `"middle"`, or `null`.
    -   This means that you can now determine which button was pressed (if any) and respond accordingly.

Closes #492 