### PR TITLE
Add record credit budget configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### :rocket: Features
 
 -   Added support for granting records credit budgets
+-   Added `xp.setRecordBudget()` and `xp.getRecordBudget()` to configure automatic credit transfers from a record's owner to the record whenever the owner is granted credits from their subscription
 
 ## V4.2.6
 

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -5787,6 +5787,72 @@ export class RecordsServer {
                     );
                 }),
 
+            setRecordBudget: procedure()
+                .origins('self')
+                .http('POST', '/api/v2/records/budget')
+                .inputs(
+                    z.object({
+                        recordName: RECORD_NAME_VALIDATION,
+                        budget: z.union([
+                            z.object({
+                                type: z.enum(['fixed', 'percent']),
+                                amount: z.coerce.string(),
+                            }),
+                            z.null(),
+                        ]),
+                    })
+                )
+                .handler(async ({ recordName, budget }, context) => {
+                    if (!this._subscriptions) {
+                        return SUBSCRIPTIONS_NOT_SUPPORTED_RESULT;
+                    }
+
+                    const validation = await this._validateSessionKey(
+                        context.sessionKey
+                    );
+                    if (validation.success === false) {
+                        return validation;
+                    }
+
+                    const result = await this._subscriptions.setRecordBudget({
+                        recordName,
+                        budget,
+                        userId: validation.userId,
+                        userRole: validation.role,
+                    });
+
+                    return result;
+                }),
+
+            getRecordBudget: procedure()
+                .origins('self')
+                .http('GET', '/api/v2/records/budget')
+                .inputs(
+                    z.object({
+                        recordName: RECORD_NAME_VALIDATION,
+                    })
+                )
+                .handler(async ({ recordName }, context) => {
+                    if (!this._subscriptions) {
+                        return SUBSCRIPTIONS_NOT_SUPPORTED_RESULT;
+                    }
+
+                    const validation = await this._validateSessionKey(
+                        context.sessionKey
+                    );
+                    if (validation.success === false) {
+                        return validation;
+                    }
+
+                    const result = await this._subscriptions.getRecordBudget({
+                        recordName,
+                        userId: validation.userId,
+                        userRole: validation.role,
+                    });
+
+                    return result;
+                }),
+
             listTransfers: procedure()
                 .origins('self')
                 .http('GET', '/api/v2/transfers')

--- a/src/aux-records/RecordsStore.ts
+++ b/src/aux-records/RecordsStore.ts
@@ -325,6 +325,31 @@ export interface Record {
      * it is fine because there are very few secrets per salt (i.e. not 1 salt per million users but 1 salt per couple record keys) and the secrets are randomly generated.
      */
     secretSalt: string;
+
+    /**
+     * The ID of the financial account that should be billed for usage of this record.
+     * Null or undefined if the record does not have its own credit account.
+     */
+    creditAccountId?: string | null;
+
+    /**
+     * Whether usage of this record should be billed to its own credit account (creditAccountId) instead of the record's owner.
+     */
+    creditBillingEnabled?: boolean;
+
+    /**
+     * The type of budget that has been configured for this record.
+     * - "fixed" means that a set number of credits will be transferred to the record's account from the owner's account upon a subscription credit grant.
+     * - "percent" means that the record will be granted a percentage of the total amount that the owner's account receives upon a subscription credit grant.
+     * Null or undefined if no budget has been configured for this record.
+     */
+    creditBudgetType?: 'fixed' | 'percent' | null;
+
+    /**
+     * The budget amount for this record.
+     * A bigint value stored as a string. Only meaningful when creditBudgetType is set.
+     */
+    creditBudgetAmount?: string | null;
 }
 
 export interface ListedRecord {

--- a/src/aux-records/SubscriptionController.spec.ts
+++ b/src/aux-records/SubscriptionController.spec.ts
@@ -11280,6 +11280,422 @@ describe('SubscriptionController', () => {
         });
     });
 
