### PR TITLE
Add the `#meshPositioningMode` tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 -   Improved `SERVER_CONFIG` to allow customizing the OpenTelemetry resource.
 -   Tags in the "recent tags" list in the `systemPortal` will now always show bot system.
+-   Added the `meshPositioningMode` tag to prevent CasualOS from repositioning meshes around the center of the bot.
+    -   There are two possible values:
+        -   `center` - The mesh will be positioned so it is centered around the bot's center. (Default)
+        -   `absolute` - The mesh won't be repositioned. It will retain the position configured in the GLTF.
 
 ## V3.3.7
 

--- a/docs/docs/tags/visualization.mdx
+++ b/docs/docs/tags/visualization.mdx
@@ -776,6 +776,21 @@ For GLTF forms, this should be the URL of the GLTF file that contains the animat
   </PossibleValue>
 </PossibleValuesTable>
 
+### `meshPositioningMode`
+
+The positioning mode that should be used for GLTF meshes.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='center'>
+    The mesh is positioned so it is centered around the bot's center. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='absolute'>
+    The mesh is not repositioned.
+  </PossibleValueCode>
+</PossibleValuesTable>
+
 ### `formOpacity`
 
 The opacity of the bot's form. Allows bots to be semi-transparent.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -976,12 +976,12 @@ export type BotSubShape =
 export type BotDragMode = 'all' | 'none' | 'moveOnly' | 'pickupOnly';
 
 /**
- * Defines the possible positioning modes that a bot can have.
+ * Defines the possible positioning modes that a bot's mesh can have.
  *
- * "stack" means the bot is able to stack with other bots.
- * "absolute" means the bot will ignore other bots.
+ * "center" means the mesh will be repositioned to be placed in the center of the bot. (default)
+ * "absolute" means the mesh will be placed in its original position.
  */
-export type BotPositioningMode = 'stack' | 'absolute';
+export type BotMeshPositioningMode = 'center' | 'absolute';
 
 /**
  * Defines the possible scaling modes that a bot's mesh can have.
@@ -1190,6 +1190,11 @@ export const DEFAULT_LABEL_ALIGNMENT: BotLabelAlignment = 'center';
  * The default bot scale mode.
  */
 export const DEFAULT_SCALE_MODE: BotScaleMode = 'fit';
+
+/**
+ * The default bot mesh positioning mode.
+ */
+export const DEFAULT_MESH_POSITIONING_MODE: BotMeshPositioningMode = 'center';
 
 /**
  * The default bot orientation mode.
@@ -2723,6 +2728,7 @@ export const KNOWN_TAGS: string[] = [
     'formLightGroundColor',
     'formBuildStep',
     'formLDrawPartsAddress',
+    'meshPositioningMode',
     'orientationMode',
     'anchorPoint',
     'gltfVersion',

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -20,7 +20,6 @@ import {
     BotsState,
     DEFAULT_USER_INACTIVE_TIME,
     DEFAULT_USER_DELETION_TIME,
-    BotPositioningMode,
     BotSpace,
     BOT_SPACE_TAG,
     PortalType,
@@ -70,6 +69,8 @@ import {
     SYSTEM_PORTAL_DIFF,
     SHEET_PORTAL,
     MenuBotSubtype,
+    BotMeshPositioningMode,
+    DEFAULT_MESH_POSITIONING_MODE,
 } from './Bot';
 import TWEEN, { Easing as TweenEasing } from '@tweenjs/tween.js';
 
@@ -2010,7 +2011,7 @@ function isIrrational(val: number): boolean {
 }
 
 /**
- * Gets the text alignment for the bot's label.
+ * Gets the scale mode for the bot.
  * @param calc The calculation context.
  * @param bot The bot.
  */
@@ -2023,6 +2024,26 @@ export function getBotScaleMode(
         return anchor;
     }
     return DEFAULT_SCALE_MODE;
