### PR TITLE
Add aux tools to casualos cli

### DIFF
--- a/src/casualos-cli/cli.ts
+++ b/src/casualos-cli/cli.ts
@@ -338,7 +338,7 @@ async function auxConvert() {
             }
         } else if (targetStat.isFile()) {
             if (targetFD.slice(-4) === '.aux') {
-                auxFiles.push(targetFD);
+                auxFiles.push(path.basename(targetFD));
             } else {
                 console.warn(`Invalid file type provided.\nExpected ".aux"`);
                 return;
@@ -356,7 +356,7 @@ async function auxConvert() {
         );
         if (existsSync(outDir) && statSync(outDir).isDirectory()) {
             let converted = 0;
-            const prefix = outDir === targetFD ? '_' : '';
+            const prefix = outDir === getDir(targetFD) ? '_' : '';
             for (let file of auxFiles) {
                 try {
                     await writeFile(
@@ -837,9 +837,12 @@ function sanitizePath(input: string): string {
     return path.resolve(path.normalize(unquoted));
 }
 
+function getDir(base: string): string {
+    return statSync(base).isDirectory() ? base : path.dirname(base);
+}
+
 function replaceWithBasename(base: string, filename: string): string {
-    const dir = statSync(base).isDirectory() ? base : path.dirname(base);
-    return path.join(dir, filename);
+    return path.join(getDir(base), filename);
 }
 
 function convertToString(str: unknown): string {


### PR DESCRIPTION
## Adds the aux command to the casualos cli.

```bash
casualos aux [options] [action]   #Work with aux files and their contents.
```

The aux command contains an **action argument** and an option (**-ls**, **--list**).
The aforementioned `-ls`/`--list` option will list all possible values for it's argument: `action`.

Currently the only **action argument** is `convert` which will effectively proxy the provided `.aux` file(s) through [**@casual-simulation/aux-common**](https://www.npmjs.com/package/@casual-simulation/aux-common)'s `getBotsStateFromStoredAux` function; subsequently outputting the result to file(s) nominally the same in the specified output directory.

The naming convention has one exemption, that is, when the target file directory and output directory are the same. To avoid overwriting, the output file will be prefixed with an underscore.

## Example Usage:

```bash
casualos aux convert
✔ Enter a value for target file or directory containing files (path). … 'path/to/testAuxs'
✔ Enter a value for output directory to write files to. … 'path/to/outDir'

🍵 Converted 14/14 Files.
--------------------------
|✔️ | abShell.aux
|✔️ | xr_toolbox.aux
|✔️ | abTests.aux
|✔️ | ab1.aux
|✔️ | ai_toolbox.aux
|✔️ | casualTutorial.aux
|✔️ | casual_toolbox.aux
|✔️ | abAction.aux
|✔️ | abCollab.aux
|✔️ | abInterface.aux
|✔️ | sim_toolbox.aux
|✔️ | abConfig.aux
|✔️ | advanced_toolbox.aux
|✔️ | eggCarton.aux
```