### PR TITLE
Add the ability to use livekit tracks in custom apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### :rocket: Features
 
+-   Added the ability to use CasualOS URLs in `<video>` HTML custom app elements.
+    -   This makes it possible to use LiveKit tracks in a custom app.
+    -   Tip: Utilize the `autoplay` attribute to automatically play video from a track.
+
 ### :bug: Bug Fixes
 
 -   Fixed an issue in `LivekitManager` where media permissions for the camera and microphone were not requested before joining a room. Resulting in silent fails for Google Chrome users. The `joinRoom` method now includes a preliminary step to check and request these permissions, ensuring a smoother user experience.

--- a/src/aux-server/aux-web/shared/MediaUtils.ts
+++ b/src/aux-server/aux-web/shared/MediaUtils.ts
@@ -1,0 +1,48 @@
+import { hasValue } from '@casual-simulation/aux-common';
+import { appManager } from './AppManager';
+import { ParsedCasualOSUrl } from './UrlUtils';
+
+/**
+ * Gets the media for the given CasualOS URL.
+ * Returns null if the media could not be found.
+ * @param url The URL that should be used to get the media.
+ */
+export async function getMediaForCasualOSUrl(
+    url: ParsedCasualOSUrl | null
+): Promise<MediaProvider> {
+    if (url && url.type === 'camera-feed') {
+        try {
+            const media = await window.navigator.mediaDevices.getUserMedia({
+                audio: false,
+                video: {
+                    // Use the user specified one if specified.
+                    // Otherwise default to environment.
+                    facingMode: hasValue(url.camera)
+                        ? {
+                              exact:
+                                  url.camera === 'front'
+                                      ? 'user'
+                                      : 'environment',
+                          }
+                        : { ideal: 'environment' },
+                },
+            });
+
+            return media;
+        } catch (err) {
+            console.warn(
+                '[Game] Unable to get camera feed for background.',
+                err
+            );
+            return;
+        }
+    } else if (url && url.type === 'video-element') {
+        for (let sim of appManager.simulationManager.simulations.values()) {
+            let stream = sim.livekit.getMediaByAddress(url.address);
+            if (stream) {
+                return stream;
+            }
+        }
+    }
+    return null;
+}

--- a/src/aux-server/aux-web/shared/UrlUtils.spec.ts
+++ b/src/aux-server/aux-web/shared/UrlUtils.spec.ts
@@ -1,0 +1,90 @@
+import { parseCasualOSUrl } from './UrlUtils';
+
+describe('parseCasualOSUrl()', () => {
+    it('should return an object describing the CasualOS URL', () => {
+        expect(parseCasualOSUrl('casualos://camera-feed')).toEqual({
+            type: 'camera-feed',
+        });
+
+        expect(parseCasualOSUrl('casualos://camera-feed/front')).toEqual({
+            type: 'camera-feed',
+            camera: 'front',
+        });
+
+        expect(parseCasualOSUrl('casualos://camera-feed/rear')).toEqual({
+            type: 'camera-feed',
+            camera: 'rear',
+        });
+
+        expect(parseCasualOSUrl('casualos://camera-feed/other')).toEqual({
+            type: 'camera-feed',
+        });
+
+        expect(
+            parseCasualOSUrl('casualos://video-element/uuid-123-abc')
+        ).toEqual({
+            type: 'video-element',
+            address: 'casualos://video-element/uuid-123-abc',
+        });
+    });
+
+    // See https://bugs.chromium.org/p/chromium/issues/detail?id=869291
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
+    it('should support Chrome and Firefox URL results', () => {
+        // How Chrome/Firefox parse casualos://camera-feed
+        expect(
+            parseCasualOSUrl({
+                protocol: 'casualos:',
+                hostname: '',
+                host: '',
+                pathname: '//camera-feed',
+            })
+        ).toEqual({
+            type: 'camera-feed',
+        });
+
+        // How Chrome/Firefox parse casualos://camera-feed/front
+        expect(
+            parseCasualOSUrl({
+                protocol: 'casualos:',
+                hostname: '',
+                host: '',
+                pathname: '//camera-feed/front',
+            })
+        ).toEqual({
+            type: 'camera-feed',
+            camera: 'front',
+        });
+
+        // How Chrome/Firefox parse casualos://camera-feed/rear
+        expect(
+            parseCasualOSUrl({
+                protocol: 'casualos:',
+                hostname: '',
+                host: '',
+                pathname: '//camera-feed/rear',
+            })
+        ).toEqual({
+            type: 'camera-feed',
+            camera: 'rear',
+        });
+
+        // How Chrome/Firefox parse casualos://video-element/uuid-123-abc
+        expect(
+            parseCasualOSUrl({
+                protocol: 'casualos:',
+                hostname: '',
+                host: '',
+                pathname: '//video-element/uuid-123-abc',
+                href: 'casualos://video-element/uuid-123-abc',
+            })
+        ).toEqual({
+            type: 'video-element',
+            address: 'casualos://video-element/uuid-123-abc',
+        });
+    });
+
+    it('should return null if given a non CasualOS URL', () => {
+        expect(parseCasualOSUrl('http://example.com')).toBe(null);
+    });
+});

