### PR TITLE
Refactor locking system to dedicated abstraction MemoryLockStore

### DIFF
--- a/src/aux-records/websockets/MemoryLockStore.ts
+++ b/src/aux-records/websockets/MemoryLockStore.ts
@@ -1,0 +1,25 @@
+/**
+ * Represents a memory lock store
+ * * This is used to store and enforce locks in memory
+ */
+export interface MemoryLockStore {
+    /**
+     * The locks that are currently being held.
+     * * The key is the id of the lock and the value is the time at which the lock will be released
+     * ! Implementation advice (private _locks map)
+     * private _locks: Map<string, number> = new Map();
+     */
+
+    /**
+     * Acquire a lock for/with the given id
+     * @param id The id to acquire the lock for
+     * @param timeout The amount of time to wait before the lock is released
+     * @returns
+     * If successful, returns a function that will release the lock when called.
+     * If unsuccessful, returns null.
+     */
+    acquireLock(
+        id: string,
+        timeout: number
+    ): Promise<() => Promise<boolean> | null>;
+}

--- a/src/aux-records/websockets/MemoryTempInstRecordsStore.ts
+++ b/src/aux-records/websockets/MemoryTempInstRecordsStore.ts
@@ -18,7 +18,7 @@ export class MemoryTempInstRecordsStore implements TemporaryInstRecordsStore {
     private _currentGeneration: string = '0';
     private _locks: Map<string, number> = new Map();
 
-    async aquireLock(
+    async acquireLock(
         id: string,
         timeout: number
     ): Promise<() => Promise<boolean>> {

--- a/src/aux-records/websockets/TemporaryInstRecordsStore.ts
+++ b/src/aux-records/websockets/TemporaryInstRecordsStore.ts
@@ -3,6 +3,7 @@ import {
     BranchRecordWithInst,
     CurrentUpdates,
 } from './InstRecordsStore';
+import { MemoryLockStore } from './MemoryLockStore';
 
 /**
  * Defines an interface for a store that keeps track of temporary inst records.
@@ -10,7 +11,7 @@ import {
  * A key feature of temporary records stores is that they act like a cache.
  * As a result, it may evict data based on configuration or other factors (like memory pressure).
  */
-export interface TemporaryInstRecordsStore {
+export interface TemporaryInstRecordsStore extends MemoryLockStore {
     /**
      * Gets info for the given branch.
      * @param branchKey The key for the branch.
@@ -210,18 +211,6 @@ export interface TemporaryInstRecordsStore {
      * Gets the current generation that dirty branches should be recorded in.
      */
     getDirtyBranchGeneration(): Promise<string>;
-
-    /**
-     * Aquires a lock with the given ID.
-     * If successful, returns a function that will release the lock when called.
-     * If unsuccessful, returns null.
-     * @param id The id of the lock.
-     * @param timeout The timeout for the lock in miliseconds. If the lock isn't released in this time, it will be automatically released.
-     */
-    aquireLock(
-        id: string,
-        timeout: number
-    ): Promise<(() => Promise<boolean>) | null>;
 
     /**
      * Marks the given branch as dirty in the current generation.

--- a/src/aux-records/websockets/WebsocketController.spec.ts
+++ b/src/aux-records/websockets/WebsocketController.spec.ts
@@ -8994,7 +8994,7 @@ describe('WebsocketController', () => {
                 ).toEqual([]);
             });
 
-            it('should aquire a lock before trying to save branch data', async () => {
+            it('should acquire a lock before trying to save branch data', async () => {
                 const generation =
                     await instStore.temp.getDirtyBranchGeneration();
                 const beforeSaveUpdates = await instStore.getCurrentUpdates(
@@ -9010,7 +9010,7 @@ describe('WebsocketController', () => {
                         update1Base64.length + update2Base64.length,
                 });
 
-                const lock = await instStore.temp.aquireLock(
+                const lock = await instStore.temp.acquireLock(
                     SAVE_PERMANENT_BRANCHES_LOCK,
                     100_000
                 );

--- a/src/aux-records/websockets/WebsocketController.ts
+++ b/src/aux-records/websockets/WebsocketController.ts
@@ -2094,7 +2094,7 @@ export class WebsocketController {
     async savePermanentBranches(timeout: number = 30_000): Promise<void> {
         const store = this._instStore;
         if (store instanceof SplitInstRecordsStore) {
-            const unlock = await store.temp.aquireLock(
+            const unlock = await store.temp.acquireLock(
                 SAVE_PERMANENT_BRANCHES_LOCK,
                 timeout
             );
@@ -2106,7 +2106,7 @@ export class WebsocketController {
                 return;
             }
             console.log(
-                '[WebsocketController] [savePermanentBranches] Lock aquired.'
+                '[WebsocketController] [savePermanentBranches] Lock acquired.'
             );
 
             try {

--- a/src/aux-server/aux-backend/redis/RedisLock.ts
+++ b/src/aux-server/aux-backend/redis/RedisLock.ts
@@ -11,18 +11,18 @@ const releaseLock = defineScript({
 });
 
 /**
- * Attempts to aquire a lock on the given key.
+ * Attempts to acquire a lock on the given key.
  * Returns a function that will release the lock when called.
- * If the lock could not be aquired, returns null.
+ * If the lock could not be acquired, returns null.
  *
  * Follows the simple implementation pattern described here:
  * https://redis.io/docs/latest/develop/use/patterns/distributed-locks/#correct-implementation-with-a-single-instance
  *
  * @param redis The redis client.
- * @param key The key that should be aquired.
+ * @param key The key that should be acquired.
  * @param timeout The timeout for the lock in miliseconds. If the lock isn't released in this time, it will be automatically released.
  */
-export async function tryAquireLock(
+export async function tryAcquireLock(
     redis: RedisClientType,
     key: string,
     timeout: number

--- a/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
+++ b/src/aux-server/aux-backend/redis/RedisTempInstRecordsStore.ts
@@ -11,7 +11,7 @@ import {
     SEMRESATTRS_SERVICE_NAME,
 } from '@opentelemetry/semantic-conventions';
 import { RedisClientType } from 'redis';
-import { tryAquireLock } from './RedisLock';
+import { tryAcquireLock } from './RedisLock';
 
 const TRACE_NAME = 'RedisTempInstRecordsStore';
 const SPAN_OPTIONS: SpanOptions = {
@@ -56,8 +56,8 @@ export class RedisTempInstRecordsStore implements TemporaryInstRecordsStore {
         this._onlyExpireRecordlessUpdates = onlyExpireRecordlessUpdates;
     }
 
-    aquireLock(id: string, timeout: number): Promise<() => Promise<boolean>> {
-        return tryAquireLock(this._redis, id, timeout);
+    acquireLock(id: string, timeout: number): Promise<() => Promise<boolean>> {
+        return tryAcquireLock(this._redis, id, timeout);
     }
 
     @traced(TRACE_NAME, SPAN_OPTIONS)

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -639,7 +639,7 @@ export default class PlayerApp extends Vue {
         return this.barcodeFormat || '';
     }
 
-    onQRStreamAquired(stream: MediaStream) {
+    onQRStreamAcquired(stream: MediaStream) {
         this._currentQRMediaStream = stream;
     }
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.vue
@@ -80,7 +80,7 @@
                         @decode="onQRCodeScanned"
                         :camera="camera"
                         :cameraId="selectedCameraId"
-                        @streamAquired="onQRStreamAquired"
+                        @streamAcquired="onQRStreamAcquired"
                     ></qrcode-stream>
                 </div>
                 <md-dialog-actions>

--- a/src/aux-server/aux-web/shared/public/vue-qrcode-reader/src/components/QrcodeStream.ts
+++ b/src/aux-server/aux-web/shared/public/vue-qrcode-reader/src/components/QrcodeStream.ts
@@ -159,7 +159,7 @@ export default {
           this.cameraInstance.stop();
         }
 
-        this.$emit('streamAquired', this.cameraInstance.stream);
+        this.$emit('streamAcquired', this.cameraInstance.stream);
       }
     },
 


### PR DESCRIPTION
Refactored the implementation of acquireLock from within another store, to its own dedicated abstraction. Updated the implementing entities to match the new abstraction. Also fixed a typo in various locations aquire -> acquire.