### PR TITLE
Fix JSX Whitespace handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,20 @@
             </div>
         );
 
-        // Previously, the output would be this:
-        // <div> <span>Hello</span> <span>World</span> </div>
+        // Previously, the output would be like this:
+        let originalOutput = (
+            <div>
+                {' '}
+                <span>Hello</span> <span>World</span>{' '}
+            </div>
+        );
 
         // Now, the output is like this:
-        // <div><span>Hello</span> <span>World</span></div>
+        let newOutput = (
+            <div>
+                <span>Hello</span> <span>World</span>
+            </div>
+        );
         // Notice the spacing between the <div> and <span> tags
         ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 #### Date: TBD
 
+### :boom: Breaking Changes
+
+-   Changed how whitespace is handled in JSX expressions by default.
+
+    -   Previously, whitespace was preserved as much as possible. This meant that all spaces and newlines which were in the JSX expression were preserved in the JSX output. It also meant that formatting JSX could change the output.
+    -   Now, whitespace is removed unless explicitly added. This means that formatting will no longer change the JSX output. Additionally, this behavior matches the whitespace behavior of other JSX compilers (React, Babel, etc.).
+    -   If you want to preserve the previous behavior, you can add the `"jsx-preserve-whitespace";` directive at the start of the script(s) you want JSX whitespace preservation on.
+    -   Here's an example of the changed behavior:
+
+        ```typescript
+        let jsx = (
+            <div>
+                <span>Hello</span>
+                <span>World</span>
+            </div>
+        );
+
+        // Previously, the output would be this:
+        // <div> <span>Hello</span> <span>World</span> </div>
+
+        // Now, the output is like this:
+        // <div><span>Hello</span> <span>World</span></div>
+        // Notice the spacing between the <div> and <span> tags
+        ```
+
 ### :rocket: Features
 
 -   Added support for specifying a custom file extension when recording files via `os.recordFile()`.

--- a/src/aux-runtime/runtime/Transpiler.spec.ts
+++ b/src/aux-runtime/runtime/Transpiler.spec.ts
@@ -350,7 +350,31 @@ describe('Transpiler', () => {
                 );
             });
 
