### PR TITLE
Remove content of curly brackets (functions) before checking if a script tag should be considered async

### DIFF
--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -534,6 +534,51 @@ export function isScript(value: unknown): value is string {
 }
 
 /**
+ * Returns a string with all content inside of curly brackets removed.
+ * @param value The string.
+ */
+function extractTopLevelCode(value: string): string {
+    let topLevelCode = '';
+    let bracketStack = [];
+    let skip = false;
+
+    for (let i = 0; i < value.length; i++) {
+        const char = value[i];
+        if (char === '{') {
+            if (bracketStack.length === 0) {
+                skip = true;
+                topLevelCode += '{';
+            }
+            bracketStack.push('{');
+        } else if (char === '}') {
+            if (bracketStack.length > 0) {
+                bracketStack.pop();
+                if (bracketStack.length === 0) {
+                    skip = false;
+                    topLevelCode += '}';
+                }
+            }
+        } else if (!skip) {
+            topLevelCode += char;
+        }
+    }
+
+    return topLevelCode;
+}
+
+/**
+ * Determines if the given value represents an async script.
+ * @param value The value.
+ */
+export function isAsyncScript(value: unknown): value is string {
+    if (!isScript(value)) {
+        return false;
+    }
+    const topLevelCode = extractTopLevelCode(value);
+    return topLevelCode.indexOf('await ') >= 0;
+}
+
+/**
  * Determines if the given value represents a script.
  * @param value The value.
  */

--- a/src/aux-common/bots/BotCalculations.ts
+++ b/src/aux-common/bots/BotCalculations.ts
@@ -534,51 +534,6 @@ export function isScript(value: unknown): value is string {
 }
 
 /**
- * Returns a string with all content inside of curly brackets removed.
- * @param value The string.
- */
-function extractTopLevelCode(value: string): string {
-    let topLevelCode = '';
-    let bracketStack = [];
-    let skip = false;
-
-    for (let i = 0; i < value.length; i++) {
-        const char = value[i];
-        if (char === '{') {
-            if (bracketStack.length === 0) {
-                skip = true;
-                topLevelCode += '{';
-            }
-            bracketStack.push('{');
-        } else if (char === '}') {
-            if (bracketStack.length > 0) {
-                bracketStack.pop();
-                if (bracketStack.length === 0) {
-                    skip = false;
-                    topLevelCode += '}';
-                }
-            }
-        } else if (!skip) {
-            topLevelCode += char;
-        }
-    }
-
-    return topLevelCode;
-}
-
-/**
- * Determines if the given value represents an async script.
- * @param value The value.
- */
-export function isAsyncScript(value: unknown): value is string {
-    if (!isScript(value)) {
-        return false;
-    }
-    const topLevelCode = extractTopLevelCode(value);
-    return topLevelCode.indexOf('await ') >= 0;
-}
-
-/**
  * Determines if the given value represents a script.
  * @param value The value.
  */

--- a/src/aux-runtime/runtime/AuxCompiler.ts
+++ b/src/aux-runtime/runtime/AuxCompiler.ts
@@ -14,7 +14,6 @@ import {
     ExportFunc,
     isModule,
     parseModule,
-    isAsyncScript,
 } from '@casual-simulation/aux-common/bots';
 import { flatMap } from 'lodash';
 import ErrorStackParser from '@casual-simulation/error-stack-parser';