--- a/src/aux-server/aux-web/shared/UrlUtils.ts
+++ b/src/aux-server/aux-web/shared/UrlUtils.ts
@@ -1,0 +1,90 @@
+import { CameraType } from '@casual-simulation/aux-common';
+
+export type ParsedCasualOSUrl = CasualOSCameraFeedUrl | CasualOSVideoElementUrl;
+
+export interface CasualOSCameraFeedUrl {
+    type: 'camera-feed';
+    camera?: CameraType;
+}
+
+export interface CasualOSVideoElementUrl {
+    type: 'video-element';
+    address: string;
+}
+
+/**
+ * Parses special CasualOS URLs into an object that indicates what it should be used for.
+ * Currently only supports "casualos://camera-feed/{rear|front}".
+ * Returns null if the URL has no special CasualOS meaning.
+ * @param url The URL that should be parsed.
+ * @returns
+ */
+export function parseCasualOSUrl(
+    url: string | Partial<URL>
+): ParsedCasualOSUrl {
+    try {
+        const uri = typeof url === 'object' ? url : new URL(url);
+        if (uri.protocol !== 'casualos:') {
+            return null;
+        }
+
+        if (uri.hostname === 'camera-feed') {
+            let camera: CameraType;
+            if (uri.pathname === '/front') {
+                camera = 'front';
+            } else if (uri.pathname === '/rear') {
+                camera = 'rear';
+            }
+
+            let result: ParsedCasualOSUrl = {
+                type: 'camera-feed',
+            };
+
+            if (camera) {
+                result.camera = camera;
+            }
+
+            return result;
+        } else if (uri.hostname === 'video-element') {
+            let result: ParsedCasualOSUrl = {
+                type: 'video-element',
+                address: uri.href,
+            };
+
+            return result;
+        } else if (uri.hostname === '') {
+            // Chrome/Firefox
+            // See https://bugs.chromium.org/p/chromium/issues/detail?id=869291 and https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
+            if (uri.pathname.startsWith('//camera-feed')) {
+                let path = uri.pathname.slice('//camera-feed'.length);
+                let camera: CameraType;
+                if (path === '/front') {
+                    camera = 'front';
+                } else if (path === '/rear') {
+                    camera = 'rear';
+                }
+
+                let result: ParsedCasualOSUrl = {
+                    type: 'camera-feed',
+                };
+
+                if (camera) {
+                    result.camera = camera;
+                }
+
+                return result;
+            } else if (uri.pathname.startsWith('//video-element')) {
+                let result: ParsedCasualOSUrl = {
+                    type: 'video-element',
+                    address: uri.href,
+                };
+
+                return result;
+            }
+        }
+
+        return null;
+    } catch {
+        return null;
+    }
+}

--- a/src/aux-server/aux-web/shared/scene/AuxTextureLoader.ts
+++ b/src/aux-server/aux-web/shared/scene/AuxTextureLoader.ts
@@ -6,8 +6,9 @@ import {
     Loader,
     VideoTexture,
 } from '@casual-simulation/three';
-import { parseCasualOSUrl, addCorsQueryParam } from './SceneUtils';
+import { addCorsQueryParam } from './SceneUtils';
 import { appManager } from '../AppManager';
+import { parseCasualOSUrl } from '../UrlUtils';
 
 // TODO: Put a max size on the cache.
 const cache = new Map<string, Promise<Texture>>();

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.spec.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.spec.ts
@@ -5,7 +5,6 @@ import {
 import {
     calculateScale,
     createCube,
-    parseCasualOSUrl,
     percentOfScreen,
     calculateHitFace,
     calculateCubeSphereIntersection,
@@ -155,95 +154,6 @@ describe('SceneUtils', () => {
                     }
                 );
             });
