### PR TITLE
Add optional HTML body config to SimpleEmailServiceAuthMessenger

### DIFF
--- a/src/aux-records-aws/README.md
+++ b/src/aux-records-aws/README.md
@@ -111,7 +111,7 @@ Amazon SES implementation of `AuthMessenger` for sending authentication codes vi
 
 -   Send authentication codes via AWS SES
 -   Template-based emails (using SES templates)
--   Plain text emails with variable substitution
+-   Plain text (and optional HTML) emails with variable substitution
 -   Supports email address type only
 -   Customizable sender address and content
 
@@ -132,16 +132,19 @@ const messenger = new SimpleEmailServiceAuthMessenger(sesClient, {
     },
 });
 
-// Using plain text with variable substitution
+// Using plain text with variable substitution (optionally with an HTML body)
 const messengerPlain = new SimpleEmailServiceAuthMessenger(sesClient, {
     fromAddress: 'noreply@example.com',
     content: {
         type: 'plain',
         subject: 'Your authentication code',
         body: 'Your code is: {{code}}',
+        html: '<p>Your code is: <strong>{{code}}</strong></p>',
     },
 });
 ```
+
+`html` is optional. When provided, SES sends a multipart/alternative email with both the plain-text and HTML bodies; when omitted, only the plain-text body is sent. This is separate from the `type: 'template'` option above, which delegates to AWS SES's own hosted templates (referenced by ARN) rather than configuring content directly.
 
 **Example Usage**:
 

--- a/src/aux-records-aws/SimpleEmailServiceAuthMessenger.spec.ts
+++ b/src/aux-records-aws/SimpleEmailServiceAuthMessenger.spec.ts
@@ -105,6 +105,58 @@ describe('SimpleEmailServiceAuthMessenger', () => {
             });
         });
 
+        it('should send a code with an html body when configured', async () => {
+            messenger = new SimpleEmailServiceAuthMessenger(ses as any, {
+                content: {
+                    type: 'plain',
+                    subject: 'Test',
+                    body: 'Your code is: {{code}}',
+                    html: '<p>Your code is: {{code}}</p>',
+                },
+                fromAddress: 'test@example.com',
+            });
+
+            ses.sendEmail.mockReturnValueOnce(
+                awsResult({
+                    MessageId: 'test',
+                })
+            );
+
+            const result = await messenger.sendCode(
+                'target@example.com',
+                'email',
+                '1234'
+            );
+
+            expect(result).toEqual({
+                success: true,
+            });
+            expect(ses.sendEmail).toHaveBeenCalledWith({
+                Destination: {
+                    ToAddresses: ['target@example.com'],
+                },
+                FromEmailAddress: 'test@example.com',
+                Content: {
+                    Simple: {
+                        Body: {
+                            Text: {
+                                Data: 'Your code is: 1234',
+                                Charset: 'UTF-8',
+                            },
+                            Html: {
+                                Data: '<p>Your code is: 1234</p>',
+                                Charset: 'UTF-8',
+                            },
+                        },
+                        Subject: {
+                            Data: 'Test',
+                            Charset: 'UTF-8',
+                        },
+                    },
+                },
+            });
+        });
+
         it('should send a code using the given AWS template', async () => {
             messenger = new SimpleEmailServiceAuthMessenger(ses as any, {
                 content: {

--- a/src/aux-records-aws/SimpleEmailServiceAuthMessenger.ts
+++ b/src/aux-records-aws/SimpleEmailServiceAuthMessenger.ts
@@ -51,6 +51,12 @@ export interface EmailPlainContent {
     type: 'plain';
     subject: string;
     body: string;
+
+    /**
+     * The HTML body of the email. If omitted, only the plain-text body is sent.
+     * Use double curly-braces {{variable}} to insert variables, same as `body`.
+     */
+    html?: string;
 }
 
 export class SimpleEmailServiceAuthMessenger implements AuthMessenger {
@@ -98,6 +104,17 @@ export class SimpleEmailServiceAuthMessenger implements AuthMessenger {
                                 ),
                                 Charset: 'UTF-8',
                             },
+                            ...(this._options.content.html
+                                ? {
+                                      Html: {
+                                          Data: renderString(
+                                              this._options.content.html,
+                                              data
+                                          ),
+                                          Charset: 'UTF-8',
+                                      },
+                                  }
+                                : {}),
                         },
                         Subject: {
                             Data: renderString(

--- a/src/aux-records/ServerConfig.ts
+++ b/src/aux-records/ServerConfig.ts
@@ -466,6 +466,13 @@ function constructServerConfigSchema() {
                 .describe(
                     'The body of the email. Use double curly-braces {{variable}} to insert variables.'
                 ),
+            html: z
+                .string()
+                .nonempty()
+                .optional()
+                .describe(
+                    'The HTML body of the email. If omitted, only the plain-text body will be sent. Use double curly-braces {{variable}} to insert variables.'
+                ),
         }),
     ]);
 


### PR DESCRIPTION
Lets the plain-content SES auth messenger send an HTML body alongside
the existing plain-text body, configured directly in CasualOS's server
config rather than through AWS SES's own hosted templates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NCrXh7KziJbqom8WQ1mEFH