### PR TITLE
Improve support for dynamic listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,37 @@
             -   `data` - (Optional) The GeoJSON data that is contained in the layer. Required if `url` is not specified.
     -   `os.removeMapLayer(layerId)` - Removes a map layer from the portal it is in. Returns a promise that resolves once the layer has been removed.
         -   `layerId` - The ID of the layer that should be removed. You can get this from the resolved value from `os.addMapLayer()`.
+-   Added the `os.addBotListener(bot, tag, listener)` and `os.removeBotListener(bot, tag, listener)` functions.
+    -   `os.addBotListener(bot, tag, listener)` Adds the given listener to the given bot for the given tag.
+        -   It can be used to add arbitrary functions to be triggered when a listener would be triggered on a bot.
+        -   This function only adds listeners, it cannot override existing listeners.
+        -   Listeners added by this function will not be called if the bot is not listening.
+        -   `bot` is the bot that the lister should be added to.
+        -   `tag` is the [listen tag](https://docs.casualos.com/tags/listen/).
+        -   `listener` is the function that should be called when the listen tag is triggered. It should be a function that accepts the following arguments:
+            -   `that` - the `that` argument of the listener.
+            -   `bot` - The bot that the listener was triggered on. (Same as `bot` above)
+            -   `tag` - The name of the tag. (Same as `tag` above)
+    -   `os.removeBotListener(bot, tag, listener)` Removes the given listener from the given bot and tag.
+        -   This function can only be used to remove listeners which have been added by `os.addBotListener()`.
+        -   `bot` is the bot that the listener should be removed from.
+        -   `tag` is the [listen tag](https://docs.casualos.com/tags/listen/).
+        -   `listener` is the function that should be removed.
+-   Added the ability to add/override bot listen tags by setting `bot.listeners.tag`.
+
+    -   For example, the following code will override the `onClick` listen tag to toast "overridden" when the bot is clicked:
+
+        ```typescript
+        bot.tags.onClick = `@os.toast("default")`;
+        bot.listeners.onClick = () => os.toast('overridden');
+
+        // when bot is clicked, "overridden" will be toasted instead of "default".
+        ```
+
+    -   Just like the `masks` property, the `listeners` property allows you to override the default tags.
+    -   The difference is that `listeners` is all about listen tags and functions. You can only set functions, and `listeners` are always `tempLocal`.
+    -   Functions set on the `listeners` property will override listen tags set by tags and tag masks.
+        -   It will only override the listener, not the tag data. In the example above, `bot.tags.onClick` will continue to return `@os.toast("default")`.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -66,6 +66,21 @@ export const GET_TAG_MASKS_SYMBOL = Symbol('get_tag_masks');
 export const REPLACE_BOT_SYMBOL = Symbol('replace_bot');
 
 /**
+ * Defines a symbol that is used to add a bot listener.
+ */
+export const ADD_BOT_LISTENER_SYMBOL = Symbol('add_bot_listener');
+
+/**
+ * Defines a symbol that is used to remove a bot listener.
+ */
+export const REMOVE_BOT_LISTENER_SYMBOL = Symbol('remove_bot_listener');
+
+/**
+ * Defines a symbol that is used to get dynamic listeners for a bot.
+ */
+export const GET_DYNAMIC_LISTENERS_SYMBOL = Symbol('get_dynamic_listeners');
+
+/**
  * Defines an interface for a bot in a script/formula.
  *
  * The difference between this and Bot is that the tags
@@ -202,6 +217,36 @@ export interface RuntimeBot {
     [REPLACE_BOT_SYMBOL]: (bot: RuntimeBot) => void;
 
     /**
+     * Registers the given function as a listener for events that would trigger the given tag.
+     * @param tagName The name of the tag that the listener should be registered for.
+     * @param listener The listener function that should be called when the tag is triggered.
+     */
+    [ADD_BOT_LISTENER_SYMBOL]: (
+        tagName: string,
+        listener: DynamicListener
+    ) => void;
+
+    /**
+     * Unregisters the given function as a listener for events that would trigger the given tag.
+     *
+     * @param tagName The name of the tag that the listener should be unregistered for.
+     * @param listener The listener function that should be removed.
+     */
+    [REMOVE_BOT_LISTENER_SYMBOL]: (
+        tagName: string,
+        listener: DynamicListener
+    ) => void;
+
+    /**
+     * Gets the list of dynamic listeners that are registered for the given tag.
+     * @param tagName The name of the tag that the listeners are registered for.
+     * @returns The list of dynamic listeners for the tag, or null if none are registered.
+     */
+    [GET_DYNAMIC_LISTENERS_SYMBOL]: (
+        tagName: string
+    ) => DynamicListener[] | null;
+
+    /**
      * Gets the listener or bot property with the given name.
      *
      * If given a property name, like `"tags"` or `"vars"`, then it will return the value of that property.
@@ -319,6 +364,24 @@ export interface CompiledBotListeners {
 }
 
 /**
+ * An interface that maps tag names to dynamic listeners which have been registered.
+ *
+ * ```typescript
+ * interface DynamicListeners {
+ *      [tag: string]: Listener[];
+ * }
+ * ```
+ *
+ * @dochash types/core
+ * @docgroup 01-core
+ * @docname DynamicListeners
+ * @docid DynamicBotListeners
+ */
+export interface DynamicBotListeners {
+    [tag: string]: DynamicListener[];
+}
+
+/**
  * An interface that maps module names to compiled modules.
  *
  * ```typescript
@@ -347,6 +410,22 @@ export interface CompiledBotExports {
  * The function signature of a bot listener.
  */
 export type CompiledBotListener = (arg?: any) => any;
+
+/**
+ * The function signature of a dynamic bot listener.
+ *
+ * That is, a listener that is registered at runtime by a user script instead of parsed from a tag.
+ *
+ * @dochash types/core
+ * @docgroup 01-core
+ * @docname Listener
+ * @docid DynamicListener
+ */
+export type DynamicListener = (
+    that: any,
+    bot: RuntimeBot,
+    tagName: string
+) => any;
 
 /**
  * Defines an interface for a bot that is precalculated.

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -359,8 +359,12 @@ export interface RuntimeBotVars {
 export interface CompiledBotListeners {
     /**
      * Gets the listener in the given tag.
+     *
+     * Can be one of the following:
+     * - A function that takes an optional argument and returns a value.
+     * - A function that takes the bot and tag name as arguments and returns a value.
      */
-    [tag: string]: (arg?: any) => any;
+    [tag: string]: DynamicListener | null;
 }
 
 /**
@@ -405,11 +409,6 @@ export interface CompiledBotModules {
 export interface CompiledBotExports {
     [tag: string]: Promise<BotModuleResult>;
 }
-
-/**
- * The function signature of a bot listener.
- */
-export type CompiledBotListener = (arg?: any) => any;
 
 /**
  * The function signature of a dynamic bot listener.

--- a/src/aux-runtime/runtime/AuxGlobalContext.ts
+++ b/src/aux-runtime/runtime/AuxGlobalContext.ts
@@ -1158,9 +1158,7 @@ export class MemoryGlobalContext implements AuxGlobalContext {
 
             if (bot.listeners) {
                 for (let key in bot.listeners) {
-                    if (typeof bot.listeners[key] === 'function') {
-                        this.recordListenerPresense(bot.id, key, false);
-                    }
+                    this.recordListenerPresense(bot.id, key, false);
                 }
             }
         }

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -14796,9 +14796,13 @@ describe('AuxLibrary', () => {
                     })
                 );
 
-                expect(onAnyCreate1).toHaveBeenCalledWith({
-                    bot: bot,
-                });
+                expect(onAnyCreate1).toHaveBeenCalledWith(
+                    {
+                        bot: bot,
+                    },
+                    bot1,
+                    'onAnyCreate'
+                );
             });
             it('should support arrays of diffs as arguments', () => {
                 uuidMock
@@ -16345,10 +16349,10 @@ describe('AuxLibrary', () => {
 
                 let arg = {};
                 handleResult(priorityShout(['abc', 'def'], arg));
-                expect(abc1).toHaveBeenCalledWith(arg);
-                expect(abc2).toHaveBeenCalledWith(arg);
-                expect(def1).toHaveBeenCalledWith(arg);
-                expect(def2).toHaveBeenCalledWith(arg);
+                expect(abc1).toHaveBeenCalledWith(arg, bot1, 'abc');
+                expect(abc2).toHaveBeenCalledWith(arg, bot2, 'abc');
+                expect(def1).toHaveBeenCalledWith(arg, bot1, 'def');
+                expect(def2).toHaveBeenCalledWith(arg, bot2, 'def');
             });
         });
 
@@ -16430,8 +16434,16 @@ describe('AuxLibrary', () => {
                 recordListeners();
 
                 handleResult(shout('sayHello', { hi: 'test' }));
-                expect(sayHello1).toHaveBeenCalledWith({ hi: 'test' });
-                expect(sayHello2).toHaveBeenCalledWith({ hi: 'test' });
+                expect(sayHello1).toHaveBeenCalledWith(
+                    { hi: 'test' },
+                    bot1,
+                    'sayHello'
+                );
+                expect(sayHello2).toHaveBeenCalledWith(
+                    { hi: 'test' },
+                    bot2,
+                    'sayHello'
+                );
             });
 
             it('should handle passing bots as arguments', () => {
@@ -16441,8 +16453,8 @@ describe('AuxLibrary', () => {
                 recordListeners();
 
                 handleResult(shout('sayHello', bot3));
-                expect(sayHello1).toHaveBeenCalledWith(bot3);
-                expect(sayHello2).toHaveBeenCalledWith(bot3);
+                expect(sayHello1).toHaveBeenCalledWith(bot3, bot1, 'sayHello');
+                expect(sayHello2).toHaveBeenCalledWith(bot3, bot2, 'sayHello');
             });
 
             it('should be able to modify bots that are arguments', () => {
@@ -16471,8 +16483,16 @@ describe('AuxLibrary', () => {
                 recordListeners();
 
                 handleResult(shout('sayHello', { bot: bot3 }));
-                expect(sayHello1).toHaveBeenCalledWith({ bot: bot3 });
-                expect(sayHello2).toHaveBeenCalledWith({ bot: bot3 });
+                expect(sayHello1).toHaveBeenCalledWith(
+                    { bot: bot3 },
+                    bot1,
+                    'sayHello'
+                );
+                expect(sayHello2).toHaveBeenCalledWith(
+                    { bot: bot3 },
+                    bot2,
+                    'sayHello'
+                );
                 expect(bot3.tags.hit1).toEqual(true);
                 expect(bot3.tags.hit2).toEqual(true);
             });
@@ -16483,8 +16503,8 @@ describe('AuxLibrary', () => {
                 recordListeners();
 
                 handleResult(shout('sayHello', true));
-                expect(sayHello1).toHaveBeenCalledWith(true);
-                expect(sayHello2).toHaveBeenCalledWith(true);
+                expect(sayHello1).toHaveBeenCalledWith(true, bot1, 'sayHello');
+                expect(sayHello2).toHaveBeenCalledWith(true, bot2, 'sayHello');
             });
 
             it('should return an array of results from the other formulas', () => {
@@ -16684,10 +16704,22 @@ describe('AuxLibrary', () => {
                     targets: [bot1, bot2, bot3],
                     listeners: [bot1, bot2, bot3], // should exclude erroring listeners
                 };
-                expect(onListen1).toHaveBeenCalledWith(expected);
-                expect(onListen2).toHaveBeenCalledWith(expected);
-                expect(onListen3).toHaveBeenCalledWith(expected);
-                expect(onListen4).not.toHaveBeenCalledWith(expected);
+                expect(onListen1).toHaveBeenCalledWith(
+                    expected,
+                    bot1,
+                    'onListen'
+                );
+                expect(onListen2).toHaveBeenCalledWith(
+                    expected,
+                    bot2,
+                    'onListen'
+                );
+                expect(onListen3).toHaveBeenCalledWith(
+                    expected,
+                    bot3,
+                    'onListen'
+                );
+                expect(onListen4).not.toHaveBeenCalled();
             });
 
             it('should send a onAnyListen shout', () => {
@@ -16713,7 +16745,11 @@ describe('AuxLibrary', () => {
                     targets: [bot1, bot2, bot3, bot4],
                     listeners: [bot1, bot2, bot3, bot4], // should exclude erroring listeners
                 };
-                expect(onAnyListen4).toHaveBeenCalledWith(expected);
+                expect(onAnyListen4).toHaveBeenCalledWith(
+                    expected,
+                    bot4,
+                    'onAnyListen'
+                );
             });
 
             it('should perform an energy check', () => {
@@ -16818,12 +16854,20 @@ describe('AuxLibrary', () => {
                         abc: 'def',
                     })
                 );
-                expect(sayHello1).toHaveBeenCalledWith({
-                    abc: 'def',
-                });
-                expect(sayHello2).toHaveBeenCalledWith({
-                    abc: 'def',
-                });
+                expect(sayHello1).toHaveBeenCalledWith(
+                    {
+                        abc: 'def',
+                    },
+                    bot1,
+                    'sayHello'
+                );
+                expect(sayHello2).toHaveBeenCalledWith(
+                    {
+                        abc: 'def',
+                    },
+                    bot2,
+                    'sayHello'
+                );
             });
 
             it('should call dynamic listeners even when there is a regular listener', () => {
@@ -16831,7 +16875,6 @@ describe('AuxLibrary', () => {
                 const sayHello11 = jest.fn(() => 11);
                 const sayHello22 = jest.fn(() => 22);
                 const sayHello33 = jest.fn(() => 33);
-                bot1[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello1);
                 bot1[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello11);
                 bot2[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello22);
                 bot3[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello33);
@@ -16846,7 +16889,7 @@ describe('AuxLibrary', () => {
                 // dynamic listeners cant return values, but they should cause the results array
                 // to include an undefined value for the called bot
                 expect(results).toEqual([1]);
-                expect(sayHello1).toHaveBeenCalledWith(123);
+                expect(sayHello1).toHaveBeenCalledWith(123, bot1, 'sayHello');
                 expect(sayHello11).toHaveBeenCalledWith(123, bot1, 'sayHello');
                 expect(sayHello22).toHaveBeenCalledWith(123, bot2, 'sayHello');
                 expect(sayHello33).toHaveBeenCalledWith(123, bot3, 'sayHello');
@@ -16917,9 +16960,17 @@ describe('AuxLibrary', () => {
                     listeners: [bot1, bot2], // should exclude erroring listeners
                 };
                 expect(onListen1).toHaveBeenCalledTimes(1);
-                expect(onListen1).toHaveBeenCalledWith(expected);
+                expect(onListen1).toHaveBeenCalledWith(
+                    expected,
+                    bot1,
+                    'onListen'
+                );
                 expect(onListen2).toHaveBeenCalledTimes(1);
-                expect(onListen2).toHaveBeenCalledWith(expected);
+                expect(onListen2).toHaveBeenCalledWith(
+                    expected,
+                    bot2,
+                    'onListen'
+                );
             });
 
             it('should throw a reasonable error if given a null listener name', () => {
@@ -17163,9 +17214,17 @@ describe('AuxLibrary', () => {
                     targets: [bot1, bot2, bot3],
                     listeners: [bot1, bot2], // should exclude erroring listeners
                 };
-                expect(onListen1).toHaveBeenCalledWith(expected);
-                expect(onListen2).toHaveBeenCalledWith(expected);
-                expect(onListen3).not.toHaveBeenCalledWith(expected);
+                expect(onListen1).toHaveBeenCalledWith(
+                    expected,
+                    bot1,
+                    'onListen'
+                );
+                expect(onListen2).toHaveBeenCalledWith(
+                    expected,
+                    bot2,
+                    'onListen'
+                );
+                expect(onListen3).not.toHaveBeenCalled();
                 expect(onListen4).not.toHaveBeenCalled();
             });
 
@@ -17187,7 +17246,11 @@ describe('AuxLibrary', () => {
                     targets: [bot1, bot2, bot3],
                     listeners: [bot1, bot2, bot3], // should exclude erroring listeners
                 };
-                expect(onAnyListen4).toHaveBeenCalledWith(expected);
+                expect(onAnyListen4).toHaveBeenCalledWith(
+                    expected,
+                    bot4,
+                    'onAnyListen'
+                );
             });
 
             it('should ignore null bots', () => {
@@ -17294,7 +17357,7 @@ describe('AuxLibrary', () => {
                 const sayHello11 = jest.fn(() => 11);
                 const sayHello22 = jest.fn(() => 22);
                 const sayHello33 = jest.fn(() => 33);
-                bot1[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello1);
+                // bot1[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello1);
                 bot1[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello11);
                 bot2[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello22);
                 bot3[ADD_BOT_LISTENER_SYMBOL]('sayHello', sayHello33);
@@ -17311,7 +17374,7 @@ describe('AuxLibrary', () => {
                 // dynamic listeners cant return values, but they should cause the results array
                 // to include an undefined value for the called bot
                 expect(results).toEqual([1]);
-                expect(sayHello1).toHaveBeenCalledWith(123);
+                expect(sayHello1).toHaveBeenCalledWith(123, bot1, 'sayHello');
                 expect(sayHello11).toHaveBeenCalledWith(123, bot1, 'sayHello');
                 expect(sayHello22).toHaveBeenCalledWith(123, bot2, 'sayHello');
                 expect(sayHello33).not.toHaveBeenCalled();
@@ -17371,10 +17434,18 @@ describe('AuxLibrary', () => {
                     listeners: [bot2, bot1], // should exclude erroring listeners
                 };
                 expect(onListen1).toHaveBeenCalledTimes(1);
-                expect(onListen1).toHaveBeenCalledWith(expected);
+                expect(onListen1).toHaveBeenCalledWith(
+                    expected,
+                    bot1,
+                    'onListen'
+                );
                 expect(onListen2).toHaveBeenCalledTimes(1);
-                expect(onListen2).toHaveBeenCalledWith(expected);
-                expect(onListen3).not.toHaveBeenCalledWith(expected);
+                expect(onListen2).toHaveBeenCalledWith(
+                    expected,
+                    bot2,
+                    'onListen'
+                );
+                expect(onListen3).not.toHaveBeenCalled();
             });
         });
 

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -173,6 +173,7 @@ import {
     addMapLayer,
     removeMapLayer,
     ADD_BOT_LISTENER_SYMBOL,
+    GET_DYNAMIC_LISTENERS_SYMBOL,
 } from '@casual-simulation/aux-common/bots';
 import { types } from 'util';
 import { attachRuntime, detachRuntime } from './RuntimeEvents';
@@ -17851,6 +17852,47 @@ describe('AuxLibrary', () => {
             expect(() => {
                 library.api.assertEqual(new Error('abc'), new Error('def'));
             }).toThrow();
+        });
+    });
+
+    describe('os.addBotListener()', () => {
+        let bot1: RuntimeBot;
+
+        beforeEach(() => {
+            bot1 = createDummyRuntimeBot('test1');
+            addToContext(context, bot1);
+        });
+
+        it('should add a listener to the bot', () => {
+            const fn = jest.fn();
+
+            library.api.os.addBotListener(bot1, 'test', fn);
+
+            const listeners = bot1[GET_DYNAMIC_LISTENERS_SYMBOL]('test');
+
+            expect(listeners).toBeDefined();
+            expect(listeners!.length).toBe(1);
+            expect(listeners![0]).toBe(fn);
+        });
+    });
+
+    describe('os.removeBotListener()', () => {
+        let bot1: RuntimeBot;
+
+        beforeEach(() => {
+            bot1 = createDummyRuntimeBot('test1');
+            addToContext(context, bot1);
+        });
+
+        it('should add a listener to the bot', () => {
+            const fn = jest.fn();
+
+            library.api.os.addBotListener(bot1, 'test', fn);
+            library.api.os.removeBotListener(bot1, 'test', fn);
+
+            const listeners = bot1[GET_DYNAMIC_LISTENERS_SYMBOL]('test');
+
+            expect(listeners).toBe(null);
         });
     });
 

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -16905,6 +16905,12 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param tagName The name of the tag that the listener should be added to.
      * @param listener The listener that should be added to the bot.
      *
+     * @example Add a listener to the bot for the "onClick" tag
+     * const listener = (that) => {
+     *   os.toast("Clicked on " + that.face);
+     * };
+     * os.addBotListener(thisBot, "onClick", listener);
+     *
      * @dochash actions/os/event
      * @docgroup 02-event-actions
      * @docname os.addBotListener
@@ -16923,6 +16929,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
      * @param bot The bot that the listener should be removed from.
      * @param tagName The name of the tag that the listener should be removed from.
      * @param listener The listener that should be removed from the bot.
+     *
+     * @example Remove a listener from the bot for the "onClick" tag
+     * os.removeBotListener(thisBot, "onClick", listener);
      *
      * @dochash actions/os/event
      * @docgroup 02-event-actions

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -17601,7 +17601,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                             INTERPRETABLE_FUNCTION
                         ](arg);
                     } else {
-                        result = listener(arg);
+                        result = listener(arg, bot, tag);
                     }
 
                     if (isGenerator(result)) {

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -113,6 +113,7 @@ import type {
     UnloadServerConfigAction,
     Point3D,
     MapLayer,
+    DynamicListener,
 } from '@casual-simulation/aux-common/bots';
 import {
     hasValue,
@@ -274,6 +275,8 @@ import {
     addMapLayer as calcAddMapLayer,
     removeMapLayer as calcRemoveMapLayer,
     GET_DYNAMIC_LISTENERS_SYMBOL,
+    ADD_BOT_LISTENER_SYMBOL,
+    REMOVE_BOT_LISTENER_SYMBOL,
 } from '@casual-simulation/aux-common/bots';
 import type {
     AIChatOptions,
@@ -3137,6 +3140,9 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
 
             os: {
                 [UNCOPIABLE]: true,
+
+                addBotListener,
+                removeBotListener,
 
                 sleep,
                 toast,
@@ -16890,6 +16896,45 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
         }
 
         return yield* event(eventName, bots, arg);
+    }
+
+    /**
+     * Adds the given listener to the given bot for the given tag.
+     *
+     * @param bot The bot that the listener should be added to.
+     * @param tagName The name of the tag that the listener should be added to.
+     * @param listener The listener that should be added to the bot.
+     *
+     * @dochash actions/os/event
+     * @docgroup 02-event-actions
+     * @docname os.addBotListener
+     * @docid os.addBotListener
+     */
+    function addBotListener(
+        bot: RuntimeBot,
+        tagName: string,
+        listener: DynamicListener
+    ): void {
+        bot[ADD_BOT_LISTENER_SYMBOL](tagName, listener);
+    }
+
+    /**
+     * Removes the given listener from a bot for a specific tag.
+     * @param bot The bot that the listener should be removed from.
+     * @param tagName The name of the tag that the listener should be removed from.
+     * @param listener The listener that should be removed from the bot.
+     *
+     * @dochash actions/os/event
+     * @docgroup 02-event-actions
+     * @docname os.removeBotListener
+     * @docid os.removeBotListener
+     */
+    function removeBotListener(
+        bot: RuntimeBot,
+        tagName: string,
+        listener: DynamicListener
+    ): void {
+        bot[REMOVE_BOT_LISTENER_SYMBOL](tagName, listener);
     }
 
     /**

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -12294,6 +12294,22 @@ export interface GeoJSONMapLayer extends MapLayerBase {
     data?: object;
 }
 
+/**
+ * The function signature of a dynamic bot listener.
+ *
+ * That is, a listener that is registered at runtime by a user script instead of parsed from a tag.
+ *
+ * @dochash types/core
+ * @docgroup 01-core
+ * @docname Listener
+ * @docid DynamicListener
+ */
+export type DynamicListener = (
+    that: any,
+    bot: Bot,
+    tagName: string
+) => any;
+
 interface Ai {
     /**
      * Sends a chat message to the AI.
@@ -12801,6 +12817,34 @@ interface Ai {
 }
 
 interface Os {
+
+    /**
+     * Adds the given listener to the given bot for the given tag.
+     * 
+     * @param bot The bot that the listener should be added to.
+     * @param tagName The name of the tag that the listener should be added to.
+     * @param listener The listener that should be added to the bot.
+     * 
+     * @dochash actions/os/event
+     * @docgroup 02-event-actions
+     * @docname os.addBotListener
+     * @docid os.addBotListener
+     */
+    addBotListener(bot: Bot, tagName: string, listener: DynamicListener): void;
+    
+    /**
+     * Removes the given listener from a bot for a specific tag.
+     * @param bot The bot that the listener should be removed from.
+     * @param tagName The name of the tag that the listener should be removed from.
+     * @param listener The listener that should be removed from the bot.
+     * 
+     * @dochash actions/os/event
+     * @docgroup 02-event-actions
+     * @docname os.removeBotListener
+     * @docid os.removeBotListener
+     */
+    removeBotListener(bot: Bot, tagName: string, listener: DynamicListener): void;
+
     /**
          * Sleeps for time in ms.
          * @param time Time in ms. 1 second is 1000ms.

--- a/src/aux-runtime/runtime/AuxRuntime.spec.ts
+++ b/src/aux-runtime/runtime/AuxRuntime.spec.ts
@@ -376,6 +376,36 @@ describe('AuxRuntime', () => {
                     expect(runtime.context.state['test'].vars.myVar).toBe(true);
                 });
 
+                it('should preserve the dynamic listeners that a bot has if it is overwritten', () => {
+                    const update1 = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                abc: 'def',
+                            }),
+                        })
+                    );
+
+                    const test = runtime.currentState['test'];
+                    const listener = jest.fn();
+                    runtime.addDynamicListener(test, 'abc', listener);
+
+                    const update2 = runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test: createBot('test', {
+                                abc: 123,
+                            }),
+                        })
+                    );
+
+                    const listeners = runtime.getDynamicListeners(
+                        runtime.currentState['test'],
+                        'abc'
+                    );
+                    expect(listeners).toBeTruthy();
+                    expect(listeners!.length).toBe(1);
+                    expect(listeners![0] === listener).toBe(true);
+                });
+
                 it('should include the space the bot was in', () => {
                     const update = runtime.stateUpdated(
                         stateUpdatedEvent({

--- a/src/aux-runtime/runtime/AuxRuntime.ts
+++ b/src/aux-runtime/runtime/AuxRuntime.ts
@@ -2406,6 +2406,7 @@ export class AuxRuntime
                     }
                 }
 
+                newBot.dynamicListeners = existing.dynamicListeners;
                 existing.script[REPLACE_BOT_SYMBOL](newBot.script);
             }
 

--- a/src/aux-runtime/runtime/CompiledBot.ts
+++ b/src/aux-runtime/runtime/CompiledBot.ts
@@ -25,6 +25,7 @@ import type {
     RuntimeBot,
     CompiledBotModules,
     CompiledBotExports,
+    DynamicBotListeners,
 } from '@casual-simulation/aux-common/bots';
 import { hasValue } from '@casual-simulation/aux-common/bots';
 import { v4 as uuid } from 'uuid';
@@ -62,6 +63,11 @@ export interface CompiledBot extends PrecalculatedBot {
      * The tags that are listeners and have been compiled into functions.
      */
     listeners: CompiledBotListeners;
+
+    /**
+     * The dynamic listeners that have been registered at runtime.
+     */
+    dynamicListeners: DynamicBotListeners;
 
     /**
      * The modules that are defined by this bot.
@@ -192,7 +198,8 @@ export function createCompiledBot(
     space?: BotSpace,
     listeners: CompiledBotListeners = {},
     signatures?: BotSignatures,
-    modules: CompiledBotModules = {}
+    modules: CompiledBotModules = {},
+    dynamicListeners: DynamicBotListeners = {}
 ): CompiledBot {
     if (hasValue(space)) {
         return {
@@ -202,6 +209,7 @@ export function createCompiledBot(
             tags: tags || values,
             values,
             listeners: listeners,
+            dynamicListeners: dynamicListeners,
             modules: modules,
             exports: {},
             signatures,
@@ -218,6 +226,7 @@ export function createCompiledBot(
         tags: tags || values,
         values,
         listeners: listeners,
+        dynamicListeners: dynamicListeners,
         modules: modules,
         exports: {},
         signatures,

--- a/src/aux-runtime/runtime/CompiledBot.ts
+++ b/src/aux-runtime/runtime/CompiledBot.ts
@@ -65,6 +65,12 @@ export interface CompiledBot extends PrecalculatedBot {
     listeners: CompiledBotListeners;
 
     /**
+     * The listeners that have been overridden by the user.
+     * These listeners will override the compiled listeners.
+     */
+    listenerOverrides: CompiledBotListeners;
+
+    /**
      * The dynamic listeners that have been registered at runtime.
      */
     dynamicListeners: DynamicBotListeners;
@@ -199,7 +205,8 @@ export function createCompiledBot(
     listeners: CompiledBotListeners = {},
     signatures?: BotSignatures,
     modules: CompiledBotModules = {},
-    dynamicListeners: DynamicBotListeners = {}
+    dynamicListeners: DynamicBotListeners = {},
+    listenerOverrides: CompiledBotListeners = {}
 ): CompiledBot {
     if (hasValue(space)) {
         return {
@@ -209,6 +216,7 @@ export function createCompiledBot(
             tags: tags || values,
             values,
             listeners: listeners,
+            listenerOverrides: listenerOverrides,
             dynamicListeners: dynamicListeners,
             modules: modules,
             exports: {},
@@ -226,6 +234,7 @@ export function createCompiledBot(
         tags: tags || values,
         values,
         listeners: listeners,
+        listenerOverrides: listenerOverrides,
         dynamicListeners: dynamicListeners,
         modules: modules,
         exports: {},

--- a/src/aux-runtime/runtime/RuntimeBot.spec.ts
+++ b/src/aux-runtime/runtime/RuntimeBot.spec.ts
@@ -19,6 +19,7 @@ import type {
     PrecalculatedBot,
     BotTagMasks,
     RuntimeBot,
+    DynamicListener,
 } from '@casual-simulation/aux-common/bots';
 import {
     BOT_SPACE_TAG,
@@ -36,6 +37,9 @@ import {
     hasValue,
     GET_TAG_MASKS_SYMBOL,
     REPLACE_BOT_SYMBOL,
+    ADD_BOT_LISTENER_SYMBOL,
+    REMOVE_BOT_LISTENER_SYMBOL,
+    GET_DYNAMIC_LISTENERS_SYMBOL,
 } from '@casual-simulation/aux-common/bots';
 import type { AuxGlobalContext } from './AuxGlobalContext';
 import { MemoryGlobalContext } from './AuxGlobalContext';
@@ -94,6 +98,18 @@ describe('RuntimeBot', () => {
     >;
     let getTagMaskMock: jest.Mock;
     let getTagLinkMock: jest.Mock;
+    let addListenerMock: jest.Mock<
+        void,
+        [CompiledBot, string, DynamicListener]
+    >;
+    let removeListenerMock: jest.Mock<
+        void,
+        [CompiledBot, string, DynamicListener]
+    >;
+    let getDynamicListenersMock: jest.Mock<
+        DynamicListener[] | null,
+        [CompiledBot, string]
+    >;
     let realtimeEditMode: RealtimeEditMode;
     let changedValue: any;
     let processor: RuntimeInterpreterGeneratorProcessor;
@@ -194,6 +210,41 @@ describe('RuntimeBot', () => {
         });
         notifyChangeMock = jest.fn();
         getTagLinkMock = jest.fn();
+
+        addListenerMock = jest.fn(
+            (bot: CompiledBot, tag: string, listener: DynamicListener) => {
+                if (!bot.dynamicListeners) {
+                    bot.dynamicListeners = {};
+                }
+                if (!bot.dynamicListeners[tag]) {
+                    bot.dynamicListeners[tag] = [];
+                }
+                bot.dynamicListeners[tag].push(listener);
+            }
+        );
+
+        removeListenerMock = jest.fn(
+            (bot: CompiledBot, tag: string, listener: DynamicListener) => {
+                if (bot.dynamicListeners && bot.dynamicListeners[tag]) {
+                    const listeners = bot.dynamicListeners[tag];
+                    const index = listeners.indexOf(listener);
+                    if (index !== -1) {
+                        listeners.splice(index, 1);
+                        if (listeners.length <= 0) {
+                            delete bot.dynamicListeners[tag];
+                        }
+                    }
+                }
+            }
+        );
+
+        getDynamicListenersMock = jest.fn((bot: CompiledBot, tag: string) => {
+            if (bot.dynamicListeners && bot.dynamicListeners[tag]) {
+                return bot.dynamicListeners[tag];
+            }
+            return null;
+        });
+
         manager = {
             updateTag: updateTagMock,
             getValue(bot: PrecalculatedBot, tag: string) {
@@ -207,6 +258,9 @@ describe('RuntimeBot', () => {
             updateTagMask: updateTagMaskMock,
             getTagMask: getTagMaskMock,
             getTagLink: getTagLinkMock,
+            addDynamicListener: addListenerMock,
+            removeDynamicListener: removeListenerMock,
+            getDynamicListeners: getDynamicListenersMock,
             currentVersion: {
                 localSites: {},
                 vector: {
@@ -2716,6 +2770,54 @@ describe('RuntimeBot', () => {
                     test: true,
                 });
             });
+        });
+    });
+
+    describe('add_bot_listener', () => {
+        it('should add a listener to the dynamic listeners', () => {
+            const listener: DynamicListener = jest.fn();
+            script[ADD_BOT_LISTENER_SYMBOL]('testListener', listener);
+
+            expect(precalc.dynamicListeners).toHaveProperty('testListener');
+
+            const listeners = precalc.dynamicListeners.testListener;
+            expect(listeners).toBeInstanceOf(Array);
+            expect(listeners.length).toBe(1);
+            expect(listeners[0] === listener).toBe(true);
+        });
+    });
+
+    describe('remove_bot_listener', () => {
+        it('should remove a listener from the dynamic listeners', () => {
+            const listener: DynamicListener = jest.fn();
+            precalc.dynamicListeners.testListener = [listener];
+
+            script[REMOVE_BOT_LISTENER_SYMBOL]('testListener', listener);
+
+            expect(precalc.dynamicListeners).not.toHaveProperty('testListener');
+        });
+    });
+
+    describe('get_dynamic_listeners', () => {
+        it('should retrieve the list of dynamic listeners', () => {
+            const listener1: DynamicListener = jest.fn();
+            const listener2: DynamicListener = jest.fn();
+            const listener3: DynamicListener = jest.fn();
+            script[ADD_BOT_LISTENER_SYMBOL]('testListener', listener1);
+            script[ADD_BOT_LISTENER_SYMBOL]('testListener', listener2);
+            script[ADD_BOT_LISTENER_SYMBOL]('other', listener3);
+
+            const listeners =
+                script[GET_DYNAMIC_LISTENERS_SYMBOL]('testListener');
+            expect(listeners).not.toBeNull();
+            expect(listeners).toBeInstanceOf(Array);
+            expect(listeners!.length).toBe(2);
+            expect(listeners![0] === listener1).toBe(true);
+            expect(listeners![1] === listener2).toBe(true);
+        });
+
+        it('should return null if there are no dynamic listeners', () => {
+            expect(script[GET_DYNAMIC_LISTENERS_SYMBOL]('tag')).toBeNull();
         });
     });
 

--- a/src/aux-runtime/runtime/RuntimeBot.spec.ts
+++ b/src/aux-runtime/runtime/RuntimeBot.spec.ts
@@ -1118,6 +1118,21 @@ describe('RuntimeBot', () => {
             expect(getListenerMock).toHaveBeenCalledWith(precalc, 'abc');
         });
 
+        it('should be able to enumerate the listeners on the bot', () => {
+            let func = () => {};
+            let func2 = () => {};
+            precalc.listeners.abc = func;
+            script.listeners.def = func2;
+
+            const keys = Object.keys(script.listeners);
+            expect(keys).toEqual(['abc', 'def']);
+
+            script.listeners.def = null;
+
+            const keys2 = Object.keys(script.listeners);
+            expect(keys2).toEqual(['abc']);
+        });
+
         describe('listener shortcut', () => {
             it('should support getting listeners directly from the runtime bot', () => {
                 let func = () => {};

--- a/src/aux-runtime/runtime/RuntimeBot.ts
+++ b/src/aux-runtime/runtime/RuntimeBot.ts
@@ -403,6 +403,12 @@ export function createRuntimeBot(
                 return false;
             }
             manager.setListener(bot, key, value);
+            // Keep the bot listener keys and the listener override keys in sync.
+            if (key in bot.listenerOverrides && !(key in bot.listeners)) {
+                bot.listeners[key] = undefined;
+            } else if (!bot.listeners[key]) {
+                delete bot.listeners[key];
+            }
             return true;
         },
     });

--- a/src/aux-runtime/runtime/RuntimeBot.ts
+++ b/src/aux-runtime/runtime/RuntimeBot.ts
@@ -25,12 +25,18 @@ import {
     UNCOPIABLE,
     INTERPRETER_OBJECT,
 } from '@casual-simulation/js-interpreter/InterpreterUtils';
-import type { TagEditOp } from '@casual-simulation/aux-common/bots';
+import type {
+    DynamicListener,
+    TagEditOp,
+} from '@casual-simulation/aux-common/bots';
 import {
+    ADD_BOT_LISTENER_SYMBOL,
     applyTagEdit,
+    GET_DYNAMIC_LISTENERS_SYMBOL,
     isTagEdit,
     mergeEdits,
     remoteEdit,
+    REMOVE_BOT_LISTENER_SYMBOL,
 } from '@casual-simulation/aux-common/bots';
 import type {
     BotTags,
@@ -636,6 +642,9 @@ export function createRuntimeBot(
         [EDIT_TAG_SYMBOL]: null,
         [EDIT_TAG_MASK_SYMBOL]: null,
         [REPLACE_BOT_SYMBOL]: null,
+        [ADD_BOT_LISTENER_SYMBOL]: null,
+        [REMOVE_BOT_LISTENER_SYMBOL]: null,
+        [GET_DYNAMIC_LISTENERS_SYMBOL]: null,
     };
 
     Object.defineProperty(script, CLEAR_CHANGES_SYMBOL, {
@@ -770,6 +779,33 @@ export function createRuntimeBot(
             } else {
                 replacement[REPLACE_BOT_SYMBOL](bot);
             }
+        },
+        configurable: true,
+        enumerable: false,
+        writable: false,
+    });
+
+    Object.defineProperty(script, ADD_BOT_LISTENER_SYMBOL, {
+        value: (tag: string, listener: DynamicListener) => {
+            manager.addDynamicListener(bot, tag, listener);
+        },
+        configurable: true,
+        enumerable: false,
+        writable: false,
+    });
+
+    Object.defineProperty(script, REMOVE_BOT_LISTENER_SYMBOL, {
+        value: (tag: string, listener: DynamicListener) => {
+            manager.removeDynamicListener(bot, tag, listener);
+        },
+        configurable: true,
+        enumerable: false,
+        writable: false,
+    });
+
+    Object.defineProperty(script, GET_DYNAMIC_LISTENERS_SYMBOL, {
+        value: (tag: string) => {
+            return manager.getDynamicListeners(bot, tag);
         },
         configurable: true,
         enumerable: false,
@@ -948,6 +984,41 @@ export interface RuntimeBotInterface extends RuntimeBatcher {
      * @param signature The tag.
      */
     getSignature(bot: CompiledBot, signature: string): string;
+
+    /**
+     * Adds the given listener to the bot for the given tag.
+     * @param bot The bot that the listener should be added to.
+     * @param tag The tag that the listener should be added for.
+     * @param listener The listener that should be added.
+     */
+    addDynamicListener(
+        bot: CompiledBot,
+        tag: string,
+        listener: DynamicListener
+    ): void;
+
+    /**
+     * Removes the given listener from the bot for the given tag.
+     * @param bot The bot that the listener should be removed from.
+     * @param tag The tag that the listener should be removed for.
+     * @param listener The listener that should be removed.
+     */
+    removeDynamicListener(
+        bot: CompiledBot,
+        tag: string,
+        listener: DynamicListener
+    ): void;
+
+    /**
+     * Gets the dynamic listeners for the given bot and tag.
+     * @param bot The bot that the listeners should be retrieved for.
+     * @param tag The tag that the listeners should be retrieved for.
+     * @returns The list of dynamic listeners for the tag, or null if none are registered.
+     */
+    getDynamicListeners(
+        bot: CompiledBot,
+        tag: string
+    ): DynamicListener[] | null;
 
     /**
      * Gets the current version that the interface is at.

--- a/src/aux-runtime/runtime/__snapshots__/AuxRuntime.spec.ts.snap
+++ b/src/aux-runtime/runtime/__snapshots__/AuxRuntime.spec.ts.snap
@@ -263,6 +263,8 @@ Array [
   "arguments",
   "that",
   "data",
+  "$__bot",
+  "$__tag",
   "___importModule",
   "___exportModule",
   "create",

--- a/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
@@ -99,7 +99,7 @@ export const testScriptBotInterface: RuntimeBotInterface = {
         return bot.tags[tag];
     },
     getListener(bot: CompiledBot, tag: string) {
-        return bot.listeners[tag];
+        return bot.listenerOverrides[tag] ?? bot.listeners[tag] ?? null;
     },
     setListener(bot: CompiledBot, tag: string, value: DynamicListener | null) {
         if (!hasValue(value)) {

--- a/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
@@ -148,6 +148,33 @@ export const testScriptBotInterface: RuntimeBotInterface = {
     getTagLink(bot: CompiledBot, tag: string) {
         return null;
     },
+    addDynamicListener(bot, tag, listener) {
+        if (!bot.dynamicListeners) {
+            bot.dynamicListeners = {};
+        }
+        if (!bot.dynamicListeners[tag]) {
+            bot.dynamicListeners[tag] = [];
+        }
+        bot.dynamicListeners[tag].push(listener);
+    },
+    removeDynamicListener(bot, tag, listener) {
+        if (bot.dynamicListeners && bot.dynamicListeners[tag]) {
+            const listeners = bot.dynamicListeners[tag];
+            const index = listeners.indexOf(listener);
+            if (index >= 0) {
+                listeners.splice(index, 1);
+                if (listeners.length <= 0) {
+                    delete bot.dynamicListeners[tag];
+                }
+            }
+        }
+    },
+    getDynamicListeners(bot, tag) {
+        if (bot.dynamicListeners && bot.dynamicListeners[tag]) {
+            return bot.dynamicListeners[tag];
+        }
+        return null;
+    },
 
     currentVersion: {
         localSites: {},

--- a/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
+++ b/src/aux-runtime/runtime/test/TestScriptBotFactory.ts
@@ -22,6 +22,7 @@ import type {
     Bot,
     BotSignatures,
     RuntimeBot,
+    DynamicListener,
 } from '@casual-simulation/aux-common/bots';
 import {
     TAG_MASK_SPACE_PRIORITIES,
@@ -99,6 +100,13 @@ export const testScriptBotInterface: RuntimeBotInterface = {
     },
     getListener(bot: CompiledBot, tag: string) {
         return bot.listeners[tag];
+    },
+    setListener(bot: CompiledBot, tag: string, value: DynamicListener | null) {
+        if (!hasValue(value)) {
+            delete bot.listenerOverrides[tag];
+        } else {
+            bot.listenerOverrides[tag] = value;
+        }
     },
     getSignature(bot: PrecalculatedBot, signature: string): string {
         if (bot.signatures) {


### PR DESCRIPTION
### :rocket: Features

-   Added the `os.addBotListener(bot, tag, listener)` and `os.removeBotListener(bot, tag, listener)` functions.
    -   `os.addBotListener(bot, tag, listener)` Adds the given listener to the given bot for the given tag.
        -   It can be used to add arbitrary functions to be triggered when a listener would be triggered on a bot.
        -   This function only adds listeners, it cannot override existing listeners.
        -   Listeners added by this function will not be called if the bot is not listening.
        -   `bot` is the bot that the lister should be added to.
        -   `tag` is the [listen tag](https://docs.casualos.com/tags/listen/).
        -   `listener` is the function that should be called when the listen tag is triggered. It should be a function that accepts the following arguments:
            -   `that` - the `that` argument of the listener.
            -   `bot` - The bot that the listener was triggered on. (Same as `bot` above)
            -   `tag` - The name of the tag. (Same as `tag` above)
    -   `os.removeBotListener(bot, tag, listener)` Removes the given listener from the given bot and tag.
        -   This function can only be used to remove listeners which have been added by `os.addBotListener()`.
        -   `bot` is the bot that the listener should be removed from.
        -   `tag` is the [listen tag](https://docs.casualos.com/tags/listen/).
        -   `listener` is the function that should be removed.
-   Added the ability to add/override bot listen tags by setting `bot.listeners.tag`.

    -   For example, the following code will override the `onClick` listen tag to toast "overridden" when the bot is clicked:

        ```typescript
        bot.tags.onClick = `@os.toast("default")`;
        bot.listeners.onClick = () => os.toast('overridden');

        // when bot is clicked, "overridden" will be toasted instead of "default".
        ```

    -   Just like the `masks` property, the `listeners` property allows you to override the default tags.
    -   The difference is that `listeners` is all about listen tags and functions. You can only set functions, and `listeners` are always `tempLocal`.
    -   Functions set on the `listeners` property will override listen tags set by tags and tag masks.
        -   It will only override the listener, not the tag data. In the example above, `bot.tags.onClick` will continue to return `@os.toast("default")`.

Closes #463 