### PR TITLE
Add support for watching remote clients to shared documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 #### Date: TBD
 
+### :rocket: Features
+
+-   Added `remoteClients` to shared documents.
+    -   `remoteClients` is an observable that you can subscribe to to get notified whenever another session (e.g. tab) connects to the document.
+
 ### :bug: Bug Fixes
 
 -   Fixed an issue where CasualOS didn't support the TypeScript `override` keyword.

--- a/src/aux-common/common/ConnectionInfo.ts
+++ b/src/aux-common/common/ConnectionInfo.ts
@@ -18,6 +18,13 @@
 import { memoize } from 'es-toolkit';
 import { z } from 'zod';
 
+/**
+ * Information about a connection.
+ *
+ * @dochash types/documents
+ * @docid ConnectionInfo
+ * @docname ConnectionInfo
+ */
 export interface ConnectionInfo {
     /**
      * The ID of the connection.

--- a/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
@@ -709,6 +709,271 @@ describe('RemoteYjsSharedDocument', () => {
                 });
             });
 
+            describe('remoteClientsRaw', () => {
+                let events: RemoteClientEvent[] = [];
+                let remoteClientsRawSubscription: Subscription;
+
+                function connectClient(connectionId: string) {
+                    connectedToBranch.next({
+                        type: 'repo/connected_to_branch',
+                        branch: {
+                            type: 'repo/watch_branch',
+                            recordName: recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        broadcast: false,
+                        connection: {
+                            connectionId,
+                            sessionId: `${connectionId}-session`,
+                            userId: `${connectionId}-user`,
+                        },
+                    });
+                }
+
+                function disconnectClient(connectionId: string) {
+                    disconnectedFromBranch.next({
+                        type: 'repo/disconnected_from_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                        broadcast: false,
+                        connection: {
+                            connectionId,
+                            sessionId: `${connectionId}-session`,
+                            userId: `${connectionId}-user`,
+                        },
+                    });
+                }
+
+                beforeEach(() => {
+                    events = [];
+
+                    remoteClientsRawSubscription =
+                        document.remoteClientsRaw.subscribe((e) =>
+                            events.push(e)
+                        );
+                    sub.add(remoteClientsRawSubscription);
+                });
+
+                it('should emit client_connected events when clients connect', async () => {
+                    connectedToBranch.next({
+                        type: 'repo/connected_to_branch',
+                        branch: {
+                            type: 'repo/watch_branch',
+                            recordName: recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        broadcast: false,
+                        connection: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                    });
+
+                    await waitAsync();
+
+                    expect(events).toEqual([
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'session-1',
+                                userId: 'user-1',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+
+                it('should not replay existing connections to the second subscriber', async () => {
+                    connectClient('remote-1');
+
+                    await waitAsync();
+
+                    const secondSubscriberEvents: RemoteClientEvent[] = [];
+                    const secondSubscription =
+                        document.remoteClientsRaw.subscribe((event) =>
+                            secondSubscriberEvents.push(event)
+                        );
+                    sub.add(secondSubscription);
+
+                    await waitAsync();
+
+                    expect(secondSubscriberEvents).toEqual([]);
+                });
+
+                it('should calculate isSelf based on the current client connection ID', async () => {
+                    connection.info = {
+                        connectionId: 'self-connection',
+                        sessionId: 'self-session',
+                        userId: 'self-user',
+                    };
+
+                    connectClient('self-connection');
+                    connectClient('remote-1');
+
+                    await waitAsync();
+
+                    expect(events).toEqual([
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'self-connection',
+                                sessionId: 'self-connection-session',
+                                userId: 'self-connection-user',
+                            },
+                            isSelf: true,
+                        },
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'remote-1-session',
+                                userId: 'remote-1-user',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+
+                it('should only call watchBranchDevices once for multiple subscribers', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    const secondSubscription =
+                        document.remoteClientsRaw.subscribe(() => {});
+                    sub.add(secondSubscription);
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                });
+
+                it('should call watchBranchDevices again after all subscribers unsubscribe and resubscribe', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    const firstSubscription =
+                        document.remoteClientsRaw.subscribe(() => {});
+                    const secondSubscription =
+                        document.remoteClientsRaw.subscribe(() => {});
+
+                    await waitAsync();
+
+                    remoteClientsRawSubscription.unsubscribe();
+                    firstSubscription.unsubscribe();
+                    secondSubscription.unsubscribe();
+
+                    await waitAsync();
+
+                    const thirdSubscription =
+                        document.remoteClientsRaw.subscribe(() => {});
+                    sub.add(thirdSubscription);
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/unwatch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/unwatch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                });
+
+                it('should unsubscribe watchBranchDevices when the document is unsubscribed', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    document.unsubscribe();
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices' ||
+                                message.type === 'repo/unwatch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        {
+                            type: 'repo/unwatch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                });
+
+                it('should emit client_disconnected events when clients disconnect', async () => {
+                    connectClient('remote-1');
+                    disconnectClient('remote-1');
+
+                    await waitAsync();
+
+                    expect(events.slice(1)).toEqual([
+                        {
+                            type: 'client_disconnected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'remote-1-session',
+                                userId: 'remote-1-user',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+            });
+
             // describe('remote events', () => {
             //     it('should send the remote event to the server', async () => {
             //         await partition.sendRemoteEvents([

--- a/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
@@ -435,13 +435,47 @@ describe('RemoteYjsSharedDocument', () => {
 
             describe('remoteClients', () => {
                 let events: RemoteClientEvent[] = [];
+                let remoteClientsSubscription: Subscription;
+
+                function connectClient(connectionId: string) {
+                    connectedToBranch.next({
+                        type: 'repo/connected_to_branch',
+                        branch: {
+                            type: 'repo/watch_branch',
+                            recordName: recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        broadcast: false,
+                        connection: {
+                            connectionId,
+                            sessionId: `${connectionId}-session`,
+                            userId: `${connectionId}-user`,
+                        },
+                    });
+                }
+
+                function disconnectClient(connectionId: string) {
+                    disconnectedFromBranch.next({
+                        type: 'repo/disconnected_from_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                        broadcast: false,
+                        connection: {
+                            connectionId,
+                            sessionId: `${connectionId}-session`,
+                            userId: `${connectionId}-user`,
+                        },
+                    });
+                }
 
                 beforeEach(() => {
                     events = [];
 
-                    sub.add(
-                        document.remoteClients.subscribe((e) => events.push(e))
-                    );
+                    remoteClientsSubscription =
+                        document.remoteClients.subscribe((e) => events.push(e));
+                    sub.add(remoteClientsSubscription);
                 });
 
                 it('should emit client_connected events when clients connect', async () => {
@@ -476,34 +510,188 @@ describe('RemoteYjsSharedDocument', () => {
                     ]);
                 });
 
-                it('should emit client_disconnected events when clients disconnect', async () => {
-                    connectedToBranch.next({
-                        type: 'repo/connected_to_branch',
-                        branch: {
-                            type: 'repo/watch_branch',
-                            recordName: recordName,
+                it('should replay existing connections to the second subscriber', async () => {
+                    connectClient('remote-1');
+
+                    await waitAsync();
+
+                    const secondSubscriberEvents: RemoteClientEvent[] = [];
+                    const secondSubscription = document.remoteClients.subscribe(
+                        (event) => secondSubscriberEvents.push(event)
+                    );
+                    sub.add(secondSubscription);
+
+                    await waitAsync();
+
+                    expect(secondSubscriberEvents).toEqual([
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'remote-1-session',
+                                userId: 'remote-1-user',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+
+                it('should calculate isSelf based on the current client connection ID', async () => {
+                    connection.info = {
+                        connectionId: 'self-connection',
+                        sessionId: 'self-session',
+                        userId: 'self-user',
+                    };
+
+                    connectClient('self-connection');
+                    connectClient('remote-1');
+
+                    await waitAsync();
+
+                    expect(events).toEqual([
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'self-connection',
+                                sessionId: 'self-connection-session',
+                                userId: 'self-connection-user',
+                            },
+                            isSelf: true,
+                        },
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'remote-1-session',
+                                userId: 'remote-1-user',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+
+                it('should only call watchBranchDevices once for multiple subscribers', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    const secondSubscription = document.remoteClients.subscribe(
+                        () => {}
+                    );
+                    sub.add(secondSubscription);
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
                             inst: 'inst',
                             branch: 'testBranch',
                         },
-                        broadcast: false,
-                        connection: {
-                            connectionId: 'remote-1',
-                            sessionId: 'session-1',
-                            userId: 'user-1',
+                    ]);
+                });
+
+                it('should call watchBranchDevices again after all subscribers unsubscribe and resubscribe', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    const firstSubscription = document.remoteClients.subscribe(
+                        () => {}
+                    );
+                    const secondSubscription = document.remoteClients.subscribe(
+                        () => {}
+                    );
+
+                    await waitAsync();
+
+                    remoteClientsSubscription.unsubscribe();
+                    firstSubscription.unsubscribe();
+                    secondSubscription.unsubscribe();
+
+                    await waitAsync();
+
+                    const thirdSubscription = document.remoteClients.subscribe(
+                        () => {}
+                    );
+                    sub.add(thirdSubscription);
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
                         },
-                    });
-                    disconnectedFromBranch.next({
-                        type: 'repo/disconnected_from_branch',
-                        recordName,
-                        inst: 'inst',
-                        branch: 'testBranch',
-                        broadcast: false,
-                        connection: {
-                            connectionId: 'remote-1',
-                            sessionId: 'session-1',
-                            userId: 'user-1',
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
                         },
-                    });
+                    ]);
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/unwatch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/unwatch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                });
+
+                it('should unsubscribe watchBranchDevices when the document is unsubscribed', async () => {
+                    document.connect();
+
+                    await waitAsync();
+
+                    document.unsubscribe();
+
+                    await waitAsync();
+
+                    expect(
+                        connection.sentMessages.filter(
+                            (message) =>
+                                message.type === 'repo/watch_branch_devices' ||
+                                message.type === 'repo/unwatch_branch_devices'
+                        )
+                    ).toEqual([
+                        {
+                            type: 'repo/watch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        {
+                            type: 'repo/unwatch_branch_devices',
+                            recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                    ]);
+                });
+
+                it('should emit client_disconnected events when clients disconnect', async () => {
+                    connectClient('remote-1');
+                    disconnectClient('remote-1');
 
                     await waitAsync();
 
@@ -512,8 +700,8 @@ describe('RemoteYjsSharedDocument', () => {
                             type: 'client_disconnected',
                             client: {
                                 connectionId: 'remote-1',
-                                sessionId: 'session-1',
-                                userId: 'user-1',
+                                sessionId: 'remote-1-session',
+                                userId: 'remote-1-user',
                             },
                             isSelf: false,
                         },

--- a/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
@@ -21,6 +21,8 @@ import { waitAsync } from '../test/TestHelpers';
 import { createDocFromUpdates, getUpdates } from '../test/YjsTestHelpers';
 import type {
     AddUpdatesMessage,
+    ConnectedToBranchMessage,
+    DisconnectedFromBranchMessage,
     ReceiveDeviceActionMessage,
     UpdatesReceivedMessage,
     WatchBranchResultMessage,
@@ -33,6 +35,7 @@ import { RemoteYjsSharedDocument } from './RemoteYjsSharedDocument';
 import type { SharedDocumentConfig } from './SharedDocumentConfig';
 import { testDocumentImplementation } from './test/DocumentTests';
 import { fromByteArray } from 'base64-js';
+import type { RemoteClientEvent } from './SharedDocument';
 
 console.log = jest.fn();
 
@@ -107,8 +110,8 @@ describe('RemoteYjsSharedDocument', () => {
             let addAtoms: Subject<AddUpdatesMessage>;
             let updatesReceived: Subject<UpdatesReceivedMessage>;
             let watchBranchResult: Subject<WatchBranchResultMessage>;
-            let connectedToBranch: Subject<any>;
-            let disconnectedFromBranch: Subject<any>;
+            let connectedToBranch: Subject<ConnectedToBranchMessage>;
+            let disconnectedFromBranch: Subject<DisconnectedFromBranchMessage>;
             let errors: any[];
             let version: CurrentVersion;
             let sub: Subscription;
@@ -171,150 +174,205 @@ describe('RemoteYjsSharedDocument', () => {
                         inst: 'inst',
                         branch: 'testBranch',
                     },
-                    {
-                        type: 'repo/watch_branch_devices',
-                        recordName: recordName,
-                        inst: 'inst',
-                        branch: 'testBranch',
-                    },
                 ]);
             });
 
-            it('should emit current and future remote clients from remoteClients', async () => {
-                setupPartition({
-                    recordName: recordName,
-                    inst: 'inst',
-                    branch: 'testBranch',
-                });
+            // it('should watch branch devices once for multiple remote client subscriptions and unwatch when all unsubscribe', async () => {
+            //     setupPartition({
+            //         recordName: recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //     });
 
-                document.connect();
-                await waitAsync();
+            //     document.connect();
+            //     await waitAsync();
 
-                connectedToBranch.next({
-                    type: 'repo/connected_to_branch',
-                    broadcast: false,
-                    branch: {
-                        type: 'repo/watch_branch',
-                        recordName,
-                        inst: 'inst',
-                        branch: 'testBranch',
-                    },
-                    connection: {
-                        connectionId: 'remote-1',
-                        sessionId: 'session-1',
-                        userId: 'user-1',
-                    },
-                });
+            //     const sub1 = document.remoteClients.subscribe(() => {});
+            //     await waitAsync();
 
-                await waitAsync();
+            //     expect(connection.sentMessages).toContainEqual({
+            //         type: 'repo/watch_branch_devices',
+            //         recordName: recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //     });
 
-                const events = [] as any[];
-                sub.add(
-                    document.remoteClients.subscribe((e) => events.push(e))
-                );
+            //     const watchCountAfterFirstSubscription =
+            //         connection.sentMessages.filter(
+            //             (m) => m.type === 'repo/watch_branch_devices'
+            //         ).length;
 
-                await waitAsync();
+            //     const sub2 = document.remoteClients.subscribe(() => {});
+            //     await waitAsync();
 
-                disconnectedFromBranch.next({
-                    type: 'repo/disconnected_from_branch',
-                    broadcast: false,
-                    recordName,
-                    inst: 'inst',
-                    branch: 'testBranch',
-                    connection: {
-                        connectionId: 'remote-1',
-                        sessionId: 'session-1',
-                        userId: 'user-1',
-                    },
-                });
+            //     const watchCountAfterSecondSubscription =
+            //         connection.sentMessages.filter(
+            //             (m) => m.type === 'repo/watch_branch_devices'
+            //         ).length;
+            //     expect(watchCountAfterSecondSubscription).toBe(
+            //         watchCountAfterFirstSubscription
+            //     );
 
-                await waitAsync();
+            //     sub1.unsubscribe();
+            //     await waitAsync();
 
-                expect(events).toEqual([
-                    {
-                        type: 'client_connected',
-                        client: {
-                            connectionId: 'remote-1',
-                            sessionId: 'session-1',
-                            userId: 'user-1',
-                        },
-                        isSelf: false,
-                    },
-                    {
-                        type: 'client_disconnected',
-                        client: {
-                            connectionId: 'remote-1',
-                            sessionId: 'session-1',
-                            userId: 'user-1',
-                        },
-                        isSelf: false,
-                    },
-                ]);
-            });
+            //     const unwatchCountAfterFirstUnsubscribe =
+            //         connection.sentMessages.filter(
+            //             (m) => m.type === 'repo/unwatch_branch_devices'
+            //         ).length;
+            //     expect(unwatchCountAfterFirstUnsubscribe).toBe(0);
 
-            it('should only emit future events from remoteClientsRaw', async () => {
-                setupPartition({
-                    recordName: recordName,
-                    inst: 'inst',
-                    branch: 'testBranch',
-                });
+            //     sub2.unsubscribe();
+            //     await waitAsync();
 
-                document.connect();
-                await waitAsync();
+            //     expect(connection.sentMessages).toContainEqual({
+            //         type: 'repo/unwatch_branch_devices',
+            //         recordName: recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //     });
+            // });
 
-                connectedToBranch.next({
-                    type: 'repo/connected_to_branch',
-                    broadcast: false,
-                    branch: {
-                        type: 'repo/watch_branch',
-                        recordName,
-                        inst: 'inst',
-                        branch: 'testBranch',
-                    },
-                    connection: {
-                        connectionId: 'remote-1',
-                        sessionId: 'session-1',
-                        userId: 'user-1',
-                    },
-                });
+            // it('should emit current and future remote clients from remoteClients', async () => {
+            //     setupPartition({
+            //         recordName: recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //     });
 
-                await waitAsync();
+            //     document.connect();
+            //     await waitAsync();
 
-                const events = [] as any[];
-                sub.add(
-                    document.remoteClientsRaw.subscribe((e) => events.push(e))
-                );
+            //     const events = [] as any[];
+            //     sub.add(
+            //         document.remoteClients.subscribe((e) => events.push(e))
+            //     );
 
-                connectedToBranch.next({
-                    type: 'repo/connected_to_branch',
-                    broadcast: false,
-                    branch: {
-                        type: 'repo/watch_branch',
-                        recordName,
-                        inst: 'inst',
-                        branch: 'testBranch',
-                    },
-                    connection: {
-                        connectionId: 'remote-2',
-                        sessionId: 'session-2',
-                        userId: 'user-2',
-                    },
-                });
+            //     connectedToBranch.next({
+            //         type: 'repo/connected_to_branch',
+            //         broadcast: false,
+            //         branch: {
+            //             type: 'repo/watch_branch',
+            //             recordName,
+            //             inst: 'inst',
+            //             branch: 'testBranch',
+            //         },
+            //         connection: {
+            //             connectionId: 'remote-1',
+            //             sessionId: 'session-1',
+            //             userId: 'user-1',
+            //         },
+            //     });
 
-                await waitAsync();
+            //     await waitAsync();
 
-                expect(events).toEqual([
-                    {
-                        type: 'client_connected',
-                        client: {
-                            connectionId: 'remote-2',
-                            sessionId: 'session-2',
-                            userId: 'user-2',
-                        },
-                        isSelf: false,
-                    },
-                ]);
-            });
+            //     disconnectedFromBranch.next({
+            //         type: 'repo/disconnected_from_branch',
+            //         broadcast: false,
+            //         recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //         connection: {
+            //             connectionId: 'remote-1',
+            //             sessionId: 'session-1',
+            //             userId: 'user-1',
+            //         },
+            //     });
+
+            //     await waitAsync();
+
+            //     expect(events).toEqual([
+            //         {
+            //             type: 'client_connected',
+            //             client: {
+            //                 connectionId: 'remote-1',
+            //                 sessionId: 'session-1',
+            //                 userId: 'user-1',
+            //             },
+            //             isSelf: false,
+            //         },
+            //         {
+            //             type: 'client_disconnected',
+            //             client: {
+            //                 connectionId: 'remote-1',
+            //                 sessionId: 'session-1',
+            //                 userId: 'user-1',
+            //             },
+            //             isSelf: false,
+            //         },
+            //     ]);
+            // });
+
+            // it('should only emit future events from remoteClientsRaw', async () => {
+            //     setupPartition({
+            //         recordName: recordName,
+            //         inst: 'inst',
+            //         branch: 'testBranch',
+            //     });
+
+            //     document.connect();
+            //     await waitAsync();
+
+            //     const events = [] as any[];
+            //     sub.add(
+            //         document.remoteClientsRaw.subscribe((e) => events.push(e))
+            //     );
+
+            //     connectedToBranch.next({
+            //         type: 'repo/connected_to_branch',
+            //         broadcast: false,
+            //         branch: {
+            //             type: 'repo/watch_branch',
+            //             recordName,
+            //             inst: 'inst',
+            //             branch: 'testBranch',
+            //         },
+            //         connection: {
+            //             connectionId: 'remote-1',
+            //             sessionId: 'session-1',
+            //             userId: 'user-1',
+            //         },
+            //     });
+
+            //     connectedToBranch.next({
+            //         type: 'repo/connected_to_branch',
+            //         broadcast: false,
+            //         branch: {
+            //             type: 'repo/watch_branch',
+            //             recordName,
+            //             inst: 'inst',
+            //             branch: 'testBranch',
+            //         },
+            //         connection: {
+            //             connectionId: 'remote-2',
+            //             sessionId: 'session-2',
+            //             userId: 'user-2',
+            //         },
+            //     });
+
+            //     await waitAsync();
+
+            //     expect(events).toEqual([
+            //         {
+            //             type: 'client_connected',
+            //             client: {
+            //                 connectionId: 'remote-1',
+            //                 sessionId: 'session-1',
+            //                 userId: 'user-1',
+            //             },
+            //             isSelf: false,
+            //         },
+            //         {
+            //             type: 'client_connected',
+            //             client: {
+            //                 connectionId: 'remote-2',
+            //                 sessionId: 'session-2',
+            //                 userId: 'user-2',
+            //             },
+            //             isSelf: false,
+            //         },
+            //     ]);
+            // });
 
             it('should send the sync event after the updates have been processed', async () => {
                 setupPartition({
@@ -373,6 +431,94 @@ describe('RemoteYjsSharedDocument', () => {
                         synced: true,
                     },
                 ]);
+            });
+
+            describe('remoteClients', () => {
+                let events: RemoteClientEvent[] = [];
+
+                beforeEach(() => {
+                    events = [];
+
+                    sub.add(
+                        document.remoteClients.subscribe((e) => events.push(e))
+                    );
+                });
+
+                it('should emit client_connected events when clients connect', async () => {
+                    connectedToBranch.next({
+                        type: 'repo/connected_to_branch',
+                        branch: {
+                            type: 'repo/watch_branch',
+                            recordName: recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        broadcast: false,
+                        connection: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                    });
+
+                    await waitAsync();
+
+                    expect(events).toEqual([
+                        {
+                            type: 'client_connected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'session-1',
+                                userId: 'user-1',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
+
+                it('should emit client_disconnected events when clients disconnect', async () => {
+                    connectedToBranch.next({
+                        type: 'repo/connected_to_branch',
+                        branch: {
+                            type: 'repo/watch_branch',
+                            recordName: recordName,
+                            inst: 'inst',
+                            branch: 'testBranch',
+                        },
+                        broadcast: false,
+                        connection: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                    });
+                    disconnectedFromBranch.next({
+                        type: 'repo/disconnected_from_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                        broadcast: false,
+                        connection: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                    });
+
+                    await waitAsync();
+
+                    expect(events.slice(1)).toEqual([
+                        {
+                            type: 'client_disconnected',
+                            client: {
+                                connectionId: 'remote-1',
+                                sessionId: 'session-1',
+                                userId: 'user-1',
+                            },
+                            isSelf: false,
+                        },
+                    ]);
+                });
             });
 
             // describe('remote events', () => {

--- a/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.spec.ts
@@ -107,6 +107,8 @@ describe('RemoteYjsSharedDocument', () => {
             let addAtoms: Subject<AddUpdatesMessage>;
             let updatesReceived: Subject<UpdatesReceivedMessage>;
             let watchBranchResult: Subject<WatchBranchResultMessage>;
+            let connectedToBranch: Subject<any>;
+            let disconnectedFromBranch: Subject<any>;
             let errors: any[];
             let version: CurrentVersion;
             let sub: Subscription;
@@ -118,12 +120,22 @@ describe('RemoteYjsSharedDocument', () => {
                 addAtoms = new Subject<AddUpdatesMessage>();
                 updatesReceived = new Subject<UpdatesReceivedMessage>();
                 watchBranchResult = new Subject();
+                connectedToBranch = new Subject();
+                disconnectedFromBranch = new Subject();
                 connection.events.set('repo/receive_action', receiveEvent);
                 connection.events.set('repo/add_updates', addAtoms);
                 connection.events.set('repo/updates_received', updatesReceived);
                 connection.events.set(
                     'repo/watch_branch_result',
                     watchBranchResult
+                );
+                connection.events.set(
+                    'repo/connected_to_branch',
+                    connectedToBranch
+                );
+                connection.events.set(
+                    'repo/disconnected_from_branch',
+                    disconnectedFromBranch
                 );
                 client = new InstRecordsClient(connection);
                 connection.connect();
@@ -158,6 +170,148 @@ describe('RemoteYjsSharedDocument', () => {
                         recordName: recordName,
                         inst: 'inst',
                         branch: 'testBranch',
+                    },
+                    {
+                        type: 'repo/watch_branch_devices',
+                        recordName: recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                    },
+                ]);
+            });
+
+            it('should emit current and future remote clients from remoteClients', async () => {
+                setupPartition({
+                    recordName: recordName,
+                    inst: 'inst',
+                    branch: 'testBranch',
+                });
+
+                document.connect();
+                await waitAsync();
+
+                connectedToBranch.next({
+                    type: 'repo/connected_to_branch',
+                    broadcast: false,
+                    branch: {
+                        type: 'repo/watch_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                    },
+                    connection: {
+                        connectionId: 'remote-1',
+                        sessionId: 'session-1',
+                        userId: 'user-1',
+                    },
+                });
+
+                await waitAsync();
+
+                const events = [] as any[];
+                sub.add(
+                    document.remoteClients.subscribe((e) => events.push(e))
+                );
+
+                await waitAsync();
+
+                disconnectedFromBranch.next({
+                    type: 'repo/disconnected_from_branch',
+                    broadcast: false,
+                    recordName,
+                    inst: 'inst',
+                    branch: 'testBranch',
+                    connection: {
+                        connectionId: 'remote-1',
+                        sessionId: 'session-1',
+                        userId: 'user-1',
+                    },
+                });
+
+                await waitAsync();
+
+                expect(events).toEqual([
+                    {
+                        type: 'client_connected',
+                        client: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                        isSelf: false,
+                    },
+                    {
+                        type: 'client_disconnected',
+                        client: {
+                            connectionId: 'remote-1',
+                            sessionId: 'session-1',
+                            userId: 'user-1',
+                        },
+                        isSelf: false,
+                    },
+                ]);
+            });
+
+            it('should only emit future events from remoteClientsRaw', async () => {
+                setupPartition({
+                    recordName: recordName,
+                    inst: 'inst',
+                    branch: 'testBranch',
+                });
+
+                document.connect();
+                await waitAsync();
+
+                connectedToBranch.next({
+                    type: 'repo/connected_to_branch',
+                    broadcast: false,
+                    branch: {
+                        type: 'repo/watch_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                    },
+                    connection: {
+                        connectionId: 'remote-1',
+                        sessionId: 'session-1',
+                        userId: 'user-1',
+                    },
+                });
+
+                await waitAsync();
+
+                const events = [] as any[];
+                sub.add(
+                    document.remoteClientsRaw.subscribe((e) => events.push(e))
+                );
+
+                connectedToBranch.next({
+                    type: 'repo/connected_to_branch',
+                    broadcast: false,
+                    branch: {
+                        type: 'repo/watch_branch',
+                        recordName,
+                        inst: 'inst',
+                        branch: 'testBranch',
+                    },
+                    connection: {
+                        connectionId: 'remote-2',
+                        sessionId: 'session-2',
+                        userId: 'user-2',
+                    },
+                });
+
+                await waitAsync();
+
+                expect(events).toEqual([
+                    {
+                        type: 'client_connected',
+                        client: {
+                            connectionId: 'remote-2',
+                            sessionId: 'session-2',
+                            userId: 'user-2',
+                        },
+                        isSelf: false,
                     },
                 ]);
             });
@@ -1082,7 +1236,10 @@ describe('RemoteYjsSharedDocument', () => {
 
                     await waitAsync();
 
-                    expect(connection.sentMessages.slice(1)).toEqual([]);
+                    const updates = connection.sentMessages.filter(
+                        (m) => m.type === 'repo/add_updates'
+                    );
+                    expect(updates).toEqual([]);
                 });
 
                 it('should not send new updates to the server if in static mode', async () => {
@@ -1101,7 +1258,10 @@ describe('RemoteYjsSharedDocument', () => {
                     });
                     await waitAsync();
 
-                    expect(connection.sentMessages.slice(1)).toEqual([]);
+                    const updates = connection.sentMessages.filter(
+                        (m) => m.type === 'repo/add_updates'
+                    );
+                    expect(updates).toEqual([]);
                 });
 
                 it('should handle an ADD_UPDATES event without any updates', async () => {
@@ -1141,9 +1301,12 @@ describe('RemoteYjsSharedDocument', () => {
                     });
                     await waitAsync();
 
-                    expect(connection.sentMessages.slice(1).length).toBe(1);
+                    const updates = connection.sentMessages.filter(
+                        (m) => m.type === 'repo/add_updates'
+                    );
+                    expect(updates.length).toBe(1);
 
-                    const addUpdatesMessage = connection.sentMessages[1];
+                    const addUpdatesMessage = updates[0];
                     expect(addUpdatesMessage.type).toEqual('repo/add_updates');
                     expect((addUpdatesMessage as any).branch).toEqual(
                         'testBranch'
@@ -1271,7 +1434,10 @@ describe('RemoteYjsSharedDocument', () => {
 
                     await waitAsync();
 
-                    expect(connection.sentMessages.slice(1).length).toBe(0);
+                    const sentUpdates = connection.sentMessages.filter(
+                        (m) => m.type === 'repo/add_updates'
+                    );
+                    expect(sentUpdates.length).toBe(0);
                 });
                 //     it('case1: should handle an update that includes updates in addition to adding a bot', async () => {
                 //         document.connect();

--- a/src/aux-common/documents/RemoteYjsSharedDocument.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.ts
@@ -17,7 +17,7 @@
  */
 import { Observable } from 'rxjs';
 import { filter, firstValueFrom, startWith, Subject, Subscription } from 'rxjs';
-import type { RemoteClientEvent, RemoteSharedDocument } from './SharedDocument';
+import type { RemoteClientEvent, SharedDocument } from './SharedDocument';
 
 import type { Doc, Transaction } from 'yjs';
 import { encodeStateAsUpdate } from 'yjs';
@@ -58,7 +58,7 @@ export function createRemoteClientYjsSharedDocument(
  */
 export class RemoteYjsSharedDocument
     extends YjsSharedDocument
-    implements RemoteSharedDocument
+    implements SharedDocument
 {
     protected _static: boolean;
     protected _skipInitialLoad: boolean;

--- a/src/aux-common/documents/RemoteYjsSharedDocument.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.ts
@@ -16,15 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Observable } from 'rxjs';
-import {
-    filter,
-    firstValueFrom,
-    map,
-    share,
-    startWith,
-    Subject,
-    Subscription,
-} from 'rxjs';
+import { filter, firstValueFrom, startWith, Subject, Subscription } from 'rxjs';
 import type { RemoteClientEvent, RemoteSharedDocument } from './SharedDocument';
 
 import type { Doc, Transaction } from 'yjs';
@@ -81,6 +73,8 @@ export class RemoteYjsSharedDocument
     protected _connectedClients = new Map<string, ConnectionInfo>();
     protected _remoteClientsSubject = new Subject<RemoteClientEvent>();
     protected _remoteClientsRaw: Observable<RemoteClientEvent>;
+    protected _watchingBranchDevices: Subscription | null = null;
+    protected _remoteClientSubscribers = 0;
 
     get remoteClients(): Observable<RemoteClientEvent> {
         const existingClients = Array.from(this._connectedClients.values()).map(
@@ -94,9 +88,8 @@ export class RemoteYjsSharedDocument
     }
 
     unsubscribe(): void {
-        this._remoteClientsSubject?.unsubscribe();
-        this._remoteClientsSubject = null;
-        this._connectedClients.clear();
+        this._stopWatchingBranchDevices();
+        this._remoteClientsSubject.unsubscribe();
         this._sub.unsubscribe();
     }
 
@@ -122,41 +115,30 @@ export class RemoteYjsSharedDocument
         // static implies read only
         this._readOnly = config.readOnly || this._static || false;
 
-        const watchDevices = new Observable<RemoteClientEvent>((subscriber) => {
-            const watchSubscription = this._client
-                .watchBranchDevices(this._recordName, this._inst, this._branch)
-                .pipe(
-                    map((event) => {
-                        if (event.type === 'repo/connected_to_branch') {
-                            this._connectedClients.set(
-                                event.connection.connectionId,
-                                event.connection
-                            );
-                            return this._clientConnectedEvent(event.connection);
-                        } else if (
-                            event.type === 'repo/disconnected_from_branch'
-                        ) {
-                            this._connectedClients.delete(
-                                event.connection.connectionId
-                            );
-                            return this._clientDisconnectedEvent(
-                                event.connection
-                            );
-                        }
-                    })
-                )
-                .subscribe(subscriber);
+        this._remoteClientsRaw = new Observable<RemoteClientEvent>(
+            (subscriber) => {
+                if (this._sub.closed) {
+                    return;
+                }
 
-            return () => {
-                this._connectedClients.clear();
-                watchSubscription.unsubscribe();
-            };
-        });
+                const remoteClientsSubscription =
+                    this._remoteClientsSubject.subscribe(subscriber);
+                this._remoteClientSubscribers += 1;
 
-        this._remoteClientsRaw = watchDevices.pipe(
-            share({
-                connector: () => this._remoteClientsSubject,
-            })
+                if (this._remoteClientSubscribers === 1) {
+                    this._startWatchingBranchDevices();
+                }
+
+                return () => {
+                    remoteClientsSubscription.unsubscribe();
+                    this._remoteClientSubscribers -= 1;
+
+                    if (this._remoteClientSubscribers <= 0) {
+                        this._remoteClientSubscribers = 0;
+                        this._stopWatchingBranchDevices();
+                    }
+                };
+            }
         );
     }
 
@@ -453,6 +435,39 @@ export class RemoteYjsSharedDocument
         return (
             client.connectionId === this._client.connection.info?.connectionId
         );
+    }
+
+    private _startWatchingBranchDevices() {
+        if (this._watchingBranchDevices) {
+            return;
+        }
+
+        this._watchingBranchDevices = this._client
+            .watchBranchDevices(this._recordName, this._inst, this._branch)
+            .subscribe((event) => {
+                if (event.type === 'repo/connected_to_branch') {
+                    this._connectedClients.set(
+                        event.connection.connectionId,
+                        event.connection
+                    );
+                    this._remoteClientsSubject.next(
+                        this._clientConnectedEvent(event.connection)
+                    );
+                } else if (event.type === 'repo/disconnected_from_branch') {
+                    this._connectedClients.delete(
+                        event.connection.connectionId
+                    );
+                    this._remoteClientsSubject.next(
+                        this._clientDisconnectedEvent(event.connection)
+                    );
+                }
+            });
+    }
+
+    private _stopWatchingBranchDevices() {
+        this._connectedClients.clear();
+        this._watchingBranchDevices?.unsubscribe();
+        this._watchingBranchDevices = null;
     }
 
     private _updateSynced(synced: boolean) {

--- a/src/aux-common/documents/RemoteYjsSharedDocument.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.ts
@@ -15,10 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import { Observable } from 'rxjs';
 import {
     filter,
     firstValueFrom,
-    Observable,
+    map,
+    share,
+    startWith,
     Subject,
     Subscription,
 } from 'rxjs';
@@ -76,17 +79,14 @@ export class RemoteYjsSharedDocument
     protected _authSource: PartitionAuthSource;
     protected _markers: string[];
     protected _connectedClients = new Map<string, ConnectionInfo>();
-    protected _remoteClientsRaw = new Subject<RemoteClientEvent>();
+    protected _remoteClientsSubject = new Subject<RemoteClientEvent>();
+    protected _remoteClientsRaw: Observable<RemoteClientEvent>;
 
     get remoteClients(): Observable<RemoteClientEvent> {
-        return new Observable<RemoteClientEvent>((subscriber) => {
-            for (let client of this._connectedClients.values()) {
-                subscriber.next(this._clientConnectedEvent(client));
-            }
-
-            const sub = this._remoteClientsRaw.subscribe(subscriber);
-            return () => sub.unsubscribe();
-        });
+        const existingClients = Array.from(this._connectedClients.values()).map(
+            (client) => this._clientConnectedEvent(client)
+        );
+        return this.remoteClientsRaw.pipe(startWith(...existingClients));
     }
 
     get remoteClientsRaw(): Observable<RemoteClientEvent> {
@@ -94,6 +94,9 @@ export class RemoteYjsSharedDocument
     }
 
     unsubscribe(): void {
+        this._remoteClientsSubject?.unsubscribe();
+        this._remoteClientsSubject = null;
+        this._connectedClients.clear();
         this._sub.unsubscribe();
     }
 
@@ -118,6 +121,43 @@ export class RemoteYjsSharedDocument
 
         // static implies read only
         this._readOnly = config.readOnly || this._static || false;
+
+        const watchDevices = new Observable<RemoteClientEvent>((subscriber) => {
+            const watchSubscription = this._client
+                .watchBranchDevices(this._recordName, this._inst, this._branch)
+                .pipe(
+                    map((event) => {
+                        if (event.type === 'repo/connected_to_branch') {
+                            this._connectedClients.set(
+                                event.connection.connectionId,
+                                event.connection
+                            );
+                            return this._clientConnectedEvent(event.connection);
+                        } else if (
+                            event.type === 'repo/disconnected_from_branch'
+                        ) {
+                            this._connectedClients.delete(
+                                event.connection.connectionId
+                            );
+                            return this._clientDisconnectedEvent(
+                                event.connection
+                            );
+                        }
+                    })
+                )
+                .subscribe(subscriber);
+
+            return () => {
+                this._connectedClients.clear();
+                watchSubscription.unsubscribe();
+            };
+        });
+
+        this._remoteClientsRaw = watchDevices.pipe(
+            share({
+                connector: () => this._remoteClientsSubject,
+            })
+        );
     }
 
     connect(): void {
@@ -279,28 +319,6 @@ export class RemoteYjsSharedDocument
             this._client.watchRateLimitExceeded().subscribe((event) => {
                 this._onRateLimitExceeded(event);
             })
-        );
-        this._sub.add(
-            this._client
-                .watchBranchDevices(this._recordName, this._inst, this._branch)
-                .subscribe((event) => {
-                    if (event.type === 'repo/connected_to_branch') {
-                        this._connectedClients.set(
-                            event.connection.connectionId,
-                            event.connection
-                        );
-                        this._remoteClientsRaw.next(
-                            this._clientConnectedEvent(event.connection)
-                        );
-                    } else if (event.type === 'repo/disconnected_from_branch') {
-                        this._connectedClients.delete(
-                            event.connection.connectionId
-                        );
-                        this._remoteClientsRaw.next(
-                            this._clientDisconnectedEvent(event.connection)
-                        );
-                    }
-                })
         );
 
         const updateHandler = (

--- a/src/aux-common/documents/RemoteYjsSharedDocument.ts
+++ b/src/aux-common/documents/RemoteYjsSharedDocument.ts
@@ -15,8 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { filter, firstValueFrom, Subscription } from 'rxjs';
-import type { SharedDocument } from './SharedDocument';
+import {
+    filter,
+    firstValueFrom,
+    Observable,
+    Subject,
+    Subscription,
+} from 'rxjs';
+import type { RemoteClientEvent, RemoteSharedDocument } from './SharedDocument';
 
 import type { Doc, Transaction } from 'yjs';
 import { encodeStateAsUpdate } from 'yjs';
@@ -33,6 +39,7 @@ import type { PartitionAuthSource } from '../partitions/PartitionAuthSource';
 import { YjsIndexedDBPersistence } from '../yjs/YjsIndexedDBPersistence';
 import { fromByteArray } from 'base64-js';
 import { getConnectionId } from '../common';
+import type { ConnectionInfo } from '../common';
 import {
     YjsSharedDocument,
     APPLY_UPDATES_TO_INST_TRANSACTION_ORIGIN,
@@ -56,7 +63,7 @@ export function createRemoteClientYjsSharedDocument(
  */
 export class RemoteYjsSharedDocument
     extends YjsSharedDocument
-    implements SharedDocument
+    implements RemoteSharedDocument
 {
     protected _static: boolean;
     protected _skipInitialLoad: boolean;
@@ -68,6 +75,23 @@ export class RemoteYjsSharedDocument
     protected _readOnly: boolean;
     protected _authSource: PartitionAuthSource;
     protected _markers: string[];
+    protected _connectedClients = new Map<string, ConnectionInfo>();
+    protected _remoteClientsRaw = new Subject<RemoteClientEvent>();
+
+    get remoteClients(): Observable<RemoteClientEvent> {
+        return new Observable<RemoteClientEvent>((subscriber) => {
+            for (let client of this._connectedClients.values()) {
+                subscriber.next(this._clientConnectedEvent(client));
+            }
+
+            const sub = this._remoteClientsRaw.subscribe(subscriber);
+            return () => sub.unsubscribe();
+        });
+    }
+
+    get remoteClientsRaw(): Observable<RemoteClientEvent> {
+        return this._remoteClientsRaw;
+    }
 
     unsubscribe(): void {
         this._sub.unsubscribe();
@@ -256,6 +280,28 @@ export class RemoteYjsSharedDocument
                 this._onRateLimitExceeded(event);
             })
         );
+        this._sub.add(
+            this._client
+                .watchBranchDevices(this._recordName, this._inst, this._branch)
+                .subscribe((event) => {
+                    if (event.type === 'repo/connected_to_branch') {
+                        this._connectedClients.set(
+                            event.connection.connectionId,
+                            event.connection
+                        );
+                        this._remoteClientsRaw.next(
+                            this._clientConnectedEvent(event.connection)
+                        );
+                    } else if (event.type === 'repo/disconnected_from_branch') {
+                        this._connectedClients.delete(
+                            event.connection.connectionId
+                        );
+                        this._remoteClientsRaw.next(
+                            this._clientDisconnectedEvent(event.connection)
+                        );
+                    }
+                })
+        );
 
         const updateHandler = (
             update: Uint8Array,
@@ -365,6 +411,30 @@ export class RemoteYjsSharedDocument
      */
     protected _onMaxSizeReached(event: MaxInstSizeReachedClientError) {
         this._onClientError.next(event);
+    }
+
+    private _clientConnectedEvent(client: ConnectionInfo): RemoteClientEvent {
+        return {
+            type: 'client_connected',
+            client,
+            isSelf: this._isSelfClient(client),
+        };
+    }
+
+    private _clientDisconnectedEvent(
+        client: ConnectionInfo
+    ): RemoteClientEvent {
+        return {
+            type: 'client_disconnected',
+            client,
+            isSelf: this._isSelfClient(client),
+        };
+    }
+
+    private _isSelfClient(client: ConnectionInfo): boolean {
+        return (
+            client.connectionId === this._client.connection.info?.connectionId
+        );
     }
 
     private _updateSynced(synced: boolean) {

--- a/src/aux-common/documents/SharedDocument.ts
+++ b/src/aux-common/documents/SharedDocument.ts
@@ -16,7 +16,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import type { ClientError } from '../websockets';
-import type { Action, CurrentVersion, StatusUpdate } from '../common';
+import type {
+    Action,
+    ConnectionInfo,
+    CurrentVersion,
+    StatusUpdate,
+} from '../common';
 import type { Observable, SubscriptionLike } from 'rxjs';
 import type { InstUpdate } from '../bots';
 
@@ -145,6 +150,59 @@ export interface SharedDocument extends SubscriptionLike {
      * @param updates The updates to apply.
      */
     applyUpdates(updates: string[]): void;
+}
+
+/**
+ * Defines an interface for shared documents that can have remote clients.
+ *
+ * @dochash types/documents
+ * @docid RemoteSharedDocument
+ * @docname RemoteSharedDocument
+ */
+export interface RemoteSharedDocument extends SharedDocument {
+    /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Additionally, the current remote clients will be emitted when the subscription is first made.
+     */
+    readonly remoteClients: Observable<RemoteClientEvent>;
+
+    /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Notably, the current remote clients will NOT be emitted when the subscription is first made, so this can be used to only listen for future client connections and disconnections.
+     */
+    readonly remoteClientsRaw: Observable<RemoteClientEvent>;
+}
+
+/**
+ * Defines an event that is emitted when a remote client connects or disconnects from a shared document.
+ *
+ * @dochash types/documents
+ * @docid RemoteClientEvent
+ * @docname RemoteClientEvent
+ */
+export interface RemoteClientEvent {
+    /**
+     * The type of the event.
+     *
+     * "client_connected" is emitted when a new client connects to the document.
+     * "client_disconnected" is emitted when a client disconnects from the document.
+     */
+    type: 'client_connected' | 'client_disconnected';
+
+    /**
+     * The connection info of the client that connected or disconnected.
+     */
+    client: ConnectionInfo;
+
+    /**
+     * Whether this event is for the current client.
+     * This will be true when `client.connectionId` is the same as the `configBot.id` and false otherwise.
+     */
+    isSelf: boolean;
 }
 
 /**

--- a/src/aux-common/documents/SharedDocument.ts
+++ b/src/aux-common/documents/SharedDocument.ts
@@ -90,6 +90,22 @@ export interface SharedDocument extends SubscriptionLike {
     onClientError: Observable<ClientError>;
 
     /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Additionally, the current remote clients will be emitted when the subscription is first made.
+     */
+    readonly remoteClients: Observable<RemoteClientEvent>;
+
+    /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Notably, the current remote clients will NOT be emitted when the subscription is first made, so this can be used to only listen for future client connections and disconnections.
+     */
+    readonly remoteClientsRaw: Observable<RemoteClientEvent>;
+
+    /**
      * Tells the document to connect to its backing store.
      */
     connect(): void;
@@ -150,31 +166,6 @@ export interface SharedDocument extends SubscriptionLike {
      * @param updates The updates to apply.
      */
     applyUpdates(updates: string[]): void;
-}
-
-/**
- * Defines an interface for shared documents that can have remote clients.
- *
- * @dochash types/documents
- * @docid RemoteSharedDocument
- * @docname RemoteSharedDocument
- */
-export interface RemoteSharedDocument extends SharedDocument {
-    /**
-     * The events that are emitted when remote clients connect or disconnect from the document.
-     *
-     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
-     * Additionally, the current remote clients will be emitted when the subscription is first made.
-     */
-    readonly remoteClients: Observable<RemoteClientEvent>;
-
-    /**
-     * The events that are emitted when remote clients connect or disconnect from the document.
-     *
-     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
-     * Notably, the current remote clients will NOT be emitted when the subscription is first made, so this can be used to only listen for future client connections and disconnections.
-     */
-    readonly remoteClientsRaw: Observable<RemoteClientEvent>;
 }
 
 /**

--- a/src/aux-common/documents/YjsSharedDocument.ts
+++ b/src/aux-common/documents/YjsSharedDocument.ts
@@ -17,6 +17,7 @@
  */
 import {
     BehaviorSubject,
+    EMPTY,
     Observable,
     startWith,
     Subject,
@@ -49,6 +50,7 @@ import type {
     SharedArrayChanges,
     SharedTextChanges,
     SharedArrayOp,
+    RemoteClientEvent,
 } from './SharedDocument';
 import { fromByteArray, toByteArray } from 'base64-js';
 import type { InstUpdate } from '../bots';
@@ -154,6 +156,14 @@ export class YjsSharedDocument implements SharedDocument {
 
     get doc() {
         return this._doc;
+    }
+
+    get remoteClients(): Observable<RemoteClientEvent> {
+        return EMPTY;
+    }
+
+    get remoteClientsRaw(): Observable<RemoteClientEvent> {
+        return EMPTY;
     }
 
     protected get _remoteSite() {

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -12522,6 +12522,22 @@ export interface SharedDocument extends SubscriptionLike {
     onClientError: Observable<ClientError>;
 
     /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Additionally, the current remote clients will be emitted when the subscription is first made.
+     */
+    readonly remoteClients: Observable<RemoteClientEvent>;
+
+    /**
+     * The events that are emitted when remote clients connect or disconnect from the document.
+     *
+     * When subscribed to, this observable will emit an event whenever a remote client connects or disconnects from the document.
+     * Notably, the current remote clients will NOT be emitted when the subscription is first made, so this can be used to only listen for future client connections and disconnections.
+     */
+    readonly remoteClientsRaw: Observable<RemoteClientEvent>;
+
+    /**
      * Tells the document to connect to its backing store.
      */
     connect(): void;
@@ -12578,6 +12594,59 @@ export interface SharedDocument extends SubscriptionLike {
      */
     applyUpdates(updates: string[]): void;
 }
+
+/**
+ * Information about a connection.
+ * 
+ * @dochash types/documents
+ * @docid ConnectionInfo
+ * @docname ConnectionInfo
+ */
+export interface ConnectionInfo {
+    /**
+     * The ID of the connection.
+     */
+    connectionId: string;
+
+    /**
+     * The ID of the session.
+     */
+    sessionId: string | null;
+
+    /**
+     * The ID of the user that is associated with the connection.
+     */
+    userId: string | null;
+}
+
+/**
+ * Defines an event that is emitted when a remote client connects or disconnects from a shared document.
+ *
+ * @dochash types/documents
+ * @docid RemoteClientEvent
+ * @docname RemoteClientEvent
+ */
+export interface RemoteClientEvent {
+    /**
+     * The type of the event.
+     *
+     * "client_connected" is emitted when a new client connects to the document.
+     * "client_disconnected" is emitted when a client disconnects from the document.
+     */
+    type: 'client_connected' | 'client_disconnected';
+
+    /**
+     * The connection info of the client that connected or disconnected.
+     */
+    client: ConnectionInfo;
+
+    /**
+     * Whether this event is for the current client.
+     * This will be true when `client.connectionId` is the same as the `configBot.id` and false otherwise.
+     */
+    isSelf: boolean;
+}
+
 
 export type SharedType = SharedMap | SharedArray | SharedText;
 


### PR DESCRIPTION
### :rocket: Features

-   Added `remoteClients` to shared documents.
    -   `remoteClients` is an observable that you can subscribe to to get notified whenever another session (e.g. tab) connects to the document.
