### PR TITLE
Add button to delete local insts

### DIFF
--- a/src/aux-common/common/WebConfig.ts
+++ b/src/aux-common/common/WebConfig.ts
@@ -29,7 +29,8 @@ export type BiosOption =
     | 'studio'
     | 'sign in'
     | 'sign up'
-    | 'sign out';
+    | 'sign out'
+    | 'delete inst';
 
 export const BIOS_OPTION_SCHEMA = z.enum([
     'enter join code',
@@ -46,6 +47,7 @@ export const BIOS_OPTION_SCHEMA = z.enum([
     'sign in',
     'sign up',
     'sign out',
+    'delete inst',
 ]);
 
 /**

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.ts
@@ -432,6 +432,15 @@ export default class PlayerHome extends Vue {
         return isJoinCode(option);
     }
 
+    private async _deleteInst(inst: string) {
+        if (window.confirm(`Are you sure you want to delete ${inst}?`)) {
+            await appManager.deleteStaticInst(inst);
+            this.instSelection = 'new-inst';
+            this.instOptions = await appManager.listStaticInsts();
+        }
+        this.showBios = true;
+    }
+
     async executeBiosOption(
         option: BiosOption,
         recordName: string,
@@ -463,6 +472,8 @@ export default class PlayerHome extends Vue {
             this._loadPublicInst();
         } else if (isJoinCode(option)) {
             this._loadJoinCode(joinCode);
+        } else if (option === 'delete inst') {
+            this._deleteInst(inst);
         } else {
             this.showBios = true;
         }

--- a/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
+++ b/src/aux-server/aux-web/aux-player/PlayerHome/PlayerHome.vue
@@ -104,6 +104,17 @@
                 <span class="spacer"></span>
 
                 <md-button
+                    v-if="
+                        instSelection !== 'new-inst' &&
+                        ['local inst', 'local', 'static inst'].includes(biosSelection)
+                    "
+                    @click="
+                        executeBiosOption('delete inst', recordSelection, instSelection, joinCode)
+                    "
+                    >delete</md-button
+                >
+
+                <md-button
                     @click="
                         executeBiosOption(biosSelection, recordSelection, instSelection, joinCode)
                     "

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -904,6 +904,16 @@ export class AppManager {
         return insts.map((i) => i.origin.inst);
     }
 
+    async deleteStaticInst(inst: string) {
+        if (!this._db) {
+            console.error(
+                '[AppManager] Could not connect db to delete inst',
+                inst
+            );
+        }
+        await deleteItem(this._db, STATIC_INSTS_STORE, inst);
+    }
+
     private async _getComIdConfig(): Promise<GetPlayerConfigSuccess> {
         try {
             const config = await this._auth.primary.getComIdWebConfig(


### PR DESCRIPTION
I added a simple button to the bios screen (when a local inst is selected) to let users delete local insts.

Uses `window.confirm(...)` to confirm the user's intent.
I'm sure I could update it to use CasualOS' show confirm modal, if you think that would be a better UX.

Resolves #413

![Screenshot 2024-12-15 at 2 29 25 PM](https://github.com/user-attachments/assets/3c75660f-2b13-450f-95cd-2bac303e0955)