+    describe('setRecordBudget()', () => {
+        const recordName = 'recordName';
+        const studioId = 'studioId';
+
+        beforeEach(async () => {
+            await store.addRecord({
+                name: recordName,
+                ownerId: userId,
+                studioId: null,
+                secretHashes: [],
+                secretSalt: '',
+            });
+        });
+
+        it('should return record_not_found if the record does not exist', async () => {
+            const result = await controller.setRecordBudget({
+                recordName: 'missingRecord',
+                budget: { type: 'fixed', amount: 100 },
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'record_not_found',
+                errorMessage: 'The given record was not found.',
+            });
+        });
+
+        it('should return not_authorized if the caller is the owner of a personal record', async () => {
+            const result = await controller.setRecordBudget({
+                recordName,
+                budget: { type: 'fixed', amount: 100 },
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'not_authorized',
+                errorMessage: 'You are not authorized to perform this action.',
+            });
+
+            const record = await store.getRecordByName(recordName);
+            expect(record.creditBudgetType).toBeFalsy();
+        });
+
+        it('should return not_authorized if the caller is unrelated to the record', async () => {
+            const result = await controller.setRecordBudget({
+                recordName,
+                budget: { type: 'fixed', amount: 100 },
+                userId: 'otherUserId',
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'not_authorized',
+                errorMessage: 'You are not authorized to perform this action.',
+            });
+        });
+
+        it('should allow superUsers to set a budget for a personal record', async () => {
+            const result = await controller.setRecordBudget({
+                recordName,
+                budget: { type: 'fixed', amount: 100 },
+                userId: 'someOtherUser',
+                userRole: 'superUser',
+            });
+
+            expect(result).toEqual({
+                success: true,
+            });
+
+            const record = await store.getRecordByName(recordName);
+            expect(record.creditBillingEnabled).toBe(true);
+            expect(record.creditBudgetType).toBe('fixed');
+            expect(record.creditBudgetAmount).toBe('100');
+            expect(record.creditAccountId).toBeTruthy();
+        });
+
+        describe('studio owned record', () => {
+            const studioRecordName = 'studioRecord';
+
+            beforeEach(async () => {
+                await store.addStudio({
+                    id: studioId,
+                    displayName: 'studio name',
+                });
+                await store.addStudioAssignment({
+                    studioId,
+                    userId,
+                    isPrimaryContact: true,
+                    role: 'admin',
+                });
+                await store.addRecord({
+                    name: studioRecordName,
+                    ownerId: null,
+                    studioId,
+                    secretHashes: [],
+                    secretSalt: '',
+                });
+            });
+
+            it('should allow studio admins to set a fixed budget', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 100 },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                });
+
+                const record = await store.getRecordByName(studioRecordName);
+                expect(record.creditBillingEnabled).toBe(true);
+                expect(record.creditBudgetType).toBe('fixed');
+                expect(record.creditBudgetAmount).toBe('100');
+                expect(record.creditAccountId).toBeTruthy();
+            });
+
+            it('should allow studio admins to set a percent budget', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'percent', amount: 10 },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                });
+
+                const record = await store.getRecordByName(studioRecordName);
+                expect(record.creditBillingEnabled).toBe(true);
+                expect(record.creditBudgetType).toBe('percent');
+                expect(record.creditBudgetAmount).toBe('10');
+            });
+
+            it('should reuse an existing credit account when one is already configured', async () => {
+                const first = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 100 },
+                    userId,
+                    userRole: null,
+                });
+                expect(first).toEqual({ success: true });
+
+                const firstRecord = await store.getRecordByName(
+                    studioRecordName
+                );
+
+                const second = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 200 },
+                    userId,
+                    userRole: null,
+                });
+                expect(second).toEqual({ success: true });
+
+                const secondRecord = await store.getRecordByName(
+                    studioRecordName
+                );
+                expect(secondRecord.creditAccountId).toBe(
+                    firstRecord.creditAccountId
+                );
+                expect(secondRecord.creditBudgetAmount).toBe('200');
+            });
+
+            it('should return unacceptable_request for an invalid budget type', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'other' as any, amount: 100 },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage:
+                        'The budget type must be either "fixed" or "percent".',
+                });
+            });
+
+            it('should return unacceptable_request for a non-integer amount', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 'not a number' },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage:
+                        'The budget amount must be an integer number or a string containing an integer.',
+                });
+            });
+
+            it('should return unacceptable_request for a negative amount', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: -10 },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage: 'The budget amount must not be negative.',
+                });
+            });
+
+            it('should return unacceptable_request for a percent amount over 100', async () => {
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'percent', amount: 101 },
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage:
+                        'The budget amount must be between 0 and 100 when the budget type is "percent".',
+                });
+            });
+
+            it('should allow clearing the budget with null', async () => {
+                await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 100 },
+                    userId,
+                    userRole: null,
+                });
+
+                const beforeClear = await store.getRecordByName(
+                    studioRecordName
+                );
+                expect(beforeClear.creditAccountId).toBeTruthy();
+
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: null,
+                    userId,
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                });
+
+                const record = await store.getRecordByName(studioRecordName);
+                expect(record.creditBillingEnabled).toBe(false);
+                expect(record.creditBudgetType).toBeFalsy();
+                expect(record.creditBudgetAmount).toBeFalsy();
+                // The credit account is preserved so that any remaining balance/history is not lost.
+                expect(record.creditAccountId).toBe(
+                    beforeClear.creditAccountId
+                );
+            });
+
+            it('should return not_authorized if the caller is not a studio admin', async () => {
+                await store.addStudioAssignment({
+                    studioId,
+                    userId: 'memberUserId',
+                    isPrimaryContact: false,
+                    role: 'member',
+                });
+
+                const result = await controller.setRecordBudget({
+                    recordName: studioRecordName,
+                    budget: { type: 'fixed', amount: 100 },
+                    userId: 'memberUserId',
+                    userRole: null,
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'not_authorized',
+                    errorMessage:
+                        'You are not authorized to perform this action.',
+                });
+            });
+        });
+    });
+
+    describe('getRecordBudget()', () => {
+        const recordName = 'recordName';
+        const studioId = 'studioId';
+
+        beforeEach(async () => {
+            await store.addRecord({
+                name: recordName,
+                ownerId: userId,
+                studioId: null,
+                secretHashes: [],
+                secretSalt: '',
+            });
+        });
+
+        it('should return record_not_found if the record does not exist', async () => {
+            const result = await controller.getRecordBudget({
+                recordName: 'missingRecord',
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'record_not_found',
+                errorMessage: 'The given record was not found.',
+            });
+        });
+
+        it('should return null when no budget has been configured', async () => {
+            const result = await controller.getRecordBudget({
+                recordName,
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: true,
+                budget: null,
+            });
+        });
+
+        it('should allow the personal record owner to read the budget', async () => {
+            await store.updateRecord({
+                ...(await store.getRecordByName(recordName)),
+                creditBudgetType: 'fixed',
+                creditBudgetAmount: '100',
+            } as any);
+
+            const result = await controller.getRecordBudget({
+                recordName,
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: true,
+                budget: {
+                    type: 'fixed',
+                    amount: '100',
+                },
+            });
+        });
+
+        it('should return not_authorized if the caller is unrelated to the record', async () => {
+            const result = await controller.getRecordBudget({
+                recordName,
+                userId: 'otherUserId',
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'not_authorized',
+                errorMessage: 'You are not authorized to perform this action.',
+            });
+        });
+
+        it('should allow superUsers to read any record budget', async () => {
+            const result = await controller.getRecordBudget({
+                recordName,
+                userId: 'someOtherUser',
+                userRole: 'superUser',
+            });
+
+            expect(result).toEqual({
+                success: true,
+                budget: null,
+            });
+        });
+
+        it('should allow studio admins to read the budget for a studio record', async () => {
+            await store.addStudio({
+                id: studioId,
+                displayName: 'studio name',
+            });
+            await store.addStudioAssignment({
+                studioId,
+                userId,
+                isPrimaryContact: true,
+                role: 'admin',
+            });
+            const studioRecordName = 'studioRecord';
+            await store.addRecord({
+                name: studioRecordName,
+                ownerId: null,
+                studioId,
+                secretHashes: [],
+                secretSalt: '',
+            });
+
+            const result = await controller.getRecordBudget({
+                recordName: studioRecordName,
+                userId,
+                userRole: null,
+            });
+
+            expect(result).toEqual({
+                success: true,
+                budget: null,
+            });
+        });
+    });
+
     describe('purchaseCredits()', () => {
         const recordName = 'recordName';
 
@@ -15422,6 +15838,271 @@ describe('SubscriptionController', () => {
                             },
                         ]
                     );
+                });
+
+                describe('record budget', () => {
+                    const recordName = 'budgetedRecord';
+
+                    beforeEach(async () => {
+                        await store.addRecord({
+                            name: recordName,
+                            ownerId: userId,
+                            studioId: null,
+                            secretHashes: [],
+                            secretSalt: '',
+                        });
+                    });
+
+                    function stripeInvoicePaidEvent() {
+                        stripeMock.constructWebhookEvent.mockReturnValueOnce({
+                            id: 'event_id',
+                            type: 'invoice.paid',
+                            object: 'event',
+                            account: 'account_id',
+                            api_version: 'api_version',
+                            created: 123,
+                            data: {
+                                object: {
+                                    id: 'invoiceId',
+                                    customer: 'customer_id',
+                                    currency: 'usd',
+                                    total: 1000,
+                                    subtotal: 1000,
+                                    tax: 0,
+                                    description: 'description',
+                                    status: 'paid',
+                                    paid: true,
+                                    hosted_invoice_url: 'invoiceUrl',
+                                    invoice_pdf: 'pdfUrl',
+                                    lines: {
+                                        object: 'list',
+                                        data: [
+                                            {
+                                                id: 'line_item_1_id',
+                                                price: {
+                                                    id: 'price_1',
+                                                    product: 'product_1_id',
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    subscription: 'sub',
+                                },
+                            },
+                            livemode: true,
+                            pending_webhooks: 1,
+                            request: {} as any,
+                        });
+                        stripeMock.getSubscriptionById.mockResolvedValueOnce({
+                            id: 'sub',
+                            status: 'active',
+                            current_period_start: 456,
+                            current_period_end: 999,
+                            cancel_at: 7777,
+                            canceled_at: null,
+                            ended_at: null,
+                            start_date: 123,
+                        });
+                    }
+
+                    it('should transfer a fixed budget from the owner to the record on grant', async () => {
+                        for (let sub of store.subscriptionConfiguration
+                            .subscriptions) {
+                            sub.creditGrant = 500;
+                        }
+
+                        const setResult = await controller.setRecordBudget({
+                            recordName,
+                            budget: { type: 'fixed', amount: 50 },
+                            userId: 'someSuperUser',
+                            userRole: 'superUser',
+                        });
+                        expect(setResult).toEqual({ success: true });
+
+                        const record = await store.getRecordByName(recordName);
+
+                        stripeInvoicePaidEvent();
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({ success: true });
+
+                        const ownerAccount = unwrap(
+                            await financialController.getFinancialAccount({
+                                userId: userId,
+                                ledger: LEDGERS.credits,
+                            })
+                        );
+
+                        checkAccounts(financialInterface, [
+                            {
+                                id: ownerAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 500n,
+                                debits_pending: 0n,
+                                debits_posted: 50n,
+                            },
+                            {
+                                id: BigInt(record.creditAccountId),
+                                credits_pending: 0n,
+                                credits_posted: 50n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+                    });
+
+                    it('should transfer a percentage of the granted credits from the owner to the record on grant', async () => {
+                        for (let sub of store.subscriptionConfiguration
+                            .subscriptions) {
+                            sub.creditGrant = 500;
+                        }
+
+                        const setResult = await controller.setRecordBudget({
+                            recordName,
+                            budget: { type: 'percent', amount: 10 },
+                            userId: 'someSuperUser',
+                            userRole: 'superUser',
+                        });
+                        expect(setResult).toEqual({ success: true });
+
+                        const record = await store.getRecordByName(recordName);
+
+                        stripeInvoicePaidEvent();
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({ success: true });
+
+                        const ownerAccount = unwrap(
+                            await financialController.getFinancialAccount({
+                                userId: userId,
+                                ledger: LEDGERS.credits,
+                            })
+                        );
+
+                        checkAccounts(financialInterface, [
+                            {
+                                id: ownerAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 500n,
+                                debits_pending: 0n,
+                                debits_posted: 50n,
+                            },
+                            {
+                                id: BigInt(record.creditAccountId),
+                                credits_pending: 0n,
+                                credits_posted: 50n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+                    });
+
+                    it('should not fail the owner grant if the record budget transfer would exceed the owner balance', async () => {
+                        for (let sub of store.subscriptionConfiguration
+                            .subscriptions) {
+                            sub.creditGrant = 500;
+                        }
+
+                        const setResult = await controller.setRecordBudget({
+                            recordName,
+                            budget: { type: 'fixed', amount: 100000 },
+                            userId: 'someSuperUser',
+                            userRole: 'superUser',
+                        });
+                        expect(setResult).toEqual({ success: true });
+
+                        stripeInvoicePaidEvent();
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({ success: true });
+
+                        const ownerAccount = unwrap(
+                            await financialController.getFinancialAccount({
+                                userId: userId,
+                                ledger: LEDGERS.credits,
+                            })
+                        );
+
+                        // The owner should still have received the full grant, since the
+                        // over-budgeted record transfer is performed as its own transaction
+                        // and should not roll back the owner's grant.
+                        checkAccounts(financialInterface, [
+                            {
+                                id: ownerAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 500n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+                    });
+
+                    it('should not transfer credits when the budget has been cleared', async () => {
+                        for (let sub of store.subscriptionConfiguration
+                            .subscriptions) {
+                            sub.creditGrant = 500;
+                        }
+
+                        await controller.setRecordBudget({
+                            recordName,
+                            budget: { type: 'fixed', amount: 50 },
+                            userId: 'someSuperUser',
+                            userRole: 'superUser',
+                        });
+                        await controller.setRecordBudget({
+                            recordName,
+                            budget: null,
+                            userId: 'someSuperUser',
+                            userRole: 'superUser',
+                        });
+
+                        const record = await store.getRecordByName(recordName);
+
+                        stripeInvoicePaidEvent();
+
+                        const result = await controller.handleStripeWebhook({
+                            requestBody: 'request_body',
+                            signature: 'request_signature',
+                        });
+
+                        expect(result).toEqual({ success: true });
+
+                        const ownerAccount = unwrap(
+                            await financialController.getFinancialAccount({
+                                userId: userId,
+                                ledger: LEDGERS.credits,
+                            })
+                        );
+
+                        checkAccounts(financialInterface, [
+                            {
+                                id: ownerAccount.account.id,
+                                credits_pending: 0n,
+                                credits_posted: 500n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                            {
+                                id: BigInt(record.creditAccountId),
+                                credits_pending: 0n,
+                                credits_posted: 0n,
+                                debits_pending: 0n,
+                                debits_posted: 0n,
+                            },
+                        ]);
+                    });
                 });
 
                 it('should do nothing if no grant is set', async () => {

--- a/src/aux-records/SubscriptionController.ts
+++ b/src/aux-records/SubscriptionController.ts
@@ -124,6 +124,7 @@ import type {
 import {
     ACCOUNT_IDS,
     ACCOUNT_NAMES,
+    AccountCodes,
     AMOUNT_MAX,
     convertBetweenLedgers,
     CURRENCIES,
@@ -659,6 +660,265 @@ export class SubscriptionController {
         }
 
         return success();
+    }
+
+    /**
+     * Sets the budget that should be used to automatically transfer credits from a record's owner to the record's own credit account whenever the owner is granted credits from their subscription.
+     * Only studio admins and superUsers are authorized to set a record's budget - record owners cannot set a budget for their own records.
+     * @param request The request.
+     */
+    @traced(TRACE_NAME)
+    async setRecordBudget(
+        request: SetRecordBudgetRequest
+    ): Promise<SetRecordBudgetResult> {
+        if (!this._financialController || !this._financialStore) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage: 'This feature is not supported.',
+            };
+        }
+
+        const record = await this._recordsStore.getRecordByName(
+            request.recordName
+        );
+
+        if (!record) {
+            return {
+                success: false,
+                errorCode: 'record_not_found',
+                errorMessage: 'The given record was not found.',
+            };
+        }
+
+        const authorizationResult =
+            await this._checkAuthorizationForRecordBudget(
+                record,
+                request.userId,
+                request.userRole
+            );
+
+        if (isFailure(authorizationResult)) {
+            return {
+                success: false,
+                ...authorizationResult.error,
+            };
+        }
+
+        const budget = request.budget;
+
+        if (budget === null) {
+            await this._recordsStore.updateRecord({
+                ...record,
+                creditBillingEnabled: false,
+                creditBudgetType: null,
+                creditBudgetAmount: null,
+            });
+
+            return {
+                success: true,
+            };
+        }
+
+        if (budget.type !== 'fixed' && budget.type !== 'percent') {
+            return {
+                success: false,
+                errorCode: 'unacceptable_request',
+                errorMessage:
+                    'The budget type must be either "fixed" or "percent".',
+            };
+        }
+
+        let amount: bigint;
+        try {
+            amount = BigInt(budget.amount);
+        } catch (err) {
+            return {
+                success: false,
+                errorCode: 'unacceptable_request',
+                errorMessage:
+                    'The budget amount must be an integer number or a string containing an integer.',
+            };
+        }
+
+        if (amount < 0n) {
+            return {
+                success: false,
+                errorCode: 'unacceptable_request',
+                errorMessage: 'The budget amount must not be negative.',
+            };
+        }
+
+        if (budget.type === 'percent' && amount > 100n) {
+            return {
+                success: false,
+                errorCode: 'unacceptable_request',
+                errorMessage:
+                    'The budget amount must be between 0 and 100 when the budget type is "percent".',
+            };
+        }
+
+        let creditAccountId = record.creditAccountId;
+        if (!creditAccountId) {
+            const accountResult = await this._financialController.createAccount(
+                AccountCodes.liabilities_record,
+                LEDGERS.credits
+            );
+
+            if (isFailure(accountResult)) {
+                logError(
+                    accountResult.error,
+                    `[SubscriptionController] [setRecordBudget recordName: ${request.recordName}] Unable to create record credit account!`
+                );
+                return {
+                    success: false,
+                    errorCode: 'server_error',
+                    errorMessage: 'Unable to create the record credit account.',
+                };
+            }
+
+            creditAccountId = accountResult.value.id;
+            await this._financialStore.createAccount({
+                id: creditAccountId,
+                ledger: LEDGERS.credits,
+                currency: CURRENCIES.get(LEDGERS.credits),
+            });
+        }
+
+        await this._recordsStore.updateRecord({
+            ...record,
+            creditAccountId,
+            creditBillingEnabled: true,
+            creditBudgetType: budget.type,
+            creditBudgetAmount: amount.toString(),
+        });
+
+        return {
+            success: true,
+        };
+    }
+
+    /**
+     * Gets the budget that has been configured for the given record.
+     * @param request The request.
+     */
+    @traced(TRACE_NAME)
+    async getRecordBudget(
+        request: GetRecordBudgetRequest
+    ): Promise<GetRecordBudgetResult> {
+        if (!this._financialController) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage: 'This feature is not supported.',
+            };
+        }
+
+        const record = await this._recordsStore.getRecordByName(
+            request.recordName
+        );
+
+        if (!record) {
+            return {
+                success: false,
+                errorCode: 'record_not_found',
+                errorMessage: 'The given record was not found.',
+            };
+        }
+
+        const authorizationResult =
+            await this._checkAuthorizationForGetRecordBudget(
+                record,
+                request.userId,
+                request.userRole
+            );
+
+        if (isFailure(authorizationResult)) {
+            return {
+                success: false,
+                ...authorizationResult.error,
+            };
+        }
+
+        return {
+            success: true,
+            budget: record.creditBudgetType
+                ? {
+                      type: record.creditBudgetType,
+                      amount: record.creditBudgetAmount,
+                  }
+                : null,
+        };
+    }
+
+    /**
+     * Checks whether the given user is authorized to set the budget for the given record.
+     * Only studio admins and superUsers are authorized - record owners are not authorized to set a budget for their own records.
+     */
+    private async _checkAuthorizationForRecordBudget(
+        record: { ownerId?: string | null; studioId?: string | null },
+        userId: string,
+        userRole: UserRole | null
+    ): Promise<Result<void, SimpleError>> {
+        if (isSuperUserRole(userRole)) {
+            return success();
+        }
+
+        if (record.studioId) {
+            const assignments = await this._recordsStore.listStudioAssignments(
+                record.studioId,
+                {
+                    userId,
+                    role: 'admin',
+                }
+            );
+
+            if (assignments.length > 0) {
+                return success();
+            }
+        }
+
+        return failure({
+            errorCode: 'not_authorized',
+            errorMessage: 'You are not authorized to perform this action.',
+        });
+    }
+
+    /**
+     * Checks whether the given user is authorized to read the budget for the given record.
+     * Record owners, studio admins, and superUsers are authorized.
+     */
+    private async _checkAuthorizationForGetRecordBudget(
+        record: { ownerId?: string | null; studioId?: string | null },
+        userId: string,
+        userRole: UserRole | null
+    ): Promise<Result<void, SimpleError>> {
+        if (isSuperUserRole(userRole)) {
+            return success();
+        }
+
+        if (record.ownerId) {
+            if (record.ownerId === userId) {
+                return success();
+            }
+        } else if (record.studioId) {
+            const assignments = await this._recordsStore.listStudioAssignments(
+                record.studioId,
+                {
+                    userId,
+                    role: 'admin',
+                }
+            );
+
+            if (assignments.length > 0) {
+                return success();
+            }
+        }
+
+        return failure({
+            errorCode: 'not_authorized',
+            errorMessage: 'You are not authorized to perform this action.',
+        });
     }
 
     /**
@@ -5376,7 +5636,105 @@ export class SubscriptionController {
             );
         }
 
+        if (creditAmount > 0) {
+            await this._transferBudgetedCreditsToRecords(
+                accountFilter,
+                accountId,
+                creditAmount
+            );
+        }
+
         return success();
+    }
+
+    /**
+     * Transfers credits from the owner's (user or studio) credit account to the credit accounts of any of the owner's records that have a budget configured.
+     * This is called after the owner has been granted credits from their subscription.
+     *
+     * Each record's transfer is performed as its own transaction (separate from the owner's grant transaction and from each other), so that a misconfigured
+     * or under-funded record budget cannot fail/rollback the owner's own credit grant or other records' transfers.
+     */
+    private async _transferBudgetedCreditsToRecords(
+        accountFilter: Omit<UniqueFinancialAccountFilter, 'ledger'>,
+        ownerAccountId: bigint | string,
+        ownerCreditAmount: bigint
+    ): Promise<void> {
+        if (!this._financialController) {
+            return;
+        }
+
+        const listedRecords = accountFilter.userId
+            ? await this._recordsStore.listRecordsByOwnerId(
+                  accountFilter.userId
+              )
+            : accountFilter.studioId
+            ? await this._recordsStore.listRecordsByStudioId(
+                  accountFilter.studioId
+              )
+            : [];
+
+        for (let listedRecord of listedRecords) {
+            const record = await this._recordsStore.getRecordByName(
+                listedRecord.name
+            );
+
+            if (
+                !record ||
+                !record.creditBillingEnabled ||
+                !record.creditAccountId ||
+                !record.creditBudgetType ||
+                record.creditBudgetAmount == null
+            ) {
+                continue;
+            }
+
+            let recordAmount: bigint;
+            try {
+                if (record.creditBudgetType === 'fixed') {
+                    recordAmount = BigInt(record.creditBudgetAmount);
+                } else {
+                    recordAmount =
+                        (ownerCreditAmount *
+                            BigInt(record.creditBudgetAmount)) /
+                        100n;
+                }
+            } catch (err) {
+                logError(
+                    err,
+                    `[SubscriptionController] [_transferBudgetedCreditsToRecords recordName: ${record.name}] Unable to parse the configured budget amount!`
+                );
+                continue;
+            }
+
+            if (recordAmount <= 0n) {
+                continue;
+            }
+
+            const transactionResult =
+                await this._financialController.internalTransaction({
+                    transfers: [
+                        {
+                            amount: recordAmount,
+                            code: TransferCodes.record_budget_transfer,
+                            debitAccountId: ownerAccountId,
+                            creditAccountId: record.creditAccountId,
+                            currency: CurrencyCodes.credits,
+                        },
+                    ],
+                });
+
+            if (isFailure(transactionResult)) {
+                logError(
+                    transactionResult.error,
+                    `[SubscriptionController] [_transferBudgetedCreditsToRecords recordName: ${record.name}] Unable to transfer budgeted credits to record!`
+                );
+                continue;
+            }
+
+            console.log(
+                `[SubscriptionController] [_transferBudgetedCreditsToRecords recordName: ${record.name}] Transferred ${recordAmount} credits to record.`
+            );
+        }
     }
 
     private async _internalTransactionExpireCredits(
@@ -7245,3 +7603,115 @@ export type PurchaseCreditsResult = Result<
     },
     SimpleError
 >;
+
+/**
+ * Defines an interface that represents a budget that has been configured for a record.
+ *
+ * @dochash types/records/extra
+ * @docname RecordCreditBudget
+ * @docid RecordCreditBudget
+ */
+export interface RecordCreditBudget {
+    /**
+     * The type of the budget.
+     * - "fixed" means that a set number of credits will be transferred to the record from the owner's account upon a subscription credit grant.
+     * - "percent" means that the record will be granted a percentage of the total amount that the owner's account receives upon a subscription credit grant.
+     */
+    type: 'fixed' | 'percent';
+
+    /**
+     * The budget amount. A bigint value represented as a string.
+     */
+    amount: string;
+}
+
+export interface SetRecordBudgetRequest {
+    /**
+     * The name of the record that the budget should be set for.
+     */
+    recordName: string;
+
+    /**
+     * The budget that should be set for the record.
+     * Null to clear the budget, which causes billing for the record to go to the owner's account.
+     */
+    budget: {
+        type: 'fixed' | 'percent';
+        amount: number | string;
+    } | null;
+
+    /**
+     * The ID of the user that is currently logged in.
+     */
+    userId: string;
+
+    /**
+     * The role of the user that is currently logged in.
+     */
+    userRole: UserRole | null;
+}
+
+/**
+ * Defines an interface that represents the result of a request to set a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname SetRecordBudgetResult
+ * @docid SetRecordBudgetResult
+ */
+export type SetRecordBudgetResult =
+    | SetRecordBudgetSuccess
+    | SetRecordBudgetFailure;
+
+export interface SetRecordBudgetSuccess {
+    success: true;
+}
+
+export interface SetRecordBudgetFailure {
+    success: false;
+    errorCode: KnownErrorCodes;
+    errorMessage: string;
+}
+
+export interface GetRecordBudgetRequest {
+    /**
+     * The name of the record that the budget should be retrieved for.
+     */
+    recordName: string;
+
+    /**
+     * The ID of the user that is currently logged in.
+     */
+    userId: string;
+
+    /**
+     * The role of the user that is currently logged in.
+     */
+    userRole: UserRole | null;
+}
+
+/**
+ * Defines an interface that represents the result of a request to get a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname GetRecordBudgetResult
+ * @docid GetRecordBudgetResult
+ */
+export type GetRecordBudgetResult =
+    | GetRecordBudgetSuccess
+    | GetRecordBudgetFailure;
+
+export interface GetRecordBudgetSuccess {
+    success: true;
+
+    /**
+     * The budget that is configured for the record.
+     * Null if no budget is configured (billing for the record goes to the owner's account).
+     */
+    budget: RecordCreditBudget | null;
+}
+
+export interface GetRecordBudgetFailure {
+    success: false;
+    errorCode: KnownErrorCodes;
+    errorMessage: string;
+}

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -2172,6 +2172,22 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/records/budget",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getRecordBudget",
+      "origins": "self",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/records/search/collection",
       },
       "inputs": Object {
@@ -9892,6 +9908,45 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
       },
       "name": "setConfigurationValue",
       "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/budget",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "budget": Object {
+            "options": Array [
+              Object {
+                "schema": Object {
+                  "amount": Object {
+                    "type": "string",
+                  },
+                  "type": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "fixed",
+                      "percent",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "type": "null",
+              },
+            ],
+            "type": "union",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "setRecordBudget",
+      "origins": "self",
     },
     Object {
       "http": Object {
@@ -12719,6 +12774,22 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/records/budget",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getRecordBudget",
+      "origins": "self",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/records/search/collection",
       },
       "inputs": Object {
@@ -20439,6 +20510,45 @@ Also see https://favicon.inbrowser.app/tools/favicon-generator to generate icons
       },
       "name": "setConfigurationValue",
       "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/records/budget",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "budget": Object {
+            "options": Array [
+              Object {
+                "schema": Object {
+                  "amount": Object {
+                    "type": "string",
+                  },
+                  "type": Object {
+                    "type": "enum",
+                    "values": Array [
+                      "fixed",
+                      "percent",
+                    ],
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "type": "null",
+              },
+            ],
+            "type": "union",
+          },
+          "recordName": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "setRecordBudget",
+      "origins": "self",
     },
     Object {
       "http": Object {

--- a/src/aux-records/financial/FinancialInterface.ts
+++ b/src/aux-records/financial/FinancialInterface.ts
@@ -394,6 +394,11 @@ export enum AccountCodes {
     liabilities_contract = 2103, // flags.debits_must_not_exceed_credits
 
     /**
+     * liabilities held by records.
+     */
+    liabilities_record = 2104, // flags.debits_must_not_exceed_credits
+
+    /**
      * Revenue accounts from platform fees.
      */
     revenue_platform_fees = 4101, // flags.debits_must_not_exceed_credits
@@ -474,6 +479,12 @@ export enum TransferCodes {
      * This generally functions as a payout to the user and corresponds to a credit to an assets account.
      */
     user_payout = 1001,
+
+    /**
+     * A credit to a record's account from its owner (user or studio), based on a configured record budget.
+     * This corresponds to a debit from the owner's account.
+     */
+    record_budget_transfer = 1002,
 
     /**
      * A credit to a contract account from a user and a corresponding debit from the corresponding payment source.
@@ -671,6 +682,7 @@ export function getFlagsForAccountCode(code: AccountCodes): AccountFlags {
         case AccountCodes.liabilities_user:
         case AccountCodes.liabilities_studio:
         case AccountCodes.liabilities_contract:
+        case AccountCodes.liabilities_record:
         case AccountCodes.revenue_platform_fees:
         case AccountCodes.credit_expiration:
             return (

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -23822,6 +23822,130 @@ describe('AuxLibrary', () => {
                 expect(context.actions).toEqual([expected]);
             });
         });
+
+        describe('xp.setRecordBudget()', () => {
+            it('should emit a recordsCallProcedure action with setRecordBudget', async () => {
+                const action: any = library.api.xp.setRecordBudget({
+                    recordName: 'myRecord',
+                    budget: {
+                        type: 'fixed',
+                        amount: 100,
+                    },
+                });
+                const expected = recordsCallProcedure(
+                    {
+                        setRecordBudget: {
+                            input: {
+                                recordName: 'myRecord',
+                                budget: {
+                                    type: 'fixed',
+                                    amount: 100,
+                                },
+                            },
+                        },
+                    },
+                    {},
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should support clearing the budget with null', async () => {
+                const action: any = library.api.xp.setRecordBudget({
+                    recordName: 'myRecord',
+                    budget: null,
+                });
+                const expected = recordsCallProcedure(
+                    {
+                        setRecordBudget: {
+                            input: {
+                                recordName: 'myRecord',
+                                budget: null,
+                            },
+                        },
+                    },
+                    {},
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept options', async () => {
+                const action: any = library.api.xp.setRecordBudget(
+                    {
+                        recordName: 'myRecord',
+                        budget: {
+                            type: 'percent',
+                            amount: 10,
+                        },
+                    },
+                    {
+                        endpoint: 'my-endpoint',
+                    }
+                );
+                const expected = recordsCallProcedure(
+                    {
+                        setRecordBudget: {
+                            input: {
+                                recordName: 'myRecord',
+                                budget: {
+                                    type: 'percent',
+                                    amount: 10,
+                                },
+                            },
+                        },
+                    },
+                    {
+                        endpoint: 'my-endpoint',
+                    },
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('xp.getRecordBudget()', () => {
+            it('should emit a recordsCallProcedure action with getRecordBudget', async () => {
+                const action: any = library.api.xp.getRecordBudget('myRecord');
+                const expected = recordsCallProcedure(
+                    {
+                        getRecordBudget: {
+                            input: {
+                                recordName: 'myRecord',
+                            },
+                        },
+                    },
+                    {},
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should accept options', async () => {
+                const action: any = library.api.xp.getRecordBudget('myRecord', {
+                    endpoint: 'my-endpoint',
+                });
+                const expected = recordsCallProcedure(
+                    {
+                        getRecordBudget: {
+                            input: {
+                                recordName: 'myRecord',
+                            },
+                        },
+                    },
+                    {
+                        endpoint: 'my-endpoint',
+                    },
+                    context.tasks.size
+                );
+                expect(action[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+        });
     });
 });
 

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -511,6 +511,8 @@ import type {
     ContractPricing,
     JSONAccountBalancesAndSubscriptionInfo,
     PurchaseCreditsResult,
+    SetRecordBudgetResult,
+    GetRecordBudgetResult,
 } from '@casual-simulation/aux-records';
 import SeedRandom from 'seedrandom';
 import { DateTime } from 'luxon';
@@ -642,6 +644,39 @@ export interface APIPurchaseCreditsRequest {
      * The URL that the user should be sent to if the purchase completes successfully.
      */
     successUrl: string;
+}
+
+/**
+ * Defines an interface that represents the options for setting a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname SetRecordBudgetRequest
+ * @docid SetRecordBudgetRequest
+ */
+export interface APISetRecordBudgetRequest {
+    /**
+     * The name of the record that the budget should be set for.
+     */
+    recordName: string;
+
+    /**
+     * The budget that should be set for the record.
+     * Setting this value to null will clear the budget, causing billing for the record to go to the owner's account.
+     */
+    budget: {
+        /**
+         * The type of the budget.
+         * - "fixed" means that a set number of credits will be transferred to the record from the owner's account upon a subscription credit grant.
+         * - "percent" means that the record will be granted a percentage of the total amount that the owner's account receives upon a subscription credit grant.
+         */
+        type: 'fixed' | 'percent';
+
+        /**
+         * The budget amount. Can be a string containing a bigint value. Must be an integer.
+         * Must be between 0 and 100 if type is "percent".
+         */
+        amount: number | string;
+    } | null;
 }
 
 export interface APIInvoiceContractRequest {
@@ -3936,6 +3971,8 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 payout: xpPayout,
                 getAccountBalances: xpGetAccountBalances,
                 purchaseCredits: xpPurchaseCredits,
+                setRecordBudget: xpSetRecordBudget,
+                getRecordBudget: xpGetRecordBudget,
             },
 
             portal: {
@@ -9762,6 +9799,94 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                         targetStudioId: request.targetStudioId,
                         returnUrl: request.returnUrl,
                         successUrl: request.successUrl,
+                    },
+                },
+            },
+            options,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Sets the budget that should be used to automatically transfer credits from a record's owner to the record's own credit account whenever the owner is granted credits from their subscription.
+     * Setting the budget to null clears it, causing billing for the record to go to the owner's account.
+     * Only studio admins and superUsers are authorized to set a record's budget.
+     *
+     * @param request The options for the request.
+     * @returns A promise that resolves with the result of the request.
+     *
+     * @example Set a fixed record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: {
+     *     type: "fixed",
+     *     amount: 100
+     *   }
+     * });
+     *
+     * @example Set a percent record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: {
+     *     type: "percent",
+     *     amount: 10
+     *   }
+     * });
+     *
+     * @example Clear a record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: null
+     * });
+     *
+     * @dochash actions/xp
+     * @docname xp.setRecordBudget
+     */
+    function xpSetRecordBudget(
+        request: APISetRecordBudgetRequest,
+        options: RecordActionOptions = {}
+    ): Promise<SetRecordBudgetResult> {
+        const task = context.createTask();
+        const event = recordsCallProcedure(
+            {
+                setRecordBudget: {
+                    input: {
+                        recordName: request.recordName,
+                        budget: request.budget,
+                    },
+                },
+            },
+            options,
+            task.taskId
+        );
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Gets the budget that has been configured for the given record.
+     *
+     * @param recordName The name of the record to get the budget for.
+     * @param options The options for the request.
+     * @returns A promise that resolves with the result of the request.
+     *
+     * @example Get a record's budget
+     * const result = await xp.getRecordBudget("myRecord");
+     * console.log(result);
+     *
+     * @dochash actions/xp
+     * @docname xp.getRecordBudget
+     */
+    function xpGetRecordBudget(
+        recordName: string,
+        options: RecordActionOptions = {}
+    ): Promise<GetRecordBudgetResult> {
+        const task = context.createTask();
+        const event = recordsCallProcedure(
+            {
+                getRecordBudget: {
+                    input: {
+                        recordName,
                     },
                 },
             },

--- a/src/aux-runtime/runtime/AuxLibraryDefinitions.def
+++ b/src/aux-runtime/runtime/AuxLibraryDefinitions.def
@@ -19627,6 +19627,108 @@ export type PurchaseCreditsResult = GenericResult<
 >;
 
 /**
+ * Defines an interface that represents a budget that has been configured for a record.
+ *
+ * @dochash types/records/extra
+ * @docname RecordCreditBudget
+ * @docid RecordCreditBudget
+ */
+export interface RecordCreditBudget {
+    /**
+     * The type of the budget.
+     * - "fixed" means that a set number of credits will be transferred to the record from the owner's account upon a subscription credit grant.
+     * - "percent" means that the record will be granted a percentage of the total amount that the owner's account receives upon a subscription credit grant.
+     */
+    type: 'fixed' | 'percent';
+
+    /**
+     * The budget amount. A bigint value represented as a string.
+     */
+    amount: string;
+}
+
+/**
+ * Defines an interface that represents the options for setting a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname SetRecordBudgetRequest
+ * @docid SetRecordBudgetRequest
+ */
+export interface APISetRecordBudgetRequest {
+    /**
+     * The name of the record that the budget should be set for.
+     */
+    recordName: string;
+
+    /**
+     * The budget that should be set for the record.
+     * Setting this value to null will clear the budget, causing billing for the record to go to the owner's account.
+     */
+    budget: {
+        /**
+         * The type of the budget.
+         * - "fixed" means that a set number of credits will be transferred to the record from the owner's account upon a subscription credit grant.
+         * - "percent" means that the record will be granted a percentage of the total amount that the owner's account receives upon a subscription credit grant.
+         */
+        type: 'fixed' | 'percent';
+
+        /**
+         * The budget amount. Can be a string containing a bigint value. Must be an integer.
+         * Must be between 0 and 100 if type is "percent".
+         */
+        amount: number | string;
+    } | null;
+}
+
+/**
+ * Defines an interface that represents the result of a request to set a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname SetRecordBudgetResult
+ * @docid SetRecordBudgetResult
+ */
+export type SetRecordBudgetResult =
+    | SetRecordBudgetSuccess
+    | SetRecordBudgetFailure;
+
+export interface SetRecordBudgetSuccess {
+    success: true;
+}
+
+export interface SetRecordBudgetFailure {
+    success: false;
+    errorCode: KnownErrorCodes;
+    errorMessage: string;
+}
+
+/**
+ * Defines an interface that represents the result of a request to get a record's budget.
+ *
+ * @dochash types/records/extra
+ * @docname GetRecordBudgetResult
+ * @docid GetRecordBudgetResult
+ */
+export type GetRecordBudgetResult =
+    | GetRecordBudgetSuccess
+    | GetRecordBudgetFailure;
+
+export interface GetRecordBudgetSuccess {
+    success: true;
+
+    /**
+     * The budget that is configured for the record.
+     * Null if no budget is configured (billing for the record goes to the owner's account).
+     */
+    budget: RecordCreditBudget | null;
+}
+
+export interface GetRecordBudgetFailure {
+    success: false;
+    errorCode: KnownErrorCodes;
+    errorMessage: string;
+}
+
+/**
  * The destination for the payout of an invoice.
  * - "stripe" means that the invoiced amount will be transfered to the users Stripe account once paid.
  * - "account" means that the invoiced amount will remain in thier CasualOS account.
@@ -19983,6 +20085,65 @@ interface Xp {
         request: APIPurchaseCreditsRequest,
         options?: RecordActionOptions
     ): Promise<PurchaseCreditsResult>;
+
+    /**
+     * Sets the budget that should be used to automatically transfer credits from a record's owner to the record's own credit account whenever the owner is granted credits from their subscription.
+     * Setting the budget to null clears it, causing billing for the record to go to the owner's account.
+     * Only studio admins and superUsers are authorized to set a record's budget.
+     *
+     * @param request The options for the request.
+     * @returns A promise that resolves with the result of the request.
+     *
+     * @example Set a fixed record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: {
+     *     type: "fixed",
+     *     amount: 100
+     *   }
+     * });
+     *
+     * @example Set a percent record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: {
+     *     type: "percent",
+     *     amount: 10
+     *   }
+     * });
+     *
+     * @example Clear a record budget
+     * const result = await xp.setRecordBudget({
+     *   recordName: "myRecord",
+     *   budget: null
+     * });
+     *
+     * @dochash actions/xp
+     * @docname xp.setRecordBudget
+     */
+    setRecordBudget(
+        request: APISetRecordBudgetRequest,
+        options?: RecordActionOptions
+    ): Promise<SetRecordBudgetResult>;
+
+    /**
+     * Gets the budget that has been configured for the given record.
+     *
+     * @param recordName The name of the record to get the budget for.
+     * @param options The options for the request.
+     * @returns A promise that resolves with the result of the request.
+     *
+     * @example Get a record's budget
+     * const result = await xp.getRecordBudget("myRecord");
+     * console.log(result);
+     *
+     * @dochash actions/xp
+     * @docname xp.getRecordBudget
+     */
+    getRecordBudget(
+        recordName: string,
+        options?: RecordActionOptions
+    ): Promise<GetRecordBudgetResult>;
 }
 
 interface Perf {

--- a/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaRecordsStore.ts
@@ -246,8 +246,14 @@ export class PrismaRecordsStore implements RecordsStore {
     @traced(TRACE_NAME)
     async updateRecord(record: Record): Promise<void> {
         await this._client
-            .$executeRaw`UPSERT INTO public."Record" ("name", "ownerId", "studioId", "secretHashes", "secretSalt", "updatedAt")
-            VALUES (${record.name}, ${record.ownerId}, ${record.studioId}, ${record.secretHashes}, ${record.secretSalt}, NOW())`;
+            .$executeRaw`UPSERT INTO public."Record" ("name", "ownerId", "studioId", "secretHashes", "secretSalt", "creditAccountId", "creditBillingEnabled", "creditBudgetType", "creditBudgetAmount", "updatedAt")
+            VALUES (${record.name}, ${record.ownerId}, ${record.studioId}, ${
+            record.secretHashes
+        }, ${record.secretSalt}, ${record.creditAccountId ?? null}, ${
+            record.creditBillingEnabled ?? false
+        }, ${record.creditBudgetType ?? null}, ${
+            record.creditBudgetAmount ?? null
+        }, NOW())`;
     }
 
     @traced(TRACE_NAME)

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -358,6 +358,9 @@ model Record {
 
     creditBillingEnabled Boolean @default(false)
 
+    creditBudgetType String?
+    creditBudgetAmount String?
+
     secretHashes String[]
     secretSalt String
 

--- a/src/aux-server/aux-backend/schemas/migrations/20260703120000_add_record_credit_budget/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20260703120000_add_record_credit_budget/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."Record" ADD COLUMN     "creditBudgetType" STRING;
+ALTER TABLE "public"."Record" ADD COLUMN     "creditBudgetAmount" STRING;

--- a/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
+++ b/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
@@ -358,6 +358,9 @@ model Record {
 
     creditBillingEnabled Boolean @default(false)
 
+    creditBudgetType String?
+    creditBudgetAmount String?
+
     secretHashes Json
     secretSalt String
 

--- a/src/aux-server/aux-backend/schemas/sqlite/migrations/20260703120000_add_record_credit_budget/migration.sql
+++ b/src/aux-server/aux-backend/schemas/sqlite/migrations/20260703120000_add_record_credit_budget/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Record" ADD COLUMN "creditBudgetType" TEXT;
+ALTER TABLE "Record" ADD COLUMN "creditBudgetAmount" TEXT;

--- a/src/aux-vm/managers/RecordsManager.ts
+++ b/src/aux-vm/managers/RecordsManager.ts
@@ -287,6 +287,8 @@ export class RecordsManager {
         ['payoutAccount', true],
         ['getBalances', true],
         ['purchaseCredits', true],
+        ['setRecordBudget', true],
+        ['getRecordBudget', true],
     ]);
 
     /**


### PR DESCRIPTION
## Summary
This PR adds support for configuring automatic credit transfers from a record's owner to the record's own credit account whenever the owner is granted credits from their subscription. This allows studios and superusers to allocate credits to specific records based on fixed amounts or percentages.

## Key Changes

- **New API Methods**: Added `setRecordBudget()` and `getRecordBudget()` to `SubscriptionController` to manage record budget configurations
  - `setRecordBudget()`: Allows studio admins and superusers to set fixed or percentage-based budgets for records
  - `getRecordBudget()`: Allows record owners, studio admins, and superusers to retrieve configured budgets

- **Budget Transfer Logic**: Implemented `_transferBudgetedCreditsToRecords()` to automatically transfer credits from owner accounts to record accounts after subscription credit grants
  - Supports both fixed amount and percentage-based budget types
  - Each record transfer is isolated in its own transaction to prevent cascading failures
  - Gracefully handles misconfigured or under-funded budgets

- **Authorization Checks**: Added authorization methods to enforce access control
  - `_checkAuthorizationForRecordBudget()`: Only studio admins and superusers can set budgets (record owners cannot)
  - `_checkAuthorizationForGetRecordBudget()`: Record owners, studio admins, and superusers can read budgets

- **Database Schema**: Extended `Record` model with new fields
  - `creditBudgetType`: Stores budget type ('fixed' or 'percent')
  - `creditBudgetAmount`: Stores budget amount as string (supports bigint values)

- **API Endpoints**: Added HTTP endpoints for budget management
  - `POST /api/v2/records/budget`: Set record budget
  - `GET /api/v2/records/budget`: Get record budget

- **Library Integration**: Exposed `xp.setRecordBudget()` and `xp.getRecordBudget()` in AuxLibrary for script access

- **Validation**: Comprehensive input validation including
  - Budget type must be 'fixed' or 'percent'
  - Amount must be a valid integer
  - Negative amounts are rejected
  - Percent budgets must be between 0-100

## Notable Implementation Details

- Credit accounts are created on-demand when a budget is first configured
- Existing credit accounts are reused when budget is updated, preserving balance history
- Clearing a budget (setting to null) disables billing but preserves the credit account for historical purposes
- Budget transfers use a dedicated transfer code (`record_budget_transfer`) for audit trail
- All budget-related operations are traced for debugging and monitoring

https://claude.ai/code/session_01WdSF4WfhZ4EMCJhXiBNfN9