+}
+
+/**
+ * Gets the mesh positioning mode for the bot.
+ * @param calc The calculation context.
+ * @param bot The bot.
+ */
+export function getBotMeshPositioningMode(
+    calc: BotCalculationContext,
+    bot: Bot
+): BotMeshPositioningMode {
+    const anchor: BotMeshPositioningMode = calculateBotValue(
+        calc,
+        bot,
+        'auxMeshPositioningMode'
+    );
+    if (anchor === 'center' || anchor === 'absolute') {
+        return anchor;
+    }
+    return DEFAULT_MESH_POSITIONING_MODE;
 }
 
 /**

--- a/src/aux-common/bots/test/BotCalculationContextTests.ts
+++ b/src/aux-common/bots/test/BotCalculationContextTests.ts
@@ -78,6 +78,7 @@ import {
     getOpenSystemPortalPane,
     getBotTheme,
     getMenuBotSubtype,
+    getBotMeshPositioningMode,
 } from '../BotCalculations';
 import {
     Bot,
@@ -3032,6 +3033,39 @@ export function botCalculationContextTests(
 
                     const calc = createPrecalculatedContext([bot]);
                     const a = getBotScaleMode(calc, bot);
+
+                    expect(a).toBe(expected);
+                }
+            );
+        });
+    });
+
+    describe('getBotMeshPositioningMode()', () => {
+        it('should default to center', () => {
+            const bot = createBot('bot');
+
+            const calc = createPrecalculatedContext([bot]);
+            const anchor = getBotMeshPositioningMode(calc, bot);
+
+            expect(anchor).toBe('center');
+        });
+
+        const cases = [
+            ['center', 'center'],
+            ['absolute', 'absolute'],
+            ['abc', 'center'],
+        ];
+        const tagCases = ['auxMeshPositioningMode', 'meshPositioningMode'];
+        describe.each(tagCases)('%s', (tag: string) => {
+            it.each(cases)(
+                'given %s it should return %s',
+                (anchor, expected) => {
+                    const bot = createBot('bot', {
+                        [tag]: anchor,
+                    });
+
+                    const calc = createPrecalculatedContext([bot]);
+                    const a = getBotMeshPositioningMode(calc, bot);
 
                     expect(a).toBe(expected);
                 }

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -1,5 +1,6 @@
 import {
     BotCalculationContext,
+    BotPositioningMode,
     BotScaleMode,
     BotShape,
     BotSubShape,
@@ -10,6 +11,7 @@ import {
     calculateBotValue,
     calculateNumericalTagValue,
     calculateStringTagValue,
+    getBotMeshPositioningMode,
     getBotScaleMode,
     getBotShape,
     getBotSubShape,
@@ -124,6 +126,7 @@ export class BotShapeDecorator
     private _ldrawPartsAddress: string = null;
     private _animation: any = null;
     private _scaleMode: BotScaleMode = null;
+    private _positioningMode: BotPositioningMode;
     private _canHaveStroke = false;
     // private _animationMode: 'tag' | 'action' = 'tag';
     private _animationMixer: AnimationMixer;
@@ -189,6 +192,7 @@ export class BotShapeDecorator
         const shape = getBotShape(calc, this.bot3D.bot);
         const subShape = getBotSubShape(calc, this.bot3D.bot);
         const scaleMode = getBotScaleMode(calc, this.bot3D.bot);
+        const positioningMode = getBotMeshPositioningMode(calc, this.bot3D.bot);
         const address = calculateBotValue(
             calc,
             this.bot3D.bot,
@@ -228,6 +232,7 @@ export class BotShapeDecorator
                 shape,
                 subShape,
                 scaleMode,
+                positioningMode,
                 address,
                 aspectRatio,
                 animationAddress,
@@ -239,6 +244,7 @@ export class BotShapeDecorator
                 shape,
                 subShape,
                 scaleMode,
+                positioningMode,
                 address,
                 aspectRatio,
                 animationAddress,
@@ -299,6 +305,7 @@ export class BotShapeDecorator
         shape: string,
         subShape: string,
         scaleMode: string,
+        positioningMode: string,
         address: string,
         aspectRatio: number,
         animationAddress: string,
@@ -309,6 +316,7 @@ export class BotShapeDecorator
             this._shape !== shape ||
             this._subShape !== subShape ||
             this._scaleMode !== scaleMode ||
+            this._positioningMode !== positioningMode ||
             this._addressAspectRatio !== aspectRatio ||
             (shape === 'mesh' &&
                 (this._address !== address ||
@@ -908,6 +916,7 @@ export class BotShapeDecorator
         shape: BotShape,
         subShape: BotSubShape,
         scaleMode: BotScaleMode,
+        positioningMode: BotPositioningMode,
         address: string,
         addressAspectRatio: number,
         animationAddress: string,
@@ -917,6 +926,7 @@ export class BotShapeDecorator
         this._shape = shape;
         this._subShape = subShape;
         this._scaleMode = scaleMode;
+        this._positioningMode = positioningMode;
         this._address = address;
         this._addressAspectRatio = addressAspectRatio;
         this._animationAddress = animationAddress;
@@ -1126,10 +1136,12 @@ export class BotShapeDecorator
             gltf.scene.scale.divideScalar(maxScale);
         }
 
-        let bottomCenter = new Vector3(-center.x, -center.y, -center.z);
+        if (this._positioningMode !== 'absolute') {
+            let bottomCenter = new Vector3(-center.x, -center.y, -center.z);
+            // Scene
+            gltf.scene.position.copy(bottomCenter);
+        }
 
-        // Scene
-        gltf.scene.position.copy(bottomCenter);
         this.scene = gltf.scene;
         this.container.add(gltf.scene);
 

--- a/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
+++ b/src/aux-server/aux-web/shared/scene/decorators/BotShapeDecorator.ts
@@ -1,6 +1,6 @@
 import {
     BotCalculationContext,
-    BotPositioningMode,
+    BotMeshPositioningMode,
     BotScaleMode,
     BotShape,
     BotSubShape,
@@ -126,7 +126,7 @@ export class BotShapeDecorator
     private _ldrawPartsAddress: string = null;
     private _animation: any = null;
     private _scaleMode: BotScaleMode = null;
-    private _positioningMode: BotPositioningMode;
+    private _positioningMode: BotMeshPositioningMode;
     private _canHaveStroke = false;
     // private _animationMode: 'tag' | 'action' = 'tag';
     private _animationMixer: AnimationMixer;
@@ -916,7 +916,7 @@ export class BotShapeDecorator
         shape: BotShape,
         subShape: BotSubShape,
         scaleMode: BotScaleMode,
-        positioningMode: BotPositioningMode,
+        positioningMode: BotMeshPositioningMode,
         address: string,
         addressAspectRatio: number,
         animationAddress: string,


### PR DESCRIPTION
### :rocket: Features

-   Added the `meshPositioningMode` tag to prevent CasualOS from repositioning meshes around the center of the bot.
    -   There are two possible values:
        -   `center` - The mesh will be positioned so it is centered around the bot's center. (Default)
        -   `absolute` - The mesh won't be repositioned. It will retain the position configured in the GLTF.

Closes #321 