### PR TITLE
Fix record key issues with `os.getSharedDocument()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Fixed an issue where strings like `e123` would be recognized as numbers.
 -   Fixed an issue where strings that look like numbers could cause labels to render differently from their strings.
 -   Fixed an issue where `os.installPackage()` and `os.listInstalledPackages()` would require the user to login first.
+-   Fixed an issue where calling `os.getSharedDocument()` with a record key would sometimes fail.
 
 ## V3.6.0
 

--- a/src/aux-common/records/AuthUtils.spec.ts
+++ b/src/aux-common/records/AuthUtils.spec.ts
@@ -39,6 +39,7 @@ import {
 } from './AuthUtils';
 import { toBase64String } from '../utils';
 import { formatV1ConnectionToken, parseConnectionToken } from '../common';
+import { formatV2RecordKey } from './RecordKeys';
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
@@ -514,6 +515,45 @@ describe('generateV1ConnectionToken()', () => {
         expect(sessionId).toBe(toBase64String('sessionId'));
         expect(connectionId).toBe(toBase64String('connectionId'));
         expect(recordName).toBe('');
+        expect(inst).toBe(toBase64String('inst'));
+        expect(password).toMatchSnapshot();
+    });
+
+    it('should parse record keys before using the record name', () => {
+        const recordKey = formatV2RecordKey(
+            'recordName',
+            'password',
+            'subjectfull'
+        );
+
+        const key = formatV1ConnectionKey(
+            'userId',
+            'sessionId',
+            'password',
+            123
+        );
+
+        const result = generateV1ConnectionToken(
+            key,
+            'connectionId',
+            recordKey,
+            'inst'
+        );
+
+        const [
+            version,
+            userId,
+            sessionId,
+            connectionId,
+            recordName,
+            inst,
+            password,
+        ] = result.split('.');
+
+        expect(userId).toBe(toBase64String('userId'));
+        expect(sessionId).toBe(toBase64String('sessionId'));
+        expect(connectionId).toBe(toBase64String('connectionId'));
+        expect(recordName).toBe(toBase64String('recordName'));
         expect(inst).toBe(toBase64String('inst'));
         expect(password).toMatchSnapshot();
     });

--- a/src/aux-common/records/AuthUtils.ts
+++ b/src/aux-common/records/AuthUtils.ts
@@ -22,6 +22,7 @@ import {
     formatV1ConnectionToken,
     parseV1ConnectionToken,
 } from '../common/ConnectionToken';
+import { isRecordKey, parseRecordKey } from './RecordKeys';
 
 /**
  * Defines an interface that represents the role that a user can have.
@@ -320,6 +321,13 @@ export function generateV1ConnectionToken(
 
     if (!parsed) {
         return null;
+    }
+
+    if (isRecordKey(recordName)) {
+        const parsed = parseRecordKey(recordName);
+        if (parsed) {
+            recordName = parsed[0]; // Use the record name from the record key
+        }
     }
 
     recordName = recordName ?? '';

--- a/src/aux-common/records/__snapshots__/AuthUtils.spec.ts.snap
+++ b/src/aux-common/records/__snapshots__/AuthUtils.spec.ts.snap
@@ -3,3 +3,5 @@
 exports[`generateV1ConnectionToken() should generate a connection token from the given connection key 1`] = `"OTkxMWY3NDllNmE4NzEzMzMyZjIzNDgzYmJmZGFjYjg2YzU3OWM4YjA0YjMyMWYyNGY0YWMyMzlhYzY0Y2NiYw=="`;
 
 exports[`generateV1ConnectionToken() should generate a connection token with a null recordName 1`] = `"MzZhZjkwMDc2MTYxOGNiMzIwOWQ2ODVjNjI3NTEzZGMxMWUyMjAwYjM1ZGIxMTgyYTFiNmYwN2YyZDU5N2Y5NQ=="`;
+
+exports[`generateV1ConnectionToken() should parse record keys before using the record name 1`] = `"OTkxMWY3NDllNmE4NzEzMzMyZjIzNDgzYmJmZGFjYjg2YzU3OWM4YjA0YjMyMWYyNGY0YWMyMzlhYzY0Y2NiYw=="`;

--- a/src/aux-records/websockets/WebsocketController.ts
+++ b/src/aux-records/websockets/WebsocketController.ts
@@ -308,7 +308,7 @@ export class WebsocketController {
                                 connection.branch
                             ));
 
-                        if (branch.temporary) {
+                        if (branch?.temporary) {
                             console.log(
                                 '[WebsocketController] Deleting temporary branch',
                                 connection.recordName,


### PR DESCRIPTION
### :bug: Bug Fixes

-   Fixed an issue where calling `os.getSharedDocument()` with a record key would sometimes fail.