### PR TITLE
Add link preview generation API endpoint

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,9 @@ importers:
       mime:
         specifier: 2.4.6
         version: 2.4.6
+      node-html-parser:
+        specifier: ^6.1.13
+        version: 6.1.13
       openai:
         specifier: 4.89.0
         version: 4.89.0(encoding@0.1.13)(ws@8.18.3)(zod@4.1.12)
@@ -8444,6 +8447,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -10056,7 +10060,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -10066,7 +10070,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -12484,6 +12488,9 @@ packages:
     resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
     engines: {node: ^12.13 || ^14.13 || >=16}
     hasBin: true
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -31667,6 +31674,11 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.1.0
+      he: 1.2.0
 
   node-int64@0.4.0: {}
 

--- a/src/aux-common/rpc/ErrorCodes.ts
+++ b/src/aux-common/rpc/ErrorCodes.ts
@@ -99,7 +99,9 @@ export type KnownErrorCodes =
     | 'item_not_found'
     | 'store_disabled'
     | 'currency_not_supported'
-    | 'invalid_user';
+    | 'invalid_user'
+    | 'url_not_html'
+    | 'site_rate_limited';
 
 /**
  * Gets the status code that should be used for the given response.
@@ -213,6 +215,10 @@ export function getStatusCode(
             return 504;
         } else if (response.errorCode === 'service_unavailable') {
             return 503;
+        } else if (response.errorCode === 'url_not_html') {
+            return 400;
+        } else if (response.errorCode === 'site_rate_limited') {
+            return 429;
         } else {
             return 400;
         }

--- a/src/aux-records/LinkPreviewController.spec.ts
+++ b/src/aux-records/LinkPreviewController.spec.ts
@@ -1,0 +1,401 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { lookup as dnsLookup } from 'node:dns/promises';
+import {
+    LinkPreviewController,
+    extractLinkPreviewData,
+    getCacheKey,
+    isPrivateOrReservedAddress,
+    normalizeUrl,
+} from './LinkPreviewController';
+import { MemoryLinkPreviewStore } from './MemoryLinkPreviewStore';
+import { MemoryRateLimiter } from './MemoryRateLimiter';
+
+jest.mock('axios');
+jest.mock('node:dns/promises');
+
+console.log = jest.fn();
+console.error = jest.fn();
+
+const mockAxios = require('axios');
+const mockedDnsLookup = dnsLookup as jest.MockedFunction<typeof dnsLookup>;
+
+describe('LinkPreviewController', () => {
+    let store: MemoryLinkPreviewStore;
+    let rateLimiter: MemoryRateLimiter;
+    let subject: LinkPreviewController;
+
+    beforeEach(() => {
+        jest.useFakeTimers({ now: 0 });
+        store = new MemoryLinkPreviewStore();
+        rateLimiter = new MemoryRateLimiter();
+        subject = new LinkPreviewController({
+            store,
+            rateLimiter,
+            config: {
+                rateLimit: {
+                    maxHits: 2,
+                    windowMs: 60_000,
+                },
+                minCacheSeconds: 1800,
+                requestTimeoutMs: 10_000,
+                maxResponseBytes: 5_000_000,
+            },
+        });
+
+        mockAxios.__reset();
+        mockedDnsLookup.mockReset();
+        mockedDnsLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+        ] as any);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    function mockHtmlResponse(
+        html: string,
+        headers: { [key: string]: string } = {}
+    ) {
+        mockAxios.__setResponse({
+            data: html,
+            headers: {
+                'content-type': 'text/html; charset=utf-8',
+                ...headers,
+            },
+            request: {
+                res: {
+                    responseUrl: 'https://example.com/page',
+                },
+            },
+        });
+    }
+
+    describe('getLinkPreview()', () => {
+        it('should reject non-http(s) URLs', async () => {
+            const result = await subject.getLinkPreview({
+                url: 'ftp://example.com/file',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'unacceptable_url',
+                errorMessage: 'The given URL is not able to be previewed.',
+            });
+            expect(mockAxios.__getRequests()).toEqual([]);
+        });
+
+        it('should reject URLs that point to private IP addresses', async () => {
+            const result = await subject.getLinkPreview({
+                url: 'http://127.0.0.1/admin',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'unacceptable_url',
+                errorMessage: 'The given URL is not able to be previewed.',
+            });
+            expect(mockAxios.__getRequests()).toEqual([]);
+            expect(mockedDnsLookup).not.toHaveBeenCalled();
+        });
+
+        it('should reject URLs whose hostname resolves to a private IP address', async () => {
+            mockedDnsLookup.mockResolvedValue([
+                { address: '10.0.0.5', family: 4 },
+            ] as any);
+
+            const result = await subject.getLinkPreview({
+                url: 'https://internal.example.com/',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'unacceptable_url',
+                errorMessage: 'The given URL is not able to be previewed.',
+            });
+            expect(mockAxios.__getRequests()).toEqual([]);
+        });
+
+        it('should fetch and parse the link preview for a URL', async () => {
+            mockHtmlResponse(`
+                <html>
+                    <head>
+                        <title>Fallback Title</title>
+                        <meta name="description" content="Fallback description" />
+                        <meta property="og:title" content="Example Title" />
+                        <meta property="og:description" content="Example description" />
+                        <meta property="og:image" content="/images/preview.png" />
+                        <meta property="og:image:width" content="1200" />
+                        <meta property="og:image:height" content="630" />
+                        <meta property="og:image:alt" content="A preview image" />
+                        <meta property="og:type" content="website" />
+                        <meta property="og:site_name" content="Example Site" />
+                        <meta property="og:locale" content="en_US" />
+                        <link rel="canonical" href="https://example.com/canonical-page" />
+                    </head>
+                    <body></body>
+                </html>
+            `);
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/page',
+            });
+
+            expect(result).toEqual({
+                success: true,
+                title: 'Example Title',
+                description: 'Example description',
+                imageUrl: 'https://example.com/images/preview.png',
+                imageWidth: 1200,
+                imageHeight: 630,
+                imageAlt: 'A preview image',
+                type: 'website',
+                canonicalUrl: 'https://example.com/canonical-page',
+                siteName: 'Example Site',
+                locale: 'en_US',
+                cachedUntilMs: 1800 * 1000,
+                meta: expect.objectContaining({
+                    'og:title': 'Example Title',
+                    description: 'Fallback description',
+                }),
+            });
+        });
+
+        it('should fall back to the title tag and meta description when OG tags are missing', async () => {
+            mockHtmlResponse(`
+                <html>
+                    <head>
+                        <title>Fallback Title</title>
+                        <meta name="description" content="Fallback description" />
+                        <link rel="icon" href="/favicon.ico" />
+                    </head>
+                </html>
+            `);
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/page',
+            });
+
+            expect(result).toMatchObject({
+                success: true,
+                title: 'Fallback Title',
+                description: 'Fallback description',
+                imageUrl: 'https://example.com/favicon.ico',
+            });
+        });
+
+        it('should return url_not_html if the response is not HTML', async () => {
+            mockAxios.__setResponse({
+                data: '{}',
+                headers: { 'content-type': 'application/json' },
+                request: { res: { responseUrl: 'https://example.com/data' } },
+            });
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/data',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'url_not_html',
+                errorMessage: 'The given URL does not point to an HTML page.',
+            });
+        });
+
+        it('should cache successful results and not fetch again while the cache is valid', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>');
+
+            const first = await subject.getLinkPreview({
+                url: 'https://example.com/page?b=2&a=1',
+            });
+            expect(first.success).toBe(true);
+            expect(mockAxios.__getRequests().length).toBe(1);
+
+            const second = await subject.getLinkPreview({
+                url: 'https://example.com/page?a=1&b=2#fragment',
+            });
+
+            expect(second).toEqual(first);
+            expect(mockAxios.__getRequests().length).toBe(1);
+        });
+
+        it('should extend the cache time using the Cache-Control max-age header', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>', {
+                'cache-control': 'public, max-age=7200',
+            });
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/page',
+            });
+
+            expect(result).toMatchObject({
+                success: true,
+                cachedUntilMs: 7200 * 1000,
+            });
+        });
+
+        it('should use the minimum cache time if the Cache-Control max-age is shorter', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>', {
+                'cache-control': 'public, max-age=60',
+            });
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/page',
+            });
+
+            expect(result).toMatchObject({
+                success: true,
+                cachedUntilMs: 1800 * 1000,
+            });
+        });
+
+        it('should rate limit requests per-origin', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>');
+
+            const r1 = await subject.getLinkPreview({
+                url: 'https://example.com/page-1',
+            });
+            const r2 = await subject.getLinkPreview({
+                url: 'https://example.com/page-2',
+            });
+            const r3 = await subject.getLinkPreview({
+                url: 'https://example.com/page-3',
+            });
+
+            expect(r1.success).toBe(true);
+            expect(r2.success).toBe(true);
+            expect(r3).toEqual({
+                success: false,
+                errorCode: 'site_rate_limited',
+                errorMessage:
+                    'Too many requests have been made for this site. Please try again later.',
+            });
+        });
+
+        it('should not rate limit requests to different origins', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>');
+
+            await subject.getLinkPreview({ url: 'https://example.com/a' });
+            await subject.getLinkPreview({ url: 'https://example.com/b' });
+            const result = await subject.getLinkPreview({
+                url: 'https://other.example.org/a',
+            });
+
+            expect(result.success).toBe(true);
+        });
+
+        it('should return a server_error if the request fails', async () => {
+            mockAxios.__setFail(true);
+
+            const result = await subject.getLinkPreview({
+                url: 'https://example.com/page',
+            });
+
+            expect(result).toEqual({
+                success: false,
+                errorCode: 'server_error',
+                errorMessage: 'A server error occurred.',
+            });
+        });
+
+        it('should send the given locale as the Accept-Language header', async () => {
+            mockHtmlResponse('<html><head><title>Title</title></head></html>');
+
+            await subject.getLinkPreview({
+                url: 'https://example.com/page',
+                locale: 'fr-FR',
+            });
+
+            expect(mockAxios.__getLastGet()).toEqual([
+                'https://example.com/page',
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'Accept-Language': 'fr-FR',
+                    }),
+                }),
+            ]);
+        });
+    });
+
+    describe('normalizeUrl()', () => {
+        it('should strip the hash', () => {
+            expect(
+                normalizeUrl(new URL('https://example.com/page#section'))
+            ).toBe('https://example.com/page');
+        });
+
+        it('should sort query parameters alphabetically', () => {
+            expect(
+                normalizeUrl(new URL('https://example.com/page?b=2&a=1&c=3'))
+            ).toBe('https://example.com/page?a=1&b=2&c=3');
+        });
+    });
+
+    describe('getCacheKey()', () => {
+        it('should produce different keys for different locales', () => {
+            const a = getCacheKey('https://example.com/page', 'en');
+            const b = getCacheKey('https://example.com/page', 'fr');
+            expect(a).not.toEqual(b);
+        });
+
+        it('should produce the same key for the same URL and locale', () => {
+            const a = getCacheKey('https://example.com/page', 'en');
+            const b = getCacheKey('https://example.com/page', 'en');
+            expect(a).toEqual(b);
+        });
+    });
+
+    describe('extractLinkPreviewData()', () => {
+        it('should collect all meta tags', () => {
+            const data = extractLinkPreviewData(
+                `<html><head>
+                    <meta property="og:title" content="Title" />
+                    <meta name="twitter:card" content="summary" />
+                </head></html>`,
+                'https://example.com/'
+            );
+
+            expect(data.meta).toEqual({
+                'og:title': 'Title',
+                'twitter:card': 'summary',
+            });
+        });
+    });
+
+    describe('isPrivateOrReservedAddress()', () => {
+        it.each([
+            ['127.0.0.1', true],
+            ['10.1.2.3', true],
+            ['172.16.0.1', true],
+            ['172.31.255.255', true],
+            ['172.32.0.1', false],
+            ['192.168.1.1', true],
+            ['169.254.1.1', true],
+            ['0.0.0.0', true],
+            ['8.8.8.8', false],
+            ['93.184.216.34', false],
+            ['::1', true],
+            ['fe80::1', true],
+            ['fc00::1', true],
+            ['2001:4860:4860::8888', false],
+        ])('should classify %s as private=%s', (ip, expected) => {
+            expect(isPrivateOrReservedAddress(ip)).toBe(expected);
+        });
+    });
+});

--- a/src/aux-records/LinkPreviewController.ts
+++ b/src/aux-records/LinkPreviewController.ts
@@ -1,0 +1,422 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type { RateLimiter } from '@casual-simulation/rate-limit-redis';
+import type { ServerError } from '@casual-simulation/aux-common/Errors';
+import type { LinkPreviewData, LinkPreviewStore } from './LinkPreviewStore';
+import { traced } from './tracing/TracingDecorators';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+import axios from 'axios';
+import * as net from 'node:net';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { parse as parseHtml } from 'node-html-parser';
+
+const TRACE_NAME = 'LinkPreviewController';
+
+const USER_AGENT = 'CasualOS-LinkPreview/1.0 (+https://casualos.com)';
+
+export interface LinkPreviewControllerOptions {
+    store: LinkPreviewStore;
+    rateLimiter: RateLimiter;
+    config: LinkPreviewConfig;
+}
+
+/**
+ * Defines the configuration options for the link preview controller.
+ */
+export interface LinkPreviewConfig {
+    /**
+     * The rate limit that should be applied per-origin (i.e. per website) to prevent
+     * hammering a single site with requests.
+     */
+    rateLimit: {
+        maxHits: number;
+        windowMs: number;
+    };
+
+    /**
+     * The minimum number of seconds that a link preview should be cached for, regardless
+     * of what the site's Cache-Control header says.
+     */
+    minCacheSeconds: number;
+
+    /**
+     * The number of miliseconds that a request for a page's HTML is allowed to take before
+     * it is aborted.
+     */
+    requestTimeoutMs: number;
+
+    /**
+     * The maximum number of bytes that will be read from a page's response.
+     */
+    maxResponseBytes: number;
+}
+
+/**
+ * Defines a controller that is able to generate link previews for URLs.
+ */
+export class LinkPreviewController {
+    private _store: LinkPreviewStore;
+    private _rateLimiter: RateLimiter;
+    private _config: LinkPreviewConfig;
+
+    constructor(options: LinkPreviewControllerOptions) {
+        this._store = options.store;
+        this._rateLimiter = options.rateLimiter;
+        this._config = options.config;
+        this._rateLimiter.init({
+            windowMs: options.config.rateLimit.windowMs,
+        });
+    }
+
+    /**
+     * Gets a link preview for the given URL.
+     * @param request The request.
+     */
+    @traced(TRACE_NAME)
+    async getLinkPreview(
+        request: GetLinkPreviewRequest
+    ): Promise<GetLinkPreviewResult> {
+        try {
+            let target: URL;
+            try {
+                target = new URL(request.url);
+            } catch {
+                return invalidUrlResult();
+            }
+
+            if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+                return invalidUrlResult();
+            }
+
+            if (await this._isBlockedHost(target.hostname)) {
+                return invalidUrlResult();
+            }
+
+            const normalizedUrl = normalizeUrl(target);
+            const cacheKey = getCacheKey(normalizedUrl, request.locale);
+
+            const cached = await this._store.getLinkPreview(cacheKey);
+            if (cached) {
+                return {
+                    success: true,
+                    ...cached.data,
+                    cachedUntilMs: cached.expireTimeMs,
+                };
+            }
+
+            const origin = new URL(normalizedUrl).origin;
+            const hits = await this._rateLimiter.increment(origin);
+            if (hits.totalHits > this._config.rateLimit.maxHits) {
+                return {
+                    success: false,
+                    errorCode: 'site_rate_limited',
+                    errorMessage:
+                        'Too many requests have been made for this site. Please try again later.',
+                };
+            }
+
+            const response = await axios.get(normalizedUrl, {
+                headers: {
+                    'User-Agent': USER_AGENT,
+                    ...(request.locale
+                        ? { 'Accept-Language': request.locale }
+                        : {}),
+                },
+                responseType: 'text',
+                timeout: this._config.requestTimeoutMs,
+                maxRedirects: 5,
+                maxContentLength: this._config.maxResponseBytes,
+                maxBodyLength: this._config.maxResponseBytes,
+                validateStatus: () => true,
+            });
+
+            const contentType = (
+                (response.headers?.['content-type'] as string) ?? ''
+            ).toLowerCase();
+            if (
+                !contentType.includes('text/html') &&
+                !contentType.includes('application/xhtml+xml')
+            ) {
+                return {
+                    success: false,
+                    errorCode: 'url_not_html',
+                    errorMessage:
+                        'The given URL does not point to an HTML page.',
+                };
+            }
+
+            const finalUrl: string =
+                response.request?.res?.responseUrl ?? normalizedUrl;
+            const data = extractLinkPreviewData(response.data, finalUrl);
+            const expireSeconds = Math.max(
+                this._config.minCacheSeconds,
+                getCacheControlMaxAgeSeconds(
+                    response.headers?.['cache-control'] as string
+                ) ?? 0
+            );
+            const expireTimeMs = Date.now() + expireSeconds * 1000;
+
+            await this._store.saveLinkPreview({
+                cacheKey,
+                data,
+                expireTimeMs,
+            });
+
+            return {
+                success: true,
+                ...data,
+                cachedUntilMs: expireTimeMs,
+            };
+        } catch (err) {
+            const span = trace.getActiveSpan();
+            span?.recordException(err);
+            span?.setStatus({ code: SpanStatusCode.ERROR });
+
+            console.error(
+                `[LinkPreviewController] An error occurred while getting the link preview.`,
+                err
+            );
+            return {
+                success: false,
+                errorCode: 'server_error',
+                errorMessage: 'A server error occurred.',
+            };
+        }
+    }
+
+    private async _isBlockedHost(hostname: string): Promise<boolean> {
+        if (hostname === 'localhost') {
+            return true;
+        }
+
+        if (net.isIP(hostname)) {
+            return isPrivateOrReservedAddress(hostname);
+        }
+
+        try {
+            const addresses = await dnsLookup(hostname, { all: true });
+            return addresses.some((a) => isPrivateOrReservedAddress(a.address));
+        } catch {
+            return true;
+        }
+    }
+}
+
+function invalidUrlResult(): GetLinkPreviewFailure {
+    return {
+        success: false,
+        errorCode: 'unacceptable_url',
+        errorMessage: 'The given URL is not able to be previewed.',
+    };
+}
+
+/**
+ * Normalizes the given URL by stripping the hash and sorting the query parameters
+ * alphabetically by name.
+ * @param url The URL to normalize.
+ */
+export function normalizeUrl(url: URL): string {
+    const sortedParams = Array.from(url.searchParams.entries()).sort(
+        ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)
+    );
+    const search = new URLSearchParams();
+    for (const [key, value] of sortedParams) {
+        search.append(key, value);
+    }
+    const query = search.toString();
+    return `${url.origin}${url.pathname}${query ? `?${query}` : ''}`;
+}
+
+/**
+ * Gets the cache key that should be used for the given normalized URL and locale.
+ */
+export function getCacheKey(normalizedUrl: string, locale?: string): string {
+    return JSON.stringify([normalizedUrl, locale ?? null]);
+}
+
+function getCacheControlMaxAgeSeconds(
+    cacheControl: string | undefined
+): number | undefined {
+    if (!cacheControl) {
+        return undefined;
+    }
+    const match = /max-age=(\d+)/i.exec(cacheControl);
+    if (!match) {
+        return undefined;
+    }
+    const seconds = Number(match[1]);
+    return Number.isFinite(seconds) ? seconds : undefined;
+}
+
+function toNumber(value: string | undefined): number | undefined {
+    if (!value) {
+        return undefined;
+    }
+    const n = Number(value);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+function resolveUrl(
+    value: string | undefined,
+    baseUrl: string
+): string | undefined {
+    if (!value) {
+        return undefined;
+    }
+    try {
+        return new URL(value, baseUrl).href;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Extracts link preview data from the given HTML document.
+ * @param html The HTML that should be parsed.
+ * @param baseUrl The URL that the HTML was retrieved from. Used to resolve relative URLs.
+ */
+export function extractLinkPreviewData(
+    html: string,
+    baseUrl: string
+): LinkPreviewData {
+    const root = parseHtml(html);
+    const meta: { [key: string]: string } = {};
+
+    for (const tag of root.querySelectorAll('meta')) {
+        const key = tag.getAttribute('property') || tag.getAttribute('name');
+        const content = tag.getAttribute('content');
+        if (key && content !== undefined && !(key in meta)) {
+            meta[key] = content;
+        }
+    }
+
+    let iconHref: string | undefined;
+    let canonicalHref: string | undefined;
+    for (const link of root.querySelectorAll('link')) {
+        const rel = (link.getAttribute('rel') ?? '').toLowerCase().split(/\s+/);
+        const href = link.getAttribute('href');
+        if (!href) {
+            continue;
+        }
+        if (!iconHref && rel.includes('icon')) {
+            iconHref = href;
+        }
+        if (!canonicalHref && rel.includes('canonical')) {
+            canonicalHref = href;
+        }
+    }
+
+    const titleTag = root.querySelector('title')?.text?.trim();
+
+    return {
+        title: meta['og:title'] || titleTag || undefined,
+        description: meta['og:description'] || meta['description'] || undefined,
+        imageUrl:
+            resolveUrl(meta['og:image'], baseUrl) ??
+            resolveUrl(iconHref, baseUrl),
+        imageHeight: toNumber(meta['og:image:height']),
+        imageWidth: toNumber(meta['og:image:width']),
+        imageAlt: meta['og:image:alt'] || undefined,
+        type: meta['og:type'] || undefined,
+        canonicalUrl:
+            resolveUrl(meta['og:url'], baseUrl) ??
+            resolveUrl(canonicalHref, baseUrl),
+        siteName: meta['og:site_name'] || undefined,
+        locale: meta['og:locale'] || undefined,
+        meta,
+    };
+}
+
+/**
+ * Determines if the given IP address is a private, loopback, link-local, or otherwise
+ * reserved address that should not be reachable from a public link preview request.
+ * @param ip The IP address to check.
+ */
+export function isPrivateOrReservedAddress(ip: string): boolean {
+    if (net.isIPv4(ip)) {
+        const parts = ip.split('.').map((p) => Number(p));
+        const [a, b, c] = parts;
+        if (a === 0) return true; // "this" network
+        if (a === 10) return true; // RFC1918
+        if (a === 127) return true; // loopback
+        if (a === 169 && b === 254) return true; // link-local
+        if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+        if (a === 192 && b === 168) return true; // RFC1918
+        if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+        if (a === 192 && b === 0 && c === 0) return true; // IETF protocol assignments
+        if (a === 192 && b === 0 && c === 2) return true; // TEST-NET-1
+        if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+        if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
+        if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
+        if (a >= 224) return true; // multicast (224-239) & reserved (240-255)
+        return false;
+    }
+
+    if (net.isIPv6(ip)) {
+        const normalized = ip.toLowerCase();
+        if (normalized === '::1' || normalized === '::') return true;
+
+        const mappedV4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(normalized);
+        if (mappedV4) {
+            return isPrivateOrReservedAddress(mappedV4[1]);
+        }
+
+        const firstGroup = parseInt(normalized.split(':')[0] || '0', 16) || 0;
+        if (firstGroup >= 0xfe80 && firstGroup <= 0xfebf) return true; // link-local fe80::/10
+        if (firstGroup >= 0xfc00 && firstGroup <= 0xfdff) return true; // unique local fc00::/7
+        if (firstGroup >= 0xff00 && firstGroup <= 0xffff) return true; // multicast ff00::/8
+        return false;
+    }
+
+    return true;
+}
+
+export interface GetLinkPreviewRequest {
+    /**
+     * The URL that a preview should be generated for.
+     */
+    url: string;
+
+    /**
+     * The locale that should be used when requesting the URL.
+     */
+    locale?: string;
+}
+
+export type GetLinkPreviewResult =
+    | GetLinkPreviewSuccess
+    | GetLinkPreviewFailure;
+
+export interface GetLinkPreviewSuccess extends LinkPreviewData {
+    success: true;
+
+    /**
+     * The unix time in miliseconds that the results should be considered cached until.
+     */
+    cachedUntilMs: number;
+}
+
+export interface GetLinkPreviewFailure {
+    success: false;
+    errorCode:
+        | ServerError
+        | 'unacceptable_url'
+        | 'url_not_html'
+        | 'site_rate_limited';
+    errorMessage: string;
+}

--- a/src/aux-records/LinkPreviewStore.ts
+++ b/src/aux-records/LinkPreviewStore.ts
@@ -1,0 +1,122 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Defines a store that is able to cache link preview data for URLs.
+ */
+export interface LinkPreviewStore {
+    /**
+     * Gets the cached link preview for the given cache key.
+     * Returns null if no cached preview exists for the key.
+     * @param cacheKey The cache key.
+     */
+    getLinkPreview(cacheKey: string): Promise<StoredLinkPreview | null>;
+
+    /**
+     * Saves the given link preview to the store.
+     * @param entry The entry to save.
+     */
+    saveLinkPreview(entry: StoredLinkPreview): Promise<void>;
+}
+
+/**
+ * Defines a link preview that has been cached in a LinkPreviewStore.
+ */
+export interface StoredLinkPreview {
+    /**
+     * The cache key that the preview was stored under.
+     * Derived from the normalized URL and the requested locale.
+     */
+    cacheKey: string;
+
+    /**
+     * The link preview data.
+     */
+    data: LinkPreviewData;
+
+    /**
+     * The unix time in miliseconds after which the cached preview should be considered expired.
+     */
+    expireTimeMs: number;
+}
+
+/**
+ * Defines the metadata that was extracted for a link preview.
+ */
+export interface LinkPreviewData {
+    /**
+     * The title of the page. Sourced from the og:title meta tag, falling back to the
+     * contents of the title tag.
+     */
+    title?: string;
+
+    /**
+     * The description of the page. Sourced from the og:description meta tag, falling back
+     * to the description meta tag.
+     */
+    description?: string;
+
+    /**
+     * The URL of the featured image for the page. Sourced from the og:image meta tag,
+     * falling back to the link[rel="icon"] tag.
+     */
+    imageUrl?: string;
+
+    /**
+     * The height of the featured image in pixels. Sourced from the og:image:height meta tag.
+     */
+    imageHeight?: number;
+
+    /**
+     * The width of the featured image in pixels. Sourced from the og:image:width meta tag.
+     */
+    imageWidth?: number;
+
+    /**
+     * The alt text for the featured image. Sourced from the og:image:alt meta tag.
+     */
+    imageAlt?: string;
+
+    /**
+     * The type of the page. Sourced from the og:type meta tag.
+     */
+    type?: string;
+
+    /**
+     * The canonical URL of the page. Sourced from the og:url meta tag, falling back to the
+     * link[rel="canonical"] tag.
+     */
+    canonicalUrl?: string;
+
+    /**
+     * The name of the site that the page belongs to. Sourced from the og:site_name meta tag.
+     */
+    siteName?: string;
+
+    /**
+     * The locale of the page. Sourced from the og:locale meta tag.
+     */
+    locale?: string;
+
+    /**
+     * All of the meta tags that were found in the page, keyed by their name or property.
+     */
+    meta: {
+        [key: string]: string;
+    };
+}

--- a/src/aux-records/MemoryLinkPreviewStore.ts
+++ b/src/aux-records/MemoryLinkPreviewStore.ts
@@ -1,0 +1,45 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type { LinkPreviewStore, StoredLinkPreview } from './LinkPreviewStore';
+
+/**
+ * Defines a link preview store that keeps everything in memory.
+ */
+export class MemoryLinkPreviewStore implements LinkPreviewStore {
+    private _items: Map<string, StoredLinkPreview> = new Map();
+
+    get items() {
+        return this._items;
+    }
+
+    async getLinkPreview(cacheKey: string): Promise<StoredLinkPreview | null> {
+        const item = this._items.get(cacheKey);
+        if (item) {
+            if (item.expireTimeMs < Date.now()) {
+                this._items.delete(cacheKey);
+            } else {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    async saveLinkPreview(entry: StoredLinkPreview): Promise<void> {
+        this._items.set(entry.cacheKey, entry);
+    }
+}

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -79,6 +79,11 @@ import {
 } from '@casual-simulation/aux-common';
 import { RateLimitController } from './RateLimitController';
 import { MemoryRateLimiter } from './MemoryRateLimiter';
+import { LinkPreviewController } from './LinkPreviewController';
+import { MemoryLinkPreviewStore } from './MemoryLinkPreviewStore';
+import { lookup as dnsLookup } from 'node:dns/promises';
+
+jest.mock('node:dns/promises');
 import type { RateLimiter } from '@casual-simulation/rate-limit-redis';
 import {
     asyncIterable,
@@ -462,6 +467,10 @@ describe('RecordsServer', () => {
     let rateLimiter: RateLimiter;
     let rateLimitController: RateLimitController;
 
+    let linkPreviewStore: MemoryLinkPreviewStore;
+    let linkPreviewRateLimiter: MemoryRateLimiter;
+    let linkPreviewController: LinkPreviewController;
+
     let filesController: FileRecordsController;
 
     let stripeMock: jest.Mocked<StripeInterface>;
@@ -718,6 +727,22 @@ describe('RecordsServer', () => {
         rateLimitController = new RateLimitController(rateLimiter, {
             maxHits: 5,
             windowMs: 1000,
+        });
+
+        linkPreviewStore = new MemoryLinkPreviewStore();
+        linkPreviewRateLimiter = new MemoryRateLimiter();
+        linkPreviewController = new LinkPreviewController({
+            store: linkPreviewStore,
+            rateLimiter: linkPreviewRateLimiter,
+            config: {
+                rateLimit: {
+                    maxHits: 1000,
+                    windowMs: 60 * 1000,
+                },
+                minCacheSeconds: 60 * 30,
+                requestTimeoutMs: 10_000,
+                maxResponseBytes: 5_000_000,
+            },
         });
 
         packageController = new PackageRecordsController({
@@ -997,6 +1022,7 @@ describe('RecordsServer', () => {
             purchasableItemsController,
             contractRecordsController: contractsController,
             viewTemplateRenderer: viewTemplateRenderer,
+            linkPreviewController,
         });
         defaultHeaders = {
             origin: 'test.com',
@@ -35855,6 +35881,167 @@ iW7ByiIykfraimQSzn7Il6dpcvug0Io=
             expect(result.statusCode).not.toEqual(429);
         });
     }
+
+    describe('GET /api/v2/link-preview', () => {
+        const mockedDnsLookup = dnsLookup as jest.MockedFunction<
+            typeof dnsLookup
+        >;
+
+        beforeEach(() => {
+            require('axios').__reset();
+            mockedDnsLookup.mockReset();
+            mockedDnsLookup.mockResolvedValue([
+                { address: '93.184.216.34', family: 4 },
+            ] as any);
+            mockHtmlResponse(
+                '<html><head><title>Default Title</title></head></html>'
+            );
+        });
+
+        function mockHtmlResponse(
+            html: string,
+            headers: { [key: string]: string } = {}
+        ) {
+            require('axios').__setResponse({
+                data: html,
+                headers: {
+                    'content-type': 'text/html; charset=utf-8',
+                    ...headers,
+                },
+                request: {
+                    res: {
+                        responseUrl: 'https://example.com/page',
+                    },
+                },
+            });
+        }
+
+        it('should return the link preview for the given URL', async () => {
+            mockHtmlResponse(
+                '<html><head><meta property="og:title" content="Example Title" /></head></html>'
+            );
+
+            const result = await server.handleHttpRequest(
+                httpGet(
+                    '/api/v2/link-preview?url=https://example.com/page',
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    title: 'Example Title',
+                    cachedUntilMs: expect.any(Number),
+                    meta: expect.objectContaining({
+                        'og:title': 'Example Title',
+                    }),
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return an unacceptable_request result if url is omitted', async () => {
+            const result = await server.handleHttpRequest(
+                httpGet('/api/v2/link-preview', apiHeaders)
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 400,
+                body: {
+                    success: false,
+                    errorCode: 'unacceptable_request',
+                    errorMessage:
+                        'The request was invalid. One or more fields were invalid.',
+                    issues: expect.any(Array),
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return url_not_html if the site does not return HTML', async () => {
+            require('axios').__setResponse({
+                data: '{}',
+                headers: { 'content-type': 'application/json' },
+                request: {
+                    res: { responseUrl: 'https://example.com/data' },
+                },
+            });
+
+            const result = await server.handleHttpRequest(
+                httpGet(
+                    '/api/v2/link-preview?url=https://example.com/data',
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 400,
+                body: {
+                    success: false,
+                    errorCode: 'url_not_html',
+                    errorMessage:
+                        'The given URL does not point to an HTML page.',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        it('should return not_supported if link previews are not configured', async () => {
+            server = new RecordsServer({
+                allowedAccountOrigins,
+                allowedApiOrigins,
+                authController,
+                livekitController,
+                recordsController,
+                eventsController,
+                dataController,
+                manualDataController,
+                filesController,
+                subscriptionController,
+                rateLimitController,
+                policyController,
+                aiController,
+                websocketController,
+                moderationController,
+            });
+
+            const result = await server.handleHttpRequest(
+                httpGet(
+                    '/api/v2/link-preview?url=https://example.com/page',
+                    apiHeaders
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 501,
+                body: {
+                    success: false,
+                    errorCode: 'not_supported',
+                    errorMessage:
+                        'Link previews are not supported by this server.',
+                },
+                headers: apiCorsHeaders,
+            });
+        });
+
+        testOrigin(
+            'GET',
+            `/api/v2/link-preview?url=${encodeURIComponent(
+                'https://example.com/page'
+            )}`
+        );
+        testCustomOrigin(
+            'GET',
+            `/api/v2/link-preview?url=${encodeURIComponent(
+                'https://example.com/page'
+            )}`,
+            undefined,
+            () => apiHeaders
+        );
+        testRateLimit('GET', `/api/v2/link-preview`);
+    });
 });
 
 describe('validateOrigin()', () => {

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -104,6 +104,7 @@ import { getStatusCode } from '@casual-simulation/aux-common';
 import type { ModerationController } from './ModerationController';
 import { COM_ID_CONFIG_SCHEMA, COM_ID_PLAYER_CONFIG } from './ComIdConfig';
 import type { LoomController } from './LoomController';
+import type { LinkPreviewController } from './LinkPreviewController';
 import type { Tracer } from '@opentelemetry/api';
 import { SpanKind, ValueType, trace } from '@opentelemetry/api';
 import { traceHttpResponse, traced } from './tracing/TracingDecorators';
@@ -260,6 +261,12 @@ export const XP_API_NOT_SUPPORTED_RESULT = {
     success: false as const,
     errorCode: 'not_supported' as const,
     errorMessage: 'xpAPI features are not supported by this server.',
+};
+
+export const LINK_PREVIEW_NOT_SUPPORTED_RESULT = {
+    success: false as const,
+    errorCode: 'not_supported' as const,
+    errorMessage: 'Link previews are not supported by this server.',
 };
 
 /**
@@ -487,6 +494,12 @@ export interface RecordsServerOptions {
      * The interface that should be used for rendering view templates.
      */
     viewTemplateRenderer?: ViewTemplateRenderer | null;
+
+    /**
+     * The controller that should be used for handling link preview requests.
+     * If null, then link previews are not supported.
+     */
+    linkPreviewController?: LinkPreviewController | null;
 }
 
 /**
@@ -513,6 +526,7 @@ export class RecordsServer {
     private _databaseRecordsController: DatabaseRecordsController | null;
     private _contractRecordsController: ContractRecordsController | null;
     private _viewTemplateRenderer: ViewTemplateRenderer | null;
+    private _linkPreviewController: LinkPreviewController | null;
 
     /**
      * The set of origins that are allowed for API requests.
@@ -599,6 +613,7 @@ export class RecordsServer {
         contractRecordsController,
         purchasableItemsController,
         viewTemplateRenderer,
+        linkPreviewController,
     }: RecordsServerOptions) {
         this._allowedAccountOrigins = allowedAccountOrigins;
         this._allowedApiOrigins = allowedApiOrigins;
@@ -634,6 +649,7 @@ export class RecordsServer {
         this._databaseRecordsController = databaseRecordsController;
         this._contractRecordsController = contractRecordsController;
         this._viewTemplateRenderer = viewTemplateRenderer;
+        this._linkPreviewController = linkPreviewController ?? null;
         this._tracer = trace.getTracer(
             'RecordsServer',
             typeof GIT_TAG === 'undefined' ? undefined : GIT_TAG
@@ -7250,6 +7266,29 @@ export class RecordsServer {
                     });
 
                     return genericResult(result);
+                }),
+
+            getLinkPreview: procedure()
+                .origins('api')
+                .http('GET', '/api/v2/link-preview')
+                .inputs(
+                    z.object({
+                        url: z.url(),
+                        locale: z.string().nonempty().optional(),
+                    })
+                )
+                .handler(async ({ url, locale }) => {
+                    if (!this._linkPreviewController) {
+                        return LINK_PREVIEW_NOT_SUPPORTED_RESULT;
+                    }
+
+                    const result =
+                        await this._linkPreviewController.getLinkPreview({
+                            url,
+                            locale,
+                        });
+
+                    return result;
                 }),
         };
     }

--- a/src/aux-records/ServerConfig.ts
+++ b/src/aux-records/ServerConfig.ts
@@ -733,6 +733,39 @@ Because repo/add_updates is a very common permission, we periodically cache perm
             .describe('The size of the window in miliseconds.'),
     });
 
+    const linkPreviewSchema = z.object({
+        rateLimit: rateLimitSchema
+            .optional()
+            .prefault({ maxHits: 1000, windowMs: 60 * 1000 })
+            .describe(
+                'The rate limit that should be applied per-origin to prevent hammering a single site with link preview requests. Defaults to 1000 hits per minute.'
+            ),
+        minCacheSeconds: z
+            .number()
+            .positive()
+            .optional()
+            .prefault(60 * 30)
+            .describe(
+                'The minimum number of seconds that a link preview should be cached for. Defaults to 30 minutes.'
+            ),
+        requestTimeoutMs: z
+            .number()
+            .positive()
+            .optional()
+            .prefault(10_000)
+            .describe(
+                'The number of miliseconds that a request for a page should be allowed to take before it is aborted. Defaults to 10 seconds.'
+            ),
+        maxResponseBytes: z
+            .number()
+            .positive()
+            .optional()
+            .prefault(5_000_000)
+            .describe(
+                'The maximum number of bytes that will be read from a page response. Defaults to 5,000,000 (5MB).'
+            ),
+    });
+
     const stripeSchema = z.object({
         secretKey: z
             .string()
@@ -1409,6 +1442,11 @@ Because repo/add_updates is a very common permission, we periodically cache perm
             .optional()
             .describe(
                 'Rate limit options for websockets. If omitted, then the rateLimit options will be used for websockets.'
+            ),
+        linkPreview: linkPreviewSchema
+            .optional()
+            .describe(
+                'Link preview options. If omitted, then the link preview API will not be supported.'
             ),
         openai: openAiSchema
             .optional()

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1858,6 +1858,26 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/link-preview",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "locale": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "url": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getLinkPreview",
+      "origins": "api",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/loom/token",
       },
       "inputs": Object {
@@ -12456,6 +12476,26 @@ Object {
       },
       "name": "getInstData",
       "origins": true,
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
+        "path": "/api/v2/link-preview",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "locale": Object {
+            "optional": true,
+            "type": "string",
+          },
+          "url": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "getLinkPreview",
+      "origins": "api",
     },
     Object {
       "http": Object {

--- a/src/aux-records/index.ts
+++ b/src/aux-records/index.ts
@@ -38,6 +38,10 @@ export * from './StripeInterface';
 export * from './MemoryRateLimiter';
 export * from './RateLimitController';
 
+export * from './LinkPreviewStore';
+export * from './MemoryLinkPreviewStore';
+export * from './LinkPreviewController';
+
 export * from './PolicyController';
 export * from './PolicyStore';
 

--- a/src/aux-records/package.json
+++ b/src/aux-records/package.json
@@ -59,6 +59,7 @@
         "livekit-server-sdk": "2.7.2",
         "luxon": "3.4.4",
         "mime": "2.4.6",
+        "node-html-parser": "^6.1.13",
         "openai": "4.89.0",
         "openid-client": "5.6.1",
         "preact": "10.28.4",

--- a/src/aux-server/aux-backend/prisma/PrismaLinkPreviewStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaLinkPreviewStore.ts
@@ -1,0 +1,73 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type {
+    LinkPreviewData,
+    LinkPreviewStore,
+    StoredLinkPreview,
+} from '@casual-simulation/aux-records';
+import { traced } from '@casual-simulation/aux-records/tracing/TracingDecorators';
+import type { PrismaClient } from './generated';
+
+const TRACE_NAME = 'PrismaLinkPreviewStore';
+
+export class PrismaLinkPreviewStore implements LinkPreviewStore {
+    private _client: PrismaClient;
+
+    constructor(client: PrismaClient) {
+        this._client = client;
+    }
+
+    @traced(TRACE_NAME)
+    async getLinkPreview(cacheKey: string): Promise<StoredLinkPreview | null> {
+        const result = await this._client.linkPreviewCache.findUnique({
+            where: { cacheKey },
+        });
+
+        if (!result) {
+            return null;
+        }
+
+        const expireTimeMs = Number(result.expireAtMs);
+        if (expireTimeMs < Date.now()) {
+            return null;
+        }
+
+        return {
+            cacheKey: result.cacheKey,
+            data: result.data as unknown as LinkPreviewData,
+            expireTimeMs,
+        };
+    }
+
+    @traced(TRACE_NAME)
+    async saveLinkPreview(entry: StoredLinkPreview): Promise<void> {
+        const expireAtMs = BigInt(Math.trunc(entry.expireTimeMs));
+        await this._client.linkPreviewCache.upsert({
+            where: { cacheKey: entry.cacheKey },
+            create: {
+                cacheKey: entry.cacheKey,
+                data: entry.data as any,
+                expireAtMs,
+            },
+            update: {
+                data: entry.data as any,
+                expireAtMs,
+            },
+        });
+    }
+}

--- a/src/aux-server/aux-backend/prisma/sqlite/SqliteLinkPreviewStore.ts
+++ b/src/aux-server/aux-backend/prisma/sqlite/SqliteLinkPreviewStore.ts
@@ -1,0 +1,77 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type {
+    LinkPreviewData,
+    LinkPreviewStore,
+    StoredLinkPreview,
+} from '@casual-simulation/aux-records';
+import { traced } from '@casual-simulation/aux-records/tracing/TracingDecorators';
+import type { PrismaClient } from '../generated-sqlite';
+
+const TRACE_NAME = 'SqliteLinkPreviewStore';
+
+export class SqliteLinkPreviewStore implements LinkPreviewStore {
+    private _client: PrismaClient;
+
+    constructor(client: PrismaClient) {
+        this._client = client;
+    }
+
+    @traced(TRACE_NAME)
+    async getLinkPreview(cacheKey: string): Promise<StoredLinkPreview | null> {
+        const result = await this._client.linkPreviewCache.findUnique({
+            where: { cacheKey },
+        });
+
+        if (!result) {
+            return null;
+        }
+
+        const expireTimeMs = Number(result.expireAtMs);
+        if (expireTimeMs < Date.now()) {
+            return null;
+        }
+
+        return {
+            cacheKey: result.cacheKey,
+            data: result.data as unknown as LinkPreviewData,
+            expireTimeMs,
+        };
+    }
+
+    @traced(TRACE_NAME)
+    async saveLinkPreview(entry: StoredLinkPreview): Promise<void> {
+        const expireAtMs = BigInt(Math.trunc(entry.expireTimeMs));
+        const now = Date.now();
+        await this._client.linkPreviewCache.upsert({
+            where: { cacheKey: entry.cacheKey },
+            create: {
+                cacheKey: entry.cacheKey,
+                data: entry.data as any,
+                expireAtMs,
+                createdAt: now,
+                updatedAt: now,
+            },
+            update: {
+                data: entry.data as any,
+                expireAtMs,
+                updatedAt: now,
+            },
+        });
+    }
+}

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -1314,6 +1314,16 @@ model Configuration {
     updatedAt DateTime @updatedAt
 }
 
+model LinkPreviewCache {
+    cacheKey String @id
+    data Json
+    expireAtMs BigInt
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    @@index([expireAtMs])
+}
+
 model Subscription {
     id String @id @db.Uuid
     stripeSubscriptionId String @unique

--- a/src/aux-server/aux-backend/schemas/migrations/20260706193034_add_link_preview_cache/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20260706193034_add_link_preview_cache/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "public"."LinkPreviewCache" (
+    "cacheKey" STRING NOT NULL,
+    "data" JSONB NOT NULL,
+    "expireAtMs" INT8 NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LinkPreviewCache_pkey" PRIMARY KEY ("cacheKey")
+);
+
+-- CreateIndex
+CREATE INDEX "LinkPreviewCache_expireAtMs_idx" ON "public"."LinkPreviewCache"("expireAtMs");

--- a/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
+++ b/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
@@ -1313,6 +1313,16 @@ model Configuration {
     updatedAt Decimal
 }
 
+model LinkPreviewCache {
+    cacheKey String @id
+    data Json
+    expireAtMs BigInt
+    createdAt Decimal
+    updatedAt Decimal
+
+    @@index([expireAtMs])
+}
+
 model Subscription {
     id String @id
     stripeSubscriptionId String @unique

--- a/src/aux-server/aux-backend/schemas/sqlite/migrations/20260706193034_add_link_preview_cache/migration.sql
+++ b/src/aux-server/aux-backend/schemas/sqlite/migrations/20260706193034_add_link_preview_cache/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "LinkPreviewCache" (
+    "cacheKey" TEXT NOT NULL PRIMARY KEY,
+    "data" JSONB NOT NULL,
+    "expireAtMs" BIGINT NOT NULL,
+    "createdAt" DECIMAL NOT NULL,
+    "updatedAt" DECIMAL NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "LinkPreviewCache_expireAtMs_idx" ON "LinkPreviewCache"("expireAtMs");

--- a/src/aux-server/aux-backend/shared/LoadServer.ts
+++ b/src/aux-server/aux-backend/shared/LoadServer.ts
@@ -276,6 +276,10 @@ export function constructServerBuilder(
         builder.useWebPushNotifications();
     }
 
+    if (config.linkPreview) {
+        builder.useLinkPreview();
+    }
+
     builder.useAutomaticPlugins();
 
     return builder;

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -45,6 +45,7 @@ import type {
     FinancialInterface,
     PurchasableItemRecordsStore,
     BackgroundJobs,
+    LinkPreviewStore,
 } from '@casual-simulation/aux-records';
 import {
     DNSDomainNameValidator,
@@ -78,6 +79,8 @@ import {
     cleanupObject,
     NotificationRecordsController,
     PackageRecordsController,
+    LinkPreviewController,
+    MemoryRateLimiter,
 } from '@casual-simulation/aux-records';
 import type { SimpleEmailServiceAuthMessengerOptions } from '@casual-simulation/aux-records-aws';
 import {
@@ -95,6 +98,7 @@ import { SESv2 } from '@aws-sdk/client-sesv2';
 import type { RedisClientType } from 'redis';
 import { createClient as createRedisClient } from 'redis';
 import { TracedRedisRateLimitStore } from '../redis/TracedRedisRateLimitStore';
+import type { RateLimiter } from '@casual-simulation/rate-limit-redis';
 import { StripeIntegration } from './StripeIntegration';
 import Stripe from 'stripe';
 import type { Db } from 'mongodb';
@@ -255,6 +259,8 @@ import { SqliteFinancialStore } from '../prisma/sqlite/SqliteFinancialStore';
 import { PrismaFinancialStore } from '../prisma/PrismaFinancialStore';
 import { SqliteContractsRecordsStore } from '../prisma/sqlite/SqliteContractsRecordsStore';
 import { PrismaContractsRecordsStore } from '../prisma/PrismaContractsRecordsStore';
+import { SqliteLinkPreviewStore } from '../prisma/sqlite/SqliteLinkPreviewStore';
+import { PrismaLinkPreviewStore } from '../prisma/PrismaLinkPreviewStore';
 import type { ContractRecordsStore } from '@casual-simulation/aux-records/contracts';
 import { ContractRecordsController } from '@casual-simulation/aux-records/contracts';
 import type z from 'zod';
@@ -367,6 +373,9 @@ export class ServerBuilder implements SubscriptionLike {
 
     private _contractsStore: ContractRecordsStore;
     private _contractsController: ContractRecordsController;
+
+    private _linkPreviewStore: LinkPreviewStore;
+    private _linkPreviewController: LinkPreviewController | null = null;
 
     private _subscriptionConfig: SubscriptionConfiguration | null = null;
     private _subscriptionController: SubscriptionController;
@@ -822,6 +831,7 @@ export class ServerBuilder implements SubscriptionLike {
                 client,
                 metricsStore
             );
+            this._linkPreviewStore = new SqliteLinkPreviewStore(client);
         } else {
             const metricsStore = (this._metricsStore = new PrismaMetricsStore(
                 prismaClient,
@@ -870,6 +880,7 @@ export class ServerBuilder implements SubscriptionLike {
                 prismaClient,
                 metricsStore
             );
+            this._linkPreviewStore = new PrismaLinkPreviewStore(prismaClient);
         }
 
         const filesLookup =
@@ -1312,6 +1323,46 @@ export class ServerBuilder implements SubscriptionLike {
         this._websocketRateLimitController = new RateLimitController(store, {
             maxHits: rateLimit.maxHits,
             windowMs: rateLimit.windowMs,
+        });
+
+        return this;
+    }
+
+    useLinkPreview(
+        options: Pick<ServerConfig, 'linkPreview' | 'redis'> = this._options
+    ): this {
+        console.log('[ServerBuilder] Using Link Previews.');
+        if (!options.linkPreview) {
+            throw new Error('Link preview options must be provided.');
+        }
+        if (!this._linkPreviewStore) {
+            throw new Error('A link preview store must be configured.');
+        }
+
+        let rateLimiter: RateLimiter;
+        if (options.redis) {
+            const client = this._ensureRedisRateLimit(options);
+            const store = new TracedRedisRateLimitStore({
+                sendCommand: (command: string, ...args: string[]) => {
+                    return client.sendCommand([command, ...args]);
+                },
+            });
+            this._initActions.push({
+                priority: 11,
+                action: async () => {
+                    await store.setup();
+                },
+            });
+            store.prefix = 'link-preview-rl:';
+            rateLimiter = store;
+        } else {
+            rateLimiter = new MemoryRateLimiter();
+        }
+
+        this._linkPreviewController = new LinkPreviewController({
+            store: this._linkPreviewStore,
+            rateLimiter,
+            config: options.linkPreview,
         });
 
         return this;
@@ -2487,6 +2538,7 @@ export class ServerBuilder implements SubscriptionLike {
             contractRecordsController: this._contractsController,
             purchasableItemsController: this._purchasableItemsController,
             viewTemplateRenderer: this._viewTemplateRenderer,
+            linkPreviewController: this._linkPreviewController,
         });
 
         const buildReturn: BuildReturn = {


### PR DESCRIPTION
## Summary
This PR adds a new link preview generation feature that allows clients to fetch metadata from URLs and display rich previews. The implementation includes a controller for generating previews, storage layer for caching results, and a new HTTP API endpoint.

## Key Changes

- **LinkPreviewController**: New controller that fetches and parses HTML from URLs to extract metadata (title, description, images, etc.) using Open Graph tags with fallbacks to standard meta tags
  - Implements security checks to block requests to private/reserved IP addresses and localhost
  - Enforces per-origin rate limiting to prevent hammering individual sites
  - Caches results with configurable TTL based on Cache-Control headers
  - Handles URL normalization and locale-specific requests

- **LinkPreviewStore**: New storage interface with implementations for both Prisma and SQLite databases
  - Stores cached preview data with expiration times
  - Automatically filters expired entries on retrieval

- **API Endpoint**: New `GET /api/v2/link-preview` endpoint that accepts:
  - `url` (required): The URL to generate a preview for
  - `locale` (optional): Locale for Accept-Language header

- **Security Features**:
  - Blocks requests to private IP ranges (RFC1918, loopback, link-local, etc.)
  - DNS resolution validation to prevent SSRF attacks
  - Validates that responses are HTML content
  - Configurable request timeouts and response size limits

- **Configuration**: New `linkPreview` config section in ServerConfig with options for:
  - Per-origin rate limiting (default: 1000 hits/minute)
  - Minimum cache duration (default: 30 minutes)
  - Request timeout (default: 10 seconds)
  - Maximum response size (default: 5MB)

- **Database Schema**: Added `LinkPreviewCache` table to store cached preview data with expiration tracking

- **Testing**: Comprehensive test suite covering URL validation, caching, rate limiting, HTML parsing, and error handling

## Implementation Details

- Uses `node-html-parser` for efficient HTML parsing
- Extracts metadata from Open Graph tags with intelligent fallbacks to standard meta tags
- Normalizes URLs by sorting query parameters to improve cache hit rates
- Implements DNS lookup validation to prevent SSRF attacks
- Integrates with existing rate limiting infrastructure
- Includes OpenTelemetry tracing support

Fixes #868 