### PR TITLE
Fixed typo in docs referencing 'os.enterVR'

### DIFF
--- a/docs/docs/tags/listen.mdx
+++ b/docs/docs/tags/listen.mdx
@@ -1628,7 +1628,7 @@ There are no arguments with this listener.
 ### `@onEnterVR`
 
 A shout that is sent whenever the device enters virtual reality mode.  
-You can exit VR by calling <ActionLink action='os.enterVR(options?)'/>.
+You can enter VR by calling <ActionLink action='os.enableVR(options?)'/>.
 
 There are no arguments with this listener.
 

--- a/docs/versioned_docs/version-3.1.36/listen-tags.mdx
+++ b/docs/versioned_docs/version-3.1.36/listen-tags.mdx
@@ -1294,7 +1294,7 @@ There are no arguments with this listener.
 ### `@onEnterVR`
 
 A shout that is sent whenever the device enters virtual reality mode.  
-You can exit VR by calling <ActionLink action='os.enterVR(options?)'/>.
+You can enter VR by calling <ActionLink action='os.enableVR(options?)'/>.
 
 There are no arguments with this listener.
 


### PR DESCRIPTION
Should have been `os.enableVR(options?)`