### PR TITLE
Fix/joining room using os.join room() fails if casual os does not have permission to camera or mic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CasualOS Changelog
 
+## V3.3.15
+
+#### Date TBD
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+-   Fixed an issue in `LivekitManager` where media permissions for the camera and microphone were not requested before joining a room. Resulting in silent fails for Google Chrome users. The `joinRoom` method now includes a preliminary step to check and request these permissions, ensuring a smoother user experience.
+
 ## V3.3.14
 
 #### Date: 12/3/2024

--- a/src/aux-vm-browser/managers/LivekitManager.ts
+++ b/src/aux-vm-browser/managers/LivekitManager.ts
@@ -98,9 +98,24 @@ export class LivekitManager implements SubscriptionLike {
         this._addressToTrack = null;
         this._trackToAddress = null;
     }
+    private async _requestMediaPermissions(): Promise<void> {
+        // Request audio and video permission (required)
+        try {
+            await navigator.mediaDevices.getUserMedia({
+                video: true,
+                audio: true,
+            });
+            console.log('[LivekitManager] Media permissions granted.');
+        } catch (error) {
+            console.error('[LivekitManager] Media permissions denied:', error);
+            throw new Error('Media permissions are required to join the room.');
+        }
+    }
 
     async joinRoom(join: RoomJoin): Promise<void> {
         try {
+            await this._requestMediaPermissions();
+
             this._livekit = await import('livekit-client');
             const room = new this._livekit.Room({
                 adaptiveStream: false,


### PR DESCRIPTION
fixes #568 