-            it('should preserve whitespace as much as possible', () => {
+            it('should preserve whitespace as much as possible if the jsx-preserve-whitespace directive is present', () => {
+                const result = transpiler.transpile(
+                    [
+                        `"jsx-preserve-whitespace";`,
+                        `<div `,
+                        `  val="123" `,
+                        `  other="str">`,
+                        `  Hello`,
+                        `</div>`,
+                    ].join('\n')
+                );
+
+                expect(result).toBe(
+                    [
+                        `"jsx-preserve-whitespace";`,
+                        `h("div",{ `,
+                        `  "val":"123" `,
+                        `  ,"other":"str"},\``,
+                        `  Hello`,
+                        `\`,)`,
+                    ].join('\n')
+                );
+            });
+
+            it('should not preserve whitespace if the jsx-preserve-whitespace directive is not present', () => {
                 const result = transpiler.transpile(
                     [
                         `<div `,
@@ -365,9 +389,23 @@ describe('Transpiler', () => {
                     [
                         `h("div",{ `,
                         `  "val":"123" `,
-                        `  ,"other":"str"},\``,
-                        `  Hello`,
-                        `\`,)`,
+                        `  ,"other":"str"},`,
+                        `  \`Hello\``,
+                        `,)`,
+                    ].join('\n')
+                );
+            });
+
+            it('should ignore empty sections of whitespace', () => {
+                const result = transpiler.transpile(
+                    [`<div>`, `  <span>Hello!</span>`, `</div>`].join('\n')
+                );
+
+                expect(result).toBe(
+                    [
+                        `h("div",null,`,
+                        `  h("span",null,\`Hello!\`,),`,
+                        `)`,
                     ].join('\n')
                 );
             });
@@ -379,6 +417,28 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(
                     `h("div",null,h("h1",null,\`Hello, World!\`,),)`
+                );
+            });
+
+            it('should be able to preserve whitespace for elements with text and other elements', () => {
+                const result = transpiler.transpile(
+                    [
+                        `"jsx-preserve-whitespace";`,
+                        `<div>`,
+                        `  Some text`,
+                        `  <h1>Hello, World!</h1>`,
+                        `</div>`,
+                    ].join('\n')
+                );
+
+                expect(result).toBe(
+                    [
+                        `"jsx-preserve-whitespace";`,
+                        'h("div",null,`',
+                        '  Some text',
+                        '  `,h("h1",null,`Hello, World!`,),`',
+                        '`,)',
+                    ].join('\n')
                 );
             });
 
@@ -394,10 +454,10 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(
                     [
-                        'h("div",null,`',
-                        `  Some text`,
-                        '  `,h("h1",null,`Hello, World!`,),`',
-                        '`,)',
+                        'h("div",null,',
+                        '  `Some text`',
+                        '  ,h("h1",null,`Hello, World!`,),',
+                        ')',
                     ].join('\n')
                 );
             });
@@ -575,10 +635,10 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(
                     [
-                        'let el = h("div",null,`',
-                        `  Some text`,
-                        '  `,h("h1",null,`Hello, World!`,),`',
-                        '`,)',
+                        'let el = h("div",null,',
+                        '  `Some text`',
+                        '  ,h("h1",null,`Hello, World!`,),',
+                        ')',
                         `for(let abc of def) {__energyCheck();`,
                         `  let test = {`,
                         `    value: abc`,
@@ -601,10 +661,10 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(
                     [
-                        'let el = h("div",null,`',
-                        `  Some text`,
-                        '  `,h("h1",null,`Hello, World!`,),`',
-                        '`,)',
+                        'let el = h("div",null,',
+                        '  `Some text`',
+                        '  ,h("h1",null,`Hello, World!`,),',
+                        ')',
                         `for(let abc of def) {__energyCheck();console.log("abc")}`,
                     ].join('\n')
                 );
@@ -624,10 +684,10 @@ describe('Transpiler', () => {
 
                 expect(result).toBe(
                     [
-                        'let el = h("div",null,`',
-                        `  Some text`,
-                        '  `,h("h1",null,`Hello, World!`,),`',
-                        '`,)',
+                        'let el = h("div",null,',
+                        '  `Some text`',
+                        '  ,h("h1",null,`Hello, World!`,),',
+                        ')',
                         `for(let abc of def)`,
                         `  {__energyCheck();console.log("abc")}`,
                     ].join('\n')
@@ -2962,6 +3022,28 @@ describe('parseDirectives()', () => {
                 endIndex: 22,
             },
         ] as const,
+        [
+            '"jsx-preserve-whitespace"; const abc = 123;',
+            {
+                noParse: false,
+                isAsync: false,
+                isModule: false,
+                jsxPreserveWhitespace: true,
+                startIndex: 0,
+                endIndex: 26,
+            },
+        ] as const,
+        [
+            '"module async -parse jsx-preserve-whitespace"; const abc = 123;',
+            {
+                noParse: true,
+                isAsync: true,
+                isModule: true,
+                jsxPreserveWhitespace: true,
+                startIndex: 0,
+                endIndex: 46,
+            },
+        ] as const,
     ];
 
     it.each(cases)('%s', (code, expected) => {
@@ -2996,6 +3078,16 @@ describe('addDirectives()', () => {
             '-parse async module',
             { noParse: true, isAsync: true, isModule: true },
             '"-parse async module";',
+        ] as const,
+        [
+            '-parse async module jsx-preserve-whitespace',
+            {
+                noParse: true,
+                isAsync: true,
+                isModule: true,
+                jsxPreserveWhitespace: true,
+            },
+            '"-parse async module jsx-preserve-whitespace";',
         ] as const,
     ];
 

--- a/src/aux-runtime/runtime/Transpiler.spec.ts
+++ b/src/aux-runtime/runtime/Transpiler.spec.ts
@@ -396,6 +396,24 @@ describe('Transpiler', () => {
                 );
             });
 
+            it('should preserve inline whitespace between elements', () => {
+                const result = transpiler.transpile(
+                    [
+                        `<div>`,
+                        `  <span>Hello</span> <span>World</span>`,
+                        `</div>`,
+                    ].join('\n')
+                );
+
+                expect(result).toBe(
+                    [
+                        `h("div",null,`,
+                        '  h("span",null,`Hello`,),` `,h("span",null,`World`,),',
+                        `)`,
+                    ].join('\n')
+                );
+            });
+
             it('should ignore empty sections of whitespace', () => {
                 const result = transpiler.transpile(
                     [`<div>`, `  <span>Hello!</span>`, `</div>`].join('\n')

--- a/src/aux-runtime/runtime/Transpiler.ts
+++ b/src/aux-runtime/runtime/Transpiler.ts
@@ -305,6 +305,8 @@ export class Transpiler {
     private _insertEnergyChecks: boolean;
     private _cache: LRUCache<string, TranspilerResult>;
 
+    private _jsxPreserveWhitespace: boolean = false;
+
     get forceSync() {
         return this._forceSync;
     }
@@ -427,6 +429,7 @@ export class Transpiler {
         if (cached) {
             return cached;
         }
+        this._jsxPreserveWhitespace = directives.jsxPreserveWhitespace ?? false;
         const macroed = replaceMacros(code);
         const node = this._parse(macroed);
         const isAsync = directives.isAsync || this._isAsyncNode(node);
@@ -2039,21 +2042,35 @@ export class Transpiler {
         const version = { '0': getClock(doc, 0) };
 
         for (let child of children) {
-            const pos = createRelativePositionFromStateVector(
-                text,
-                version,
-                child.end,
-                undefined,
-                true
-            );
-            this._replace(child, doc, text, metadata);
+            let changed = false;
+            const changeHandler = () => {
+                changed = true;
+            };
+            try {
+                text.observe(changeHandler);
+                const pos = createRelativePositionFromStateVector(
+                    text,
+                    version,
+                    child.end,
+                    undefined,
+                    true
+                );
+                this._replace(child, doc, text, metadata);
 
-            doc.clientID += 1;
-            const absoluteEnd = createAbsolutePositionFromRelativePosition(
-                pos,
-                doc
-            );
-            text.insert(absoluteEnd.index, ',');
+                if (!changed) {
+                    // Skip inserting comma if nothing was changed
+                    continue;
+                }
+
+                doc.clientID += 1;
+                const absoluteEnd = createAbsolutePositionFromRelativePosition(
+                    pos,
+                    doc
+                );
+                text.insert(absoluteEnd.index, ',');
+            } finally {
+                text.unobserve(changeHandler);
+            }
         }
     }
 
@@ -2061,8 +2078,27 @@ export class Transpiler {
         doc.clientID += 1;
         const version = { '0': getClock(doc, 0) };
 
-        const startIndex = node.start;
-        const endIndex = node.end;
+        let startIndex: number;
+        let endIndex: number;
+
+        if (!this._jsxPreserveWhitespace) {
+            // Find the first non-whitespace character for the start index
+            const startMatch = /\S/.exec(node.raw);
+
+            if (!startMatch) {
+                // If there are no non-whitespace characters, we can skip processing this node
+                return;
+            }
+
+            startIndex = startMatch.index + node.start;
+
+            // Find the last non-whitespace character for the end index
+            const endMatch = /\S\s*$/.exec(node.raw);
+            endIndex = endMatch.index + 1 + node.start;
+        } else {
+            startIndex = node.start;
+            endIndex = node.end;
+        }
 
         const absoluteStart = createAbsolutePositionFromStateVector(
             doc,
@@ -2523,6 +2559,16 @@ export interface TranspilerDirectives {
     noParse: boolean;
     isAsync: boolean;
     isModule: boolean;
+    /**
+     * Whether to preserve whitespace during JSX compilation.
+     * This is useful for cases where whitespace is significant, but is non-standard.
+     *
+     * If set to true, then whitespace in JSX nodes will be preserved in the output.
+     * If false, then whitespace will be removed unless explicitly added with `{" "}` or `{"\n"}`.
+     *
+     * Defaults to false.
+     */
+    jsxPreserveWhitespace?: boolean;
 
     startIndex?: number;
     endIndex?: number;
@@ -2569,6 +2615,8 @@ export function parseDirectives(code: string): TranspilerDirectives {
             directives.isAsync = true;
         } else if (part === 'module') {
             directives.isModule = true;
+        } else if (part === 'jsx-preserve-whitespace') {
+            directives.jsxPreserveWhitespace = true;
         }
     }
     return directives;
@@ -2600,6 +2648,9 @@ export function addDirectives(
     }
     if (directives.isModule) {
         directiveString += 'module ';
+    }
+    if (directives.jsxPreserveWhitespace) {
+        directiveString += 'jsx-preserve-whitespace ';
     }
     directiveString = directiveString.trim() + '";';
     return directiveString + code;

--- a/src/aux-runtime/runtime/Transpiler.ts
+++ b/src/aux-runtime/runtime/Transpiler.ts
@@ -2082,19 +2082,27 @@ export class Transpiler {
         let endIndex: number;
 
         if (!this._jsxPreserveWhitespace) {
-            // Find the first non-whitespace character for the start index
-            const startMatch = /\S/.exec(node.raw);
+            const isMultiLine = /\r|\n/.test(node.raw);
 
-            if (!startMatch) {
-                // If there are no non-whitespace characters, we can skip processing this node
-                return;
+            if (isMultiLine) {
+                // Find the first non-whitespace character for the start index
+                const startMatch = /\S/.exec(node.raw);
+
+                if (!startMatch) {
+                    // If there are no non-whitespace characters, we can skip processing this node
+                    return;
+                }
+
+                startIndex = startMatch.index + node.start;
+
+                // Find the last non-whitespace character for the end index
+                const endMatch = /\S\s*$/.exec(node.raw);
+                endIndex = endMatch.index + 1 + node.start;
+            } else {
+                // For single line text, we preserve the whitespace
+                startIndex = node.start;
+                endIndex = node.end;
             }
-
-            startIndex = startMatch.index + node.start;
-
-            // Find the last non-whitespace character for the end index
-            const endMatch = /\S\s*$/.exec(node.raw);
-            endIndex = endMatch.index + 1 + node.start;
         } else {
             startIndex = node.start;
             endIndex = node.end;


### PR DESCRIPTION
### :boom: Breaking Changes

-   Changed how whitespace is handled in JSX expressions by default.

    -   Previously, whitespace was preserved as much as possible. This meant that all spaces and newlines which were in the JSX expression were preserved in the JSX output. It also meant that formatting JSX could change the output.
    -   Now, whitespace is removed unless explicitly added. This means that formatting will no longer change the JSX output. Additionally, this behavior matches the whitespace behavior of other JSX compilers (React, Babel, etc.).
    -   If you want to preserve the previous behavior, you can add the `"jsx-preserve-whitespace";` directive at the start of the script(s) you want JSX whitespace preservation on.
    -   Here's an example of the changed behavior:

        ```typescript
        let jsx = (
            <div>
                <span>Hello</span>
                <span>World</span>
            </div>
        );

        // Previously, the output would be like this:
        let originalOutput = (
            <div>
                {' '}
                <span>Hello</span> <span>World</span>{' '}
            </div>
        );

        // Now, the output is like this:
        let newOutput = (
            <div>
                <span>Hello</span> <span>World</span>
            </div>
        );
        // Notice the spacing between the <div> and <span> tags
        ```