### PR TITLE
Support adding Privo users by email, display name, or user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
     -   Requires the `ENABLE_DOM` environment variable to be set to `true` either during build or when running the server.
     -   Additionally requires that the `VM_ORIGIN` environment variable is set to something other than where the CasualOS frontend is served from (should serve the same files, but be a different origin for security purposes).
 
+### :rocket: Features
+
+-   Improved studios to support adding Privo users by email, display name, or user ID.
+    -   Additionally improved studios to only show members by name and display name when Privo support is enabled.
+
 ### :bug: Bug Fixes
 
 -   Improved error handling for `ai.generateImage()` requests with unacceptable parameters.

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -136,31 +136,7 @@ describe('AuthController', () => {
     let messenger: MemoryAuthMessenger;
     let controller: AuthController;
     let privoClient: PrivoClientInterface;
-    let privoClientMock: {
-        createChildAccount: jest.Mock<
-            ReturnType<PrivoClientInterface['createChildAccount']>
-        >;
-        createAdultAccount: jest.Mock<
-            ReturnType<PrivoClientInterface['createAdultAccount']>
-        >;
-        getUserInfo: jest.Mock<ReturnType<PrivoClientInterface['getUserInfo']>>;
-        generateAuthorizationUrl: jest.Mock<
-            ReturnType<PrivoClientInterface['generateAuthorizationUrl']>
-        >;
-        processAuthorizationCallback: jest.Mock<
-            ReturnType<PrivoClientInterface['processAuthorizationCallback']>
-        >;
-        checkEmail: jest.Mock<ReturnType<PrivoClientInterface['checkEmail']>>;
-        checkDisplayName: jest.Mock<
-            ReturnType<PrivoClientInterface['checkDisplayName']>
-        >;
-        generateLogoutUrl: jest.Mock<
-            ReturnType<PrivoClientInterface['generateLogoutUrl']>
-        >;
-        resendConsentRequest: jest.Mock<
-            ReturnType<PrivoClientInterface['resendConsentRequest']>
-        >;
-    };
+    let privoClientMock: jest.MockedObject<PrivoClientInterface>;
     let nowMock: jest.Mock<number>;
     let relyingParty: RelyingParty;
 
@@ -209,6 +185,7 @@ describe('AuthController', () => {
             checkDisplayName: jest.fn(),
             generateLogoutUrl: jest.fn(),
             resendConsentRequest: jest.fn(),
+            lookupServiceId: jest.fn(),
         };
 
         relyingParty = {

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -762,6 +762,7 @@ export class MemoryStore
                     name: user.name,
                     email: user.email,
                     phoneNumber: user.phoneNumber,
+                    privoServiceId: user.privoServiceId,
                 },
             });
         }

