### PR TITLE
Add metrics for HTTP and WebSocket events

### DIFF
--- a/docker/conf/otel-collector.yaml
+++ b/docker/conf/otel-collector.yaml
@@ -10,8 +10,15 @@ exporters:
         endpoint: tempo:4317
         tls:
             insecure: true
+    prometheus:
+        endpoint: 0.0.0.0:4319
+        namespace: casualos
+
 service:
     pipelines:
         traces:
             receivers: [otlp]
             exporters: [otlp]
+        metrics:
+            receivers: [otlp]
+            exporters: [prometheus]

--- a/docker/conf/prometheus.yaml
+++ b/docker/conf/prometheus.yaml
@@ -6,6 +6,9 @@ scrape_configs:
     - job_name: 'prometheus'
       static_configs:
           - targets: ['localhost:9090']
+    - job_name: 'otel'
+      static_configs:
+          - targets: ['otel-collector:4319']
     - job_name: 'tempo'
       static_configs:
           - targets: ['tempo:3200']

--- a/docker/conf/prometheus.yaml
+++ b/docker/conf/prometheus.yaml
@@ -3,9 +3,6 @@ global:
     evaluation_interval: 15s
 
 scrape_configs:
-    - job_name: 'prometheus'
-      static_configs:
-          - targets: ['localhost:9090']
     - job_name: 'otel'
       static_configs:
           - targets: ['otel-collector:4319']

--- a/docker/docker-compose.dev-otel.yml
+++ b/docker/docker-compose.dev-otel.yml
@@ -49,6 +49,7 @@ services:
         ports:
             - '4317:4317' # otlp grpc
             - '4318:4318' # otlp http
+            - '4319:4319' # prometheus metrics
 
     # Tempo runs as user 10001, and docker compose creates the volume as root.
     # As such, we need to chown the volume in order for Tempo to start correctly.

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -21,7 +21,6 @@ import { randomBytes } from 'tweetnacl';
 import {
     hashHighEntropyPasswordWithSalt,
     hashPasswordWithSalt,
-    verifyPassword,
     verifyPasswordAgainstHashes,
 } from '@casual-simulation/crypto';
 import { fromByteArray } from 'base64-js';
@@ -256,7 +255,7 @@ export class AuthController {
 
                 // sessionSecret and sessionId are high-entropy (128 bits of random data)
                 // so we should use a hash that is optimized for high-entropy inputs.
-                secretHash: hashHighEntropyPasswordWithSalt(
+                secretHash: this.hashHighEntropyPasswordWithSalt(
                     sessionSecret,
                     sessionId
                 ),
@@ -304,6 +303,14 @@ export class AuthController {
                 errorMessage: 'A server error occurred.',
             };
         }
+    }
+
+    @traced(TRACE_NAME)
+    hashHighEntropyPasswordWithSalt(
+        sessionSecret: string,
+        sessionId: string
+    ): string {
+        return hashHighEntropyPasswordWithSalt(sessionSecret, sessionId);
     }
 
     @traced(TRACE_NAME)
@@ -426,7 +433,7 @@ export class AuthController {
             );
             const code = randomCode();
 
