### PR TITLE
Add support for relative file path-style imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@
             ```
 -   Included Subscription info in the `xp.getAccountBalances()` result.
     -   Successful results now include a `subscription` property which contains information about the user/studio's current subscription and includes information like: subscription tier, credit expiration policy, and subscription period (start and end).
+-   Added support for file path-style imports:
+    -   Instead of `.otherTag`, now you can use `./otherTag`
+    -   Instead of `:parent.tag`, now you can use `../parent/tag`
 
 ### :bug: Bug Fixes
 

--- a/src/aux-runtime/runtime/AuxRuntime.spec.ts
+++ b/src/aux-runtime/runtime/AuxRuntime.spec.ts
@@ -10486,6 +10486,240 @@ describe('AuxRuntime', () => {
                 });
             });
 
+            describe('file path imports', () => {
+                it('should be able to resolve modules on the same bot using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module.component',
+                                library: `📄export const abc = 'def';`,
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('./library', {
+                        botId: 'test2',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: 'module.component.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules on the same bot using file path syntax even if they dont have a system', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                library: `📄export const abc = 'def';`,
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('./library', {
+                        botId: 'test2',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: '🔗test2.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules on parent systems using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'module.component',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('../library', {
+                        botId: 'test1',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: 'module.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules on grandparent systems using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'module.component.child',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('../../library', {
+                        botId: 'test1',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: 'module.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules with nested paths using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module.other',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'module.component',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('../other/library', {
+                        botId: 'test1',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: 'module.other.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules with multiple nested levels using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'base.deep.nested',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'base.other.component',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule(
+                        '../../deep/nested/library',
+                        {
+                            botId: 'test1',
+                            tag: 'test',
+                        }
+                    );
+
+                    expect(m).toMatchObject({
+                        id: 'base.deep.nested.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should be able to resolve modules on different bots using file path syntax', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module.component',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'module.component',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('./library', {
+                        botId: 'test1',
+                        tag: 'test',
+                    });
+
+                    expect(m).toMatchObject({
+                        id: 'module.component.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+
+                it('should prefer system relative paths over file paths', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                            test1: createBot('test1', {
+                                system: 'lib',
+                                test: 123,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('.library', {
+                        botId: 'test1',
+                        tag: 'test',
+                    });
+
+                    // Should resolve to lib.library, not test1.library
+                    expect(m).toMatchObject({
+                        id: 'lib.library',
+                        url: 'lib.library',
+                    });
+                });
+
+                it('should not convert paths that dont start with ./ or ../', async () => {
+                    runtime.stateUpdated(
+                        stateUpdatedEvent({
+                            test2: createBot('test2', {
+                                system: 'module',
+                                library: `📄export const abc = 'def';`,
+                            }),
+                        })
+                    );
+                    await waitAsync();
+
+                    const m = await runtime.resolveModule('module.library');
+
+                    expect(m).toMatchObject({
+                        id: 'module.library',
+                        botId: 'test2',
+                        tag: 'library',
+                    });
+                });
+            });
+
             it.skip('should be able to resolve modules based on system quickly', async () => {
                 let state: PartialPrecalculatedBotsState = {};
                 for (let i = 0; i < 1000; i++) {

--- a/src/aux-runtime/runtime/AuxRuntime.ts
+++ b/src/aux-runtime/runtime/AuxRuntime.ts
@@ -663,6 +663,71 @@ export class AuxRuntime
     }
 
     /**
+     * Converts a file-like relative path to a system-relative path.
+     * Examples:
+     *   `./tag` → `.tag`
+     *   `../tag` → `:tag`
+     *   `../../tag` → `::tag`
+     *   `../other/tag` → `:other.tag`
+     *   `../other/nested/tag` → `:other.nested.tag`
+     *
+     * @param moduleName The module name to convert.
+     * @returns The converted module name, or the original if not a file-like path.
+     */
+    private static _convertFilePathToSystemPath(moduleName: string): string {
+        // Check if it starts with ./ or ../
+        if (!moduleName.startsWith('./') && !moduleName.startsWith('../')) {
+            return moduleName;
+        }
+
+        let prefixCount = 0;
+        let index = 0;
+
+        // Count the number of ../ or ./ prefixes
+        while (index < moduleName.length) {
+            if (
+                index + 2 < moduleName.length &&
+                moduleName[index] === '.' &&
+                moduleName[index + 1] === '.' &&
+                moduleName[index + 2] === '/'
+            ) {
+                // Found ../
+                prefixCount++;
+                index += 3;
+            } else if (
+                index + 1 < moduleName.length &&
+                moduleName[index] === '.' &&
+                moduleName[index + 1] === '/'
+            ) {
+                // Found ./
+                index += 2;
+                break;
+            } else {
+                break;
+            }
+        }
+
+        // Extract the remaining path
+        const remainingPath = moduleName.substring(index);
+
+        // Replace / with . in the remaining path
+        const systemPath = remainingPath.replace(/\//g, '.');
+
+        // Build the result with appropriate number of : prefixes
+        let result = '';
+        for (let i = 0; i < prefixCount; i++) {
+            result += ':';
+        }
+
+        // For ./ prefix (when prefixCount is 0), add . prefix
+        if (prefixCount === 0 && moduleName.startsWith('./')) {
+            result = '.';
+        }
+
+        return result + systemPath;
+    }
+
+    /**
      * Attempts to resolve the module with the given name.
      * @param moduleName The name of the module to resolve.
      * @param meta The metadata that should be used to resolve the module.
@@ -760,6 +825,10 @@ export class AuxRuntime
                 }
             }
         }
+
+        // Convert file-like relative paths to system-relative paths
+        // This should happen first so file paths can also be caught by @onResolveModule
+        moduleName = AuxRuntime._convertFilePathToSystemPath(moduleName);
 
         const isRelativeImport =
             moduleName.startsWith('.') || moduleName.startsWith(':');


### PR DESCRIPTION
### :rocket: Features

-   Added support for file path-style imports:
    -   Instead of `.otherTag`, now you can use `./otherTag`
    -   Instead of `:parent.tag`, now you can use `../parent/tag`

#### Example

```typescript
// my.system.tag
export const abc = 123;
```

```typescript
// my.other.system.tag

// Previously this would have to be "my.system.tag" or "::system.tag"
import { abc } from "../../system/tag";

os.toast(abc);
```