### PR TITLE
Add the `xp.purchaseCredits()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,21 @@
             ```
 -   Included Subscription info in the `xp.getAccountBalances()` result.
     -   Successful results now include a `subscription` property which contains information about the user/studio's current subscription and includes information like: subscription tier, credit expiration policy, and subscription period (start and end).
+-   Added the `xp.purchaseCredits(request)` function.
+    -   Creates and returns a checkout session URL that grants a user/studio credits.
+    -   `request` should be an object that has the following properties:
+        -   `targetUserId` - The ID of the user that the purchased credits should be granted to. Currently must be the ID of the user. Can be omitted if `targetStudioId` is specified.
+        -   `targetStudioId` - The ID of the studio that the purchased credits should be granted to. Currently only studio admins are allowed to purchase credits for a studio.
+        -   `returnUrl` - The URL that the user should be redirected to when they cancel the checkout session.
+        -   `successUrl` - The URL that the user should be redirected to when the complete the checkout session.
+    -   Before purchasing credits is supported, the following must be configured:
+        -   `SERVER_CONFIG.subscriptions.purchaseCreditsConfig` must be set to an object with the following properties:
+            -   `product` (string) - The ID of the stripe product. Must have a price with the following metadata:
+                -   `casualos.credits` - The number of credits that will be granted for each unit purchased.
+            -   `adjustableQuantity` (boolean; optional) - Whether the quantity can be adjusted by the user. Defaults to true.
+            -   `defaultQuantity` (number; optional) - The default quantity of the product to purchase. Defaults to 1.
+            -   `maxQuantity` (number; optional) - The maximum allowed quantity. Defaults to 999,999 (Stripe max).
+            -   `minQuantity` (number; optional) - The minimum allowed quantity. Defaults to 0.
 
 ### :bug: Bug Fixes
 

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -1383,7 +1383,8 @@ export interface AuthCheckoutSession {
 
 export type AuthCheckoutSessionItem =
     | AuthCheckoutSessionRoleItem
-    | AuthCheckoutSessionContractItem;
+    | AuthCheckoutSessionContractItem
+    | AuthCheckoutSessionCreditsItem;
 
 export interface AuthCheckoutSessionRoleItem {
     /**
@@ -1434,6 +1435,25 @@ export interface AuthCheckoutSessionContractItem {
      * The value of the contract being purchased.
      */
     value: number;
+}
+
+export interface AuthCheckoutSessionCreditsItem {
+    type: 'credits';
+
+    /**
+     * The ID of the user that is purchasing the credits.
+     */
+    userId: string;
+
+    /**
+     * The ID of the studio that the credits are being purchased for.
+     */
+    targetStudioId: string | null;
+
+    /**
+     * The ID of the user that the credits are being purchased for.
+     */
+    targetUserId: string | null;
 }
 
 /**

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -31399,6 +31399,250 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
         );
     });
 
+    describe('POST /api/v2/credits/purchase', () => {
+        const studioId = 'studioId';
+
+        beforeEach(async () => {
+            await financialController.init();
+
+            store.subscriptionConfiguration = createTestSubConfiguration(
+                (config) =>
+                    config.addSubscription('sub1', (sub) =>
+                        sub.withTier('tier1').withAllDefaultFeatures()
+                    )
+            );
+
+            const owner = await store.findUser(ownerId);
+            await store.saveUser({
+                ...owner,
+                subscriptionId: 'sub1',
+                subscriptionStatus: 'active',
+            });
+
+            const user = await store.findUser(userId);
+            await store.saveUser({
+                ...user,
+                stripeCustomerId: 'customerId',
+            });
+
+            await store.createStudioForUser(
+                {
+                    id: studioId,
+                    displayName: 'my studio',
+                    comId: 'comId',
+                    logoUrl: 'logoUrl',
+                    comIdConfig: {
+                        allowedStudioCreators: 'anyone',
+                    },
+                    playerConfig: {
+                        ab1BootstrapURL: 'ab1BootstrapURL',
+                    },
+                    subscriptionId: 'sub1',
+                    subscriptionStatus: 'active',
+                    stripeCustomerId: 'studioCustomerId',
+                    stripeAccountId: 'accountId',
+                    stripeAccountStatus: 'active',
+                    stripeAccountRequirementsStatus: 'complete',
+                },
+                userId
+            );
+
+            stripeMock.createCheckoutSession.mockResolvedValue({
+                id: 'sessionId',
+                url: 'checkoutUrl',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            stripeMock.getProductAndPriceInfo.mockResolvedValue({
+                id: 'productId',
+                default_price: {
+                    id: 'priceId',
+                    currency: 'usd',
+                    recurring: null,
+                    unit_amount: 1000,
+                    metadata: {
+                        'casualos.credits': '100',
+                    },
+                },
+                name: 'Credits Package',
+                description: '100 credits for $10',
+            });
+        });
+
+        it('should return the checkout URL when purchasing a contract', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/credits/purchase`,
+                    JSON.stringify({
+                        targetStudioId: studioId,
+                        returnUrl: 'http://example.com',
+                        successUrl: 'http://example.com/success',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    url: 'checkoutUrl',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return not_logged_in when the user is not logged in', async () => {
+            stripeMock.createCheckoutSession.mockResolvedValue({
+                id: 'sessionId',
+                url: 'checkoutUrl',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            delete apiHeaders['authorization'];
+
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/credits/purchase`,
+                    JSON.stringify({
+                        targetStudioId: studioId,
+                        returnUrl: 'http://example.com',
+                        successUrl: 'http://example.com/success',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 401,
+                body: {
+                    success: false,
+                    errorCode: 'not_logged_in',
+                    errorMessage:
+                        'The user is not logged in. A session key must be provided for this operation.',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return not_authorized when another user is specified as the target', async () => {
+            stripeMock.createCheckoutSession.mockResolvedValue({
+                id: 'sessionId',
+                url: 'checkoutUrl',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/credits/purchase`,
+                    JSON.stringify({
+                        targetUserId: 'wrong-user',
+                        returnUrl: 'http://example.com',
+                        successUrl: 'http://example.com/success',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 403,
+                body: {
+                    success: false,
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You cannot purchase credits for other users.',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return not_authorized when the user is not an admin of the studio', async () => {
+            stripeMock.createCheckoutSession.mockResolvedValue({
+                id: 'sessionId',
+                url: 'checkoutUrl',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            await store.createStudioForUser(
+                {
+                    id: 'otherStudioId',
+                    displayName: 'my studio',
+                    comId: 'comId',
+                    logoUrl: 'logoUrl',
+                    comIdConfig: {
+                        allowedStudioCreators: 'anyone',
+                    },
+                    playerConfig: {
+                        ab1BootstrapURL: 'ab1BootstrapURL',
+                    },
+                    subscriptionId: 'sub1',
+                    subscriptionStatus: 'active',
+                    stripeCustomerId: 'customerId',
+                    stripeAccountId: 'accountId',
+                    stripeAccountStatus: 'active',
+                    stripeAccountRequirementsStatus: 'complete',
+                },
+                ownerId
+            );
+
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/credits/purchase`,
+                    JSON.stringify({
+                        targetStudioId: 'otherStudioId',
+                        returnUrl: 'http://example.com',
+                        successUrl: 'http://example.com/success',
+                    }),
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 403,
+                body: {
+                    success: false,
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You are not authorized to purchase credits for this studio.',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        testOrigin('POST', `/api/v2/credits/purchase`, () =>
+            JSON.stringify({
+                targetStudioId: studioId,
+                returnUrl: 'http://example.com',
+                successUrl: 'http://example.com/success',
+            })
+        );
+        testCustomOrigin('POST', `/api/v2/credits/purchase`, () =>
+            JSON.stringify({
+                targetStudioId: studioId,
+                returnUrl: 'http://example.com',
+                successUrl: 'http://example.com/success',
+            })
+        );
+        testBodyIsJson((body) =>
+            httpPost(`/api/v2/credits/purchase`, body, apiHeaders)
+        );
+        testRateLimit(() =>
+            httpPost(
+                `/api/v2/credits/purchase`,
+                JSON.stringify({
+                    targetStudioId: studioId,
+                    returnUrl: 'http://example.com',
+                    successUrl: 'http://example.com/success',
+                }),
+                defaultHeaders
+            )
+        );
+    });
+
     describe('POST /api/v2/records/contract/pricing', () => {
         const purchaseRecordName = 'studioId';
 

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -6851,7 +6851,7 @@ export class RecordsServer {
 
             purchaseCredits: procedure()
                 .origins('self')
-                .http('POST', '/api/v2/records/credits/purchase')
+                .http('POST', '/api/v2/credits/purchase')
                 .inputs(
                     z.object({
                         targetUserId: z
@@ -6883,10 +6883,14 @@ export class RecordsServer {
                     ) => {
                         const sessionKeyValidation =
                             await this._validateSessionKey(context.sessionKey);
-                        if (
-                            sessionKeyValidation.success === false &&
-                            sessionKeyValidation.errorCode !== 'no_session_key'
-                        ) {
+
+                        if (sessionKeyValidation.success === false) {
+                            if (
+                                sessionKeyValidation.errorCode ===
+                                'no_session_key'
+                            ) {
+                                return NOT_LOGGED_IN_RESULT;
+                            }
                             return sessionKeyValidation;
                         }
 

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -6849,6 +6849,62 @@ export class RecordsServer {
                     }
                 ),
 
+            purchaseCredits: procedure()
+                .origins('self')
+                .http('POST', '/api/v2/records/credits/purchase')
+                .inputs(
+                    z.object({
+                        targetUserId: z
+                            .string()
+                            .nonempty()
+                            .optional()
+                            .nullable(),
+                        targetStudioId: z
+                            .string()
+                            .nonempty()
+                            .optional()
+                            .nullable(),
+                        instances:
+                            INSTANCES_ARRAY_VALIDATION.optional().nullable(),
+                        returnUrl: z.url(),
+                        successUrl: z.url(),
+                    })
+                )
+                .handler(
+                    async (
+                        {
+                            targetUserId,
+                            targetStudioId,
+                            instances,
+                            returnUrl,
+                            successUrl,
+                        },
+                        context
+                    ) => {
+                        const sessionKeyValidation =
+                            await this._validateSessionKey(context.sessionKey);
+                        if (
+                            sessionKeyValidation.success === false &&
+                            sessionKeyValidation.errorCode !== 'no_session_key'
+                        ) {
+                            return sessionKeyValidation;
+                        }
+
+                        const result =
+                            await this._subscriptions.purchaseCredits({
+                                userId: sessionKeyValidation.userId,
+                                targetUserId,
+                                targetStudioId,
+
+                                returnUrl,
+                                successUrl,
+                                instances,
+                            });
+
+                        return genericResult(result);
+                    }
+                ),
+
             getContractPricing: procedure()
                 .origins('api')
                 .http('POST', '/api/v2/records/contract/pricing')

--- a/src/aux-records/StripeInterface.ts
+++ b/src/aux-records/StripeInterface.ts
@@ -56,7 +56,7 @@ export interface StripeInterface {
      * Gets the checkout session with the given ID.
      * @param id The ID of the checkout session.
      */
-    getCheckoutSessionById(id: string): Promise<StripeCheckoutResponse>;
+    getCheckoutSessionById(id: string): Promise<StripeCheckoutSession>;
 
     /**
      * Creates a new portal session for a user.
@@ -974,41 +974,47 @@ export type StripeEventAccountUpdated = z.infer<
     typeof STRIPE_EVENT_ACCOUNT_UPDATED_SCHEMA
 >;
 
+export const STRIPE_CHECKOUT_SESSION_SCHEMA = z.object({
+    id: z.string(),
+    client_reference_id: z.string().nullable(),
+    object: z.literal('checkout.session'),
+    status: z.enum(['complete', 'expired', 'open']),
+    payment_status: z.enum(['no_payment_required', 'paid', 'unpaid']),
+    line_items: z
+        .object({
+            object: z.literal('list'),
+            data: z.array(
+                z.object({
+                    id: z.string(),
+                    amount_subtotal: z.number().positive(),
+                    amount_total: z.number().positive(),
+                    quantity: z.number(),
+                    price: z
+                        .object({
+                            id: z.string(),
+                            product: z.string(),
+                        })
+                        .nullable(),
+                    metadata: z.record(z.string(), z.string()).optional(),
+                })
+            ),
+        })
+        .nullable()
+        .optional(),
+});
+
 export const STRIPE_EVENT_CHECKOUT_SESSION_SCHEMA = z.object({
     data: z.object({
-        object: z.object({
-            id: z.string(),
-            client_reference_id: z.string().nullable(),
-            object: z.literal('checkout.session'),
-            status: z.enum(['complete', 'expired', 'open']),
-            payment_status: z.enum(['no_payment_required', 'paid', 'unpaid']),
-            line_items: z
-                .object({
-                    object: z.literal('list'),
-                    data: z.array(
-                        z.object({
-                            id: z.string(),
-                            amount_subtotal: z.number().positive(),
-                            amount_total: z.number().positive(),
-                            quantity: z.number(),
-                            price: z
-                                .object({
-                                    id: z.string(),
-                                    product: z.string(),
-                                })
-                                .nullable(),
-                            metadata: z.record(z.string(), z.string()),
-                        })
-                    ),
-                })
-                .nullable()
-                .optional(),
-        }),
+        object: STRIPE_CHECKOUT_SESSION_SCHEMA,
     }),
 });
 
 export type StripeEventCheckoutSession = z.infer<
     typeof STRIPE_EVENT_CHECKOUT_SESSION_SCHEMA
+>;
+
+export type StripeCheckoutSession = z.infer<
+    typeof STRIPE_CHECKOUT_SESSION_SCHEMA
 >;
 
 /**

--- a/src/aux-records/StripeInterface.ts
+++ b/src/aux-records/StripeInterface.ts
@@ -986,13 +986,17 @@ export const STRIPE_CHECKOUT_SESSION_SCHEMA = z.object({
             data: z.array(
                 z.object({
                     id: z.string(),
-                    amount_subtotal: z.number().positive(),
-                    amount_total: z.number().positive(),
-                    quantity: z.number(),
+                    amount_subtotal: z.number().nonnegative(),
+                    amount_total: z.number().nonnegative(),
+                    amount_tax: z.number().nonnegative().nullable(),
+                    amount_discount: z.number().nonnegative().nullable(),
+                    quantity: z.number().nonnegative(),
+                    currency: z.string(),
                     price: z
                         .object({
                             id: z.string(),
                             product: z.string(),
+                            unit_amount: z.number().nonnegative().optional(),
                         })
                         .nullable(),
                     metadata: z.record(z.string(), z.string()).optional(),
@@ -1001,6 +1005,7 @@ export const STRIPE_CHECKOUT_SESSION_SCHEMA = z.object({
         })
         .nullable()
         .optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
 });
 
 export const STRIPE_EVENT_CHECKOUT_SESSION_SCHEMA = z.object({

--- a/src/aux-records/StripeInterface.ts
+++ b/src/aux-records/StripeInterface.ts
@@ -182,6 +182,11 @@ export interface StripePrice {
      * The amount of units that are charged for each renewal.
      */
     unit_amount: number;
+
+    /**
+     * The metadata for the price.
+     */
+    metadata?: Record<string, string>;
 }
 
 /**
@@ -192,6 +197,11 @@ export interface StripeCheckoutRequest {
      * The ID of the product that the checkout request is for.
      */
     line_items: {
+        /**
+         * Wether the quantity of the line item can be adjusted by the user in the checkout page.
+         */
+        adjustable_quantity?: boolean;
+
         /**
          * The ID of the price for the line item.
          */
@@ -248,6 +258,11 @@ export interface StripeCheckoutRequest {
          * The quantity to purchase.
          */
         quantity?: number;
+
+        /**
+         * The metadata for the line item.
+         */
+        metadata?: Record<string, string>;
     }[];
 
     /**
@@ -645,6 +660,11 @@ export interface StripeProduct {
      * The default price for the product.
      */
     default_price: StripePrice;
+
+    /**
+     * The metadata for the product.
+     */
+    metadata?: Record<string, string>;
 }
 
 export interface StripeCreateAccountLinkRequest {
@@ -947,6 +967,27 @@ export const STRIPE_EVENT_CHECKOUT_SESSION_SCHEMA = z.object({
             object: z.literal('checkout.session'),
             status: z.enum(['complete', 'expired', 'open']),
             payment_status: z.enum(['no_payment_required', 'paid', 'unpaid']),
+            line_items: z
+                .object({
+                    object: z.literal('list'),
+                    data: z.array(
+                        z.object({
+                            id: z.string(),
+                            amount_subtotal: z.number().positive(),
+                            amount_total: z.number().positive(),
+                            quantity: z.number(),
+                            price: z
+                                .object({
+                                    id: z.string(),
+                                    product: z.string(),
+                                })
+                                .nullable(),
+                            metadata: z.record(z.string(), z.string()),
+                        })
+                    ),
+                })
+                .nullable()
+                .optional(),
         }),
     }),
 });