-            const hash = hashPasswordWithSalt(code, requestId);
+            const hash = this.hashPasswordWithSalt(code, requestId);
 
             const loginRequest: AuthLoginRequest = {
                 userId: user.id,
@@ -606,7 +613,7 @@ export class AuthController {
             let validCode = false;
             try {
                 if (
-                    verifyPasswordAgainstHashes(
+                    this.verifyPasswordAgainstHashes(
                         request.code,
                         loginRequest.requestId,
                         [loginRequest.secretHash]
@@ -668,7 +675,7 @@ export class AuthController {
                 requestId: loginRequest.requestId,
                 // sessionSecret and sessionId are high-entropy (128 bits of random data)
                 // so we should use a hash that is optimized for high-entropy inputs.
-                secretHash: hashHighEntropyPasswordWithSalt(
+                secretHash: this.hashHighEntropyPasswordWithSalt(
                     sessionSecret,
                     sessionId
                 ),
@@ -1070,7 +1077,7 @@ export class AuthController {
 
                 // sessionSecret and sessionId are high-entropy (128 bits of random data)
                 // so we should use a hash that is optimized for high-entropy inputs.
-                secretHash: hashHighEntropyPasswordWithSalt(
+                secretHash: this.hashHighEntropyPasswordWithSalt(
                     sessionSecret,
                     sessionId
                 ),
@@ -1303,7 +1310,7 @@ export class AuthController {
                 userId: userId,
                 sessionId: newSessionId,
                 requestId: null,
-                secretHash: hashPasswordWithSalt(
+                secretHash: this.hashPasswordWithSalt(
                     newSessionSecret,
                     newSessionId
                 ),
@@ -1350,6 +1357,14 @@ export class AuthController {
                 errorMessage: 'A server error occurred.',
             };
         }
+    }
+
+    @traced(TRACE_NAME)
+    hashPasswordWithSalt(
+        newSessionSecret: string,
+        newSessionId: string
+    ): string {
+        return hashPasswordWithSalt(newSessionSecret, newSessionId);
     }
 
     @traced(TRACE_NAME)
@@ -1759,7 +1774,7 @@ export class AuthController {
 
                 // sessionSecret and sessionId are high-entropy (128 bits of random data)
                 // so we should use a hash that is optimized for high-entropy inputs.
-                secretHash: hashHighEntropyPasswordWithSalt(
+                secretHash: this.hashHighEntropyPasswordWithSalt(
                     sessionSecret,
                     sessionId
                 ),
@@ -1946,9 +1961,11 @@ export class AuthController {
             }
 
             if (
-                !verifyPasswordAgainstHashes(sessionSecret, session.sessionId, [
-                    session.secretHash,
-                ])
+                !this.verifyPasswordAgainstHashes(
+                    sessionSecret,
+                    session.sessionId,
+                    [session.secretHash]
+                )
             ) {
                 console.log(
                     '[AuthController] [validateSessionKey] Session secret was invalid.'
@@ -2052,6 +2069,15 @@ export class AuthController {
                 errorMessage: 'A server error occurred.',
             };
         }
+    }
+
+    @traced(TRACE_NAME)
+    verifyPasswordAgainstHashes(
+        sessionSecret: string,
+        sessionId: string,
+        hashes: string[]
+    ) {
+        return verifyPasswordAgainstHashes(sessionSecret, sessionId, hashes);
     }
 
     @traced(TRACE_NAME)
@@ -2453,7 +2479,7 @@ export class AuthController {
                 userId: userId,
                 sessionId: newSessionId,
                 requestId: null,
-                secretHash: hashPasswordWithSalt(
+                secretHash: this.hashPasswordWithSalt(
                     newSessionSecret,
                     newSessionId
                 ),

--- a/src/aux-records/RecordsController.spec.ts
+++ b/src/aux-records/RecordsController.spec.ts
@@ -16,7 +16,6 @@ import {
 } from './RecordsController';
 import {
     hashHighEntropyPasswordWithSalt,
-    hashPassword,
     hashPasswordWithSalt,
 } from '@casual-simulation/crypto';
 import { randomBytes } from 'tweetnacl';

--- a/src/aux-records/RecordsController.ts
+++ b/src/aux-records/RecordsController.ts
@@ -14,10 +14,8 @@ import {
     fromBase64String,
 } from '@casual-simulation/aux-common';
 import {
-    createRandomPassword,
     hashHighEntropyPasswordWithSalt,
     hashPasswordWithSalt,
-    verifyPasswordAgainstHashes,
 } from '@casual-simulation/crypto';
 import { randomBytes } from 'tweetnacl';
 import { fromByteArray } from 'base64-js';
@@ -431,7 +429,7 @@ export class RecordsController {
             const passwordBytes = randomBytes(16);
             const password = fromByteArray(passwordBytes); // convert to human-readable string
             const salt = record.secretSalt;
-            const passwordHash = hashHighEntropyPasswordWithSalt(
+            const passwordHash = this.hashHighEntropyPasswordWithSalt(
                 password,
                 salt
             );
@@ -464,6 +462,14 @@ export class RecordsController {
                 errorReason: 'server_error',
             };
         }
+    }
+
+    @traced(TRACE_NAME)
+    hashHighEntropyPasswordWithSalt(
+        sessionSecret: string,
+        sessionId: string
+    ): string {
+        return hashHighEntropyPasswordWithSalt(sessionSecret, sessionId);
     }
 
     /**
@@ -532,7 +538,7 @@ export class RecordsController {
                     }
                 } else {
                     // Check v1 hashes
-                    const hash = hashPasswordWithSalt(
+                    const hash = this.hashPasswordWithSalt(
                         password,
                         record.secretSalt
                     );
@@ -604,6 +610,11 @@ export class RecordsController {
                 errorMessage: 'A server error occurred.',
             };
         }
+    }
+
+    @traced(TRACE_NAME)
+    hashPasswordWithSalt(password: string, secretSalt: string) {
+        return hashPasswordWithSalt(password, secretSalt);
     }
 
     /**

--- a/src/aux-records/Utils.ts
+++ b/src/aux-records/Utils.ts
@@ -1,5 +1,4 @@
-import { fromByteArray, toByteArray } from 'base64-js';
-import _, { omitBy, padStart, sortBy, StringChain } from 'lodash';
+import _, { omitBy, padStart, sortBy } from 'lodash';
 import { sha256, hmac } from 'hash.js';
 import { PUBLIC_READ_MARKER } from '@casual-simulation/aux-common';
 import axios from 'axios';

--- a/src/aux-records/tracing/TracingDecorators.ts
+++ b/src/aux-records/tracing/TracingDecorators.ts
@@ -126,7 +126,7 @@ export function traced(
             const histogram = getHistogram(metricOptions.histogram);
             const counter = getCounter(metricOptions.counter);
             const errorCounter = getCounter(metricOptions.errorCounter);
-            const startTime = Date.now();
+            const startTime = histogram ? Date.now() : null;
             const _this = this;
             return tracer.startActiveSpan(propertyKey, options, (span) => {
                 try {
@@ -135,14 +135,16 @@ export function traced(
                         return ret.then(
                             (result) => {
                                 span.end();
-                                const endTime = Date.now();
-                                histogram?.record(
-                                    endTime - startTime,
-                                    metricOptions.histogram?.attributes?.(
-                                        args,
-                                        result
-                                    )
-                                );
+                                if (histogram) {
+                                    const endTime = Date.now();
+                                    histogram.record(
+                                        endTime - startTime,
+                                        metricOptions.histogram?.attributes?.(
+                                            args,
+                                            result
+                                        )
+                                    );
+                                }
 
                                 counter?.add(
                                     1,

--- a/src/aux-server/aux-backend/shared/Instrumentation.ts
+++ b/src/aux-server/aux-backend/shared/Instrumentation.ts
@@ -104,19 +104,6 @@ export function setupInstrumentation(options: ServerConfig) {
         console.log(`[Instrumentation] Skipping Prisma instrumentation.`);
     }
 
-    const histogramView = new View({
-        aggregation: new ExplicitBucketHistogramAggregation([
-            0, 1, 5, 10, 15, 20, 25, 30,
-        ]),
-        instrumentName: 'duration',
-        instrumentType: InstrumentType.HISTOGRAM,
-    });
-
-    const counterView = new View({
-        instrumentName: 'http*',
-        instrumentType: InstrumentType.COUNTER,
-    });
-
     const resource = new Resource({
         [SEMRESATTRS_SERVICE_NAME]: 'casualos',
         [SEMRESATTRS_SERVICE_VERSION]: GIT_TAG || 'dev',
@@ -128,7 +115,6 @@ export function setupInstrumentation(options: ServerConfig) {
         traceExporter: traceExporter,
         metricReader: metrics,
         instrumentations: instrumentation,
-        views: [histogramView, counterView],
     });
 
     sdk.start();

--- a/src/aux-server/aux-backend/shared/Instrumentation.ts
+++ b/src/aux-server/aux-backend/shared/Instrumentation.ts
@@ -3,8 +3,13 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { Resource } from '@opentelemetry/resources';
 import {
+    Aggregation,
     ConsoleMetricExporter,
+    ExplicitBucketHistogramAggregation,
+    InstrumentType,
+    MeterProvider,
     PeriodicExportingMetricReader,
+    View,
 } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
@@ -13,9 +18,7 @@ import {
     SEMRESATTRS_SERVICE_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import { PrismaInstrumentation } from '@prisma/instrumentation';
-import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis-4';
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-import { ServerConfig } from '@casual-simulation/aux-records';
+import type { ServerConfig } from '@casual-simulation/aux-records';
 
 /**
  * Configures instrumentation for a server.
@@ -101,15 +104,31 @@ export function setupInstrumentation(options: ServerConfig) {
         console.log(`[Instrumentation] Skipping Prisma instrumentation.`);
     }
 
+    const histogramView = new View({
+        aggregation: new ExplicitBucketHistogramAggregation([
+            0, 1, 5, 10, 15, 20, 25, 30,
+        ]),
+        instrumentName: 'duration',
+        instrumentType: InstrumentType.HISTOGRAM,
+    });
+
+    const counterView = new View({
+        instrumentName: 'http*',
+        instrumentType: InstrumentType.COUNTER,
+    });
+
+    const resource = new Resource({
+        [SEMRESATTRS_SERVICE_NAME]: 'casualos',
+        [SEMRESATTRS_SERVICE_VERSION]: GIT_TAG || 'dev',
+        ...options.telemetry.resource,
+    });
+
     const sdk = new NodeSDK({
-        resource: new Resource({
-            [SEMRESATTRS_SERVICE_NAME]: 'casualos',
-            [SEMRESATTRS_SERVICE_VERSION]: GIT_TAG || 'dev',
-            ...options.telemetry.resource,
-        }),
+        resource,
         traceExporter: traceExporter,
         metricReader: metrics,
         instrumentations: instrumentation,
+        views: [histogramView, counterView],
     });
 
     sdk.start();


### PR DESCRIPTION
### :rocket: Features

-   Improved the server to record metrics for how long HTTP and Websocket requests take to complete and also the status they have when finishing.