### PR TITLE
Updated wrist portal offsets for generic controllers and hands.

### DIFF
--- a/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
+++ b/src/aux-server/aux-web/aux-player/scene/PlayerPageSimulation3D.ts
@@ -49,23 +49,23 @@ import Bowser from 'bowser';
 
 const wristOffsets = {
     generic_hand_right: {
-        positionOffset: new Vector3(0.1, 0.05, -0.05),
+        positionOffset: new Vector3(0.075, -0.025, 0.025),
         rotationOffset: new Euler(
-            -120 * ThreeMath.DEG2RAD,
+            -160 * ThreeMath.DEG2RAD,
             90 * ThreeMath.DEG2RAD,
             -90 * ThreeMath.DEG2RAD
         ),
     },
     generic_hand_left: {
-        positionOffset: new Vector3(-0.1, 0.05, -0.05),
+        positionOffset: new Vector3(-0.075, -0.025, 0.025),
         rotationOffset: new Euler(
-            -120 * ThreeMath.DEG2RAD,
-            90 * ThreeMath.DEG2RAD,
-            -90 * ThreeMath.DEG2RAD
+            -160 * ThreeMath.DEG2RAD,
+            -90 * ThreeMath.DEG2RAD,
+            90 * ThreeMath.DEG2RAD
         ),
     },
     generic_controller_right: {
-        positionOffset: new Vector3(0.05, 0.1, 0.1),
+        positionOffset: new Vector3(0.1, 0.0, 0.05),
         rotationOffset: new Euler(
             -120 * ThreeMath.DEG2RAD,
             90 * ThreeMath.DEG2RAD,
@@ -73,7 +73,7 @@ const wristOffsets = {
         ),
     },
     generic_controller_left: {
-        positionOffset: new Vector3(-0.05, 0.1, 0.1),
+        positionOffset: new Vector3(-0.1, 0.0, 0.05),
         rotationOffset: new Euler(
             -120 * ThreeMath.DEG2RAD,
             -90 * ThreeMath.DEG2RAD,


### PR DESCRIPTION
Updated some position and rotation offsets values for left and right generic controllers and hands. This specifically fixes the wrist portals only being visible with your palms facing you and being rotation 90 degrees incorrectly.

<img width="1888" height="1054" alt="Screenshot 2026-02-12 at 3 53 41 PM" src="https://github.com/user-attachments/assets/796b89e3-1547-4268-a1be-fa25cab5493c" />
<img width="1888" height="1054" alt="Screenshot 2026-02-12 at 3 53 58 PM" src="https://github.com/user-attachments/assets/f020e235-9186-48c5-b159-d5fd7e8d0874" />
