### PR TITLE
Add support for parent window messaging in embedded CasualOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### :rocket: Features
 
+-   Added support for sending and receiving messages with the window that CasualOS is embedded in.
+    -   Added `os.sendEmbedMessage(message, targetOrigin)` to send a message to the parent window.
+    -   Added `@onEmbedMessage` to listen for messages sent from the parent window.
+    -   Added `isEmbedded` to `os.device()` to indicate whether CasualOS is currently embedded in an iframe.
 -   Added support for granting records credit budgets
 -   Added support for expiring private insts.
     -   Added optional `expires` support to inst/branch/package records and websocket `repo/watch_branch` requests.

--- a/docs/docs/tags/listen.mdx
+++ b/docs/docs/tags/listen.mdx
@@ -2738,3 +2738,23 @@ if (that.module === 'myCustomModule') {
     return 'https://example.com/myCustomModule.js';
 }
 ```
+
+### `@onEmbedMessage`
+
+A shout that is sent to all bots when a message is received from the parent window that CasualOS is embedded in.
+See <ActionLink action='os.sendEmbedMessage'/> for how to send a message to the parent window.
+
+#### Arguments:
+```typescript
+let that: {
+    /**
+     * The origin of the window that sent the message.
+     */
+    origin: string;
+
+    /**
+     * The message that was sent.
+     */
+    message: any;
+};
+```

--- a/src/aux-common/bots/Bot.ts
+++ b/src/aux-common/bots/Bot.ts
@@ -1754,6 +1754,11 @@ export const ON_ANY_POINTER_DOWN: string = 'onAnyBotPointerDown';
 export const ON_ANY_POINTER_UP: string = 'onAnyBotPointerUp';
 
 /**
+ * The name of the event that is triggered when a message is received from the parent window that CasualOS is embedded in.
+ */
+export const ON_EMBED_MESSAGE_ACTION_NAME: string = 'onEmbedMessage';
+
+/**
  * The name of the event that is triggered when a QR Code is scanned.
  */
 export const ON_QR_CODE_SCANNED_ACTION_NAME: string = 'onQRCodeScanned';

--- a/src/aux-common/bots/BotEvents.ts
+++ b/src/aux-common/bots/BotEvents.ts
@@ -135,6 +135,7 @@ export type AsyncActions =
     | ShowAlertAction
     | ShowConfirmAction
     | ShareAction
+    | SendEmbedMessageAction
     | ImportAUXAction
     | RegisterBuiltinPortalAction
     | RegisterPrefixAction
@@ -2539,6 +2540,26 @@ export interface ShareOptions {
  */
 export interface ShareAction extends AsyncAction, ShareOptions {
     type: 'share';
+}
+
+/**
+ * Defines an event that sends a message to the parent window that CasualOS is embedded in.
+ *
+ * @dochash types/os/system
+ * @docname SendEmbedMessageAction
+ */
+export interface SendEmbedMessageAction extends AsyncAction {
+    type: 'send_embed_message';
+
+    /**
+     * The message that should be sent to the parent window.
+     */
+    message: any;
+
+    /**
+     * The origin that the parent window must have in order to receive the message.
+     */
+    targetOrigin?: string;
 }
 
 /**
@@ -5809,6 +5830,25 @@ export function share(
         type: 'share',
         taskId,
         ...options,
+    };
+}
+
+/**
+ * Creates an action that sends a message to the parent window that CasualOS is embedded in.
+ * @param message The message to send to the parent window.
+ * @param targetOrigin The origin that the parent window must have in order to receive the message.
+ * @param taskId The ID of the task.
+ */
+export function sendEmbedMessage(
+    message: any,
+    targetOrigin?: string,
+    taskId?: number | string
+): SendEmbedMessageAction {
+    return {
+        type: 'send_embed_message',
+        taskId,
+        message,
+        targetOrigin,
     };
 }
 

--- a/src/aux-runtime/runtime/AuxDevice.ts
+++ b/src/aux-runtime/runtime/AuxDevice.ts
@@ -64,4 +64,9 @@ export interface AuxDevice {
      * Null if it was not loaded from a comID.
      */
     comID: string | null;
+
+    /**
+     * Whether the CasualOS frontend was loaded inside an iframe.
+     */
+    isEmbedded: boolean;
 }

--- a/src/aux-runtime/runtime/AuxGlobalContext.spec.ts
+++ b/src/aux-runtime/runtime/AuxGlobalContext.spec.ts
@@ -88,6 +88,7 @@ describe('AuxGlobalContext', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             },
             factory,
             notifier,

--- a/src/aux-runtime/runtime/AuxLibrary.spec.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.spec.ts
@@ -89,6 +89,7 @@ import {
     localFormAnimation,
     showInput,
     share,
+    sendEmbedMessage,
     getRemoteCount,
     getRemotes,
     action,
@@ -358,6 +359,7 @@ describe('AuxLibrary', () => {
             allowCollaborationUpgrade: true,
             ab1BootstrapUrl: 'bootstrapURL',
             comID: null,
+            isEmbedded: false,
         };
         notifier = {
             notifyChange: jest.fn(),
@@ -4520,7 +4522,14 @@ describe('AuxLibrary', () => {
                     ab1BootstrapUrl: null,
                     allowCollaborationUpgrade: null,
                     comID: null,
+                    isEmbedded: null,
                 });
+            });
+
+            it('should include isEmbedded from the device info', () => {
+                device.isEmbedded = true;
+                const d = library.api.os.device();
+                expect(d.isEmbedded).toBe(true);
             });
         });
 
@@ -4579,6 +4588,7 @@ describe('AuxLibrary', () => {
                     supportsVR: true,
                     supportsDOM: false,
                     comID: null,
+                    isEmbedded: false,
                 };
                 const promise: any = library.api.os.enableCollaboration();
                 const expected = enableCollaboration(context.tasks.size);
@@ -4595,6 +4605,7 @@ describe('AuxLibrary', () => {
                     supportsVR: true,
                     supportsDOM: false,
                     comID: null,
+                    isEmbedded: false,
                 };
                 const promise: any = library.api.os.enableCollaboration();
                 expect(promise[ORIGINAL_OBJECT]).toBeUndefined();
@@ -4614,6 +4625,7 @@ describe('AuxLibrary', () => {
                     supportsVR: true,
                     supportsDOM: false,
                     comID: null,
+                    isEmbedded: false,
                 };
                 const promise: any = library.api.os.enableCollaboration();
                 expect(promise[ORIGINAL_OBJECT]).toBeUndefined();
@@ -6583,6 +6595,35 @@ describe('AuxLibrary', () => {
                 );
                 expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
                 expect(context.actions).toEqual([expected]);
+            });
+        });
+
+        describe('os.sendEmbedMessage()', () => {
+            it('should return a SendEmbedMessageAction when embedded', () => {
+                device.isEmbedded = true;
+                const promise: any = library.api.os.sendEmbedMessage(
+                    { hello: 'world' },
+                    'https://example.com'
+                );
+                const expected = sendEmbedMessage(
+                    { hello: 'world' },
+                    'https://example.com',
+                    context.tasks.size
+                );
+                expect(promise[ORIGINAL_OBJECT]).toEqual(expected);
+                expect(context.actions).toEqual([expected]);
+            });
+
+            it('should throw if not embedded', () => {
+                device.isEmbedded = false;
+                expect(() => {
+                    library.api.os.sendEmbedMessage({ hello: 'world' });
+                }).toThrow(
+                    new Error(
+                        'os.sendEmbedMessage() can only be used when CasualOS is embedded in an iframe.'
+                    )
+                );
+                expect(context.actions).toEqual([]);
             });
         });
 
@@ -12233,6 +12274,7 @@ describe('AuxLibrary', () => {
                         allowCollaborationUpgrade: true,
                         ab1BootstrapUrl: 'bootstrapURL',
                         comID: null,
+                        isEmbedded: false,
                     };
                     notifier = {
                         notifyChange: jest.fn(),

--- a/src/aux-runtime/runtime/AuxLibrary.ts
+++ b/src/aux-runtime/runtime/AuxLibrary.ts
@@ -174,6 +174,7 @@ import {
     webhook as calcWebhook,
     superShout as calcSuperShout,
     share as calcShare,
+    sendEmbedMessage as calcSendEmbedMessage,
     registerPrefix as calcRegisterPrefix,
     localPositionTween as calcLocalPositionTween,
     localRotationTween as calcLocalRotationTween,
@@ -3730,6 +3731,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
                 cancelSound,
                 hasBotInMiniPortal,
                 share,
+                sendEmbedMessage,
                 closeCircleWipe,
                 openCircleWipe,
                 addDropSnap,
@@ -6898,6 +6900,7 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
             allowCollaborationUpgrade: null as boolean,
             ab1BootstrapUrl: null as string,
             comID: null as string,
+            isEmbedded: null as boolean,
         };
     }
 
@@ -8914,6 +8917,39 @@ export function createDefaultLibrary(context: AuxGlobalContext) {
     function share(options: ShareOptions): Promise<void> {
         const task = context.createTask();
         const event = calcShare(options, task.taskId);
+        return addAsyncAction(task, event);
+    }
+
+    /**
+     * Sends a message to the parent window that this CasualOS instance is embedded in.
+     * Returns a Promise that resolves when the message has been sent.
+     * Throws an error if this CasualOS instance is not embedded in an iframe.
+     *
+     * The message must be structure cloneable (transferrables are not supported).
+     *
+     * @param message the message to send to the parent window.
+     * @param targetOrigin the origin that the parent window must have in order to receive the message. If not specified, then the message will be sent to the parent window regardless of its origin.
+     *
+     * @example Send a message to the parent window.
+     * await os.sendEmbedMessage({ hello: 'world' });
+     *
+     * @example Send a message to the parent window with a specific target origin.
+     * await os.sendEmbedMessage({ hello: 'world' }, 'https://example.com');
+     *
+     * @dochash actions/os/system
+     * @docname os.sendEmbedMessage
+     */
+    function sendEmbedMessage(
+        message: any,
+        targetOrigin?: string
+    ): Promise<void> {
+        if (!context.device?.isEmbedded) {
+            throw new Error(
+                'os.sendEmbedMessage() can only be used when CasualOS is embedded in an iframe.'
+            );
+        }
+        const task = context.createTask();
+        const event = calcSendEmbedMessage(message, targetOrigin, task.taskId);
         return addAsyncAction(task, event);
     }
 

--- a/src/aux-runtime/runtime/AuxRuntime.spec.ts
+++ b/src/aux-runtime/runtime/AuxRuntime.spec.ts
@@ -198,6 +198,7 @@ describe('AuxRuntime', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'bootstrap',
                 comID: null,
+                isEmbedded: false,
             };
 
             if (type === 'interpreted') {
@@ -14439,6 +14440,7 @@ describe('AuxRuntime', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'bootstrap',
                 comID: null,
+                isEmbedded: false,
             };
 
             interpreter = new Interpreter();
@@ -18908,6 +18910,7 @@ describe('original action tests', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'bootstrap',
                 comID: null,
+                isEmbedded: false,
             });
 
             expect(result.actions).toEqual([
@@ -18921,6 +18924,7 @@ describe('original action tests', () => {
                             allowCollaborationUpgrade: true,
                             ab1BootstrapUrl: 'bootstrap',
                             comID: null,
+                            isEmbedded: false,
                         },
                     },
                 }),
@@ -18953,6 +18957,7 @@ describe('original action tests', () => {
                             allowCollaborationUpgrade: null,
                             ab1BootstrapUrl: null,
                             comID: null,
+                            isEmbedded: null,
                         },
                     },
                 }),

--- a/src/aux-runtime/runtime/RuntimeBot.spec.ts
+++ b/src/aux-runtime/runtime/RuntimeBot.spec.ts
@@ -136,6 +136,7 @@ describe('RuntimeBot', () => {
             allowCollaborationUpgrade: true,
             ab1BootstrapUrl: 'ab1Bootstrap',
             comID: null,
+            isEmbedded: false,
         };
         realtimeEditMode = RealtimeEditMode.Immediate;
         changedValue = null;

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -1838,6 +1838,7 @@ export class ServerBuilder implements SubscriptionLike {
                 allowCollaborationUpgrade: false,
                 ab1BootstrapUrl: null,
                 comID: null,
+                isEmbedded: false,
             },
         };
 

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.embedMessages.spec.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.embedMessages.spec.ts
@@ -1,0 +1,86 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { shouldForwardEmbedMessage } from './PlayerApp.embedMessages';
+
+describe('shouldForwardEmbedMessage()', () => {
+    it('should return true for a message from the actual parent window', () => {
+        const parentWindow = {};
+
+        const result = shouldForwardEmbedMessage(
+            { source: parentWindow, origin: 'https://example.com' },
+            parentWindow,
+            true,
+            'https://auth.example.com'
+        );
+
+        expect(result).toBe(true);
+    });
+
+    it('should return false when the message source is not the parent window', () => {
+        const parentWindow = {};
+        const otherSource = {};
+
+        const result = shouldForwardEmbedMessage(
+            { source: otherSource, origin: 'https://example.com' },
+            parentWindow,
+            true,
+            'https://auth.example.com'
+        );
+
+        expect(result).toBe(false);
+    });
+
+    it('should return false when the message origin matches the auth origin', () => {
+        const parentWindow = {};
+
+        const result = shouldForwardEmbedMessage(
+            { source: parentWindow, origin: 'https://auth.example.com' },
+            parentWindow,
+            true,
+            'https://auth.example.com'
+        );
+
+        expect(result).toBe(false);
+    });
+
+    it('should return false when the page is not embedded', () => {
+        const parentWindow = {};
+
+        const result = shouldForwardEmbedMessage(
+            { source: parentWindow, origin: 'https://example.com' },
+            parentWindow,
+            false,
+            'https://auth.example.com'
+        );
+
+        expect(result).toBe(false);
+    });
+
+    it('should return true when no auth origin is configured', () => {
+        const parentWindow = {};
+
+        const result = shouldForwardEmbedMessage(
+            { source: parentWindow, origin: 'https://example.com' },
+            parentWindow,
+            true,
+            null
+        );
+
+        expect(result).toBe(true);
+    });
+});

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.embedMessages.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.embedMessages.ts
@@ -1,0 +1,47 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Determines whether the given message event should be forwarded to bots as an `onEmbedMessage` shout.
+ *
+ * Only messages that were posted directly by the actual parent window are forwarded. This excludes
+ * messages from the auth iframe (and its origin), since that channel can carry sensitive auth data,
+ * as well as any other iframe that CasualOS embeds internally (e.g. the VM iframe).
+ *
+ * @param event The message event that was received.
+ * @param parentWindow The `window.parent` of the current window.
+ * @param isEmbedded Whether the current window is embedded in an iframe.
+ * @param authOrigin The origin of the auth site, if configured.
+ */
+export function shouldForwardEmbedMessage(
+    event: { source: unknown; origin: string },
+    parentWindow: unknown,
+    isEmbedded: boolean,
+    authOrigin: string | null | undefined
+): boolean {
+    if (!isEmbedded) {
+        return false;
+    }
+    if (event.source !== parentWindow) {
+        return false;
+    }
+    if (authOrigin && event.origin === authOrigin) {
+        return false;
+    }
+    return true;
+}

--- a/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
+++ b/src/aux-server/aux-web/aux-player/PlayerApp/PlayerApp.ts
@@ -65,8 +65,10 @@ import {
     ON_AUDIO_SAMPLE,
     ON_BEGIN_AUDIO_RECORDING,
     ON_END_AUDIO_RECORDING,
+    ON_EMBED_MESSAGE_ACTION_NAME,
     action,
 } from '@casual-simulation/aux-common';
+import { shouldForwardEmbedMessage } from './PlayerApp.embedMessages';
 import type SnackbarOptions from '../../shared/SnackbarOptions';
 import { copyToClipboard, navigateToUrl } from '../../shared/SharedUtils';
 import LoadApp from '../../shared/vue-components/LoadApp/LoadApp';
@@ -381,6 +383,7 @@ export default class PlayerApp extends Vue {
     showChangeLogin: boolean = false;
     private _isLoggingIn: boolean = false;
     private _deferredPWAPrompt: BeforeInstallPromptEvent | null = null;
+    private _onEmbedMessage: (event: MessageEvent) => void;
 
     showNotificationPermissionDialog: boolean = false;
     showNotificationPermissionMessage: string =
@@ -545,6 +548,24 @@ export default class PlayerApp extends Vue {
             // Store the event so it can be triggered later
             this._deferredPWAPrompt = e as BeforeInstallPromptEvent;
         });
+
+        this._onEmbedMessage = (event: MessageEvent) => {
+            if (
+                !shouldForwardEmbedMessage(
+                    event,
+                    window.parent,
+                    window.parent !== window,
+                    appManager.config?.authOrigin
+                )
+            ) {
+                return;
+            }
+            this._superAction(ON_EMBED_MESSAGE_ACTION_NAME, {
+                origin: event.origin,
+                message: event.data,
+            });
+        };
+        window.addEventListener('message', this._onEmbedMessage);
     }
 
     onRecordsUIVisible() {
@@ -573,6 +594,7 @@ export default class PlayerApp extends Vue {
 
     beforeDestroy() {
         this._subs.forEach((s) => s.unsubscribe());
+        window.removeEventListener('message', this._onEmbedMessage);
     }
 
     snackbarClick(action: SnackbarOptions['action']) {
@@ -1151,6 +1173,29 @@ export default class PlayerApp extends Vue {
                                 e.taskId,
                                 "This device doesn't support sharing"
                             )
+                        );
+                    }
+                } else if (e.type === 'send_embed_message') {
+                    try {
+                        if (window.parent && window.parent !== window) {
+                            window.parent.postMessage(
+                                e.message,
+                                e.targetOrigin ?? '*'
+                            );
+                            simulation.helper.transaction(
+                                asyncResult(e.taskId, null)
+                            );
+                        } else {
+                            simulation.helper.transaction(
+                                asyncError(
+                                    e.taskId,
+                                    'os.sendEmbedMessage() can only be used when CasualOS is embedded in an iframe.'
+                                )
+                            );
+                        }
+                    } catch (error) {
+                        simulation.helper.transaction(
+                            asyncError(e.taskId, (error as Error).toString())
                         );
                     }
                 } else if (e.type === 'begin_audio_recording') {

--- a/src/aux-server/aux-web/shared/AppManager.ts
+++ b/src/aux-server/aux-web/shared/AppManager.ts
@@ -756,6 +756,7 @@ export class AppManager {
             ab1BootstrapUrl: this._ab1BootstrapUrl,
             ab1BootstrapAux: this._ab1BootstrapAux,
             comID: this._comId,
+            isEmbedded: isInIframe(),
         };
     }
 
@@ -1387,6 +1388,14 @@ export class AppManager {
             console.error('Unable to fetch config from storage', err);
             return null;
         }
+    }
+}
+
+function isInIframe(): boolean {
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
     }
 }
 

--- a/src/aux-vm/portals/CustomAppHelper.spec.ts
+++ b/src/aux-vm/portals/CustomAppHelper.spec.ts
@@ -72,6 +72,7 @@ describe('CustomAppHelper', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         memory = createMemoryPartition({
@@ -108,6 +109,7 @@ describe('CustomAppHelper', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         const helper = new AuxHelper('user', partitions, runtime);

--- a/src/aux-vm/portals/HtmlAppBackend.spec.ts
+++ b/src/aux-vm/portals/HtmlAppBackend.spec.ts
@@ -78,6 +78,7 @@ describe('HtmlAppBackend', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         memory = createMemoryPartition({
@@ -108,6 +109,7 @@ describe('HtmlAppBackend', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         const helper = new AuxHelper(userId, partitions, runtime);

--- a/src/aux-vm/vm/AuxHelper.spec.ts
+++ b/src/aux-vm/vm/AuxHelper.spec.ts
@@ -113,6 +113,7 @@ describe('AuxHelper', () => {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         subs.push(runtime);

--- a/src/aux-vm/vm/BaseAuxChannel.spec.ts
+++ b/src/aux-vm/vm/BaseAuxChannel.spec.ts
@@ -1213,6 +1213,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1274,6 +1275,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1364,6 +1366,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1465,6 +1468,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1583,6 +1587,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1760,6 +1765,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         ab1BootstrapUrl: 'bootstrap',
                         comID: null,
+                        isEmbedded: false,
                     }
                 );
 
@@ -1825,6 +1831,7 @@ describe('BaseAuxChannel', () => {
                             supportsVR: false,
                             supportsDOM: false,
                             comID: null,
+                            isEmbedded: false,
                         },
                     },
                     partitions: {
@@ -1923,6 +1930,7 @@ describe('BaseAuxChannel', () => {
                             supportsVR: false,
                             supportsDOM: false,
                             comID: null,
+                            isEmbedded: false,
                         },
                     },
                     partitions: {
@@ -2010,6 +2018,7 @@ describe('BaseAuxChannel', () => {
                             supportsVR: false,
                             supportsDOM: false,
                             comID: null,
+                            isEmbedded: false,
                         },
                     },
                     partitions: {
@@ -2219,6 +2228,7 @@ describe('BaseAuxChannel', () => {
                         allowCollaborationUpgrade: false,
                         isCollaborative: false,
                         comID: null,
+                        isEmbedded: false,
                     },
                 },
                 partitions: {
@@ -2247,6 +2257,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: false,
                 isCollaborative: false,
                 comID: null,
+                isEmbedded: false,
             });
 
             await channel.updateDevice({
@@ -2257,6 +2268,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: true,
                 isCollaborative: true,
                 comID: null,
+                isEmbedded: false,
             });
 
             const { result: device2 } = await channel.runtime.execute(
@@ -2271,6 +2283,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: true,
                 isCollaborative: true,
                 comID: null,
+                isEmbedded: false,
             });
         });
 
@@ -2298,6 +2311,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: true,
                 isCollaborative: true,
                 comID: null,
+                isEmbedded: false,
             });
 
             await waitAsync();
@@ -2329,6 +2343,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: true,
                 isCollaborative: false,
                 comID: null,
+                isEmbedded: false,
             });
 
             await waitAsync();
@@ -2362,6 +2377,7 @@ describe('BaseAuxChannel', () => {
                 allowCollaborationUpgrade: false,
                 isCollaborative: false,
                 comID: null,
+                isEmbedded: false,
             });
 
             await waitAsync();

--- a/src/aux-vm/vm/test/TestAuxVM.ts
+++ b/src/aux-vm/vm/test/TestAuxVM.ts
@@ -97,6 +97,7 @@ export class TestAuxVM implements AuxVM {
                 allowCollaborationUpgrade: true,
                 ab1BootstrapUrl: 'ab1Bootstrap',
                 comID: null,
+                isEmbedded: false,
             }
         );
         this._runtime.userId = configBotId;


### PR DESCRIPTION
## Summary
This PR adds support for sending and receiving messages between CasualOS and its parent window when embedded in an iframe. This enables better integration with host applications that embed CasualOS.

## Key Changes

- **New API: `os.sendEmbedMessage(message, targetOrigin)`**
  - Allows bots to send messages to the parent window
  - Includes optional `targetOrigin` parameter for security (defaults to `*`)
  - Throws an error if CasualOS is not embedded in an iframe
  - Returns a Promise that resolves when the message is sent

- **New Event: `@onEmbedMessage`**
  - Triggered when a message is received from the parent window
  - Provides `origin` and `message` properties to the event handler
  - Only forwards messages directly from the parent window (not from internal iframes like auth)

- **Device Info Enhancement**
  - Added `isEmbedded` property to `os.device()` to indicate whether CasualOS is running in an iframe
  - Automatically detected by checking if `window.self !== window.top`

- **Security Filtering**
  - Created `shouldForwardEmbedMessage()` utility function to validate incoming messages
  - Filters out messages from auth iframe origin to prevent sensitive data leakage
  - Only forwards messages from the actual parent window, not from other iframes

- **Implementation Details**
  - Added message event listener in `PlayerApp` that validates and forwards messages to bots
  - Added `send_embed_message` action type to handle outgoing messages
  - Properly cleans up event listeners on component destruction
  - Comprehensive test coverage for message filtering logic

## Files Modified
- Core API: `AuxLibrary.ts`, `BotEvents.ts`, `AuxDevice.ts`
- Player App: `PlayerApp.ts` with new embed message handler
- App Manager: `AppManager.ts` to detect iframe context
- Documentation: `listen.mdx` with `@onEmbedMessage` documentation
- Tests: Updated all test files to include `isEmbedded` in device mock objects

https://claude.ai/code/session_01F3cPeQMzZp4y1cGQHSiYdY