-        });
-    });
-
-    describe('parseCasualOSUrl()', () => {
-        it('should return an object describing the CasualOS URL', () => {
-            expect(parseCasualOSUrl('casualos://camera-feed')).toEqual({
-                type: 'camera-feed',
-            });
-
-            expect(parseCasualOSUrl('casualos://camera-feed/front')).toEqual({
-                type: 'camera-feed',
-                camera: 'front',
-            });
-
-            expect(parseCasualOSUrl('casualos://camera-feed/rear')).toEqual({
-                type: 'camera-feed',
-                camera: 'rear',
-            });
-
-            expect(parseCasualOSUrl('casualos://camera-feed/other')).toEqual({
-                type: 'camera-feed',
-            });
-
-            expect(
-                parseCasualOSUrl('casualos://video-element/uuid-123-abc')
-            ).toEqual({
-                type: 'video-element',
-                address: 'casualos://video-element/uuid-123-abc',
-            });
-        });
-
-        // See https://bugs.chromium.org/p/chromium/issues/detail?id=869291
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
-        it('should support Chrome and Firefox URL results', () => {
-            // How Chrome/Firefox parse casualos://camera-feed
-            expect(
-                parseCasualOSUrl({
-                    protocol: 'casualos:',
-                    hostname: '',
-                    host: '',
-                    pathname: '//camera-feed',
-                })
-            ).toEqual({
-                type: 'camera-feed',
-            });
-
-            // How Chrome/Firefox parse casualos://camera-feed/front
-            expect(
-                parseCasualOSUrl({
-                    protocol: 'casualos:',
-                    hostname: '',
-                    host: '',
-                    pathname: '//camera-feed/front',
-                })
-            ).toEqual({
-                type: 'camera-feed',
-                camera: 'front',
-            });
-
-            // How Chrome/Firefox parse casualos://camera-feed/rear
-            expect(
-                parseCasualOSUrl({
-                    protocol: 'casualos:',
-                    hostname: '',
-                    host: '',
-                    pathname: '//camera-feed/rear',
-                })
-            ).toEqual({
-                type: 'camera-feed',
-                camera: 'rear',
-            });
-
-            // How Chrome/Firefox parse casualos://video-element/uuid-123-abc
-            expect(
-                parseCasualOSUrl({
-                    protocol: 'casualos:',
-                    hostname: '',
-                    host: '',
-                    pathname: '//video-element/uuid-123-abc',
-                    href: 'casualos://video-element/uuid-123-abc',
-                })
-            ).toEqual({
-                type: 'video-element',
-                address: 'casualos://video-element/uuid-123-abc',
-            });
-        });
-
-        it('should return null if given a non CasualOS URL', () => {
-            expect(parseCasualOSUrl('http://example.com')).toBe(null);
         });
     });
 

--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -1310,83 +1310,6 @@ export function getThreeJSQuaternionFromBotRotation(rotation: {
     }
 }
 
-/**
- * Parses special CasualOS URLs into an object that indicates what it should be used for.
- * Currently only supports "casualos://camera-feed/{rear|front}".
- * Returns null if the URL has no special CasualOS meaning.
- * @param url The URL that should be parsed.
- * @returns
- */
-export function parseCasualOSUrl(
-    url: string | Partial<URL>
-): ParsedCasualOSUrl {
-    try {
-        const uri = typeof url === 'object' ? url : new URL(url);
-        if (uri.protocol !== 'casualos:') {
-            return null;
-        }
-
-        if (uri.hostname === 'camera-feed') {
-            let camera: CameraType;
-            if (uri.pathname === '/front') {
-                camera = 'front';
-            } else if (uri.pathname === '/rear') {
-                camera = 'rear';
-            }
-
-            let result: ParsedCasualOSUrl = {
-                type: 'camera-feed',
-            };
-
-            if (camera) {
-                result.camera = camera;
-            }
-
-            return result;
-        } else if (uri.hostname === 'video-element') {
-            let result: ParsedCasualOSUrl = {
-                type: 'video-element',
-                address: uri.href,
-            };
-
-            return result;
-        } else if (uri.hostname === '') {
-            // Chrome/Firefox
-            // See https://bugs.chromium.org/p/chromium/issues/detail?id=869291 and https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
-            if (uri.pathname.startsWith('//camera-feed')) {
-                let path = uri.pathname.slice('//camera-feed'.length);
-                let camera: CameraType;
-                if (path === '/front') {
-                    camera = 'front';
-                } else if (path === '/rear') {
-                    camera = 'rear';
-                }
-
-                let result: ParsedCasualOSUrl = {
-                    type: 'camera-feed',
-                };
-
-                if (camera) {
-                    result.camera = camera;
-                }
-
-                return result;
-            } else if (uri.pathname.startsWith('//video-element')) {
-                let result: ParsedCasualOSUrl = {
-                    type: 'video-element',
-                    address: uri.href,
-                };
-
-                return result;
-            }
-        }
-
-        return null;
-    } catch {
-        return null;
-    }
-}
-
 export function addCorsQueryParam(url: string): string {
     let uri = new URL(url);
 
@@ -1406,18 +1329,6 @@ export function addCorsQueryParam(url: string): string {
     }
 
     return uri.href;
-}
-
-export type ParsedCasualOSUrl = CasualOSCameraFeedUrl | CasualOSVideoElementUrl;
-
-export interface CasualOSCameraFeedUrl {
-    type: 'camera-feed';
-    camera?: CameraType;
-}
-
-export interface CasualOSVideoElementUrl {
-    type: 'video-element';
-    address: string;
 }
 
 export type TweenCameraPosition = GridCameraPosition | WorldCameraPosition;


### PR DESCRIPTION
### :rocket: Features

-   Added the ability to use CasualOS URLs in `<video>` HTML custom app elements.
    -   This makes it possible to use LiveKit tracks in a custom app.
    -   Tip: Utilize the `autoplay` attribute to automatically play video from a track.

Closes #575 