--- a/src/aux-records/PolicyController.spec.ts
+++ b/src/aux-records/PolicyController.spec.ts
@@ -4456,6 +4456,7 @@ describe('PolicyController', () => {
                         checkDisplayName: jest.fn(),
                         generateLogoutUrl: jest.fn(),
                         resendConsentRequest: jest.fn(),
+                        lookupServiceId: jest.fn(),
                     };
                     auth = new AuthController(
                         store,
@@ -4470,6 +4471,7 @@ describe('PolicyController', () => {
                         messenger: store,
                         metrics: store,
                         store,
+                        privo: privoClient,
                     });
 
                     controller = new PolicyController(auth, records, store);

--- a/src/aux-records/RecordsController.ts
+++ b/src/aux-records/RecordsController.ts
@@ -50,6 +50,10 @@ import type { SystemNotificationMessenger } from './SystemNotificationMessenger'
 import { isSuperUserRole } from './AuthUtils';
 import { traced } from './tracing/TracingDecorators';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
+import type {
+    PrivoClientInterface,
+    PrivoGetUserInfoResponse,
+} from './PrivoClient';
 
 const TRACE_NAME = 'RecordsController';
 
@@ -59,6 +63,7 @@ export interface RecordsControllerConfig {
     metrics: MetricsStore;
     config: ConfigurationStore;
     messenger: SystemNotificationMessenger | null;
+    privo: PrivoClientInterface | null;
 }
 
 /**
@@ -70,6 +75,7 @@ export class RecordsController {
     private _metrics: MetricsStore;
     private _config: ConfigurationStore;
     private _messenger: SystemNotificationMessenger | null;
+    private _privo: PrivoClientInterface | null;
 
     constructor(config: RecordsControllerConfig) {
         this._store = config.store;
@@ -77,6 +83,7 @@ export class RecordsController {
         this._metrics = config.metrics;
         this._config = config.config;
         this._messenger = config.messenger;
+        this._privo = config.privo;
     }
 
     /**
@@ -1532,21 +1539,66 @@ export class RecordsController {
                     request.addedEmail ? 'email' : 'phone'
                 );
 
-                if (!addedUser) {
+                if (addedUser) {
+                    addedUserId = addedUser.id;
+                }
+            }
+
+            if (
+                !addedUserId &&
+                this._privo &&
+                (request.addedEmail ||
+                    request.addedPhoneNumber ||
+                    request.addedDisplayName)
+            ) {
+                const privoServiceId = await this._privo.lookupServiceId({
+                    displayName: request.addedDisplayName ?? undefined,
+                    email: request.addedEmail ?? undefined,
+                    phoneNumber: request.addedPhoneNumber ?? undefined,
+                });
+
+                if (privoServiceId) {
+                    const user = await this._auth.findUserByPrivoServiceId(
+                        privoServiceId
+                    );
+                    if (user) {
+                        addedUserId = user.id;
+                    }
+                }
+            }
+
+            if (!addedUserId) {
+                if (
+                    this._privo &&
+                    !request.addedEmail &&
+                    !request.addedPhoneNumber &&
+                    !request.addedUserId &&
+                    !request.addedDisplayName
+                ) {
                     return {
                         success: false,
-                        errorCode: 'user_not_found',
-                        errorMessage: 'The user was not able to be found.',
+                        errorCode: 'unacceptable_request',
+                        errorMessage:
+                            'You must provide a display name, email, phone number, or user ID to add a studio member.',
+                    };
+                } else if (
+                    !this._privo &&
+                    !request.addedEmail &&
+                    !request.addedPhoneNumber &&
+                    !request.addedUserId
+                ) {
+                    return {
+                        success: false,
+                        errorCode: 'unacceptable_request',
+                        errorMessage:
+                            'You must provide an email, phone number, or user ID to add a studio member.',
                     };
                 }
 
-                addedUserId = addedUser.id;
-            } else {
                 return {
                     success: false,
-                    errorCode: 'unacceptable_request',
-                    errorMessage:
-                        'You must provide an email, phone number, or user ID to add a studio member.',
+                    errorCode: 'user_not_found',
+                    errorMessage: 'The user was not able to be found.',
                 };
             }
 
@@ -2164,6 +2216,11 @@ export interface AddStudioMemberRequest {
      * The ID of the user that should be added to the studio.
      */
     addedUserId?: string;
+
+    /**
+     * The display name of the user that should be added to the studio.
+     */
+    addedDisplayName?: string;
 
     /**
      * The role that the added user should have in the studio.

--- a/src/aux-records/RecordsController.ts
+++ b/src/aux-records/RecordsController.ts
@@ -1451,10 +1451,44 @@ export class RecordsController {
                 role = userAssignment.role;
             }
 
+            const resultMembers: ListedStudioMember[] = await Promise.all(
+                members.map(async (m) => {
+                    if (this._privo && m.user.privoServiceId) {
+                        const result = await this._privo.getUserInfo(
+                            m.user.privoServiceId
+                        );
+                        return {
+                            studioId: m.studioId,
+                            userId: m.userId,
+                            isPrimaryContact: m.isPrimaryContact,
+                            role: m.role,
+                            user: {
+                                id: m.user.id,
+                                name: result.givenName,
+                                displayName: result.displayName,
+                            },
+                        };
+                    } else {
+                        return {
+                            studioId: m.studioId,
+                            userId: m.userId,
+                            isPrimaryContact: m.isPrimaryContact,
+                            role: m.role,
+                            user: {
+                                id: m.user.id,
+                                name: m.user.name,
+                                email: m.user.email,
+                                phoneNumber: m.user.phoneNumber,
+                            },
+                        };
+                    }
+                })
+            );
+
             if (role === 'admin') {
                 return {
                     success: true,
-                    members: members.map((m) => ({
+                    members: resultMembers.map((m) => ({
                         studioId: m.studioId,
                         userId: m.userId,
                         isPrimaryContact: m.isPrimaryContact,
@@ -1464,6 +1498,7 @@ export class RecordsController {
                             name: m.user.name,
                             email: m.user.email,
                             phoneNumber: m.user.phoneNumber,
+                            displayName: m.user.displayName,
                         },
                     })),
                 };
@@ -1471,7 +1506,7 @@ export class RecordsController {
 
             return {
                 success: true,
-                members: members.map((m) => ({
+                members: resultMembers.map((m) => ({
                     studioId: m.studioId,
                     userId: m.userId,
                     isPrimaryContact: m.isPrimaryContact,
@@ -1479,6 +1514,7 @@ export class RecordsController {
                     user: {
                         id: m.user.id,
                         name: m.user.name,
+                        displayName: m.user.displayName,
                     },
                 })),
             };
@@ -2183,6 +2219,7 @@ export interface ListedStudioMemberUser {
     name: string;
     email?: string;
     phoneNumber?: string;
+    displayName?: string;
 }
 
 export interface ListStudioMembersFailure {

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -428,31 +428,7 @@ describe('RecordsServer', () => {
     const apiOrigin = 'https://api-origin.com';
     const recordName = 'testRecord';
     let privoClient: PrivoClientInterface;
-    let privoClientMock: {
-        createChildAccount: jest.Mock<
-            ReturnType<PrivoClientInterface['createChildAccount']>
-        >;
-        createAdultAccount: jest.Mock<
-            ReturnType<PrivoClientInterface['createAdultAccount']>
-        >;
-        getUserInfo: jest.Mock<ReturnType<PrivoClientInterface['getUserInfo']>>;
-        generateAuthorizationUrl: jest.Mock<
-            ReturnType<PrivoClientInterface['generateAuthorizationUrl']>
-        >;
-        processAuthorizationCallback: jest.Mock<
-            ReturnType<PrivoClientInterface['processAuthorizationCallback']>
-        >;
-        checkEmail: jest.Mock<ReturnType<PrivoClientInterface['checkEmail']>>;
-        checkDisplayName: jest.Mock<
-            ReturnType<PrivoClientInterface['checkDisplayName']>
-        >;
-        generateLogoutUrl: jest.Mock<
-            ReturnType<PrivoClientInterface['generateLogoutUrl']>
-        >;
-        resendConsentRequest: jest.Mock<
-            ReturnType<PrivoClientInterface['resendConsentRequest']>
-        >;
-    };
+    let privoClientMock: jest.MockedObject<PrivoClientInterface>;
 
     beforeEach(async () => {
         allowedAccountOrigins = new Set([accountOrigin]);
@@ -504,6 +480,7 @@ describe('RecordsServer', () => {
             checkDisplayName: jest.fn(),
             generateLogoutUrl: jest.fn(),
             resendConsentRequest: jest.fn(),
+            lookupServiceId: jest.fn(),
         };
         relyingParty = {
             id: 'relying_party_id',
@@ -539,6 +516,7 @@ describe('RecordsServer', () => {
             config: store,
             metrics: store,
             messenger: store,
+            privo: privoClient,
         });
 
         policyController = new PolicyController(
@@ -17848,6 +17826,176 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
                     },
                 },
             ]);
+        });
+
+        describe('privo', () => {
+            it('should be able to add members by email address', async () => {
+                await store.saveNewUser({
+                    id: 'testUser4',
+                    email: null,
+                    phoneNumber: null,
+                    privoServiceId: 'serviceId',
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                privoClientMock.lookupServiceId.mockResolvedValueOnce(
+                    'serviceId'
+                );
+
+                const result = await server.handleHttpRequest(
+                    httpPost(
+                        '/api/v2/studios/members',
+                        JSON.stringify({
+                            studioId,
+                            addedEmail: 'test4@example.com',
+                            role: 'member',
+                        }),
+                        authenticatedHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                    },
+                    headers: accountCorsHeaders,
+                });
+
+                const list = await store.listStudioAssignments(studioId, {
+                    userId: 'testUser4',
+                });
+
+                expect(list).toEqual([
+                    {
+                        studioId,
+                        userId: 'testUser4',
+                        role: 'member',
+                        isPrimaryContact: false,
+                        user: {
+                            id: 'testUser4',
+                            email: null,
+                            phoneNumber: null,
+                        },
+                    },
+                ]);
+                expect(privoClientMock.lookupServiceId).toHaveBeenCalledWith({
+                    email: 'test4@example.com',
+                });
+            });
+
+            it('should be able to add members by phone number', async () => {
+                await store.saveNewUser({
+                    id: 'testUser4',
+                    email: null,
+                    phoneNumber: null,
+                    privoServiceId: 'serviceId',
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                privoClientMock.lookupServiceId.mockResolvedValueOnce(
+                    'serviceId'
+                );
+
+                const result = await server.handleHttpRequest(
+                    httpPost(
+                        '/api/v2/studios/members',
+                        JSON.stringify({
+                            studioId,
+                            addedPhoneNumber: '+1111',
+                            role: 'member',
+                        }),
+                        authenticatedHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                    },
+                    headers: accountCorsHeaders,
+                });
+
+                const list = await store.listStudioAssignments(studioId, {
+                    userId: 'testUser4',
+                });
+
+                expect(list).toEqual([
+                    {
+                        studioId,
+                        userId: 'testUser4',
+                        role: 'member',
+                        isPrimaryContact: false,
+                        user: {
+                            id: 'testUser4',
+                            email: null,
+                            phoneNumber: null,
+                        },
+                    },
+                ]);
+                expect(privoClientMock.lookupServiceId).toHaveBeenCalledWith({
+                    phoneNumber: '+1111',
+                });
+            });
+
+            it('should be able to add members by display name', async () => {
+                await store.saveNewUser({
+                    id: 'testUser4',
+                    email: null,
+                    phoneNumber: null,
+                    privoServiceId: 'serviceId',
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                privoClientMock.lookupServiceId.mockResolvedValueOnce(
+                    'serviceId'
+                );
+
+                const result = await server.handleHttpRequest(
+                    httpPost(
+                        '/api/v2/studios/members',
+                        JSON.stringify({
+                            studioId,
+                            addedDisplayName: 'test user',
+                            role: 'member',
+                        }),
+                        authenticatedHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                    },
+                    headers: accountCorsHeaders,
+                });
+
+                const list = await store.listStudioAssignments(studioId, {
+                    userId: 'testUser4',
+                });
+
+                expect(list).toEqual([
+                    {
+                        studioId,
+                        userId: 'testUser4',
+                        role: 'member',
+                        isPrimaryContact: false,
+                        user: {
+                            id: 'testUser4',
+                            email: null,
+                            phoneNumber: null,
+                        },
+                    },
+                ]);
+                expect(privoClientMock.lookupServiceId).toHaveBeenCalledWith({
+                    displayName: 'test user',
+                });
+            });
         });
 
         testUrl('POST', '/api/v2/studios/members', () =>

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -17877,6 +17877,7 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
                             id: 'testUser4',
                             email: null,
                             phoneNumber: null,
+                            privoServiceId: 'serviceId',
                         },
                     },
                 ]);
@@ -17933,6 +17934,7 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
                             id: 'testUser4',
                             email: null,
                             phoneNumber: null,
+                            privoServiceId: 'serviceId',
                         },
                     },
                 ]);
@@ -17989,6 +17991,7 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
                             id: 'testUser4',
                             email: null,
                             phoneNumber: null,
+                            privoServiceId: 'serviceId',
                         },
                     },
                 ]);

--- a/src/aux-records/RecordsServer.ts
+++ b/src/aux-records/RecordsServer.ts
@@ -3302,6 +3302,14 @@ export class RecordsServer {
                             })
                             .nonempty('addedPhoneNumber must not be empty')
                             .optional(),
+                        addedDisplayName: z
+                            .string({
+                                invalid_type_error:
+                                    'addedDisplayName must be a string.',
+                                required_error: 'addedDisplayName is required.',
+                            })
+                            .nonempty('addedDisplayName must not be empty')
+                            .optional(),
                         role: z.union([
                             z.literal('admin'),
                             z.literal('member'),
@@ -3315,6 +3323,7 @@ export class RecordsServer {
                             addedUserId,
                             addedEmail,
                             addedPhoneNumber,
+                            addedDisplayName,
                             role,
                         },
                         context
@@ -3338,6 +3347,7 @@ export class RecordsServer {
                             addedUserId,
                             addedEmail,
                             addedPhoneNumber,
+                            addedDisplayName,
                         });
                         return result;
                     }

--- a/src/aux-records/RecordsStore.ts
+++ b/src/aux-records/RecordsStore.ts
@@ -478,6 +478,11 @@ export interface ListedStudioAssignmentUser {
      * The phone number of the user.
      */
     phoneNumber: string;
+
+    /**
+     * The ID of the privo service that the user is associated with.
+     */
+    privoServiceId: string | null;
 }
 
 /**

--- a/src/aux-records/TestUtils.ts
+++ b/src/aux-records/TestUtils.ts
@@ -75,6 +75,7 @@ export function createTestControllers(
         config: store,
         metrics: store,
         messenger: store,
+        privo: null,
     });
     const policies = new PolicyController(auth, records, store);
 

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -3505,6 +3505,10 @@ Object {
       },
       "inputs": Object {
         "schema": Object {
+          "addedDisplayName": Object {
+            "optional": true,
+            "type": "string",
+          },
           "addedEmail": Object {
             "optional": true,
             "type": "string",
@@ -7352,6 +7356,10 @@ Object {
       },
       "inputs": Object {
         "schema": Object {
+          "addedDisplayName": Object {
+            "optional": true,
+            "type": "string",
+          },
           "addedEmail": Object {
             "optional": true,
             "type": "string",

--- a/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
@@ -1359,6 +1359,7 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
                     name: user.name,
                     email: user.email,
                     phoneNumber: user.phoneNumber,
+                    privoServiceId: user.privoServiceId,
                 },
             });
         }

--- a/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
@@ -631,6 +631,7 @@ export class PrismaRecordsStore implements RecordsStore {
                         name: true,
                         email: true,
                         phoneNumber: true,
+                        privoServiceId: true,
                     },
                 },
                 role: true,
@@ -661,6 +662,7 @@ export class PrismaRecordsStore implements RecordsStore {
                     name: a.user.name,
                     email: a.user.email,
                     phoneNumber: a.user.phoneNumber,
+                    privoServiceId: a.user.privoServiceId,
                 },
             };
 

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -1604,6 +1604,7 @@ export class ServerBuilder implements SubscriptionLike {
             config: this._configStore,
             metrics: this._metricsStore,
             messenger: this._notificationMessenger,
+            privo: this._privoClient ?? null,
         });
         this._policyController = new PolicyController(
             this._authController,

--- a/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
+++ b/src/aux-server/aux-web/aux-auth/shared/AuthManager.ts
@@ -127,6 +127,8 @@ if (typeof (globalThis as any).USE_PRIVO_LOGIN === 'undefined') {
 
 console.log(`[AuthManager] Use Privo Login: ${USE_PRIVO_LOGIN}`);
 
+declare let ENABLE_SMS_AUTHENTICATION: boolean;
+
 export class AuthManager {
     private _userId: string;
     private _sessionId: string;
@@ -217,6 +219,10 @@ export class AuthManager {
 
     get usePrivoLogin() {
         return this._usePrivoLogin;
+    }
+
+    get supportsSms() {
+        return ENABLE_SMS_AUTHENTICATION === true;
     }
 
     get userInfoLoaded() {

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.ts
@@ -19,12 +19,12 @@ import { getFormErrors } from '@casual-simulation/aux-records';
 import FieldErrors from '../../../shared/vue-components/FieldErrors/FieldErrors';
 import type { BiosOption } from '@casual-simulation/aux-common';
 import { isEqual } from 'lodash';
+import type { RecordsClientInputs } from '@casual-simulation/aux-records/RecordsClient';
 
 // TODO: Support uploading logos
 // import vueBotPond from 'vue-filepond';
 // import 'filepond/dist/filepond.min.css';
 // const FilePond = vueBotPond();
-
 @Component({
     components: {
         'svg-icon': SvgIcon,
@@ -117,6 +117,10 @@ export default class AuthStudio extends Vue {
 
     // TODO: Support uploading logos
     // logoFile: File = null;
+
+    get usePrivoLogin() {
+        return authManager.usePrivoLogin;
+    }
 
     get addressFieldClass() {
         return this.addMemberErrorCode ? 'md-invalid' : '';
@@ -517,11 +521,40 @@ export default class AuthStudio extends Vue {
     async addMember() {
         try {
             this.addingMember = true;
-            const result = await authManager.client.addStudioMember({
+            const request: RecordsClientInputs['addStudioMember'] = {
                 studioId: this.studioId,
-                addedEmail: this.addMemberEmail,
                 role: this.addMemberRole as StudioAssignmentRole,
-            });
+            };
+            const isEmail = this.addMemberEmail.includes('@');
+            if (this.usePrivoLogin && !isEmail) {
+                request.addedDisplayName = this.addMemberEmail;
+            } else if (isEmail) {
+                request.addedEmail = this.addMemberEmail;
+            } else if (authManager.supportsSms) {
+                request.addedPhoneNumber = this.addMemberEmail;
+            } else {
+                request.addedUserId = this.addMemberEmail;
+            }
+
+            let result = await authManager.client.addStudioMember(request);
+
+            if (
+                result.success === false &&
+                result.errorCode === 'user_not_found'
+            ) {
+                if (!request.addedUserId) {
+                    // Try adding the user by userId if we didn't already try that
+                    const idResult = await authManager.client.addStudioMember({
+                        studioId: this.studioId,
+                        role: this.addMemberRole as StudioAssignmentRole,
+                        addedUserId: this.addMemberEmail,
+                    });
+
+                    if (idResult.success === true) {
+                        result = idResult;
+                    }
+                }
+            }
 
             if (result.success === true) {
                 this.showAddMember = false;

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
@@ -34,7 +34,7 @@
                 <md-table-row v-for="member of members" :key="member.userId">
                     <md-table-cell>{{ member.user.name || member.user.email }}</md-table-cell>
                     <md-table-cell>{{
-                        member.user.email || member.user.phoneNumber
+                        member.user.email || member.user.phoneNumber || member.user.displayName
                     }}</md-table-cell>
                     <md-table-cell>{{ member.role }}</md-table-cell>
                     <md-table-cell>{{ member.isPrimaryContact }}</md-table-cell>

--- a/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
+++ b/src/aux-server/aux-web/aux-auth/site/AuthStudio/AuthStudio.vue
@@ -188,7 +188,7 @@
             </md-dialog-content>
             <md-dialog-content v-else>
                 <md-field :class="addressFieldClass">
-                    <label>Email</label>
+                    <label>Email <span v-if="usePrivoLogin">or Display Name</span></label>
                     <md-input v-model="addMemberEmail" />
                     <span v-if="addMemberErrorCode === 'user_not_found'" class="md-error"
                         >No user with this email was found.</span


### PR DESCRIPTION
### :rocket: Features

-   Improved studios to support adding Privo users by email, display name, or user ID.
    -   Additionally improved studios to only show members by name and display name when Privo support is enabled.

Closes #554 