### PR TITLE
Fix line distance rendering when no arrow head is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### :bug: Bug Fixes
 
 -   Fixed an issue where an older version of session key hashes would be used when refreshing a session, leading to slowdowns when validating session keys.
+-   Fixed an issue where lines wouldn't draw to the center of the target bot when the bot was smaller than the arrow head length.
 
 ## V3.3.7
 

--- a/src/aux-server/aux-web/shared/scene/Arrow3D.ts
+++ b/src/aux-server/aux-web/shared/scene/Arrow3D.ts
@@ -9,6 +9,7 @@ import { AuxBot3D } from './AuxBot3D';
 import { DimensionGroup3D } from './DimensionGroup3D';
 import { BuilderGroup3D } from './BuilderGroup3D';
 import { disposeMaterial, buildSRGBColor } from './SceneUtils';
+import { DebugObjectManager } from './debugobjectmanager/DebugObjectManager';
 
 export class Arrow3D extends Object3D {
     public static DefaultColor: Color = buildSRGBColor(1, 1, 1);
@@ -97,6 +98,11 @@ export class Arrow3D extends Object3D {
             headWidth = undefined;
         }
 
+        if (!this._hasArrowTip) {
+            headLength = 0;
+            headWidth = 0;
+        }
+
         this._arrowHelper.setLength(length, headLength, headWidth);
     }
 
@@ -151,7 +157,7 @@ export class Arrow3D extends Object3D {
 
             if (!this._hasArrowTip) {
                 this._arrowHelper.cone.visible = false;
-                dir.setLength(dir.length() + 0.2);
+                dir.setLength(dir.length());
             } else {
                 this._arrowHelper.cone.visible = true;
                 // Decrease length of direction vector so that it only goes


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where lines wouldn't draw to the center of the target bot when the bot was smaller than the arrow head length.

Fixes #460 