### PR TITLE
Implement additional properties to determine which bot and tag is displayed in the code editor for a code tool bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 -   Improved the `pack-aux` and `unpack-aux` commands in the CLI to replace bot IDs with a placeholder by default.
     -   This helps prevent version control churn if the AUX files are being packed and repacked a lot.
+-   Added additional properties to `@onClick` and `@onAnyBotClicked` for code tool bots:
+    -   `codeBot` - The bot that is currently being displayed in the code editor.
+    -   `codeTag` - The tag that is currently being displayed in the code editor.
+    -   `codeTagSpace` - The space of the tag that is currently being displayed in the code editor.
 
 ### :bug: Bug Fixes
 

--- a/docs/docs/tags/listen.mdx
+++ b/docs/docs/tags/listen.mdx
@@ -126,6 +126,27 @@ let that: {
    * For "mouse" modalities, which button was used to click the bot.
    */
   buttonId: 'left' | 'middle' | 'right';
+
+  /**
+   * The bot that is currently displayed in the code editor.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeBot?: Bot;
+
+  /**
+   * The tag that is currently displayed in the code editor.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeTag?: string;
+
+  /**
+   * The space of the tag that the code editor is currently displaying.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeTagSpace?: string;
 };
 ```
 
@@ -783,6 +804,27 @@ let that: {
    * For "mouse" modalities, which button was used to click the bot.
    */
   buttonId: 'left' | 'middle' | 'right';
+
+  /**
+   * The bot that is currently displayed in the code editor.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeBot?: Bot;
+
+  /**
+   * The tag that is currently displayed in the code editor.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeTag?: string;
+
+  /**
+   * The space of the tag that the code editor is currently displaying.
+   * 
+   * Only available if the clicked bot is a code tool.
+  */
+  codeTagSpace?: string;
 };
 ```
 

--- a/src/aux-server/aux-web/shared/vue-components/CodeToolsPortal/CodeToolsPortal.ts
+++ b/src/aux-server/aux-web/shared/vue-components/CodeToolsPortal/CodeToolsPortal.ts
@@ -50,6 +50,10 @@ interface CodeTool {
 export default class CodeToolsPortal extends Vue {
     @Prop({ required: true }) simId: string;
 
+    @Prop({ required: true }) botId: string;
+    @Prop({ required: true }) tag: string;
+    @Prop({ required: false }) space: string;
+
     tools: CodeTool[] = [];
 
     private _sub: Subscription;
@@ -84,13 +88,13 @@ export default class CodeToolsPortal extends Vue {
         const sim = appManager.simulationManager.simulations.get(tool.simId);
         if (sim) {
             const bot = sim.helper.botsState[tool.botId];
+            const codeBot = this.botId
+                ? sim.helper.botsState[this.botId]
+                : null;
             if (bot) {
                 sim.helper.transaction(
-                    action(
-                        CLICK_ACTION_NAME,
-                        [bot.id],
-                        sim.helper.userId,
-                        onClickArg(
+                    action(CLICK_ACTION_NAME, [bot.id], sim.helper.userId, {
+                        ...onClickArg(
                             null,
                             tool.dimension,
                             null,
@@ -98,13 +102,13 @@ export default class CodeToolsPortal extends Vue {
                             null,
                             null,
                             null
-                        )
-                    ),
-                    action(
-                        ANY_CLICK_ACTION_NAME,
-                        null,
-                        sim.helper.userId,
-                        onAnyClickArg(
+                        ),
+                        codeBot,
+                        codeTag: this.tag,
+                        codeTagSpace: this.space,
+                    }),
+                    action(ANY_CLICK_ACTION_NAME, null, sim.helper.userId, {
+                        ...onAnyClickArg(
                             null,
                             tool.dimension,
                             bot,
@@ -113,8 +117,11 @@ export default class CodeToolsPortal extends Vue {
                             null,
                             null,
                             null
-                        )
-                    )
+                        ),
+                        codeBot,
+                        codeTag: this.tag,
+                        codeTagSpace: this.space,
+                    })
                 );
             }
         }

--- a/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
+++ b/src/aux-server/aux-web/shared/vue-components/MonacoTagEditor/MonacoTagEditor.vue
@@ -26,7 +26,7 @@
                 >
             </div>
             <div class="editor-toggles">
-                <code-tools :simId="simId"></code-tools>
+                <code-tools :simId="simId" :botId="bot.id" :tag="tag" :space="space"></code-tools>
                 <md-button
                     @click="makeNormalTag()"
                     class="md-dense"


### PR DESCRIPTION
### :rocket: Features

-   Added additional properties to `@onClick` and `@onAnyBotClicked` for code tool bots:
    -   `codeBot` - The bot that is currently being displayed in the code editor.
    -   `codeTag` - The tag that is currently being displayed in the code editor.
    -   `codeTagSpace` - The space of the tag that is currently being displayed in the code editor.

Closes #647 