### PR TITLE
Tweaked base toon material and default lighting.

### DIFF
--- a/src/aux-server/aux-web/shared/scene/SceneUtils.ts
+++ b/src/aux-server/aux-web/shared/scene/SceneUtils.ts
@@ -99,7 +99,8 @@ export function baseAuxSkyboxMeshMaterial() {
 }
 
 const getToonGradientMap = memoize(() => {
-    const bands = new Uint8Array([0, 42, 85, 127, 185, 230, 255]);
+    const bands = new Uint8Array([40, 85, 127, 255]);
+
     const texture = new DataTexture(bands, bands.length, 1, RedFormat);
     texture.magFilter = NearestFilter;
     texture.minFilter = NearestFilter;


### PR DESCRIPTION
Assigning a gradient map to the base toon material gives the base bot forms a more elegant lighting look towards the original vision of a flat shaded look. 

Adjusted the default lighting so that it better matched the brightness of the original scene before the the three.js upgrade.