### PR TITLE
Add support for multiline input in menu bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
     -   `formMapHeightOffset` can be set to offset the displayed heights when a `formMapHeightProvider` is provided.
 -   Updated lambda functions to use 1024 MB instead of 256 MB.
 -   Added a note for `@onBotChanged` to the documentation that it will only be triggered if the bot was not just created.
+-   Added the `formInputMultiline` tag.
+    -   Set to `true` to allow multiple lines in `input` form menu bots.
+    -   Set to `false` to disallow multiple lines.
+    -   Set to `null` to allow multiple lines by using <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/components.jsx
+++ b/docs/docs/components.jsx
@@ -177,6 +177,7 @@ export const tagMap = {
     formMapHeightProvider: 'tags/visualization',
     formMapHeightProviderAPIKey: 'tags/visualization',
     formMapHeightOffset: 'tags/visualization',
+    formInputMultiline: 'tags/visualization',
     gltfVersion: 'tags/visualization',
     progressBar: 'tags/visualization',
     progressBarColor: 'tags/visualization',
@@ -444,6 +445,7 @@ export const ReadOnlyBadge = ({}) => (<Badge type='warning'>Read-Only</Badge>);
 export const VideoBadge = ({url}) => (<Badge type='info'><a href={url} target='_blank'>Video</a></Badge>);
 
 export const ConfigBotBadge = ({url}) => (<Badge type='primary'>Config Bot</Badge>);
+export const UrlSyncBadge = ({url}) => (<Badge>Synced to URL</Badge>);
 
 export const HistoryBotBadge = ({url}) => (<Badge type='primary'>History Bot</Badge>);
 

--- a/docs/docs/tags/config-bot.mdx
+++ b/docs/docs/tags/config-bot.mdx
@@ -38,15 +38,18 @@ import {
   ImuPortalBadge,
   MapPortalBadge,
   tagMap,
+  UrlSyncBadge,
 } from '../components.jsx';
 
 import { GlossaryRef } from '../glossary/index';
 
 ## Config bot Tags
 
-All tags on the config bot will be synced with the URL query parameters.
-This means that setting the `#abc` tag on the config bot to `hello` will update the URL to include `abc=hello`.
+Tags on the config bot can be synced with the URL query parameters. Any tag which is already a query parameter will be synced with the configBot tags, while some tags that are added to the configBot will be added to the URL query parameters.
+This means that setting the `#gridPortal` tag on the config bot to `hello` will update the URL to include `gridPortal=hello`.
 It also means that putting `miniGridPortal=myDimension` into the query string will set the <TagLink tag='miniGridPortal'/> tag to `myDimension`.
+
+In this document, tags which can be added to the URL query parameters will have the <UrlSyncBadge/> badge next to them.
 
 ### `bios`
 
@@ -98,6 +101,7 @@ The BIOS option that was used to initialize CasualOS.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The instance that is loaded into CasualOS.
@@ -106,6 +110,7 @@ The instance that is loaded into CasualOS.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The static instance that is loaded into CasualOS. Not present if the inst is not a static inst.
@@ -158,6 +163,7 @@ The place that the inst should be loaded from.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The theme that CasualOS should use.
@@ -201,6 +207,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The dimension that is loaded into the <GlossaryRef term="gridPortal">'grid' portal</GlossaryRef> in CasualOS.
@@ -211,6 +218,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The dimension that is loaded into the "mini" portal in CasualOS.
@@ -220,6 +228,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The dimension that is loaded into the "sheet" portal in CasualOS.
@@ -229,6 +238,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The search value that is loaded into the <GlossaryRef term="systemPortal">"system" portal</GlossaryRef> in CasualOS.
@@ -239,6 +249,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The name of the tag that should be used when showing bots in the <GlossaryRef term="systemPortal">systemPortal</GlossaryRef>.
@@ -298,6 +309,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The value that should be used to search across all the tags in all the bots in the inst.
@@ -305,6 +317,11 @@ The results of the search will be displayed in the <GlossaryRef term="systemPort
 Only available on the config bot.
 
 ### `systemPortalDiff`
+
+<Badges>
+  <ConfigBotBadge/>
+  <UrlSyncBadge/>
+</Badges>
 
 The name of the tag should be used as a second system portal to compare with the tag specified by the <TagLink tag='systemPortalTag'/> (`system` by default).
 
@@ -316,15 +333,27 @@ The result of this comparision will be shown in the system portal, indicating wh
 
 ### `systemPortalDiffBot`
 
+<Badges>
+  <ConfigBotBadge/>
+</Badges>
+
 The ID of the bot that is currently selected in the system portal diff.
 Only available on the config bot.
 
 ### `systemPortalDiffTag`
 
+<Badges>
+  <ConfigBotBadge/>
+</Badges>
+
 The name of the tag that is currently selected in the system portal diff.
 Only available on the config bot.
 
 ### `systemPortalDiffTagSpace`
+
+<Badges>
+  <ConfigBotBadge/>
+</Badges>
 
 The space of the tag that is selected in the system portal diff.
 If null, then the tag space is the same as the <TagLink tag='systemPortalDiffBot'/> space.
@@ -334,6 +363,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The pane that the user is currently viewing in the system portal.
@@ -361,6 +391,7 @@ The pane that the user is currently viewing in the system portal.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The prefix that indicates which tags should be loaded into the "IDE" portal in CasualOS.
@@ -370,6 +401,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The dimension that is loaded into the <GlossaryRef term="mapPortal">"map" portal</GlossaryRef> in CasualOS.
@@ -382,6 +414,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The dimension that is loaded into the "mini map" portal in CasualOS.
@@ -421,6 +454,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The [Jitsi Meet](https://meet.jit.si/) room code of the meeting that should be joined.
@@ -434,6 +468,7 @@ Only available on the config bot.
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The ID of the bot whose data should be shown in the bot portal.
@@ -454,6 +489,7 @@ botPortalBot.tags.botPortalAnchorPoint = 'top';
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The Bot ID and tag that should be edited in the tag portal.
@@ -475,6 +511,7 @@ configBot.tags.tagPortal = getID(configBot) + "." + tag;
 
 <Badges>
   <ConfigBotBadge/>
+  <UrlSyncBadge/>
 </Badges>
 
 The space of the tag mask that should be edited in the tag portal.
@@ -521,38 +558,6 @@ When set to `true`, CasualOS will start updating the `imuPortalBot` with the dat
 Note that not all devices support the IMU portal. In particular, laptops and desktop computers will likely not support the IMU portal while mobile devices probably will.
 
 Only available on the config bot.
-
-### `dataPortal`
-
-The data portal is a special portal that can be used in a web request to get bot data directly from the inst.
-Similar to webhooks, you specify the inst and data portal in the query string of the URL.
-
-If given a bot ID, then the bot will be returned as JSON.
-
-If no bot matches the given value, then it will be treated as a tag and all the values for the given tag will be returned.
-
-If the tag ends with a common extension (like `.html` or `.txt` or `.json`), then the returned data will be [tagged](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) with the corresponding [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
-This will let web browsers and other common software know what type of data they are dealing with and handle it correctly. (i.e. display a webpage)
-Alternatively, you can specify the `dataPortalContentType` query parameter to override the default content type.
-
-If there is only one tag and it ends with an extension like specified above then the content directly from the tag will be returned.
-
-#### Examples:
-
-1. Request the JSON of the Bot with the given ID:
-```
-https://auxplayer.org?inst=my-aux&dataPortal=bf68e5cc-993b-42fd-a142-a23de6d2cdcb
-```
-
-2. Request all the <TagLink tag='label'/> tags values.
-```
-https://auxplayer.org?inst=my-aux&dataPortal=label
-```
-
-3. Request a web page from the `test.html` tag.
-```
-https://auxplayer.org?inst=my-aux&dataPortal=test.html
-```
 
 ### `mousePointerPosition`
 

--- a/docs/docs/tags/visualization.mdx
+++ b/docs/docs/tags/visualization.mdx
@@ -606,6 +606,8 @@ The subtype that the form should use. Useful for specifying how a mesh should be
 
 Wether the input should allow multiple lines of text.
 
+Not supported when <TagLink tag='formSubtype'/> is set to `password`.
+
 #### Possible values are:
 
 <PossibleValuesTable>

--- a/docs/docs/tags/visualization.mdx
+++ b/docs/docs/tags/visualization.mdx
@@ -542,6 +542,7 @@ The shape that the bot should be displayed as.
     The bot will appear as an input box in the menu portal.
     You also need to place the bot in the dimension that the menu portal is showing for the input to appear.
     You can change the type of input using the <TagLink tag='formSubtype'/> tag.
+    You can also change wether the input allows multiple lines of text using the <TagLink tag='formInputMultiline'/> tag.
   </PossibleValueCode>
   <PossibleValueCode value='light'>
     The bot will appear as a light.
@@ -598,6 +599,30 @@ The subtype that the form should use. Useful for specifying how a mesh should be
   </PossibleValueCode>
   <PossibleValueCode value='password'>
     A bot with the <TagLink tag='form'/> set to `input` will function as a password input. (Characters are masked)
+  </PossibleValueCode>
+</PossibleValuesTable>
+
+### `formInputMultiline
+
+Wether the input should allow multiple lines of text.
+
+#### Possible values are:
+
+<PossibleValuesTable>
+  <PossibleValueCode value='null'>
+    The input allows multiple lines.
+    On Desktop, new lines can be added by using <kbd>Shift</kbd>+<kbd>Enter</kbd>.
+    On Mobile, new lines can be added by using the "return" key on the keyboard.
+    Pressing <kbd>Enter</kbd> by itself will submit the input. (default)
+  </PossibleValueCode>
+  <PossibleValueCode value='false'>
+    The input will only allow a single line of text.
+    Pressing <kbd>Enter</kbd> will submit the input.
+  </PossibleValueCode>
+  <PossibleValueCode value='true'>
+    The input will allow multiple lines of text.
+    Pressing <kbd>Enter</kbd> will create a new line of text.
+    You can press (<kbd>Ctrl</kbd>/<kbd>Cmd</kbd>)+<kbd>Enter</kbd> to submit the input.
   </PossibleValueCode>
 </PossibleValuesTable>
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -2758,6 +2758,7 @@ export const KNOWN_TAGS: string[] = [
     'formMapHeightProvider',
     'formMapHeightProviderAPIKey',
     'formMapHeightOffset',
+    'formInputMultiline',
     'meshPositioningMode',
     'orientationMode',
     'anchorPoint',

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -1616,6 +1616,8 @@ export class ServerBuilder implements SubscriptionLike {
     }
 
     build(): BuildReturn {
+        console.log(`CasualOS Version:`, GIT_TAG, GIT_HASH);
+
         if (this._actions.length > 0) {
             throw new Error(
                 'Some setup actions require async setup. Use buildAsync() instead.'

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -109,3 +109,7 @@
     margin: 0;
     padding-top: 0;
 }
+
+.menu-bot .menu-input.md-field .md-button.md-toggle-password {
+    top: 0;
+}

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.css
@@ -26,6 +26,9 @@
     display: inline-block;
     width: 24px;
     height: 24px;
+    min-height: 24px;
+    min-width: 24px;
+    flex: 0 0 24px;
     margin-right: 8px;
 }
 
@@ -65,10 +68,14 @@
 
 .md-list.md-theme-default
     .menu-bot.md-list-item.no-hover
-    .md-list-item-container:not(.md-list-item-default):not(.md-list-item-expand):not([disabled]):hover,
+    .md-list-item-container:not(.md-list-item-default):not(
+        .md-list-item-expand
+    ):not([disabled]):hover,
 .md-list.md-theme-dark
     .menu-bot.md-list-item.no-hover
-    .md-list-item-container:not(.md-list-item-default):not(.md-list-item-expand):not([disabled]):hover {
+    .md-list-item-container:not(.md-list-item-default):not(
+        .md-list-item-expand
+    ):not([disabled]):hover {
     color: var(
         --md-theme-default-text-primary-on-background,
         rgba(0, 0, 0, 0.87)
@@ -88,4 +95,17 @@
 
 .menu-bot .md-field.md-theme-none:after {
     background-color: var(--menu-label-color);
+}
+
+/* .md-field.md-has-textarea */
+
+.menu-bot .md-field label,
+.menu-bot .md-field.md-focused label {
+    top: 5px;
+}
+
+.menu-bot .menu-input.md-field {
+    min-height: initial;
+    margin: 0;
+    padding-top: 0;
 }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -74,6 +74,7 @@ import { formatModalityButtonId, Input } from '../../shared/scene/Input';
 import { SvgIcon } from '@casual-simulation/aux-components';
 import { Subscription } from 'rxjs';
 import type { BotManager } from '@casual-simulation/aux-vm-browser';
+import Bowser from 'bowser';
 
 @Component({
     components: {
@@ -108,6 +109,7 @@ export default class MenuBot extends Vue {
     hoverStyle: MenuBotResolvedHoverStyle = 'hover';
     cursor: string = null;
     alwaysShowSubmit: boolean = false;
+    inputMultiline: 'default' | boolean = 'default';
 
     private _down: boolean = false;
     private _hover: boolean = false;
@@ -127,7 +129,8 @@ export default class MenuBot extends Vue {
         return {
             ...this.extraStyle,
             'background-color': this.backgroundColor,
-            height: this.scaleY === 'auto' ? 'auto' : this.scaleY * 40 + 'px',
+            'min-height':
+                this.scaleY === 'auto' ? 'auto' : this.scaleY * 40 + 'px',
         };
     }
 
@@ -168,6 +171,7 @@ export default class MenuBot extends Vue {
             this._updateText(calc, item.bot);
             this._updateCursor(calc, item.bot);
             this._updateAlwaysShowSubmit(calc, item.bot);
+            this._updateInputMultiline(calc, item.bot);
 
             this._updateSim(simulation);
         } else {
@@ -414,6 +418,40 @@ export default class MenuBot extends Vue {
         }
     }
 
+    handleInputEnter(event: KeyboardEvent) {
+        const conditionalSubmit = () => {
+            if (hasValue(this.text)) {
+                this.submitInput(false);
+            }
+        };
+
+        const isMobile =
+            Bowser.parse(navigator.userAgent).platform.type === 'mobile';
+        if (this.inputMultiline === false) {
+            // always prevent newlines
+            event.preventDefault();
+
+            if (!isMobile) {
+                // On desktop, hitting Enter should submit the input.
+                conditionalSubmit();
+            }
+            return;
+        } else if (this.inputMultiline === 'default') {
+            // allow newlines using shift+enter or on mobile
+            if (!event.shiftKey && !isMobile) {
+                event.preventDefault();
+                conditionalSubmit();
+                return;
+            }
+        }
+
+        if (!event.shiftKey && event.ctrlKey) {
+            // If ctrl is pressed, submit the input.
+            event.preventDefault();
+            conditionalSubmit();
+        }
+    }
+
     async submitInput(dropFocus: boolean) {
         if (dropFocus) {
             const input = <Vue>this.$refs.textInput;
@@ -547,6 +585,16 @@ export default class MenuBot extends Vue {
             'menuItemShowSubmitWhenEmpty',
             false
         );
+    }
+
+    private _updateInputMultiline(calc: BotCalculationContext, bot: Bot) {
+        this.inputMultiline =
+            calculateBooleanTagValue(
+                calc,
+                bot,
+                'auxFormInputMultiline',
+                null
+            ) ?? 'default';
     }
 
     private async _ignoreTextUpdates(action: (text: string) => Promise<void>) {

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.ts
@@ -425,8 +425,9 @@ export default class MenuBot extends Vue {
             }
         };
 
-        const isMobile =
-            Bowser.parse(navigator.userAgent).platform.type === 'mobile';
+        const parsed = Bowser.parse(navigator.userAgent);
+        const isMobile = parsed.platform.type === 'mobile';
+        const isMac = /mac/gi.test(parsed.os.name);
         if (this.inputMultiline === false) {
             // always prevent newlines
             event.preventDefault();
@@ -445,8 +446,11 @@ export default class MenuBot extends Vue {
             }
         }
 
-        if (!event.shiftKey && event.ctrlKey) {
-            // If ctrl is pressed, submit the input.
+        if (
+            !event.shiftKey &&
+            ((event.ctrlKey && !isMac) || (isMac && event.metaKey))
+        ) {
+            // If ctrl/cmd is pressed, submit the input.
             event.preventDefault();
             conditionalSubmit();
         }

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -14,7 +14,19 @@
                 </span>
                 <md-field class="menu-input" md-inline md-theme="none">
                     <label v-show="label">{{ label }}</label>
+                    <md-input
+                        v-if="subType === 'password'"
+                        :type="subType"
+                        class="text-input"
+                        :style="{ color: labelColor }"
+                        ref="textInput"
+                        v-model="text"
+                        @input="onTextUpdated()"
+                        v-on:keydown.enter="submitInput(false)"
+                        md-autogrow
+                    ></md-input>
                     <md-textarea
+                        v-else
                         :type="subType"
                         class="text-input"
                         :style="{ color: labelColor }"

--- a/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
+++ b/src/aux-server/aux-web/aux-player/MenuBot/MenuBot.vue
@@ -14,15 +14,16 @@
                 </span>
                 <md-field class="menu-input" md-inline md-theme="none">
                     <label v-show="label">{{ label }}</label>
-                    <md-input
+                    <md-textarea
                         :type="subType"
                         class="text-input"
                         :style="{ color: labelColor }"
                         ref="textInput"
                         v-model="text"
                         @input="onTextUpdated()"
-                        v-on:keyup.enter="submitInput(false)"
-                    ></md-input>
+                        v-on:keydown.enter="handleInputEnter"
+                        md-autogrow
+                    ></md-textarea>
                 </md-field>
                 <md-button
                     v-show="text || alwaysShowSubmit"


### PR DESCRIPTION
### :rocket: Features

-   Added the `formInputMultiline` tag.
    -   Set to `true` to allow multiple lines in `input` form menu bots.
    -   Set to `false` to disallow multiple lines.
    -   Set to `null` to allow multiple lines by using <kbd>Shift</kbd>+<kbd>Enter</kbd>.

Closes #617