@@ -848,7 +847,7 @@ export class AuxCompiler {
         if (transpiled.metadata.isModule) {
             // All modules are async
             async = true;
-        } else if (isAsyncScript(script)) {
+        } else if (transpiled.metadata.isAsync) {
             async = true;
         }
         if (options.forceSync) {

--- a/src/aux-runtime/runtime/AuxCompiler.ts
+++ b/src/aux-runtime/runtime/AuxCompiler.ts
@@ -14,6 +14,7 @@ import {
     ExportFunc,
     isModule,
     parseModule,
+    isAsyncScript,
 } from '@casual-simulation/aux-common/bots';
 import { flatMap } from 'lodash';
 import ErrorStackParser from '@casual-simulation/error-stack-parser';
@@ -847,7 +848,7 @@ export class AuxCompiler {
         if (transpiled.metadata.isModule) {
             // All modules are async
             async = true;
-        } else if (script.indexOf('await ') >= 0) {
+        } else if (isAsyncScript(script)) {
             async = true;
         }
         if (options.forceSync) {

--- a/src/aux-runtime/runtime/Transpiler.spec.ts
+++ b/src/aux-runtime/runtime/Transpiler.spec.ts
@@ -657,6 +657,52 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(`await test();`);
             });
+
+            it('should identify code with a top-level await expression as async', () => {
+                const result =
+                    transpiler.transpileWithMetadata(`await test();`);
+
+                expect(result.metadata.isAsync).toBe(true);
+            });
+
+            it('should identify code with await inside brackets as async', () => {
+                const result = transpiler.transpileWithMetadata(`{
+                    await test();
+                }`);
+
+                expect(result.metadata.isAsync).toBe(true);
+            });
+
+            it('should identify variables that await their definitions as async', () => {
+                const result = transpiler.transpileWithMetadata(
+                    `let abc = await test();`
+                );
+
+                expect(result.metadata.isAsync).toBe(true);
+            });
+
+            it('should identify await statements in function arguments as async', () => {
+                const result =
+                    transpiler.transpileWithMetadata(`abc( await test() );`);
+
+                expect(result.metadata.isAsync).toBe(true);
+            });
+
+            it('should identify code with await inside a function as synchronous', () => {
+                const result = transpiler.transpileWithMetadata(
+                    'async function abc() { await test(); }'
+                );
+
+                expect(result.metadata.isAsync).toBe(false);
+            });
+
+            it('should identify code with await inside a lambda function as synchronous', () => {
+                const result = transpiler.transpileWithMetadata(
+                    'const abc = async () => await test();'
+                );
+
+                expect(result.metadata.isAsync).toBe(false);
+            });
         });
 
         describe('force sync', () => {

--- a/src/aux-runtime/runtime/Transpiler.ts
+++ b/src/aux-runtime/runtime/Transpiler.ts
@@ -302,6 +302,21 @@ export class Transpiler {
     }
 
     /**
+     * Determines if the given node contains any await expressions.
+     * @param node The node.
+     */
+    private _isAsyncNode(node: any): boolean {
+        for (const child of node.body) {
+            if (child.type === 'ExpressionStatement') {
+                if (child.expression.type === 'AwaitExpression') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Transpiles the given code into ES6 JavaScript Code.
      */
     private _transpile(code: string): TranspilerResult {
@@ -311,6 +326,7 @@ export class Transpiler {
         }
         const macroed = replaceMacros(code);
         const node = this._parse(macroed);
+        const isAsync = this._isAsyncNode(node);
 
         // we create a YJS document to track
         // text changes. This lets us use a separate client ID for each change
@@ -326,6 +342,7 @@ export class Transpiler {
         let metadata: TranspilerResult['metadata'] = {
             doc,
             text,
+            isAsync,
             isModule: false,
         };
 
@@ -2138,6 +2155,11 @@ export interface TranspilerResult {
          * Whether the code is a module (contains import or export statements).
          */
         isModule: boolean;
+
+        /**
+         * Whether the code is async (contains await expressions).
+         */
+        isAsync: boolean;
     };
 }
 

--- a/src/aux-runtime/runtime/Transpiler.ts
+++ b/src/aux-runtime/runtime/Transpiler.ts
@@ -359,8 +359,6 @@ export class Transpiler {
         const macroed = replaceMacros(code);
         const node = this._parse(macroed);
         const isAsync = this._isAsyncNode(node);
-        console.log('macroed:', macroed);
-        console.log('isAsync', isAsync);
 
         // we create a YJS document to track
         // text changes. This lets us use a separate client ID for each change


### PR DESCRIPTION
Fixes #569. AuxCompiler will now ignore nested content when checking if a script tag should be treated as asynchronous.