--- a/src/aux-records/StripeInterface.ts
+++ b/src/aux-records/StripeInterface.ts
@@ -200,7 +200,22 @@ export interface StripeCheckoutRequest {
         /**
          * Wether the quantity of the line item can be adjusted by the user in the checkout page.
          */
-        adjustable_quantity?: boolean;
+        adjustable_quantity?: {
+            /**
+             * Whether the quantity can be adjusted by the user in the checkout page.
+             */
+            enabled: boolean;
+
+            /**
+             * The maximum quantity the customer can purchase for the Checkout Session. By default this value is 99. You can specify a value up to 999999.
+             */
+            maximum?: number;
+
+            /**
+             * The minimum quantity the customer must purchase for the Checkout Session. By default this value is 0.
+             */
+            minimum?: number;
+        };
 
         /**
          * The ID of the price for the line item.

--- a/src/aux-records/SubscriptionConfigBuilder.ts
+++ b/src/aux-records/SubscriptionConfigBuilder.ts
@@ -571,6 +571,15 @@ export class SubscriptionConfigBuilder {
         return this;
     }
 
+    withCreditPurchaseConfig(config: {
+        product?: string;
+        adjustableQuantity?: boolean;
+        defaultQuantity?: number;
+    }): this {
+        this._config.purchaseCreditsConfig = config;
+        return this;
+    }
+
     addSubscription(
         id: string,
         build: (sub: SubscriptionBuilder) => SubscriptionBuilder

--- a/src/aux-records/SubscriptionConfigBuilder.ts
+++ b/src/aux-records/SubscriptionConfigBuilder.ts
@@ -571,11 +571,9 @@ export class SubscriptionConfigBuilder {
         return this;
     }
 
-    withCreditPurchaseConfig(config: {
-        product?: string;
-        adjustableQuantity?: boolean;
-        defaultQuantity?: number;
-    }): this {
+    withCreditPurchaseConfig(
+        config: SubscriptionConfiguration['purchaseCreditsConfig']
+    ): this {
         this._config.purchaseCreditsConfig = config;
         return this;
     }

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -1025,6 +1025,25 @@ export const getSubscriptionConfigSchema = memoize(() =>
                     .describe(
                         'The default quantity of the line item during checkout. Defaults to 1.'
                     ),
+
+                maxQuantity: z
+                    .int()
+                    .positive()
+                    .min(1)
+                    .max(999_999)
+                    .default(999_999)
+                    .describe(
+                        'The maximum quantity that the user can purchase at once. Must be between 1 and 999,999. Defaults to 999,999.'
+                    ),
+
+                minQuantity: z
+                    .int()
+                    .nonnegative()
+                    .min(0)
+                    .default(0)
+                    .describe(
+                        'The minimum quantity that the user can purchase at once. Must be at least 0. Defaults to 0.'
+                    ),
             })
             .prefault({})
             .describe(
@@ -1177,6 +1196,8 @@ export interface SubscriptionConfiguration {
         product?: string;
         adjustableQuantity?: boolean;
         defaultQuantity?: number;
+        maxQuantity?: number;
+        minQuantity?: number;
     };
 }
 

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -1003,6 +1003,34 @@ export const getSubscriptionConfigSchema = memoize(() =>
                 'Additional options that should be passed to stripe.checkout.sessions.create().'
             ),
 
+        purchaseCreditsConfig: z
+            .object({
+                product: z
+                    .string()
+                    .optional()
+                    .nullable()
+                    .describe(
+                        'The Stripe product that should be used for purchasing credits. If omitted, then purchasing credits will not be supported. The product\'s prices should have the following metadata properties: "casualos.credits" (The number of credits to grant when purchasing).'
+                    ),
+                adjustableQuantity: z
+                    .boolean()
+                    .default(true)
+                    .describe(
+                        'Whether the quantity of the line item should be adjustable by the user during checkout. Defaults to true.'
+                    ),
+                defaultQuantity: z
+                    .int()
+                    .positive()
+                    .default(1)
+                    .describe(
+                        'The default quantity of the line item during checkout. Defaults to 1.'
+                    ),
+            })
+            .prefault({})
+            .describe(
+                'Configuration for purchasing credits. Defaults to an empty object, which means that purchasing credits is not supported.'
+            ),
+
         subscriptions: z
             .array(getSubscriptionSchema())
             .describe('The list of subscriptions that are in use.'),
@@ -1144,6 +1172,12 @@ export interface SubscriptionConfiguration {
      * The features that should be used when a tier does not have a features configuration.
      */
     defaultFeatures: DefaultFeaturesConfiguration;
+
+    purchaseCreditsConfig?: {
+        product?: string;
+        adjustableQuantity?: boolean;
+        defaultQuantity?: number;
+    };
 }
 
 // export interface APISubscription {

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -10798,7 +10798,9 @@ describe('SubscriptionController', () => {
                 mode: 'payment',
                 line_items: [
                     {
-                        adjustable_quantity: true,
+                        adjustable_quantity: {
+                            enabled: true,
+                        },
                         price: 'price_123',
                         quantity: 1,
                         metadata: {
@@ -10870,7 +10872,9 @@ describe('SubscriptionController', () => {
                 mode: 'payment',
                 line_items: [
                     {
-                        adjustable_quantity: true,
+                        adjustable_quantity: {
+                            enabled: true,
+                        },
                         price: 'price_123',
                         quantity: 5,
                         metadata: {
@@ -10942,7 +10946,9 @@ describe('SubscriptionController', () => {
                 mode: 'payment',
                 line_items: [
                     {
-                        adjustable_quantity: false,
+                        adjustable_quantity: {
+                            enabled: false,
+                        },
                         price: 'price_123',
                         quantity: 1,
                         metadata: {

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -10800,6 +10800,8 @@ describe('SubscriptionController', () => {
                     {
                         adjustable_quantity: {
                             enabled: true,
+                            maximum: 999_999,
+                            minimum: 0,
                         },
                         price: 'price_123',
                         quantity: 1,
@@ -10874,6 +10876,8 @@ describe('SubscriptionController', () => {
                     {
                         adjustable_quantity: {
                             enabled: true,
+                            maximum: 999_999,
+                            minimum: 0,
                         },
                         price: 'price_123',
                         quantity: 5,
@@ -10948,9 +10952,89 @@ describe('SubscriptionController', () => {
                     {
                         adjustable_quantity: {
                             enabled: false,
+                            maximum: 999_999,
+                            minimum: 0,
                         },
                         price: 'price_123',
                         quantity: 1,
+                        metadata: {
+                            targetUserId: userId,
+                            targetStudioId: null,
+                        },
+                    },
+                ],
+                // should redirect the user to the success URL because it is automatically fulfilled
+                success_url: 'success-url',
+                cancel_url: 'return-url',
+                customer: 'customer_id',
+                metadata: {
+                    userId: userId,
+                },
+            });
+
+            expect(store.checkoutSessions).toEqual([]);
+        });
+
+        it('should use the configured maximum and minimum quantities', async () => {
+            store.subscriptionConfiguration = createTestSubConfiguration(
+                (config) =>
+                    config.withCreditPurchaseConfig({
+                        product: 'prod_123',
+                        adjustableQuantity: true,
+                        defaultQuantity: 5,
+                        maxQuantity: 100,
+                        minQuantity: 2,
+                    })
+            );
+
+            stripeMock.createCheckoutSession.mockResolvedValueOnce({
+                url: 'checkout_url',
+                id: 'checkout_id',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            stripeMock.getProductAndPriceInfo.mockResolvedValueOnce({
+                id: 'prod_123',
+                name: 'Credits',
+                description: '100 credits',
+                default_price: {
+                    id: 'price_123',
+                    currency: 'usd',
+                    recurring: null,
+                    unit_amount: 100,
+                    metadata: {
+                        'casualos.credits': '500',
+                    },
+                },
+            });
+
+            const result = await controller.purchaseCredits({
+                userId: userId,
+                targetUserId: userId,
+                targetStudioId: null,
+                returnUrl: 'return-url',
+                successUrl: 'success-url',
+                instances: [],
+            });
+
+            expect(result).toEqual(
+                success({
+                    url: 'checkout_url',
+                })
+            );
+
+            expect(stripeMock.createCheckoutSession).toHaveBeenCalledWith({
+                mode: 'payment',
+                line_items: [
+                    {
+                        adjustable_quantity: {
+                            enabled: true,
+                            maximum: 100,
+                            minimum: 2,
+                        },
+                        price: 'price_123',
+                        quantity: 5,
                         metadata: {
                             targetUserId: userId,
                             targetStudioId: null,

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -10808,7 +10808,6 @@ describe('SubscriptionController', () => {
                         quantity: 1,
                         metadata: {
                             targetUserId: userId,
-                            targetStudioId: null,
                         },
                     },
                 ],
@@ -10884,7 +10883,6 @@ describe('SubscriptionController', () => {
                         quantity: 5,
                         metadata: {
                             targetUserId: userId,
-                            targetStudioId: null,
                         },
                     },
                 ],
@@ -10960,7 +10958,6 @@ describe('SubscriptionController', () => {
                         quantity: 1,
                         metadata: {
                             targetUserId: userId,
-                            targetStudioId: null,
                         },
                     },
                 ],
@@ -11038,7 +11035,6 @@ describe('SubscriptionController', () => {
                         quantity: 5,
                         metadata: {
                             targetUserId: userId,
-                            targetStudioId: null,
                         },
                     },
                 ],

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -10715,6 +10715,255 @@ describe('SubscriptionController', () => {
         });
     });
 
+    describe('purchaseCredits()', () => {
+        const recordName = 'recordName';
+
+        beforeEach(async () => {
+            store.subscriptionConfiguration = createTestSubConfiguration(
+                (config) =>
+                    config.addSubscription('sub1', (sub) =>
+                        sub
+                            .withTier('tier1')
+                            .withAllDefaultFeatures()
+                            .withContracts()
+                            .withContractsCurrencyLimit('usd', {
+                                maxCost: 10000,
+                                minCost: 10,
+                                fee: {
+                                    type: 'fixed',
+                                    amount: 10,
+                                },
+                            })
+                    )
+            );
+
+            nowMock.mockReturnValue(101);
+
+            await store.addRecord({
+                name: recordName,
+                ownerId: userId,
+                studioId: null,
+                secretHashes: [],
+                secretSalt: '',
+            });
+
+            const user = await store.findUser(userId);
+            await store.saveUser({
+                ...user,
+                stripeCustomerId: 'customer_id',
+                subscriptionId: 'sub1',
+                subscriptionStatus: 'active',
+            });
+        });
+
+        it('should create a new checkout session', async () => {
+            stripeMock.createCheckoutSession.mockResolvedValueOnce({
+                url: 'checkout_url',
+                id: 'checkout_id',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            stripeMock.getProductAndPriceInfo.mockResolvedValueOnce({
+                id: 'prod_123',
+                name: 'Credits',
+                description: '100 credits',
+                default_price: {
+                    id: 'price_123',
+                    currency: 'usd',
+                    recurring: null,
+                    unit_amount: 100,
+                    metadata: {
+                        'casualos.credits': '500',
+                    },
+                },
+            });
+
+            const result = await controller.purchaseCredits({
+                userId: userId,
+                targetUserId: userId,
+                targetStudioId: null,
+                returnUrl: 'return-url',
+                successUrl: 'success-url',
+                instances: [],
+            });
+
+            expect(result).toEqual(
+                success({
+                    url: 'checkout_url',
+                })
+            );
+
+            expect(stripeMock.createCheckoutSession).toHaveBeenCalledWith({
+                mode: 'payment',
+                line_items: [
+                    {
+                        adjustable_quantity: true,
+                        price: 'price_123',
+                        quantity: 1,
+                        metadata: {
+                            targetUserId: userId,
+                            targetStudioId: null,
+                        },
+                    },
+                ],
+                // should redirect the user to the success URL because it is automatically fulfilled
+                success_url: 'success-url',
+                cancel_url: 'return-url',
+                customer: 'customer_id',
+                metadata: {
+                    userId: userId,
+                },
+            });
+
+            expect(store.checkoutSessions).toEqual([]);
+        });
+
+        it('should use the configured default quantity', async () => {
+            store.subscriptionConfiguration = createTestSubConfiguration(
+                (config) =>
+                    config.withCreditPurchaseConfig({
+                        product: 'prod_123',
+                        adjustableQuantity: true,
+                        defaultQuantity: 5,
+                    })
+            );
+
+            stripeMock.createCheckoutSession.mockResolvedValueOnce({
+                url: 'checkout_url',
+                id: 'checkout_id',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            stripeMock.getProductAndPriceInfo.mockResolvedValueOnce({
+                id: 'prod_123',
+                name: 'Credits',
+                description: '100 credits',
+                default_price: {
+                    id: 'price_123',
+                    currency: 'usd',
+                    recurring: null,
+                    unit_amount: 100,
+                    metadata: {
+                        'casualos.credits': '500',
+                    },
+                },
+            });
+
+            const result = await controller.purchaseCredits({
+                userId: userId,
+                targetUserId: userId,
+                targetStudioId: null,
+                returnUrl: 'return-url',
+                successUrl: 'success-url',
+                instances: [],
+            });
+
+            expect(result).toEqual(
+                success({
+                    url: 'checkout_url',
+                })
+            );
+
+            expect(stripeMock.createCheckoutSession).toHaveBeenCalledWith({
+                mode: 'payment',
+                line_items: [
+                    {
+                        adjustable_quantity: true,
+                        price: 'price_123',
+                        quantity: 5,
+                        metadata: {
+                            targetUserId: userId,
+                            targetStudioId: null,
+                        },
+                    },
+                ],
+                // should redirect the user to the success URL because it is automatically fulfilled
+                success_url: 'success-url',
+                cancel_url: 'return-url',
+                customer: 'customer_id',
+                metadata: {
+                    userId: userId,
+                },
+            });
+
+            expect(store.checkoutSessions).toEqual([]);
+        });
+
+        it('should disallow adjusting quantity if configured', async () => {
+            store.subscriptionConfiguration = createTestSubConfiguration(
+                (config) =>
+                    config.withCreditPurchaseConfig({
+                        product: 'prod_123',
+                        adjustableQuantity: false,
+                        defaultQuantity: 1,
+                    })
+            );
+
+            stripeMock.createCheckoutSession.mockResolvedValueOnce({
+                url: 'checkout_url',
+                id: 'checkout_id',
+                payment_status: 'unpaid',
+                status: 'open',
+            });
+
+            stripeMock.getProductAndPriceInfo.mockResolvedValueOnce({
+                id: 'prod_123',
+                name: 'Credits',
+                description: '100 credits',
+                default_price: {
+                    id: 'price_123',
+                    currency: 'usd',
+                    recurring: null,
+                    unit_amount: 100,
+                    metadata: {
+                        'casualos.credits': '500',
+                    },
+                },
+            });
+
+            const result = await controller.purchaseCredits({
+                userId: userId,
+                targetUserId: userId,
+                targetStudioId: null,
+                returnUrl: 'return-url',
+                successUrl: 'success-url',
+                instances: [],
+            });
+
+            expect(result).toEqual(
+                success({
+                    url: 'checkout_url',
+                })
+            );
+
+            expect(stripeMock.createCheckoutSession).toHaveBeenCalledWith({
+                mode: 'payment',
+                line_items: [
+                    {
+                        adjustable_quantity: false,
+                        price: 'price_123',
+                        quantity: 1,
+                        metadata: {
+                            targetUserId: userId,
+                            targetStudioId: null,
+                        },
+                    },
+                ],
+                // should redirect the user to the success URL because it is automatically fulfilled
+                success_url: 'success-url',
+                cancel_url: 'return-url',
+                customer: 'customer_id',
+                metadata: {
+                    userId: userId,
+                },
+            });
+
+            expect(store.checkoutSessions).toEqual([]);
+        });
+    });
+
     describe('cancelContract()', () => {
         const recordName = 'recordName';
 
@@ -17285,6 +17534,338 @@ describe('SubscriptionController', () => {
             //         });
             //     });
             // });
+        });
+
+        describe('purchaseCredits', () => {
+            let user: AuthUser;
+            const recordName = 'recordName';
+
+            beforeEach(async () => {
+                store.subscriptionConfiguration = createTestSubConfiguration();
+
+                const userAccount = unwrap(
+                    await financialController.getOrCreateFinancialAccount({
+                        userId: userId,
+                        ledger: LEDGERS.usd,
+                    })
+                );
+                user = await store.findUser(userId);
+
+                user = {
+                    ...user,
+                    stripeAccountId: 'account_id',
+                    stripeAccountRequirementsStatus: null,
+                    stripeAccountStatus: null,
+                };
+
+                await store.saveUser(user);
+
+                await store.addRecord({
+                    name: recordName,
+                    ownerId: userId,
+                    secretHashes: [],
+                    secretSalt: '',
+                    studioId: null,
+                });
+
+                nowMock.mockReturnValue(200);
+            });
+
+            describe('checkout.session.completed', () => {
+                describe('user', () => {
+                    it('should transfer credits to the user', async () => {
+                        stripeMock.constructWebhookEvent.mockReturnValueOnce({
+                            id: 'event_id',
+                            type: 'checkout.session.completed',
+                            object: 'event',
+                            account: 'account_id',
+                            api_version: 'api_version',
+                            created: 123,
+                            data: {
+                                object: {
+                                    id: 'checkout_id',
+                                    object: 'checkout.session',
+                                    client_reference_id: null,
+                                    payment_status: 'paid',
+                                    status: 'complete',
+                                    line_items: {
+                                        object: 'list',
+                                        data: [
+                                            {
+                                                id: 'line_item_1_id',
+                                                amount_subtotal: 123,
+                                                amount_total: 133,
+                                                amount_tax: 10,
+                                                amount_discount: 0,
+                                                currency: 'usd',
+                                                quantity: 1,
+                                                price: {
+                                                    id: 'price_123',
+                                                    product: 'prod_123',
+                                                    unit_amount: 100,
+                                                },
+                                                metadata: {
+                                                    targetUserId: userId,
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    metadata: {
+                                        userId: 'test',
+                                    },
+                                },
+                            },
+                            livemode: true,
+                            pending_webhooks: 1,
+                            request: {} as any,
+                        });
+
+                        stripeMock.getProductAndPriceInfo.mockResolvedValueOnce(
+                            {
+                                id: 'prod_123',
+                                name: '100 Credits',
+                                description: '100 Credits',
+                                default_price: {
+                                    id: 'price_123',
+                                    unit_amount: 123,
+                                    currency: 'usd',
+                                    recurring: null,
+                                    metadata: {
+                                        'casualos.credits': '100',
+                                    },
+                                },
+                            }
+                        );
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({
+                            success: true,
+                        });
+
+                        expect(
+                            stripeMock.constructWebhookEvent
+                        ).toHaveBeenCalledWith(
+                            'request_body',
+                            'request_signature',
+                            'webhook-secret'
+                        );
+
+                        const userAccount = unwrap(
+                            await financialController.getOrCreateFinancialAccount(
+                                {
+                                    userId: userId,
+                                    ledger: LEDGERS.credits,
+                                }
+                            )
+                        );
+
+                        await checkAccounts(financialInterface, [
+                            {
+                                id: userAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 100n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                            {
+                                id: ACCOUNT_IDS.assets_stripe,
+                                credits_pending: 0n,
+                                credits_posted: 0n,
+                                debits_pending: 0n,
+                                debits_posted: 123n,
+                            },
+                            {
+                                id: ACCOUNT_IDS.liquidity_usd,
+                                credits_pending: 0n,
+                                credits_posted: 123n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+
+                        checkTransfers(
+                            await financialInterface.lookupTransfers([4n, 5n]),
+                            [
+                                {
+                                    id: 4n,
+                                    amount: 123n,
+                                    code: TransferCodes.purchase_credits,
+                                    credit_account_id:
+                                        ACCOUNT_IDS.liquidity_usd,
+                                    debit_account_id: ACCOUNT_IDS.assets_stripe,
+                                    ledger: LEDGERS.usd,
+                                    flags: TransferFlags.linked,
+                                },
+                                {
+                                    id: 5n,
+                                    amount: 100n,
+                                    code: TransferCodes.purchase_credits,
+                                    debit_account_id:
+                                        ACCOUNT_IDS.liquidity_credits,
+                                    credit_account_id: userAccount.account.id,
+                                    ledger: LEDGERS.credits,
+                                    flags: TransferFlags.none,
+                                },
+                            ]
+                        );
+                    });
+                });
+
+                describe('studio', () => {
+                    const studioId = 'studioId';
+                    beforeEach(async () => {
+                        await store.addStudio({
+                            id: studioId,
+                            displayName: 'test studio',
+                        });
+                    });
+
+                    it('should transfer credits to the studio', async () => {
+                        stripeMock.constructWebhookEvent.mockReturnValueOnce({
+                            id: 'event_id',
+                            type: 'checkout.session.completed',
+                            object: 'event',
+                            account: 'account_id',
+                            api_version: 'api_version',
+                            created: 123,
+                            data: {
+                                object: {
+                                    id: 'checkout_id',
+                                    object: 'checkout.session',
+                                    client_reference_id: null,
+                                    payment_status: 'paid',
+                                    status: 'complete',
+                                    line_items: {
+                                        object: 'list',
+                                        data: [
+                                            {
+                                                id: 'line_item_1_id',
+                                                amount_subtotal: 123,
+                                                amount_total: 133,
+                                                amount_tax: 10,
+                                                amount_discount: 0,
+                                                currency: 'usd',
+                                                quantity: 1,
+                                                price: {
+                                                    id: 'price_123',
+                                                    product: 'prod_123',
+                                                    unit_amount: 100,
+                                                },
+                                                metadata: {
+                                                    targetStudioId: studioId,
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    metadata: {
+                                        userId: 'test',
+                                    },
+                                },
+                            },
+                            livemode: true,
+                            pending_webhooks: 1,
+                            request: {} as any,
+                        });
+
+                        stripeMock.getProductAndPriceInfo.mockResolvedValueOnce(
+                            {
+                                id: 'prod_123',
+                                name: '100 Credits',
+                                description: '100 Credits',
+                                default_price: {
+                                    id: 'price_123',
+                                    unit_amount: 123,
+                                    currency: 'usd',
+                                    recurring: null,
+                                    metadata: {
+                                        'casualos.credits': '100',
+                                    },
+                                },
+                            }
+                        );
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({
+                            success: true,
+                        });
+
+                        expect(
+                            stripeMock.constructWebhookEvent
+                        ).toHaveBeenCalledWith(
+                            'request_body',
+                            'request_signature',
+                            'webhook-secret'
+                        );
+
+                        const studioAccount = unwrap(
+                            await financialController.getOrCreateFinancialAccount(
+                                {
+                                    studioId,
+                                    ledger: LEDGERS.credits,
+                                }
+                            )
+                        );
+
+                        await checkAccounts(financialInterface, [
+                            {
+                                id: studioAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 100n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                            {
+                                id: ACCOUNT_IDS.assets_stripe,
+                                credits_pending: 0n,
+                                credits_posted: 0n,
+                                debits_pending: 0n,
+                                debits_posted: 123n,
+                            },
+                            {
+                                id: ACCOUNT_IDS.liquidity_usd,
+                                credits_pending: 0n,
+                                credits_posted: 123n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+
+                        checkTransfers(
+                            await financialInterface.lookupTransfers([4n, 5n]),
+                            [
+                                {
+                                    id: 4n,
+                                    amount: 123n,
+                                    code: TransferCodes.purchase_credits,
+                                    credit_account_id:
+                                        ACCOUNT_IDS.liquidity_usd,
+                                    debit_account_id: ACCOUNT_IDS.assets_stripe,
+                                    ledger: LEDGERS.usd,
+                                    flags: TransferFlags.linked,
+                                },
+                                {
+                                    id: 5n,
+                                    amount: 100n,
+                                    code: TransferCodes.purchase_credits,
+                                    debit_account_id:
+                                        ACCOUNT_IDS.liquidity_credits,
+                                    credit_account_id: studioAccount.account.id,
+                                    ledger: LEDGERS.credits,
+                                    flags: TransferFlags.none,
+                                },
+                            ]
+                        );
+                    });
+                });
+            });
         });
     });
 });

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -42,6 +42,7 @@ import {
 } from '@casual-simulation/aux-common';
 import type {
     StripeAccountStatus,
+    StripeCheckoutSession,
     StripeInterface,
     StripeProduct,
 } from './StripeInterface';
@@ -17664,6 +17665,38 @@ describe('SubscriptionController', () => {
             describe('checkout.session.completed', () => {
                 describe('user', () => {
                     it('should transfer credits to the user', async () => {
+                        const checkoutSession: StripeCheckoutSession = {
+                            id: 'checkout_id',
+                            object: 'checkout.session',
+                            client_reference_id: null,
+                            payment_status: 'paid',
+                            status: 'complete',
+                            line_items: {
+                                object: 'list',
+                                data: [
+                                    {
+                                        id: 'line_item_1_id',
+                                        amount_subtotal: 123,
+                                        amount_total: 133,
+                                        amount_tax: 10,
+                                        amount_discount: 0,
+                                        currency: 'usd',
+                                        quantity: 1,
+                                        price: {
+                                            id: 'price_123',
+                                            product: 'prod_123',
+                                            unit_amount: 100,
+                                        },
+                                        metadata: {
+                                            targetUserId: userId,
+                                        },
+                                    },
+                                ],
+                            },
+                            metadata: {
+                                userId: 'test',
+                            },
+                        };
                         stripeMock.constructWebhookEvent.mockReturnValueOnce({
                             id: 'event_id',
                             type: 'checkout.session.completed',
@@ -17672,43 +17705,15 @@ describe('SubscriptionController', () => {
                             api_version: 'api_version',
                             created: 123,
                             data: {
-                                object: {
-                                    id: 'checkout_id',
-                                    object: 'checkout.session',
-                                    client_reference_id: null,
-                                    payment_status: 'paid',
-                                    status: 'complete',
-                                    line_items: {
-                                        object: 'list',
-                                        data: [
-                                            {
-                                                id: 'line_item_1_id',
-                                                amount_subtotal: 123,
-                                                amount_total: 133,
-                                                amount_tax: 10,
-                                                amount_discount: 0,
-                                                currency: 'usd',
-                                                quantity: 1,
-                                                price: {
-                                                    id: 'price_123',
-                                                    product: 'prod_123',
-                                                    unit_amount: 100,
-                                                },
-                                                metadata: {
-                                                    targetUserId: userId,
-                                                },
-                                            },
-                                        ],
-                                    },
-                                    metadata: {
-                                        userId: 'test',
-                                    },
-                                },
+                                object: checkoutSession,
                             },
                             livemode: true,
                             pending_webhooks: 1,
                             request: {} as any,
                         });
+                        stripeMock.getCheckoutSessionById.mockResolvedValueOnce(
+                            checkoutSession
+                        );
 
                         stripeMock.getProductAndPriceInfo.mockResolvedValueOnce(
                             {
@@ -17815,6 +17820,38 @@ describe('SubscriptionController', () => {
                     });
 
                     it('should transfer credits to the studio', async () => {
+                        const checkoutSession: StripeCheckoutSession = {
+                            id: 'checkout_id',
+                            object: 'checkout.session',
+                            client_reference_id: null,
+                            payment_status: 'paid',
+                            status: 'complete',
+                            line_items: {
+                                object: 'list',
+                                data: [
+                                    {
+                                        id: 'line_item_1_id',
+                                        amount_subtotal: 123,
+                                        amount_total: 133,
+                                        amount_tax: 10,
+                                        amount_discount: 0,
+                                        currency: 'usd',
+                                        quantity: 1,
+                                        price: {
+                                            id: 'price_123',
+                                            product: 'prod_123',
+                                            unit_amount: 100,
+                                        },
+                                        metadata: {
+                                            targetStudioId: studioId,
+                                        },
+                                    },
+                                ],
+                            },
+                            metadata: {
+                                userId: 'test',
+                            },
+                        };
                         stripeMock.constructWebhookEvent.mockReturnValueOnce({
                             id: 'event_id',
                             type: 'checkout.session.completed',
@@ -17823,43 +17860,15 @@ describe('SubscriptionController', () => {
                             api_version: 'api_version',
                             created: 123,
                             data: {
-                                object: {
-                                    id: 'checkout_id',
-                                    object: 'checkout.session',
-                                    client_reference_id: null,
-                                    payment_status: 'paid',
-                                    status: 'complete',
-                                    line_items: {
-                                        object: 'list',
-                                        data: [
-                                            {
-                                                id: 'line_item_1_id',
-                                                amount_subtotal: 123,
-                                                amount_total: 133,
-                                                amount_tax: 10,
-                                                amount_discount: 0,
-                                                currency: 'usd',
-                                                quantity: 1,
-                                                price: {
-                                                    id: 'price_123',
-                                                    product: 'prod_123',
-                                                    unit_amount: 100,
-                                                },
-                                                metadata: {
-                                                    targetStudioId: studioId,
-                                                },
-                                            },
-                                        ],
-                                    },
-                                    metadata: {
-                                        userId: 'test',
-                                    },
-                                },
+                                object: checkoutSession,
                             },
                             livemode: true,
                             pending_webhooks: 1,
                             request: {} as any,
                         });
+                        stripeMock.getCheckoutSessionById.mockResolvedValueOnce(
+                            checkoutSession
+                        );
 
                         stripeMock.getProductAndPriceInfo.mockResolvedValueOnce(
                             {

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -21,6 +21,7 @@ import type {
 } from './AuthController';
 import { INVALID_KEY_ERROR_MESSAGE } from './AuthController';
 import type {
+    AuthCheckoutSession,
     AuthStore,
     AuthUser,
     UpdateCheckoutSessionRequest,
@@ -140,6 +141,7 @@ import type {
 import type { Account, Transfer } from 'tigerbeetle-node';
 import { TransferFlags } from 'tigerbeetle-node';
 import type { SubscriptionFilter } from './MetricsStore';
+import z from 'zod';
 
 /**
  * The number of bytes that the access key secret should be.
@@ -3196,6 +3198,240 @@ export class SubscriptionController {
         }
     }
 
+    /**
+     * Attempts to purchase credits for the given account.
+     */
+    @traced(TRACE_NAME)
+    async purchaseCredits(
+        request: PurchaseCreditsRequest
+    ): Promise<PurchaseCreditsResult> {
+        if (!this._financialController) {
+            return failure({
+                errorCode: 'not_supported',
+                errorMessage: 'This operation is not supported.',
+            });
+        }
+
+        if (request.targetStudioId && request.targetUserId) {
+            return failure({
+                errorCode: 'invalid_request',
+                errorMessage:
+                    'Cannot purchase credits for both a user and a studio at the same time.',
+            });
+        }
+
+        const config = await this._getConfig();
+
+        if (!config.purchaseCreditsConfig?.product) {
+            console.warn(
+                '[SubscriptionController] [purchaseCredits] Attempted to purchase credits but no product is configured for purchasing credits.'
+            );
+            return failure({
+                errorCode: 'not_supported',
+                errorMessage: 'Purchasing credits is not supported.',
+            });
+        }
+
+        let customerId: string;
+        if (request.targetUserId) {
+            if (request.targetUserId !== request.userId) {
+                return failure({
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You cannot purchase credits for other users.',
+                });
+            }
+
+            const user = await this._authStore.findUser(request.targetUserId);
+
+            if (!user) {
+                return failure({
+                    errorCode: 'not_found',
+                    errorMessage: 'The user could not be found.',
+                });
+            }
+
+            if (
+                !user.subscriptionId ||
+                !isActiveSubscription(
+                    user.subscriptionStatus,
+                    user.subscriptionPeriodStartMs,
+                    user.subscriptionPeriodEndMs
+                )
+            ) {
+                console.log(
+                    `[SubscriptionController] [purchaseCredits] User ${user.id} does not have an active subscription and cannot purchase credits.`
+                );
+                return failure({
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'Credits can only be purchased for users with an active subscription.',
+                });
+            }
+
+            if (!user.stripeCustomerId) {
+                console.log(
+                    `[SubscriptionController] [purchaseCredits] User ${user.id} does not have a Stripe customer account and cannot purchase credits.`
+                );
+                return failure({
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'The user does not have a Stripe customer account.',
+                });
+            }
+
+            console.log(
+                `[SubscriptionController] [purchaseCredits] User ${user.id} is attempting to purchase credits.`
+            );
+            customerId = user.stripeCustomerId;
+        } else if (request.targetStudioId) {
+            const studioAssignments =
+                await this._recordsStore.listStudioAssignments(
+                    request.targetStudioId,
+                    {
+                        role: 'admin',
+                        userId: request.userId,
+                    }
+                );
+
+            if (studioAssignments.length === 0) {
+                return failure({
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You are not authorized to purchase credits for this studio.',
+                });
+            }
+
+            const studio = await this._recordsStore.getStudioById(
+                request.targetStudioId
+            );
+
+            if (!studio) {
+                return failure({
+                    errorCode: 'not_found',
+                    errorMessage: 'The studio could not be found.',
+                });
+            }
+
+            if (
+                !studio.subscriptionId ||
+                !isActiveSubscription(
+                    studio.subscriptionStatus,
+                    studio.subscriptionPeriodStartMs,
+                    studio.subscriptionPeriodEndMs
+                )
+            ) {
+                console.log(
+                    `[SubscriptionController] [purchaseCredits] Studio ${studio.id} does not have an active subscription and cannot purchase credits.`
+                );
+                return failure({
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'Credits can only be purchased for studios with an active subscription.',
+                });
+            }
+
+            if (!studio.stripeCustomerId) {
+                console.log(
+                    `[SubscriptionController] [purchaseCredits] Studio ${studio.id} does not have a Stripe customer account and cannot purchase credits.`
+                );
+                return failure({
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'The studio does not have a Stripe customer account.',
+                });
+            }
+
+            console.log(
+                `[SubscriptionController] [purchaseCredits] User ${request.userId} is attempting to purchase credits for studio ${studio.id}.`
+            );
+            customerId = studio.stripeCustomerId;
+        }
+
+        const productInfo = await wrap(
+            async () =>
+                await this._stripe.getProductAndPriceInfo(
+                    config.purchaseCreditsConfig.product
+                )
+        );
+
+        if (isFailure(productInfo)) {
+            logError(
+                productInfo.error,
+                `[SubscriptionController] [purchaseCredits] Failed to retrieve product info for credits purchase:`
+            );
+            return failure({
+                errorCode: 'server_error',
+                errorMessage: 'The server encountered an error.',
+            });
+        }
+
+        const product = productInfo.value;
+
+        const parseResult = getCreditsFromMetadata(
+            product.default_price.metadata,
+            product.metadata
+        );
+
+        if (!parseResult) {
+            console.error(
+                `[SubscriptionController] [purchaseCredits] Failed to parse product metadata for credits purchase! The "casualos.credits" field is required in the product or price metadata and must be a string or number that can be parsed into a bigint.`
+            );
+            return failure({
+                errorCode: 'server_error',
+                errorMessage: 'The server encountered an error.',
+            });
+        }
+
+        const sessionResult = await wrap(() =>
+            this._stripe.createCheckoutSession({
+                mode: 'payment',
+                line_items: [
+                    {
+                        adjustable_quantity:
+                            config.purchaseCreditsConfig.adjustableQuantity ??
+                            true,
+                        price: product.default_price.id,
+                        quantity:
+                            config.purchaseCreditsConfig.defaultQuantity || 1,
+                        metadata: {
+                            targetUserId: request.targetUserId,
+                            targetStudioId: request.targetStudioId,
+                        },
+                    },
+                ],
+                success_url: request.successUrl,
+                cancel_url: request.returnUrl,
+                customer: customerId,
+                metadata: {
+                    userId: request.userId,
+                },
+            })
+        );
+
+        if (isFailure(sessionResult)) {
+            logError(
+                sessionResult.error,
+                `[SubscriptionController] [purchaseCredits] Failed to create checkout session for credits purchase:`
+            );
+            return failure({
+                errorCode: 'server_error',
+                errorMessage: 'The server encountered an error.',
+            });
+        }
+        const session = sessionResult.value;
+
+        console.log(
+            `[SubscriptionController] [purchaseCredits] Successfully created checkout session (${session.id}) for credits purchase.`
+        );
+
+        // We don't create a checkout session because we fulfill credit purchases immediately in the Stripe webhook handler.
+
+        return success({
+            url: session.url,
+        });
+    }
+
     @traced(TRACE_NAME)
     private async _payoutToStripe(
         request: InternalPayoutRequest
@@ -4290,28 +4526,184 @@ export class SubscriptionController {
         const stripeSession = sessionEvent.data.object;
         const sessionId = stripeSession.client_reference_id;
 
-        if (!sessionId) {
-            console.log(
-                `[SubscriptionController] [handleStripeWebhook] No client_reference_id found in the event.`
+        if (sessionId) {
+            const session = await this._authStore.getCheckoutSessionById(
+                sessionId
             );
-            return {
-                success: true,
-            };
+
+            if (session) {
+                return await this._fulfillTrackedStripeCheckoutSession(
+                    stripeSession,
+                    session,
+                    event,
+                    sessionId
+                );
+            } else {
+                console.error(
+                    `[SubscriptionController] [handleStripeWebhook] No session found for the client_reference_id (${sessionId}).`
+                );
+                return {
+                    success: false,
+                    errorCode: 'invalid_request',
+                    errorMessage:
+                        'No checkout session was found with the provided client_reference_id.',
+                };
+            }
         }
 
-        const session = await this._authStore.getCheckoutSessionById(sessionId);
+        console.log(
+            `[SubscriptionController] [handleStripeWebhook] Received checkout session event for credits purchase, but no session was found with the provided client_reference_id (${sessionId}). This may be due to the session being created before the purchaseCreditsConfig was added to the configuration.`
+        );
 
-        if (!session) {
-            console.log(
-                `[SubscriptionController] [handleStripeWebhook] Could not find session with ID (${sessionId}).`
-            );
-            return {
-                success: false,
-                errorCode: 'invalid_request',
-                errorMessage: 'The session could not be found.',
-            };
+        return await this._fulfillUntrackedStripeCheckoutSession(
+            config,
+            stripeSession
+        );
+    }
+
+    /**
+     * Some stripe checkout sessions are "untracked". This means that we don't create a checkout session in our database for them. These ones should be fulfilled by looking directly at the line items in the stripe checkout session data.
+     * @param config The current subscription config.
+     * @param stripeSession The checkout session data from the stripe webhook event.
+     */
+    private async _fulfillUntrackedStripeCheckoutSession(
+        config: SubscriptionConfiguration,
+        stripeSession: StripeEventCheckoutSession['data']['object']
+    ): Promise<HandleStripeWebhookResponse> {
+        const purchaseCreditsProductId = config.purchaseCreditsConfig?.product;
+        const productData = purchaseCreditsProductId
+            ? await this._stripe.getProductAndPriceInfo(
+                  purchaseCreditsProductId
+              )
+            : null;
+
+        const creditsMetadata = productData
+            ? getCreditsFromMetadata(
+                  productData.default_price.metadata,
+                  productData.metadata
+              )
+            : null;
+        const creditsPerUnit = creditsMetadata?.data['casualos.credits'] ?? 0n;
+
+        const transfers: InternalTransfer[] = [];
+
+        for (let lineItem of stripeSession.line_items.data) {
+            if (
+                purchaseCreditsProductId &&
+                lineItem.price?.product === purchaseCreditsProductId
+            ) {
+                console.log(
+                    `[SubscriptionController] [handleStripeWebhook] Processing line item for credits purchase. lineItemId: ${lineItem.id} priceId: ${lineItem.price.id} productId: ${lineItem.price.product}`
+                );
+
+                const amount = lineItem.amount_subtotal;
+                const quantity = lineItem.quantity ?? 1;
+                const totalCredits = creditsPerUnit * BigInt(quantity);
+                const totalUsd = amount;
+
+                const targetStudioId = lineItem.metadata.targetStudioId;
+                const targetUserId = lineItem.metadata.targetUserId;
+
+                if (targetStudioId && targetUserId) {
+                    console.error(
+                        `[SubscriptionController] [handleStripeWebhook] Both targetStudioId and targetUserId are set for a credits purchase. This is not supported. studioId: ${targetStudioId} userId: ${targetUserId}`
+                    );
+                    return {
+                        success: false,
+                        errorCode: 'invalid_request',
+                        errorMessage: 'Invalid metadata for credits purchase.',
+                    };
+                }
+
+                const account =
+                    await this._financialController.getOrCreateFinancialAccount(
+                        {
+                            ledger: LEDGERS.credits,
+                            studioId: targetStudioId,
+                            userId: targetUserId,
+                        }
+                    );
+
+                if (isFailure(account)) {
+                    logError(
+                        account.error,
+                        `[SubscriptionController] [handleStripeWebhook] Failed to get or create financial account for credits purchase:`
+                    );
+                    return {
+                        success: false,
+                        errorCode: 'server_error',
+                        errorMessage: 'A server error occurred.',
+                    };
+                }
+
+                console.log(
+                    `[SubscriptionController] [handleStripeWebhook] Adding transfers for credits purchase. totalUsd: ${totalUsd} totalCredits: ${totalCredits} targetStudioId: ${targetStudioId} targetUserId: ${targetUserId} accountId: ${account.value.account.id}`
+                );
+
+                transfers.push(
+                    {
+                        amount: totalUsd,
+                        code: TransferCodes.purchase_credits,
+                        currency: CurrencyCodes.usd,
+                        debitAccountId: ACCOUNT_IDS.assets_stripe,
+                        creditAccountId: ACCOUNT_IDS.liquidity_usd,
+                    },
+                    {
+                        amount: totalCredits,
+                        code: TransferCodes.purchase_credits,
+                        currency: CurrencyCodes.credits,
+                        debitAccountId: ACCOUNT_IDS.liquidity_credits,
+                        creditAccountId: account.value.account.id, // This will be updated to the correct user account during fulfillment
+                    }
+                );
+            } else {
+                console.warn(
+                    `[SubscriptionController] [handleStripeWebhook lineItem: ${lineItem.id} priceId: ${lineItem.price.id}] Skipping unrecognized line item!`
+                );
+            }
         }
 
+        if (transfers.length > 0) {
+            const transactionResult =
+                await this._financialController.internalTransaction({
+                    transfers,
+                });
+
+            if (isFailure(transactionResult)) {
+                logError(
+                    transactionResult.error,
+                    `[SubscriptionController] [handleStripeWebhook] Failed to create internal transaction for credits purchase:`
+                );
+                return {
+                    success: false,
+                    errorCode: 'server_error',
+                    errorMessage: 'A server error occurred.',
+                };
+            }
+        } else {
+            console.log(
+                `[SubscriptionController] [handleStripeWebhook] No line items found for credits purchase in checkout session.`
+            );
+        }
+
+        return {
+            success: true,
+        };
+    }
+
+    /**
+     * Some stripe checkout sessions are also tracked in our database. For these, we update the data in our database based on the data from the stripe webhook event, and then fulfill the checkout session if it has been paid for and should be automatically fulfilled.
+     * @param stripeSession The stripe checkout session data.
+     * @param session The checkout session data from our database.
+     * @param event The stripe webhook event.
+     * @param sessionId The ID of the checkout session in our database.
+     */
+    private async _fulfillTrackedStripeCheckoutSession(
+        stripeSession: StripeEventCheckoutSession['data']['object'],
+        session: AuthCheckoutSession,
+        event: StripeEvent,
+        sessionId: string
+    ): Promise<HandleStripeWebhookResponse> {
         if (session.stripeCheckoutSessionId !== stripeSession.id) {
             console.log(
                 `[SubscriptionController] [handleStripeWebhook] Stripe checkout session ID (${stripeSession.id}) does not match stored ID (${session.stripeCheckoutSessionId}).`
@@ -5010,6 +5402,19 @@ export class SubscriptionController {
         };
     }
 }
+
+const productMetadataSchema = z.object({
+    'casualos.credits': z.coerce.bigint(),
+});
+const getCreditsFromMetadata = (...values: unknown[]) => {
+    for (const value of values) {
+        const result = productMetadataSchema.safeParse(value);
+        if (result.success) {
+            return result;
+        }
+    }
+    return null;
+};
 
 /**
  * Gets the account status for the given stripe account.
@@ -6567,3 +6972,53 @@ export interface JSONAccountBalancesAndSubscriptionInfo
      */
     subscription?: SubscriptionInfo;
 }
+
+export interface PurchaseCreditsRequest {
+    /**
+     * The ID of the user that is currently logged in.
+     * Null if the user is not logged in.
+     */
+    userId: string | null;
+
+    /**
+     * The instances that the request is being made from.
+     */
+    instances: string[];
+
+    /**
+     * The ID of the studio that the credits are being purchased for.
+     * Must be null when targetUserId is specified, and must be specified when targetUserId is null.
+     */
+    targetStudioId: string | null;
+
+    /**
+     * The ID of the user that the credits are being purchased for.
+     * Must be null when targetStudioId is specified, and must be specified when targetStudioId is null.
+     */
+    targetUserId: string | null;
+
+    /**
+     * The URL that the user should be redirected to if the purchase is canceled.
+     */
+    returnUrl: string;
+
+    /**
+     * The URL that the user should be redirected to if the purchase is unsuccessful.
+     */
+    successUrl: string;
+
+    /**
+     * The current unix time in miliseconds. This should only be used when testing.
+     */
+    nowMs?: number;
+}
+
+export type PurchaseCreditsResult = Result<
+    {
+        /**
+         * The URL that the user should be directed to to complete the purchase.
+         */
+        url?: string;
+    },
+    SimpleError
+>;

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -3392,6 +3392,11 @@ export class SubscriptionController {
                             enabled:
                                 config.purchaseCreditsConfig
                                     .adjustableQuantity ?? true,
+                            maximum:
+                                config.purchaseCreditsConfig.maxQuantity ??
+                                999_999,
+                            minimum:
+                                config.purchaseCreditsConfig.minQuantity ?? 0,
                         },
                         price: product.default_price.id,
                         quantity:

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -7038,6 +7038,13 @@ export interface PurchaseCreditsRequest {
     nowMs?: number;
 }
 
+/**
+ * Defines an interface that represents the result of a request to purchase credits for an account.
+ *
+ * @dochash types/records/extra
+ * @docname PurchaseCreditsResult
+ * @docid PurchaseCreditsResult
+ */
 export type PurchaseCreditsResult = Result<
     {
         /**

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -3388,9 +3388,11 @@ export class SubscriptionController {
                 mode: 'payment',
                 line_items: [
                     {
-                        adjustable_quantity:
-                            config.purchaseCreditsConfig.adjustableQuantity ??
-                            true,
+                        adjustable_quantity: {
+                            enabled:
+                                config.purchaseCreditsConfig
+                                    .adjustableQuantity ?? true,
+                        },
                         price: product.default_price.id,
                         quantity:
                             config.purchaseCreditsConfig.defaultQuantity || 1,

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -30,6 +30,7 @@ import type {
 import type {
     StripeAccount,
     StripeCheckoutRequest,
+    StripeCheckoutSession,
     StripeCreateAccountLinkRequest,
     StripeEvent,
     StripeEventAccountUpdated,
@@ -3402,8 +3403,8 @@ export class SubscriptionController {
                         quantity:
                             config.purchaseCreditsConfig.defaultQuantity || 1,
                         metadata: {
-                            targetUserId: request.targetUserId,
-                            targetStudioId: request.targetStudioId,
+                            targetUserId: request.targetUserId ?? undefined,
+                            targetStudioId: request.targetStudioId ?? undefined,
                         },
                     },
                 ],
@@ -4530,8 +4531,8 @@ export class SubscriptionController {
         event: StripeEvent,
         sessionEvent: StripeEventCheckoutSession
     ): Promise<HandleStripeWebhookResponse> {
-        const stripeSession = sessionEvent.data.object;
-        const sessionId = stripeSession.client_reference_id;
+        // const stripeSession = sessionEvent.data.object;
+        const sessionId = sessionEvent.data.object.client_reference_id;
 
         if (sessionId) {
             const session = await this._authStore.getCheckoutSessionById(
@@ -4540,7 +4541,7 @@ export class SubscriptionController {
 
             if (session) {
                 return await this._fulfillTrackedStripeCheckoutSession(
-                    stripeSession,
+                    sessionEvent.data.object,
                     session,
                     event,
                     sessionId
@@ -4564,7 +4565,7 @@ export class SubscriptionController {
 
         return await this._fulfillUntrackedStripeCheckoutSession(
             config,
-            stripeSession
+            sessionEvent.data.object
         );
     }
 
@@ -4575,8 +4576,13 @@ export class SubscriptionController {
      */
     private async _fulfillUntrackedStripeCheckoutSession(
         config: SubscriptionConfiguration,
-        stripeSession: StripeEventCheckoutSession['data']['object']
+        stripeSession: StripeCheckoutSession
     ): Promise<HandleStripeWebhookResponse> {
+        // Get the full session data from stripe
+        stripeSession = await this._stripe.getCheckoutSessionById(
+            stripeSession.id
+        );
+
         const purchaseCreditsProductId = config.purchaseCreditsConfig?.product;
         const productData = purchaseCreditsProductId
             ? await this._stripe.getProductAndPriceInfo(
@@ -4608,12 +4614,23 @@ export class SubscriptionController {
                 const totalCredits = creditsPerUnit * BigInt(quantity);
                 const totalUsd = amount;
 
-                const targetStudioId = lineItem.metadata.targetStudioId;
-                const targetUserId = lineItem.metadata.targetUserId;
+                const targetStudioId =
+                    lineItem.metadata.targetStudioId || undefined;
+                const targetUserId =
+                    lineItem.metadata.targetUserId || undefined;
 
                 if (targetStudioId && targetUserId) {
                     console.error(
                         `[SubscriptionController] [handleStripeWebhook] Both targetStudioId and targetUserId are set for a credits purchase. This is not supported. studioId: ${targetStudioId} userId: ${targetUserId}`
+                    );
+                    return {
+                        success: false,
+                        errorCode: 'invalid_request',
+                        errorMessage: 'Invalid metadata for credits purchase.',
+                    };
+                } else if (!targetStudioId && !targetUserId) {
+                    console.error(
+                        `[SubscriptionController] [handleStripeWebhook] Neither targetStudioId nor targetUserId is set for a credits purchase. This is not supported. lineItemId: ${lineItem.id}`
                     );
                     return {
                         success: false,
@@ -4639,6 +4656,7 @@ export class SubscriptionController {
                     return {
                         success: false,
                         errorCode: 'server_error',
+
                         errorMessage: 'A server error occurred.',
                     };
                 }

--- a/src/aux-records/TestUtils.ts
+++ b/src/aux-records/TestUtils.ts
@@ -62,6 +62,8 @@ export function createTestSubConfiguration(
                     defaultQuantity: 1,
                     adjustableQuantity: true,
                     product: 'prod_123',
+                    maxQuantity: 999_999,
+                    minQuantity: 0,
                 })
                 .withWebhookSecret('webhook-secret')
                 .withUserDefaultFeatures((f) => f.withAllDefaultFeatures())

--- a/src/aux-records/TestUtils.ts
+++ b/src/aux-records/TestUtils.ts
@@ -58,6 +58,11 @@ export function createTestSubConfiguration(
                 .withCancelUrl('https://cancel-url/')
                 .withReturnUrl('https://return-url/')
                 .withSuccessUrl('https://success-url/')
+                .withCreditPurchaseConfig({
+                    defaultQuantity: 1,
+                    adjustableQuantity: true,
+                    product: 'prod_123',
+                })
                 .withWebhookSecret('webhook-secret')
                 .withUserDefaultFeatures((f) => f.withAllDefaultFeatures())
                 .withStudioDefaultFeatures((f) => f.withAllDefaultFeatures())

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -7032,6 +7032,45 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
     Object {
       "http": Object {
         "method": "POST",
+        "path": "/api/v2/credits/purchase",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "nullable": true,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "returnUrl": Object {
+            "type": "string",
+          },
+          "successUrl": Object {
+            "type": "string",
+          },
+          "targetStudioId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "targetUserId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "purchaseCredits",
+      "origins": "self",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
         "path": "/api/v2/records/contract/pricing",
       },
       "inputs": Object {
@@ -17461,6 +17500,45 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
       },
       "name": "purchaseContract",
       "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/credits/purchase",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "instances": Object {
+            "maxLength": 3,
+            "minLength": 1,
+            "nullable": true,
+            "optional": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "returnUrl": Object {
+            "type": "string",
+          },
+          "successUrl": Object {
+            "type": "string",
+          },
+          "targetStudioId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+          "targetUserId": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "purchaseCredits",
+      "origins": "self",
     },
     Object {
       "http": Object {

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -8716,6 +8716,44 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
                     "schema": Object {},
                     "type": "object",
                   },
+                  "purchaseCreditsConfig": Object {
+                    "defaultValue": Object {},
+                    "description": "Configuration for purchasing credits. Defaults to an empty object, which means that purchasing credits is not supported.",
+                    "hasDefault": true,
+                    "schema": Object {
+                      "adjustableQuantity": Object {
+                        "defaultValue": true,
+                        "description": "Whether the quantity of the line item should be adjustable by the user during checkout. Defaults to true.",
+                        "hasDefault": true,
+                        "type": "boolean",
+                      },
+                      "defaultQuantity": Object {
+                        "defaultValue": 1,
+                        "description": "The default quantity of the line item during checkout. Defaults to 1.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "maxQuantity": Object {
+                        "defaultValue": 999999,
+                        "description": "The maximum quantity that the user can purchase at once. Must be between 1 and 999,999. Defaults to 999,999.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "minQuantity": Object {
+                        "defaultValue": 0,
+                        "description": "The minimum quantity that the user can purchase at once. Must be at least 0. Defaults to 0.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "product": Object {
+                        "description": "The Stripe product that should be used for purchasing credits. If omitted, then purchasing credits will not be supported. The product's prices should have the following metadata properties: \\"casualos.credits\\" (The number of credits to grant when purchasing).",
+                        "nullable": true,
+                        "optional": true,
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
                   "returnUrl": Object {
                     "description": "The URL that users should be redirected to when exiting the Stripe subscription management customer portal.",
                     "type": "string",
@@ -19109,6 +19147,44 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
                     "nullable": true,
                     "optional": true,
                     "schema": Object {},
+                    "type": "object",
+                  },
+                  "purchaseCreditsConfig": Object {
+                    "defaultValue": Object {},
+                    "description": "Configuration for purchasing credits. Defaults to an empty object, which means that purchasing credits is not supported.",
+                    "hasDefault": true,
+                    "schema": Object {
+                      "adjustableQuantity": Object {
+                        "defaultValue": true,
+                        "description": "Whether the quantity of the line item should be adjustable by the user during checkout. Defaults to true.",
+                        "hasDefault": true,
+                        "type": "boolean",
+                      },
+                      "defaultQuantity": Object {
+                        "defaultValue": 1,
+                        "description": "The default quantity of the line item during checkout. Defaults to 1.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "maxQuantity": Object {
+                        "defaultValue": 999999,
+                        "description": "The maximum quantity that the user can purchase at once. Must be between 1 and 999,999. Defaults to 999,999.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "minQuantity": Object {
+                        "defaultValue": 0,
+                        "description": "The minimum quantity that the user can purchase at once. Must be at least 0. Defaults to 0.",
+                        "hasDefault": true,
+                        "type": "number",
+                      },
+                      "product": Object {
+                        "description": "The Stripe product that should be used for purchasing credits. If omitted, then purchasing credits will not be supported. The product's prices should have the following metadata properties: \\"casualos.credits\\" (The number of credits to grant when purchasing).",
+                        "nullable": true,
+                        "optional": true,
+                        "type": "string",
+                      },
+                    },
                     "type": "object",
                   },
                   "returnUrl": Object {

--- a/src/aux-records/__snapshots__/ServerConfig.spec.ts.snap
+++ b/src/aux-records/__snapshots__/ServerConfig.spec.ts.snap
@@ -372,6 +372,12 @@ Object {
           },
         },
       },
+      "purchaseCreditsConfig": Object {
+        "adjustableQuantity": true,
+        "defaultQuantity": 1,
+        "maxQuantity": 999999,
+        "minQuantity": 0,
+      },
       "returnUrl": "https://example.com/",
       "subscriptions": Array [
         Object {
@@ -2010,6 +2016,12 @@ Object {
           },
         },
       },
+      "purchaseCreditsConfig": Object {
+        "adjustableQuantity": true,
+        "defaultQuantity": 1,
+        "maxQuantity": 999999,
+        "minQuantity": 0,
+      },
       "returnUrl": "https://example.com/",
       "subscriptions": Array [],
       "successUrl": "https://example.com/",
@@ -2421,6 +2433,12 @@ Object {
             "tokenLifetimeMs": 300000,
           },
         },
+      },
+      "purchaseCreditsConfig": Object {
+        "adjustableQuantity": true,
+        "defaultQuantity": 1,
+        "maxQuantity": 999999,
+        "minQuantity": 0,
       },
       "returnUrl": "https://example.com/",
       "subscriptions": Array [

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -23647,6 +23647,61 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
         });
+
+        describe('xp.purchaseCredits()', () => {
+            it('should emit a recordsCallProcedure action with getAccountBalances', async () => {
+                const action: any = library.api.xp.purchaseCredits({
+                    targetUserId: 'user123',
+                    returnUrl: 'abc',
+                    successUrl: 'def',
+                });
+                const expected = recordsCallProcedure(
+                    {
+                        purchaseCredits: {
+                            input: {
+                                targetUserId: 'user123',
+                                returnUrl: 'abc',
+                                successUrl: 'def',
+                            },
+                        },
+                    },
+                    {},
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept options', async () => {
+                const action: any = library.api.xp.purchaseCredits(
+                    {
+                        targetUserId: 'user123',
+                        returnUrl: 'abc',
+                        successUrl: 'def',
+                    },
+                    {
+                        endpoint: 'my-endpoint',
+                    }
+                );
+                const expected = recordsCallProcedure(
+                    {
+                        purchaseCredits: {
+                            input: {
+                                targetUserId: 'user123',
+                                returnUrl: 'abc',
+                                successUrl: 'def',
+                            },
+                        },
+                    },
+                    {
+                        endpoint: 'my-endpoint',
+                    },
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
     });
 });
 

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -510,6 +510,7 @@ import type {
     PayoutDestination,
     ContractPricing,
     JSONAccountBalancesAndSubscriptionInfo,
+    PurchaseCreditsResult,
 } from '@casual-simulation/aux-records';
 import SeedRandom from 'seedrandom';
 import { DateTime } from 'luxon';
@@ -642,23 +643,6 @@ export interface APIPurchaseCreditsRequest {
      */
     successUrl: string;
 }
-
-/**
- * Defines an interface that represents the result of a request to purchase credits for an account.
- *
- * @dochash types/records/extra
- * @docname PurchaseCreditsResult
- * @docid PurchaseCreditsResult
- */
-export type PurchaseCreditsResult = GenericResult<
-    {
-        /**
-         * The URL that the user should be directed to to complete the purchase.
-         */
-        url?: string;
-    },
-    SimpleError
->;
 
 export interface APIInvoiceContractRequest {
     contractId: string;

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -611,6 +611,37 @@ export interface APIPurchaseContractRequest {
     returnUrl: string;
     successUrl: string;
 }
+
+/**
+ * Defines an interface that represents the options for purchasing credits for an account.
+ *
+ * @dochash types/records/extra
+ * @docname PurchaseCreditsRequest
+ * @docid PurchaseCreditsRequest
+ */
+export interface APIPurchaseCreditsRequest {
+    /**
+     * The ID of the user that the credits should be purchased for.
+     * Currently, credits can only be purchased for yourself.
+     */
+    targetUserId?: string;
+
+    /**
+     * The ID of the studio that the credits should be purchased for.
+     * Currently, only studio admins can purchase credits.
+     */
+    targetStudioId?: string;
+
+    /**
+     * The URL that the user should be sent to if they cancel the purchase.
+     */
+    returnUrl: string;
+
+    /**
+     * The URL that the user should be sent to if the purchase completes successfully.
+     */
+    successUrl: string;
+}
 export interface APIInvoiceContractRequest {
     contractId: string;
     amount: number;
@@ -3902,6 +3933,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 payInvoice: xpPayInvoice,
                 payout: xpPayout,
                 getAccountBalances: xpGetAccountBalances,
+                purchaseCredits: xpPurchaseCredits,
             },
 
             portal: {
@@ -9677,6 +9709,63 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 },
             },
             rest,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Creates a new checkout session that can be used to purchase credits for an account. Returns a promise which resolves with the URL that the user should be redirected to in order to complete the purchase.
+     *
+     * @param options The options for the request.
+     * @returns A promise that resolves with the account balances.
+     *
+     * @example Purchase credits for the current user.
+     * const purchaseResult = await xp.purchaseCredits({
+     *   targetUserId: authBot.id,
+     *   returnUrl: configBot.tags.url,
+     *   successUrl: configBot.tags.url
+     * });
+     * if (purchaseResult.success) {
+     *   os.goToURL(purchaseResult.url);
+     * } else {
+     *   os.toast("Failed to create checkout session")
+     * }
+     *
+     * @example Purchase credits for a studio.
+     * const purchaseResult = await xp.purchaseCredits({
+     *   targetUserId: "studioId",
+     *   returnUrl: configBot.tags.url,
+     *   successUrl: configBot.tags.url
+     * });
+     * if (purchaseResult.success) {
+     *   os.goToURL(purchaseResult.url);
+     * } else {
+     *   os.toast("Failed to create checkout session")
+     * }
+     *
+     * @dochash actions/xp
+     * @docname xp.purchaseCredits
+     */
+    function xpPurchaseCredits(
+        request: APIPurchaseCreditsRequest,
+        options: RecordActionOptions = {}
+    ): Promise<
+        GenericResult<JSONAccountBalancesAndSubscriptionInfo, SimpleError>
+    > {
+        const task = context.createTask();
+        const event = recordsCallProcedure(
+            {
+                purchaseCredits: {
+                    input: {
+                        targetUserId: request.targetUserId,
+                        targetStudioId: request.targetStudioId,
+                        returnUrl: request.returnUrl,
+                        successUrl: request.successUrl,
+                    },
+                },
+            },
+            options,
             task.taskId
         );
         return addAsyncAction(task, event);

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -642,6 +642,24 @@ export interface APIPurchaseCreditsRequest {
      */
     successUrl: string;
 }
+
+/**
+ * Defines an interface that represents the result of a request to purchase credits for an account.
+ *
+ * @dochash types/records/extra
+ * @docname PurchaseCreditsResult
+ * @docid PurchaseCreditsResult
+ */
+export type PurchaseCreditsResult = GenericResult<
+    {
+        /**
+         * The URL that the user should be directed to to complete the purchase.
+         */
+        url?: string;
+    },
+    SimpleError
+>;
+
 export interface APIInvoiceContractRequest {
     contractId: string;
     amount: number;
@@ -9750,9 +9768,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function xpPurchaseCredits(
         request: APIPurchaseCreditsRequest,
         options: RecordActionOptions = {}
-    ): Promise<
-        GenericResult<JSONAccountBalancesAndSubscriptionInfo, SimpleError>
-    > {
+    ): Promise<PurchaseCreditsResult> {
         const task = context.createTask();
         const event = recordsCallProcedure(
             {

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -19563,6 +19563,55 @@ export interface APIInvoiceContractRequest {
     payoutDestination: InvoicePayoutDestination;
 }
 
+
+/**
+ * Defines an interface that represents the options for purchasing credits for an account.
+ *
+ * @dochash types/records/extra
+ * @docname PurchaseCreditsRequest
+ * @docid PurchaseCreditsRequest
+ */
+export interface APIPurchaseCreditsRequest {
+    /**
+     * The ID of the user that the credits should be purchased for.
+     * Currently, credits can only be purchased for yourself.
+     */
+    targetUserId?: string;
+
+    /**
+     * The ID of the studio that the credits should be purchased for.
+     * Currently, only studio admins can purchase credits.
+     */
+    targetStudioId?: string;
+
+    /**
+     * The URL that the user should be sent to if they cancel the purchase.
+     */
+    returnUrl: string;
+
+    /**
+     * The URL that the user should be sent to if the purchase completes successfully.
+     */
+    successUrl: string;
+}
+
+/**
+ * Defines an interface that represents the result of a request to purchase credits for an account.
+ * 
+ * @dochash types/records/extra
+ * @docname PurchaseCreditsResult
+ * @docid PurchaseCreditsResult
+ */
+export type PurchaseCreditsResult = GenericResult<
+    {
+        /**
+         * The URL that the user should be directed to to complete the purchase.
+         */
+        url?: string;
+    },
+    SimpleError
+>;
+
 /**
  * The destination for the payout of an invoice.
  * - "stripe" means that the invoiced amount will be transfered to the users Stripe account once paid.
@@ -19882,6 +19931,44 @@ interface Xp {
          */
         subscription?: SubscriptionInfo;
     }, SimpleError>>;
+
+    /**
+     * Creates a new checkout session that can be used to purchase credits for an account. Returns a promise which resolves with the URL that the user should be redirected to in order to complete the purchase.
+     *
+     * @param options The options for the request.
+     * @returns A promise that resolves with the account balances.
+     *
+     * @example Purchase credits for the current user.
+     * const purchaseResult = await xp.purchaseCredits({
+     *   targetUserId: authBot.id,
+     *   returnUrl: configBot.tags.url,
+     *   successUrl: configBot.tags.url
+     * });
+     * if (purchaseResult.success) {
+     *   os.goToURL(purchaseResult.url);
+     * } else {
+     *   os.toast("Failed to create checkout session")
+     * }
+     *
+     * @example Purchase credits for a studio.
+     * const purchaseResult = await xp.purchaseCredits({
+     *   targetUserId: "studioId",
+     *   returnUrl: configBot.tags.url,
+     *   successUrl: configBot.tags.url
+     * });
+     * if (purchaseResult.success) {
+     *   os.goToURL(purchaseResult.url);
+     * } else {
+     *   os.toast("Failed to create checkout session")
+     * }
+     *
+     * @dochash actions/xp
+     * @docname xp.purchaseCredits
+     */
+    purchaseCredits(
+        request: APIPurchaseCreditsRequest,
+        options?: RecordActionOptions
+    ): Promise<PurchaseCreditsResult>;
 }
 
 interface Perf {

--- a/src/aux-server/aux-backend/shared/StripeIntegration.ts
+++ b/src/aux-server/aux-backend/shared/StripeIntegration.ts
@@ -15,30 +15,32 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import type {
-    CreateStripeAccountSessionRequest,
-    StripeAccount,
-    StripeAccountLink,
-    StripeAccountSession,
-    StripeCheckoutRequest,
-    StripeCheckoutResponse,
-    StripeCreateAccountLinkRequest,
-    StripeCreateAccountRequest,
-    StripeCreateCustomerRequest,
-    StripeCreateCustomerResponse,
-    StripeCreateLoginLinkRequest,
-    StripeCreateTransferRequest,
-    StripeEvent,
-    StripeInterface,
-    StripeListActiveSubscriptionsResponse,
-    StripePaymentIntent,
-    StripePortalRequest,
-    StripePortalResponse,
-    StripePrice,
-    StripeProduct,
-    StripeSubscription,
-    StripeSubscriptionItem,
-    StripeTransfer,
+import type { StripeCheckoutSession } from '@casual-simulation/aux-records';
+import {
+    STRIPE_CHECKOUT_SESSION_SCHEMA,
+    type CreateStripeAccountSessionRequest,
+    type StripeAccount,
+    type StripeAccountLink,
+    type StripeAccountSession,
+    type StripeCheckoutRequest,
+    type StripeCheckoutResponse,
+    type StripeCreateAccountLinkRequest,
+    type StripeCreateAccountRequest,
+    type StripeCreateCustomerRequest,
+    type StripeCreateCustomerResponse,
+    type StripeCreateLoginLinkRequest,
+    type StripeCreateTransferRequest,
+    type StripeEvent,
+    type StripeInterface,
+    type StripeListActiveSubscriptionsResponse,
+    type StripePaymentIntent,
+    type StripePortalRequest,
+    type StripePortalResponse,
+    type StripePrice,
+    type StripeProduct,
+    type StripeSubscription,
+    type StripeSubscriptionItem,
+    type StripeTransfer,
 } from '@casual-simulation/aux-records';
 import { traced } from '@casual-simulation/aux-records/tracing/TracingDecorators';
 import type { SpanOptions } from '@opentelemetry/api';
@@ -83,12 +85,12 @@ export class StripeIntegration implements StripeInterface {
     test?: StripeInterface;
 
     @traced(TRACE_NAME, SPAN_OPTIONS)
-    async getCheckoutSessionById(id: string): Promise<StripeCheckoutResponse> {
+    async getCheckoutSessionById(id: string): Promise<StripeCheckoutSession> {
         const session = await this._stripe.checkout.sessions.retrieve(id, {
-            expand: ['invoice'],
+            expand: ['line_items'],
         });
 
-        return this._convertCheckoutSession(session);
+        return STRIPE_CHECKOUT_SESSION_SCHEMA.parse(session);
     }
 
     @traced(TRACE_NAME, SPAN_OPTIONS)

--- a/src/aux-vm/managers/RecordsManager.spec.ts
+++ b/src/aux-vm/managers/RecordsManager.spec.ts
@@ -7881,6 +7881,22 @@ describe('RecordsManager', () => {
                         1
                     ),
                 ] as const,
+                [
+                    'purchaseCredits',
+                    recordsCallProcedure(
+                        {
+                            purchaseCredits: {
+                                input: {
+                                    targetUserId: 'user123',
+                                    returnUrl: 'https://example.com/return',
+                                    successUrl: 'https://example.com/success',
+                                },
+                            },
+                        },
+                        {},
+                        1
+                    ),
+                ] as const,
             ];
 
             describe.each(allowedProcedures)('%s', (name, event) => {

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -228,6 +228,10 @@ export class RecordsManager {
     private _httpRequestId: number = 0;
     private _client: ReturnType<typeof createRecordsClient>;
 
+    /**
+     * A map of procedure names to whether or not they require the user to be logged in to call.
+     * Procedures that are not in this map are not allowed to be called from the simulation.
+     */
     private _allowedProcedures = new Map<keyof RecordsClientActions, boolean>([
         ['createRecord', true],
         ['recordWebhook', true],
@@ -282,6 +286,7 @@ export class RecordsManager {
         ['payContractInvoice', true],
         ['payoutAccount', true],
         ['getBalances', true],
+        ['purchaseCredits', true],
     ]);
 
     /**


### PR DESCRIPTION
-   Added the `xp.purchaseCredits(request)` function.
    -   Creates and returns a checkout session URL that grants a user/studio credits.
    -   `request` should be an object that has the following properties:
        -   `targetUserId` - The ID of the user that the purchased credits should be granted to. Currently must be the ID of the user. Can be omitted if `targetStudioId` is specified.
        -   `targetStudioId` - The ID of the studio that the purchased credits should be granted to. Currently only studio admins are allowed to purchase credits for a studio.
        -   `returnUrl` - The URL that the user should be redirected to when they cancel the checkout session.
        -   `successUrl` - The URL that the user should be redirected to when the complete the checkout session.
    -   Before purchasing credits is supported, the following must be configured:
        -   `SERVER_CONFIG.subscriptions.purchaseCreditsConfig` must be set to an object with the following properties:
            -   `product` (string) - The ID of the stripe product. Must have a price with the following metadata:
                -   `casualos.credits` - The number of credits that will be granted for each unit purchased.
            -   `adjustableQuantity` (boolean; optional) - Whether the quantity can be adjusted by the user. Defaults to true.
            -   `defaultQuantity` (number; optional) - The default quantity of the product to purchase. Defaults to 1.
            -   `maxQuantity` (number; optional) - The maximum allowed quantity. Defaults to 999,999 (Stripe max).
            -   `minQuantity` (number; optional) - The minimum allowed quantity. Defaults to 0.