### PR TITLE
Add support for configuring custom OpenID Connect providers

### DIFF
--- a/src/aux-common/rpc/ErrorCodes.ts
+++ b/src/aux-common/rpc/ErrorCodes.ts
@@ -101,7 +101,8 @@ export type KnownErrorCodes =
     | 'currency_not_supported'
     | 'invalid_user'
     | 'url_not_html'
-    | 'site_rate_limited';
+    | 'site_rate_limited'
+    | 'session_key_required_for_openid';
 
 /**
  * Gets the status code that should be used for the given response.
@@ -219,6 +220,8 @@ export function getStatusCode(
             return 400;
         } else if (response.errorCode === 'site_rate_limited') {
             return 429;
+        } else if (response.errorCode === 'session_key_required_for_openid') {
+            return 401;
         } else {
             return 400;
         }

--- a/src/aux-records/AuthController.spec.ts
+++ b/src/aux-records/AuthController.spec.ts
@@ -53,6 +53,7 @@ import { allowAllDefaultFeatures } from './SubscriptionConfiguration';
 import { MemoryStore } from './MemoryStore';
 import { DateTime } from 'luxon';
 import type { PrivoClientInterface } from './PrivoClient';
+import type { GenericOpenIDClientInterface } from './GenericOpenIDClient';
 import type {
     VerifiedRegistrationResponse,
     VerifyAuthenticationResponseOpts,
@@ -149,6 +150,8 @@ describe('AuthController', () => {
     // let financialInterface: MemoryFinancialInterface;
     // let financialController: FinancialController;
     let privoClientMock: jest.MockedObject<PrivoClientInterface>;
+    let genericOpenIDClient: GenericOpenIDClientInterface;
+    let genericOpenIDClientMock: jest.MockedObject<GenericOpenIDClientInterface>;
     let nowMock: jest.Mock<number>;
     let relyingParty: RelyingParty;
 
@@ -202,6 +205,11 @@ describe('AuthController', () => {
             lookupServiceId: jest.fn(),
         };
 
+        genericOpenIDClient = genericOpenIDClientMock = {
+            generateAuthorizationUrl: jest.fn(),
+            processAuthorizationCallback: jest.fn(),
+        };
+
         relyingParty = {
             name: 'example relying party',
             id: 'example.com',
@@ -217,7 +225,8 @@ describe('AuthController', () => {
             store,
             store,
             privoClient,
-            [relyingParty]
+            [relyingParty],
+            genericOpenIDClient
         );
 
         uuidMock.mockReset();
@@ -2835,6 +2844,140 @@ describe('AuthController', () => {
                 errorMessage: 'The given provider is not supported.',
             });
         });
+
+        describe('custom provider', () => {
+            beforeEach(() => {
+                nowMock.mockReturnValue(
+                    DateTime.utc(2023, 1, 1, 0, 0, 0).toMillis()
+                );
+
+                store.openIdConfiguration = {
+                    providers: [
+                        {
+                            id: 'google',
+                            name: 'Google',
+                            discoveryUri:
+                                'https://accounts.google.com/.well-known/openid-configuration',
+                            redirectUri: 'https://example.com/redirect',
+                            clientId: 'clientId',
+                            clientSecret: 'clientSecret',
+                            requestScopes: ['openid', 'email', 'profile'],
+                        },
+                    ],
+                };
+            });
+
+            it('should return the redirect URL', async () => {
+                uuidMock
+                    .mockReturnValueOnce('uuid')
+                    .mockReturnValueOnce('uuid2');
+                genericOpenIDClientMock.generateAuthorizationUrl.mockResolvedValueOnce(
+                    {
+                        codeVerifier: 'verifier',
+                        codeMethod: 'method',
+                        authorizationUrl: 'https://mock_authorization_url',
+                        redirectUrl: 'https://redirect_url',
+                        scope: 'openid email profile',
+                    }
+                );
+
+                const result = await controller.requestOpenIDLogin({
+                    provider: 'google',
+                    ipAddress: '127.0.0.1',
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    authorizationUrl: 'https://mock_authorization_url',
+                    requestId: 'uuid',
+                });
+
+                expect(store.openIdLoginRequests).toEqual([
+                    {
+                        requestId: 'uuid',
+                        state: 'uuid2',
+                        provider: 'google',
+                        codeVerifier: 'verifier',
+                        codeMethod: 'method',
+                        authorizationUrl: 'https://mock_authorization_url',
+                        redirectUrl: 'https://redirect_url',
+                        scope: 'openid email profile',
+                        requestTimeMs: DateTime.utc(
+                            2023,
+                            1,
+                            1,
+                            0,
+                            0,
+                            0
+                        ).toMillis(),
+                        expireTimeMs:
+                            DateTime.utc(2023, 1, 1, 0, 0, 0).toMillis() +
+                            OPEN_ID_LOGIN_REQUEST_LIFETIME_MS,
+                        completedTimeMs: null,
+                        ipAddress: '127.0.0.1',
+                    },
+                ]);
+
+                expect(
+                    genericOpenIDClientMock.generateAuthorizationUrl
+                ).toHaveBeenCalledWith(
+                    store.openIdConfiguration.providers[0],
+                    'uuid2'
+                );
+            });
+
+            it('should return not_supported if the provider is not configured', async () => {
+                const result = await controller.requestOpenIDLogin({
+                    provider: 'not_google',
+                    ipAddress: '127.0.0.1',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'not_supported',
+                    errorMessage: 'The given provider is not supported.',
+                });
+            });
+
+            it('should return not_supported if no generic OpenID client is configured', async () => {
+                controller = new AuthController(
+                    store,
+                    messenger,
+                    store,
+                    store,
+                    privoClient,
+                    [relyingParty]
+                );
+
+                const result = await controller.requestOpenIDLogin({
+                    provider: 'google',
+                    ipAddress: '127.0.0.1',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'not_supported',
+                    errorMessage: 'The given provider is not supported.',
+                });
+            });
+
+            it('should return an error if the generic OpenID client throws an error', async () => {
+                genericOpenIDClientMock.generateAuthorizationUrl.mockRejectedValueOnce(
+                    new Error('mock error')
+                );
+
+                const result = await controller.requestOpenIDLogin({
+                    provider: 'google',
+                    ipAddress: '127.0.0.1',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'server_error',
+                    errorMessage: 'A server error occurred.',
+                });
+            });
+        });
     });
 
     describe('requestWebAuthnRegistration()', () => {
@@ -4020,6 +4163,21 @@ describe('AuthController', () => {
             it('should return not_supported when no privo client is configured', async () => {
                 store.privoConfiguration = null;
 
+                await store.saveOpenIDLoginRequest({
+                    requestId: 'requestId',
+                    state: 'state',
+                    redirectUrl: 'https://redirect_url',
+                    authorizationUrl: 'https://mock_authorization_url',
+                    codeMethod: 'method',
+                    codeVerifier: 'verifier',
+                    requestTimeMs: Date.now() - 100,
+                    expireTimeMs: Date.now() + 100,
+                    completedTimeMs: null,
+                    provider: PRIVO_OPEN_ID_PROVIDER,
+                    scope: 'scope1 scope2',
+                    ipAddress: '127.0.0.1',
+                });
+
                 const result = await controller.processOpenIDAuthorizationCode({
                     state: 'state',
                     authorizationCode: 'code',
@@ -4860,7 +5018,7 @@ describe('AuthController', () => {
                 });
             });
 
-            it('should return invalid_request if the request is for a non-privo provider', async () => {
+            it('should return not_supported if the request is for an unconfigured non-privo provider', async () => {
                 uuidMock.mockReturnValueOnce('uuid');
                 privoClientMock.processAuthorizationCallback.mockResolvedValueOnce(
                     {
@@ -4917,8 +5075,8 @@ describe('AuthController', () => {
 
                 expect(result).toEqual({
                     success: false,
-                    errorCode: 'invalid_request',
-                    errorMessage: 'The login request is invalid.',
+                    errorCode: 'not_supported',
+                    errorMessage: 'The given provider is not supported.',
                 });
             });
 
@@ -5205,6 +5363,416 @@ describe('AuthController', () => {
                     errorMessage:
                         "The login request is invalid. You attempted to sign into an account that is associated with a parent email address. This is not allowed because we don't ask consent for parent accounts, but all accounts must have consent. Please sign up with a new account instead.",
                 });
+            });
+        });
+
+        describe('custom provider', () => {
+            const providerConfig = {
+                id: 'google',
+                name: 'Google',
+                discoveryUri:
+                    'https://accounts.google.com/.well-known/openid-configuration',
+                redirectUri: 'https://example.com/redirect',
+                clientId: 'clientId',
+                clientSecret: 'clientSecret',
+                requestScopes: ['openid', 'email', 'profile'],
+            };
+
+            beforeEach(() => {
+                nowMock.mockReturnValue(
+                    DateTime.utc(2023, 1, 1, 0, 0, 0).toMillis()
+                );
+
+                randomBytesMock
+                    .mockReturnValueOnce(sessionId)
+                    .mockReturnValueOnce(sessionSecret)
+                    .mockReturnValueOnce(connectionSecret);
+
+                store.openIdConfiguration = {
+                    providers: [providerConfig],
+                };
+            });
+
+            async function saveGoogleLoginRequest() {
+                await store.saveOpenIDLoginRequest({
+                    requestId: 'requestId',
+                    state: 'state',
+                    authorizationUrl: 'https://mock_authorization_url',
+                    redirectUrl: 'https://redirect_url',
+                    codeVerifier: 'verifier',
+                    codeMethod: 'method',
+                    requestTimeMs: Date.now() - 100,
+                    expireTimeMs: Date.now() + 100,
+                    authorizationCode: 'code',
+                    authorizationTimeMs: Date.now(),
+                    completedTimeMs: null,
+                    ipAddress: '127.0.0.1',
+                    provider: 'google',
+                    scope: 'openid email profile',
+                });
+            }
+
+            it('should log in the linked user without requiring a session key', async () => {
+                await store.saveNewUser({
+                    id: 'userId',
+                    email: 'test@example.com',
+                    phoneNumber: null,
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                await store.saveOpenIDIdentity({
+                    provider: 'google',
+                    subject: 'sub1',
+                    userId: 'userId',
+                    createdAtMs: Date.now(),
+                });
+
+                await saveGoogleLoginRequest();
+
+                genericOpenIDClientMock.processAuthorizationCallback.mockResolvedValueOnce(
+                    {
+                        accessToken: 'accessToken',
+                        refreshToken: 'refreshToken',
+                        tokenType: 'Bearer',
+                        idToken: 'idToken',
+                        expiresIn: 1000,
+                        userInfo: {
+                            sub: 'sub1',
+                            email: 'test@example.com',
+                            name: 'Test Name',
+                        },
+                    }
+                );
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    userId: 'userId',
+                    sessionKey: expect.any(String),
+                    connectionKey: expect.any(String),
+                    expireTimeMs: Date.now() + SESSION_LIFETIME_MS,
+                    metadata: {
+                        hasUserAuthenticator: false,
+                        userAuthenticatorCredentialIds: [],
+                        hasPushSubscription: false,
+                        pushSubscriptionIds: [],
+                    },
+                });
+
+                expect(
+                    genericOpenIDClientMock.processAuthorizationCallback
+                ).toHaveBeenCalledWith(providerConfig, {
+                    code: 'code',
+                    state: 'state',
+                    codeVerifier: 'verifier',
+                    redirectUrl: 'https://redirect_url',
+                });
+            });
+
+            it('should create a new user and populate name/email when no session key is provided and no user matches the email', async () => {
+                uuidMock.mockReturnValueOnce('newUserId');
+
+                await saveGoogleLoginRequest();
+
+                genericOpenIDClientMock.processAuthorizationCallback.mockResolvedValueOnce(
+                    {
+                        accessToken: 'accessToken',
+                        refreshToken: 'refreshToken',
+                        tokenType: 'Bearer',
+                        idToken: 'idToken',
+                        expiresIn: 1000,
+                        userInfo: {
+                            sub: 'sub1',
+                            email: 'new@example.com',
+                            name: 'New User',
+                        },
+                    }
+                );
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    userId: 'newUserId',
+                    sessionKey: expect.any(String),
+                    connectionKey: expect.any(String),
+                    expireTimeMs: Date.now() + SESSION_LIFETIME_MS,
+                    metadata: {
+                        hasUserAuthenticator: false,
+                        userAuthenticatorCredentialIds: [],
+                        hasPushSubscription: false,
+                        pushSubscriptionIds: [],
+                    },
+                });
+
+                const user = await store.findUser('newUserId');
+                expect(user.email).toBe('new@example.com');
+                expect(user.name).toBe('New User');
+
+                expect(
+                    await store.findUserIdForOpenIDIdentity('google', 'sub1')
+                ).toBe('newUserId');
+            });
+
+            it('should return session_key_required_for_openid if a user matches the email and no session key is provided', async () => {
+                await store.saveNewUser({
+                    id: 'userId',
+                    email: 'test@example.com',
+                    phoneNumber: null,
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                await saveGoogleLoginRequest();
+
+                genericOpenIDClientMock.processAuthorizationCallback.mockResolvedValueOnce(
+                    {
+                        accessToken: 'accessToken',
+                        refreshToken: 'refreshToken',
+                        tokenType: 'Bearer',
+                        idToken: 'idToken',
+                        expiresIn: 1000,
+                        userInfo: {
+                            sub: 'sub1',
+                            email: 'test@example.com',
+                            name: 'Test Name',
+                        },
+                    }
+                );
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'session_key_required_for_openid',
+                    errorMessage: expect.any(String),
+                });
+
+                expect(
+                    await store.findUserIdForOpenIDIdentity('google', 'sub1')
+                ).toBe(null);
+            });
+
+            it('should link the identity and log in when a valid session key is provided for a user matching the email', async () => {
+                const userId = 'userId';
+                const sessionId = toBase64String('sessionId');
+                const code = 'code';
+                const sessionKey = formatV1SessionKey(
+                    userId,
+                    sessionId,
+                    code,
+                    Date.now() + 1000
+                );
+
+                await store.saveNewUser({
+                    id: userId,
+                    email: 'test@example.com',
+                    phoneNumber: null,
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                await store.saveSession({
+                    requestId: 'sessionRequestId',
+                    sessionId,
+                    secretHash: hashLowEntropyPasswordWithSalt(code, sessionId),
+                    connectionSecret: code,
+                    expireTimeMs: Date.now() + 1000,
+                    grantedTimeMs: Date.now(),
+                    previousSessionId: null,
+                    nextSessionId: null,
+                    revokeTimeMs: null,
+                    userId,
+                    ipAddress: '127.0.0.1',
+                });
+
+                await saveGoogleLoginRequest();
+
+                genericOpenIDClientMock.processAuthorizationCallback.mockResolvedValueOnce(
+                    {
+                        accessToken: 'accessToken',
+                        refreshToken: 'refreshToken',
+                        tokenType: 'Bearer',
+                        idToken: 'idToken',
+                        expiresIn: 1000,
+                        userInfo: {
+                            sub: 'sub1',
+                            email: 'test@example.com',
+                            name: 'Test Name',
+                        },
+                    }
+                );
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                    sessionKey,
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    userId,
+                    sessionKey: expect.any(String),
+                    connectionKey: expect.any(String),
+                    expireTimeMs: Date.now() + SESSION_LIFETIME_MS,
+                    metadata: {
+                        hasUserAuthenticator: false,
+                        userAuthenticatorCredentialIds: [],
+                        hasPushSubscription: false,
+                        pushSubscriptionIds: [],
+                    },
+                });
+
+                expect(
+                    await store.findUserIdForOpenIDIdentity('google', 'sub1')
+                ).toBe(userId);
+            });
+
+            it('should return the session key validation error if an invalid session key is provided', async () => {
+                await store.saveNewUser({
+                    id: 'userId',
+                    email: 'test@example.com',
+                    phoneNumber: null,
+                    allSessionRevokeTimeMs: null,
+                    currentLoginRequestId: null,
+                });
+
+                await saveGoogleLoginRequest();
+
+                genericOpenIDClientMock.processAuthorizationCallback.mockResolvedValueOnce(
+                    {
+                        accessToken: 'accessToken',
+                        refreshToken: 'refreshToken',
+                        tokenType: 'Bearer',
+                        idToken: 'idToken',
+                        expiresIn: 1000,
+                        userInfo: {
+                            sub: 'sub1',
+                            email: 'test@example.com',
+                            name: 'Test Name',
+                        },
+                    }
+                );
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                    sessionKey: 'wrong',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_session_key',
+                    errorMessage: expect.any(String),
+                });
+            });
+
+            it('should return not_supported if the provider is not configured', async () => {
+                store.openIdConfiguration = {
+                    providers: [],
+                };
+
+                await saveGoogleLoginRequest();
+
+                const result = await controller.completeOpenIDLogin({
+                    ipAddress: '127.0.0.1',
+                    requestId: 'requestId',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'not_supported',
+                    errorMessage: 'The given provider is not supported.',
+                });
+            });
+        });
+    });
+
+    describe('listOpenIDProviders()', () => {
+        it('should include Privo when it is configured', async () => {
+            store.privoConfiguration = {
+                gatewayEndpoint: 'endpoint',
+                featureIds: {
+                    adultPrivoSSO: 'adultAccount',
+                    childPrivoSSO: 'childAccount',
+                    joinAndCollaborate: 'joinAndCollaborate',
+                    publishProjects: 'publish',
+                    projectDevelopment: 'dev',
+                    buildAIEggs: 'buildaieggs',
+                },
+                clientId: 'clientId',
+                clientSecret: 'clientSecret',
+                publicEndpoint: 'publicEndpoint',
+                roleIds: {
+                    child: 'childRole',
+                    adult: 'adultRole',
+                    parent: 'parentRole',
+                },
+                clientTokenScopes: 'scope1 scope2',
+                userTokenScopes: 'scope1 scope2',
+                redirectUri: 'redirectUri',
+                ageOfConsent: 18,
+            };
+
+            const result = await controller.listOpenIDProviders();
+
+            expect(result).toEqual({
+                success: true,
+                providers: [
+                    {
+                        id: PRIVO_OPEN_ID_PROVIDER,
+                        name: 'Privo',
+                    },
+                ],
+            });
+        });
+
+        it('should include configured custom providers', async () => {
+            store.openIdConfiguration = {
+                providers: [
+                    {
+                        id: 'google',
+                        name: 'Google',
+                        discoveryUri:
+                            'https://accounts.google.com/.well-known/openid-configuration',
+                        redirectUri: 'https://example.com/redirect',
+                        clientId: 'clientId',
+                        clientSecret: 'clientSecret',
+                        requestScopes: ['openid', 'email', 'profile'],
+                    },
+                ],
+            };
+
+            const result = await controller.listOpenIDProviders();
+
+            expect(result).toEqual({
+                success: true,
+                providers: [
+                    {
+                        id: 'google',
+                        name: 'Google',
+                    },
+                ],
+            });
+        });
+
+        it('should return an empty list when nothing is configured', async () => {
+            const result = await controller.listOpenIDProviders();
+
+            expect(result).toEqual({
+                success: true,
+                providers: [],
             });
         });
     });

--- a/src/aux-records/AuthController.ts
+++ b/src/aux-records/AuthController.ts
@@ -73,6 +73,8 @@ import type {
 } from './PrivoClient';
 import { DateTime } from 'luxon';
 import type { PrivoConfiguration } from './PrivoConfiguration';
+import type { GenericOpenIDClientInterface } from './GenericOpenIDClient';
+import type { OpenIDProviderConfiguration } from './OpenIDConfiguration';
 import type { ZodIssue } from 'zod';
 import type {
     PublicKeyCredentialCreationOptionsJSON,
@@ -208,6 +210,7 @@ export class AuthController {
     private _messenger: AuthMessenger;
     private _config: ConfigurationStore;
     private _privoClient: PrivoClientInterface = null;
+    private _genericOpenIDClient: GenericOpenIDClientInterface = null;
     private _webAuthNRelyingParties: RelyingParty[];
     private _privoEnabled: boolean;
 
@@ -225,7 +228,8 @@ export class AuthController {
         configStore: ConfigurationStore,
         recordsStore: RecordsStore,
         privoClient: PrivoClientInterface = null,
-        relyingParties: RelyingParty[] = []
+        relyingParties: RelyingParty[] = [],
+        genericOpenIDClient: GenericOpenIDClientInterface = null
     ) {
         this._store = authStore;
         this._messenger = messenger;
@@ -234,6 +238,7 @@ export class AuthController {
         this._privoClient = privoClient;
         this._webAuthNRelyingParties = relyingParties;
         this._privoEnabled = this._privoClient !== null;
+        this._genericOpenIDClient = genericOpenIDClient;
     }
 
     /**
@@ -262,6 +267,20 @@ export class AuthController {
      */
     set privoClient(value: PrivoClientInterface) {
         this._privoClient = value;
+    }
+
+    /**
+     * Gets the generic OpenID client that is used for custom OpenID providers.
+     */
+    get genericOpenIDClient(): GenericOpenIDClientInterface {
+        return this._genericOpenIDClient;
+    }
+
+    /**
+     * Sets the generic OpenID client that is used for custom OpenID providers.
+     */
+    set genericOpenIDClient(value: GenericOpenIDClientInterface) {
+        this._genericOpenIDClient = value;
     }
 
     @traced(TRACE_NAME)
@@ -815,51 +834,70 @@ export class AuthController {
         request: OpenIDLoginRequest
     ): Promise<OpenIDLoginRequestResult> {
         try {
-            if (request.provider !== PRIVO_OPEN_ID_PROVIDER) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage: 'The given provider is not supported.',
-                };
-            }
+            let providerId: string;
+            let providerConfig: OpenIDProviderConfiguration = null;
 
-            if (!this._privoClient) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
-            }
+            if (request.provider === PRIVO_OPEN_ID_PROVIDER) {
+                if (!this._privoClient) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage:
+                            'Privo features are not supported on this server.',
+                    };
+                }
 
-            const config = await this._config.getPrivoConfiguration();
+                const config = await this._config.getPrivoConfiguration();
 
-            if (!config) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
+                if (!config) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage:
+                            'Privo features are not supported on this server.',
+                    };
+                }
+
+                providerId = PRIVO_OPEN_ID_PROVIDER;
+            } else {
+                const openIdConfig =
+                    await this._config.getOpenIDConfiguration();
+                providerConfig = openIdConfig?.providers.find(
+                    (p) => p.id === request.provider
+                );
+
+                if (!providerConfig || !this._genericOpenIDClient) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage: 'The given provider is not supported.',
+                    };
+                }
+
+                providerId = providerConfig.id;
             }
 
             const requestId = uuid();
             const state = uuid();
-            const result = await this._privoClient.generateAuthorizationUrl(
-                state
-            );
+
+            const authorizationUrlResult = providerConfig
+                ? await this._genericOpenIDClient.generateAuthorizationUrl(
+                      providerConfig,
+                      state
+                  )
+                : await this._privoClient.generateAuthorizationUrl(state);
 
             const loginRequest: AuthOpenIDLoginRequest = {
                 requestId: requestId,
                 state: state,
-                provider: PRIVO_OPEN_ID_PROVIDER,
-                codeMethod: result.codeMethod,
-                codeVerifier: result.codeVerifier,
-                authorizationUrl: result.authorizationUrl,
-                redirectUrl: result.redirectUrl,
+                provider: providerId,
+                codeMethod: authorizationUrlResult.codeMethod,
+                codeVerifier: authorizationUrlResult.codeVerifier,
+                authorizationUrl: authorizationUrlResult.authorizationUrl,
+                redirectUrl: authorizationUrlResult.redirectUrl,
                 completedTimeMs: null,
                 ipAddress: request.ipAddress,
-                scope: result.scope,
+                scope: authorizationUrlResult.scope,
                 requestTimeMs: Date.now(),
                 expireTimeMs: Date.now() + OPEN_ID_LOGIN_REQUEST_LIFETIME_MS,
             };
@@ -868,7 +906,7 @@ export class AuthController {
 
             return {
                 success: true,
-                authorizationUrl: result.authorizationUrl,
+                authorizationUrl: authorizationUrlResult.authorizationUrl,
                 requestId: requestId,
             };
         } catch (err) {
@@ -877,7 +915,7 @@ export class AuthController {
             span?.setStatus({ code: SpanStatusCode.ERROR });
 
             console.error(
-                '[AuthController] Error occurred while requesting Privo login',
+                '[AuthController] Error occurred while requesting OpenID login',
                 err
             );
             return {
@@ -893,26 +931,6 @@ export class AuthController {
         request: ProcessOpenIDAuthorizationCodeRequest
     ): Promise<ProcessOpenIDAuthorizationCodeResult> {
         try {
-            if (!this._privoClient) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
-            }
-
-            const config = await this._config.getPrivoConfiguration();
-
-            if (!config) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
-            }
-
             const state = request.state;
             const loginRequest =
                 await this._store.findOpenIDLoginRequestByState(state);
@@ -924,6 +942,42 @@ export class AuthController {
                     errorCode: 'invalid_request',
                     errorMessage: INVALID_AUTHORIZATION_REQUEST_ERROR_MESSAGE,
                 };
+            }
+
+            if (loginRequest.provider === PRIVO_OPEN_ID_PROVIDER) {
+                if (!this._privoClient) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage:
+                            'Privo features are not supported on this server.',
+                    };
+                }
+
+                const config = await this._config.getPrivoConfiguration();
+
+                if (!config) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage:
+                            'Privo features are not supported on this server.',
+                    };
+                }
+            } else {
+                const openIdConfig =
+                    await this._config.getOpenIDConfiguration();
+                const providerConfig = openIdConfig?.providers.find(
+                    (p) => p.id === loginRequest.provider
+                );
+
+                if (!providerConfig || !this._genericOpenIDClient) {
+                    return {
+                        success: false,
+                        errorCode: 'not_supported',
+                        errorMessage: 'The given provider is not supported.',
+                    };
+                }
             }
 
             let validRequest = true;
@@ -938,14 +992,6 @@ export class AuthController {
             }
 
             if (!validRequest) {
-                return {
-                    success: false,
-                    errorCode: 'invalid_request',
-                    errorMessage: INVALID_AUTHORIZATION_REQUEST_ERROR_MESSAGE,
-                };
-            }
-
-            if (loginRequest.provider !== PRIVO_OPEN_ID_PROVIDER) {
                 return {
                     success: false,
                     errorCode: 'invalid_request',
@@ -968,7 +1014,7 @@ export class AuthController {
             span?.setStatus({ code: SpanStatusCode.ERROR });
 
             console.error(
-                '[AuthController] Error occurred while processing Privo authorization code',
+                '[AuthController] Error occurred while processing OpenID authorization code',
                 err
             );
             return {
@@ -984,26 +1030,6 @@ export class AuthController {
         request: CompleteOpenIDLoginRequest
     ): Promise<CompleteOpenIDLoginResult> {
         try {
-            if (!this._privoClient) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
-            }
-
-            const config = await this._config.getPrivoConfiguration();
-
-            if (!config) {
-                return {
-                    success: false,
-                    errorCode: 'not_supported',
-                    errorMessage:
-                        'Privo features are not supported on this server.',
-                };
-            }
-
             const requestId = request.requestId;
             const loginRequest = await this._store.findOpenIDLoginRequest(
                 requestId
@@ -1034,14 +1060,6 @@ export class AuthController {
                 };
             }
 
-            if (loginRequest.provider !== PRIVO_OPEN_ID_PROVIDER) {
-                return {
-                    success: false,
-                    errorCode: 'invalid_request',
-                    errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
-                };
-            }
-
             if (
                 !loginRequest.authorizationTimeMs ||
                 !loginRequest.authorizationCode
@@ -1053,7 +1071,204 @@ export class AuthController {
                 };
             }
 
-            const result = await this._privoClient.processAuthorizationCallback(
+            if (loginRequest.provider === PRIVO_OPEN_ID_PROVIDER) {
+                return await this._completePrivoOpenIDLogin(
+                    loginRequest,
+                    request
+                );
+            }
+
+            return await this._completeGenericOpenIDLogin(
+                loginRequest,
+                request
+            );
+        } catch (err) {
+            const span = trace.getActiveSpan();
+            span?.recordException(err);
+            span?.setStatus({ code: SpanStatusCode.ERROR });
+
+            console.error(
+                '[AuthController] Error occurred while completing OpenID login',
+                err
+            );
+            return {
+                success: false,
+                errorCode: 'server_error',
+                errorMessage: 'A server error occurred.',
+            };
+        }
+    }
+
+    private async _completePrivoOpenIDLogin(
+        loginRequest: AuthOpenIDLoginRequest,
+        request: CompleteOpenIDLoginRequest
+    ): Promise<CompleteOpenIDLoginResult> {
+        if (!this._privoClient) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage:
+                    'Privo features are not supported on this server.',
+            };
+        }
+
+        const config = await this._config.getPrivoConfiguration();
+
+        if (!config) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage:
+                    'Privo features are not supported on this server.',
+            };
+        }
+
+        const result = await this._privoClient.processAuthorizationCallback({
+            code: loginRequest.authorizationCode,
+            state: loginRequest.state,
+            codeVerifier: loginRequest.codeVerifier,
+            redirectUrl: loginRequest.redirectUrl,
+        });
+
+        const serviceId = result.userInfo.serviceId;
+        const email = result.userInfo.email;
+
+        if (
+            result.userInfo.roleIdentifier !== config.roleIds.adult &&
+            result.userInfo.roleIdentifier !== config.roleIds.child
+        ) {
+            return {
+                success: false,
+                errorCode: 'invalid_request',
+                errorMessage:
+                    "The login request is invalid. You attempted to sign into an account that is associated with a parent email address. This is not allowed because we don't ask consent for parent accounts, but all accounts must have consent. Please sign up with a new account instead.",
+            };
+        }
+
+        let user: AuthUser;
+        if (serviceId) {
+            user = await this._store.findUserByPrivoServiceId(
+                result.userInfo.serviceId
+            );
+        }
+
+        if (!user && email) {
+            user = await this._store.findUserByAddress(email, 'email');
+        }
+
+        if (!user) {
+            console.log(
+                '[AuthController] [completeOpenIDLogin] Could not find user.'
+            );
+            return {
+                success: false,
+                errorCode: 'invalid_request',
+                errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
+            };
+        }
+
+        if (!user.privoServiceId) {
+            console.log(
+                `[AuthController] [completeOpenIDLogin] Updating user service ID.`
+            );
+            user = {
+                ...user,
+                privoServiceId: serviceId,
+            };
+            await this._store.saveUser({
+                ...user,
+            });
+        } else if (user.privoServiceId !== serviceId) {
+            console.log(
+                `[AuthController] [completeOpenIDLogin] User's service ID (${user.privoServiceId}) doesnt match the one returned by Privo (${serviceId}).`
+            );
+            return {
+                success: false,
+                errorCode: 'invalid_request',
+                errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
+            };
+        }
+
+        const privacyFeatures = getPrivacyFeaturesFromPermissions(
+            config.featureIds,
+            result.userInfo.permissions
+        );
+
+        if (
+            user.privacyFeatures?.publishData !== privacyFeatures.publishData ||
+            user.privacyFeatures?.allowPublicData !==
+                privacyFeatures.allowPublicData ||
+            user.privacyFeatures?.allowAI !== privacyFeatures.allowAI ||
+            user.privacyFeatures?.allowPublicInsts !==
+                privacyFeatures.allowPublicInsts
+        ) {
+            console.log(
+                `[AuthController] [completeOpenIDLogin] Updating user privacy features.`
+            );
+
+            user = {
+                ...user,
+                privacyFeatures,
+            };
+            await this._store.saveUser({
+                ...user,
+            });
+        }
+
+        const now = Date.now();
+        const expiry = now + result.expiresIn * 1000;
+
+        const { info } = await this._issueSession({
+            userId: user.id,
+            lifetimeMs: SESSION_LIFETIME_MS,
+            oidRequestId: loginRequest.requestId,
+            oidAccessToken: result.accessToken,
+            oidRefreshToken: result.refreshToken,
+            oidIdToken: result.idToken,
+            oidScope: loginRequest.scope,
+            oidTokenType: result.tokenType,
+            oidExpiresAtMs: expiry,
+            oidProvider: loginRequest.provider,
+            ipAddress: request.ipAddress,
+        });
+
+        return {
+            success: true,
+            ...info,
+        };
+    }
+
+    /**
+     * Completes an OpenID login for a custom (non-Privo) provider.
+     *
+     * Unlike Privo, a custom OpenID provider is not trusted to authoritatively
+     * own an email address, so a login that would link to an *existing* user
+     * (either because that user already linked this exact provider identity, or
+     * because a user with a matching email exists) requires proof that the
+     * caller is already authenticated as that user via a session key. Brand new
+     * users don't need a session key, since there's no existing account that
+     * could be hijacked.
+     */
+    private async _completeGenericOpenIDLogin(
+        loginRequest: AuthOpenIDLoginRequest,
+        request: CompleteOpenIDLoginRequest
+    ): Promise<CompleteOpenIDLoginResult> {
+        const openIdConfig = await this._config.getOpenIDConfiguration();
+        const providerConfig = openIdConfig?.providers.find(
+            (p) => p.id === loginRequest.provider
+        );
+
+        if (!providerConfig || !this._genericOpenIDClient) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage: 'The given provider is not supported.',
+            };
+        }
+
+        const result =
+            await this._genericOpenIDClient.processAuthorizationCallback(
+                providerConfig,
                 {
                     code: loginRequest.authorizationCode,
                     state: loginRequest.state,
@@ -1062,112 +1277,161 @@ export class AuthController {
                 }
             );
 
-            const serviceId = result.userInfo.serviceId;
-            const email = result.userInfo.email;
+        const subject = result.userInfo.sub;
+        const email = result.userInfo.email;
+        const name = result.userInfo.name;
 
-            if (
-                result.userInfo.roleIdentifier !== config.roleIds.adult &&
-                result.userInfo.roleIdentifier !== config.roleIds.child
-            ) {
-                return {
-                    success: false,
-                    errorCode: 'invalid_request',
-                    errorMessage:
-                        "The login request is invalid. You attempted to sign into an account that is associated with a parent email address. This is not allowed because we don't ask consent for parent accounts, but all accounts must have consent. Please sign up with a new account instead.",
-                };
-            }
+        const linkedUserId = await this._store.findUserIdForOpenIDIdentity(
+            loginRequest.provider,
+            subject
+        );
 
-            let user: AuthUser;
-            if (serviceId) {
-                user = await this._store.findUserByPrivoServiceId(
-                    result.userInfo.serviceId
-                );
-            }
+        let user: AuthUser;
 
-            if (!user && email) {
-                user = await this._store.findUserByAddress(email, 'email');
-            }
+        if (linkedUserId) {
+            user = await this._store.findUser(linkedUserId);
 
             if (!user) {
-                console.log(
-                    '[AuthController] [completeOpenIDLogin] Could not find user.'
-                );
                 return {
                     success: false,
                     errorCode: 'invalid_request',
                     errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
                 };
             }
-
-            if (!user.privoServiceId) {
-                console.log(
-                    `[AuthController] [completeOpenIDLogin] Updating user service ID.`
-                );
-                user = {
-                    ...user,
-                    privoServiceId: serviceId,
-                };
-                await this._store.saveUser({
-                    ...user,
-                });
-            } else if (user.privoServiceId !== serviceId) {
-                console.log(
-                    `[AuthController] [completeOpenIDLogin] User's service ID (${user.privoServiceId}) doesnt match the one returned by Privo (${serviceId}).`
-                );
-                return {
-                    success: false,
-                    errorCode: 'invalid_request',
-                    errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
-                };
-            }
-
-            const privacyFeatures = getPrivacyFeaturesFromPermissions(
-                config.featureIds,
-                result.userInfo.permissions
+        } else if (request.sessionKey) {
+            const validation = await validateSessionKey(
+                this,
+                request.sessionKey
             );
 
-            if (
-                user.privacyFeatures?.publishData !==
-                    privacyFeatures.publishData ||
-                user.privacyFeatures?.allowPublicData !==
-                    privacyFeatures.allowPublicData ||
-                user.privacyFeatures?.allowAI !== privacyFeatures.allowAI ||
-                user.privacyFeatures?.allowPublicInsts !==
-                    privacyFeatures.allowPublicInsts
-            ) {
-                console.log(
-                    `[AuthController] [completeOpenIDLogin] Updating user privacy features.`
-                );
-
-                user = {
-                    ...user,
-                    privacyFeatures,
+            if (validation.success === false) {
+                return {
+                    success: false,
+                    errorCode:
+                        validation.errorCode === 'no_session_key'
+                            ? 'session_key_required_for_openid'
+                            : validation.errorCode,
+                    errorMessage: validation.errorMessage,
                 };
-                await this._store.saveUser({
-                    ...user,
-                });
             }
 
-            const now = Date.now();
-            const expiry = now + result.expiresIn * 1000;
+            user = await this._store.findUser(validation.userId);
 
-            const { info } = await this._issueSession({
+            if (!user) {
+                return {
+                    success: false,
+                    errorCode: 'invalid_request',
+                    errorMessage: INVALID_REQUEST_ERROR_MESSAGE,
+                };
+            }
+
+            await this._store.saveOpenIDIdentity({
+                provider: loginRequest.provider,
+                subject,
                 userId: user.id,
-                lifetimeMs: SESSION_LIFETIME_MS,
-                oidRequestId: loginRequest.requestId,
-                oidAccessToken: result.accessToken,
-                oidRefreshToken: result.refreshToken,
-                oidIdToken: result.idToken,
-                oidScope: loginRequest.scope,
-                oidTokenType: result.tokenType,
-                oidExpiresAtMs: expiry,
-                oidProvider: loginRequest.provider,
-                ipAddress: request.ipAddress,
+                createdAtMs: Date.now(),
             });
+        } else {
+            const existingUser = email
+                ? await this._store.findUserByAddress(email, 'email')
+                : null;
+
+            if (existingUser) {
+                return {
+                    success: false,
+                    errorCode: 'session_key_required_for_openid',
+                    errorMessage:
+                        'A valid session key is required to link this OpenID account to an existing user.',
+                };
+            }
+
+            user = {
+                id: uuid(),
+                email: email ?? null,
+                phoneNumber: null,
+                name: name ?? null,
+                allSessionRevokeTimeMs: null,
+                currentLoginRequestId: null,
+            };
+
+            const saveUserResult = await this._store.saveNewUser(user);
+
+            if (saveUserResult.success === false) {
+                console.error(
+                    '[AuthController] Error saving new user',
+                    saveUserResult
+                );
+                return {
+                    success: false,
+                    errorCode: 'server_error',
+                    errorMessage: 'A server error occurred.',
+                };
+            }
+
+            await this._store.saveOpenIDIdentity({
+                provider: loginRequest.provider,
+                subject,
+                userId: user.id,
+                createdAtMs: Date.now(),
+            });
+        }
+
+        const now = Date.now();
+        const expiry = now + result.expiresIn * 1000;
+
+        const { info } = await this._issueSession({
+            userId: user.id,
+            lifetimeMs: SESSION_LIFETIME_MS,
+            oidRequestId: loginRequest.requestId,
+            oidAccessToken: result.accessToken,
+            oidRefreshToken: result.refreshToken,
+            oidIdToken: result.idToken,
+            oidScope: loginRequest.scope,
+            oidTokenType: result.tokenType,
+            oidExpiresAtMs: expiry,
+            oidProvider: loginRequest.provider,
+            ipAddress: request.ipAddress,
+        });
+
+        return {
+            success: true,
+            ...info,
+        };
+    }
+
+    /**
+     * Lists the OpenID providers that are configured on this server.
+     * Includes Privo (if configured) as well as any configured custom providers.
+     */
+    @traced(TRACE_NAME)
+    async listOpenIDProviders(): Promise<ListOpenIDProvidersResult> {
+        try {
+            const providers: OpenIDProviderInfo[] = [];
+
+            if (this._privoClient) {
+                const privoConfig = await this._config.getPrivoConfiguration();
+                if (privoConfig) {
+                    providers.push({
+                        id: PRIVO_OPEN_ID_PROVIDER,
+                        name: 'Privo',
+                    });
+                }
+            }
+
+            if (this._genericOpenIDClient) {
+                const openIdConfig =
+                    await this._config.getOpenIDConfiguration();
+                for (const provider of openIdConfig?.providers ?? []) {
+                    providers.push({
+                        id: provider.id,
+                        name: provider.name,
+                    });
+                }
+            }
 
             return {
                 success: true,
-                ...info,
+                providers,
             };
         } catch (err) {
             const span = trace.getActiveSpan();
@@ -1175,7 +1439,7 @@ export class AuthController {
             span?.setStatus({ code: SpanStatusCode.ERROR });
 
             console.error(
-                '[AuthController] Error occurred while completing Privo login',
+                '[AuthController] Error occurred while listing OpenID providers',
                 err
             );
             return {
@@ -3554,6 +3818,16 @@ export interface CompleteOpenIDLoginRequest {
      * The IP address that the request is from.
      */
     ipAddress: string;
+
+    /**
+     * The session key of the user that is completing the login.
+     * Required for custom (non-Privo) OpenID providers when the login would
+     * link to an existing user account, in order to prevent account takeover
+     * by a rogue OpenID account that shares an email address with an existing
+     * CasualOS user. Not required if the OpenID identity has already been
+     * linked to a user, or if the login will create a brand new user.
+     */
+    sessionKey?: string | null;
 }
 
 export type CompleteOpenIDLoginResult =
@@ -3570,7 +3844,42 @@ export interface CompleteOpenIDLoginFailure {
         | ServerError
         | 'not_supported'
         | 'invalid_request'
-        | 'not_completed';
+        | 'not_completed'
+        | 'session_key_required_for_openid'
+        | 'unacceptable_session_key'
+        | 'invalid_key'
+        | 'session_expired'
+        | 'user_is_banned';
+    errorMessage: string;
+}
+
+/**
+ * Defines information about an OpenID provider that is available for login.
+ */
+export interface OpenIDProviderInfo {
+    /**
+     * The ID of the provider.
+     */
+    id: string;
+
+    /**
+     * The human-readable name of the provider.
+     */
+    name: string;
+}
+
+export type ListOpenIDProvidersResult =
+    | ListOpenIDProvidersSuccess
+    | ListOpenIDProvidersFailure;
+
+export interface ListOpenIDProvidersSuccess {
+    success: true;
+    providers: OpenIDProviderInfo[];
+}
+
+export interface ListOpenIDProvidersFailure {
+    success: false;
+    errorCode: ServerError;
     errorMessage: string;
 }
 

--- a/src/aux-records/AuthStore.ts
+++ b/src/aux-records/AuthStore.ts
@@ -189,6 +189,23 @@ export interface AuthStore {
     ): Promise<void>;
 
     /**
+     * Finds the ID of the user that has linked the given custom OpenID provider identity.
+     * Returns null if no user has linked the given identity.
+     * @param provider The ID of the OpenID provider.
+     * @param subject The subject (user ID) that the OpenID provider reported.
+     */
+    findUserIdForOpenIDIdentity(
+        provider: string,
+        subject: string
+    ): Promise<string | null>;
+
+    /**
+     * Saves a link between a user and a custom OpenID provider identity.
+     * @param identity The identity that should be saved.
+     */
+    saveOpenIDIdentity(identity: AuthCustomOpenIDIdentity): Promise<void>;
+
+    /**
      * Increments the attempt count for the given login request.
      * @param userId The ID of the user.
      * @param requestId The ID of the login request.
@@ -1017,6 +1034,31 @@ export interface AuthOpenIDLoginRequest {
      * The IP Address that the request came from.
      */
     ipAddress: string;
+}
+
+/**
+ * Defines an interface that represents a link between a user and a custom OpenID provider identity.
+ */
+export interface AuthCustomOpenIDIdentity {
+    /**
+     * The ID of the OpenID provider that the identity is for.
+     */
+    provider: string;
+
+    /**
+     * The subject (user ID) that the OpenID provider reported for the user.
+     */
+    subject: string;
+
+    /**
+     * The ID of the user that the identity is linked to.
+     */
+    userId: string;
+
+    /**
+     * The unix timestamp in miliseconds that the identity was linked at.
+     */
+    createdAtMs: number;
 }
 
 export interface AuthSubscription {

--- a/src/aux-records/CachingConfigStore.ts
+++ b/src/aux-records/CachingConfigStore.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import type { PrivoConfiguration } from './PrivoConfiguration';
+import type { OpenIDConfiguration } from './OpenIDConfiguration';
 import type { Cache } from './Cache';
 import type {
     ConfigurationInput,
@@ -25,6 +26,7 @@ import type {
 import {
     CONFIGURATION_SCHEMAS_MAP,
     MODERATION_CONFIG_KEY,
+    OPENID_CONFIG_KEY,
     PLAYER_WEB_MANIFEST_KEY,
     PRIVO_CONFIG_KEY,
     SUBSCRIPTIONS_CONFIG_KEY,
@@ -180,6 +182,17 @@ export class CachingConfigStore implements ConfigurationStore {
                     typeof PRIVO_CONFIG_KEY
                 > | null
         )) as PrivoConfiguration;
+    }
+
+    @traced(TRACE_NAME)
+    async getOpenIDConfiguration(): Promise<OpenIDConfiguration> {
+        return (await this._getConfiguration(
+            OPENID_CONFIG_KEY,
+            async () =>
+                (await this._store.getOpenIDConfiguration()) as ConfigurationOutput<
+                    typeof OPENID_CONFIG_KEY
+                > | null
+        )) as OpenIDConfiguration;
     }
 
     @traced(TRACE_NAME)

--- a/src/aux-records/ConfigurationStore.ts
+++ b/src/aux-records/ConfigurationStore.ts
@@ -20,6 +20,7 @@ import {
     type SubscriptionConfiguration,
 } from './SubscriptionConfiguration';
 import { privoSchema, type PrivoConfiguration } from './PrivoConfiguration';
+import { openIdSchema, type OpenIDConfiguration } from './OpenIDConfiguration';
 import {
     moderationSchema,
     type ModerationConfiguration,
@@ -39,6 +40,8 @@ import { memoize } from 'es-toolkit';
 export const SUBSCRIPTIONS_CONFIG_KEY = 'subscriptions';
 
 export const PRIVO_CONFIG_KEY = 'privo';
+
+export const OPENID_CONFIG_KEY = 'openid';
 
 export const MODERATION_CONFIG_KEY = 'moderation';
 
@@ -97,6 +100,11 @@ export interface DefaultConfiguration {
     privo: PrivoConfiguration;
 
     /**
+     * The default openid configuration.
+     */
+    openid: OpenIDConfiguration;
+
+    /**
      * The default moderation configuration.
      */
     moderation: ModerationConfiguration;
@@ -123,6 +131,7 @@ export const CONFIGURATION_SCHEMAS = [
         schema: getSubscriptionConfigSchema(),
     } as const,
     { key: PRIVO_CONFIG_KEY, schema: privoSchema } as const,
+    { key: OPENID_CONFIG_KEY, schema: openIdSchema } as const,
     { key: MODERATION_CONFIG_KEY, schema: moderationSchema } as const,
     { key: WEB_CONFIG_KEY, schema: WEB_CONFIG_SCHEMA } as const,
     { key: PLAYER_WEB_MANIFEST_KEY, schema: WEB_MANIFEST_SCHEMA } as const,
@@ -136,6 +145,7 @@ export const CONFIGURATION_SCHEMAS = [
 export const CONFIGURATION_SCHEMAS_MAP = {
     [SUBSCRIPTIONS_CONFIG_KEY]: getSubscriptionConfigSchema(),
     [PRIVO_CONFIG_KEY]: privoSchema,
+    [OPENID_CONFIG_KEY]: openIdSchema,
     [MODERATION_CONFIG_KEY]: moderationSchema,
     [WEB_CONFIG_KEY]: WEB_CONFIG_SCHEMA,
     [PLAYER_WEB_MANIFEST_KEY]: WEB_MANIFEST_SCHEMA,
@@ -172,6 +182,11 @@ export interface ConfigurationStore {
      * Retrieves the privo configuration from the store.
      */
     getPrivoConfiguration(): Promise<PrivoConfiguration | null>;
+
+    /**
+     * Retrieves the openid configuration from the store.
+     */
+    getOpenIDConfiguration(): Promise<OpenIDConfiguration | null>;
 
     /**
      * Retrieves the moderation configuration from the store.

--- a/src/aux-records/GenericOpenIDClient.ts
+++ b/src/aux-records/GenericOpenIDClient.ts
@@ -150,7 +150,16 @@ export class GenericOpenIDClient implements GenericOpenIDClientInterface {
     ): Promise<Client> {
         let client = this._clients.get(config.id);
         if (!client) {
-            const issuer = await Issuer.discover(config.discoveryUri);
+            let issuer: Issuer<Client>;
+            if (config.issuer) {
+                issuer = new Issuer(config.issuer);
+            } else if (config.discoveryUri) {
+                issuer = await Issuer.discover(config.discoveryUri);
+            } else {
+                throw new Error(
+                    `The OpenID provider "${config.id}" must specify either a discoveryUri or an issuer.`
+                );
+            }
             client = new issuer.Client({
                 client_id: config.clientId,
                 client_secret: config.clientSecret,

--- a/src/aux-records/GenericOpenIDClient.ts
+++ b/src/aux-records/GenericOpenIDClient.ts
@@ -1,0 +1,233 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type { OpenIDProviderConfiguration } from './OpenIDConfiguration';
+import type { Client } from 'openid-client';
+import { Issuer, generators } from 'openid-client';
+import { z } from 'zod';
+import { traced } from './tracing/TracingDecorators';
+import type { SpanOptions } from '@opentelemetry/api';
+import { SpanKind } from '@opentelemetry/api';
+
+/**
+ * Defines an interface for objects that can perform the OpenID Connect
+ * authorization code flow (with PKCE) against an arbitrary, dynamically
+ * configured OpenID provider.
+ */
+export interface GenericOpenIDClientInterface {
+    /**
+     * Generates a URL that can be used to authorize a user with the given provider.
+     * @param config The configuration of the provider that should be used.
+     * @param state The state that should be included in the request.
+     */
+    generateAuthorizationUrl(
+        config: OpenIDProviderConfiguration,
+        state: string
+    ): Promise<GenericOpenIDAuthorizationUrlResult>;
+
+    /**
+     * Processes the authorization callback from the given provider and exchanges the
+     * authorization code for tokens and user info.
+     * @param config The configuration of the provider that should be used.
+     * @param request The request.
+     */
+    processAuthorizationCallback(
+        config: OpenIDProviderConfiguration,
+        request: ProcessGenericOpenIDCallbackRequest
+    ): Promise<ProcessGenericOpenIDCallbackResponse>;
+}
+
+export interface GenericOpenIDAuthorizationUrlResult {
+    /**
+     * The URL that the user should be redirected to in order to authorize with the provider.
+     */
+    authorizationUrl: string;
+
+    /**
+     * The URL that the provider should redirect the user back to.
+     */
+    redirectUrl: string;
+
+    /**
+     * The PKCE code verifier that was generated for the request.
+     */
+    codeVerifier: string;
+
+    /**
+     * The PKCE code challenge method that was used for the request.
+     */
+    codeMethod: string;
+
+    /**
+     * The scope that was requested.
+     */
+    scope: string;
+}
+
+export interface ProcessGenericOpenIDCallbackRequest {
+    /**
+     * The authorization code that was received from the provider.
+     */
+    code: string;
+
+    /**
+     * The state that was received from the provider.
+     */
+    state: string;
+
+    /**
+     * The PKCE code verifier that was generated for the original request.
+     */
+    codeVerifier: string;
+
+    /**
+     * The URL that the provider redirected the user back to.
+     */
+    redirectUrl: string;
+}
+
+export interface GenericOpenIDUserInfo {
+    /**
+     * The subject that the provider reported for the user.
+     */
+    sub: string;
+
+    /**
+     * The email address that the provider reported for the user.
+     */
+    email?: string | null;
+
+    /**
+     * The name that the provider reported for the user.
+     */
+    name?: string | null;
+}
+
+export interface ProcessGenericOpenIDCallbackResponse {
+    accessToken: string;
+    refreshToken: string;
+    idToken: string;
+    expiresIn: number;
+    tokenType: string;
+    userInfo: GenericOpenIDUserInfo;
+}
+
+const TRACE_NAME = 'GenericOpenIDClient';
+const SPAN_OPTIONS: SpanOptions = {
+    kind: SpanKind.CLIENT,
+    attributes: {
+        'peer.service': 'openid',
+        'service.name': 'openid',
+    },
+};
+
+/**
+ * Defines a class that can perform the OpenID Connect authorization code flow
+ * (with PKCE) against arbitrary, dynamically configured OpenID providers.
+ *
+ * Discovered issuers/clients are cached per provider ID so that discovery only
+ * has to happen once per provider.
+ */
+export class GenericOpenIDClient implements GenericOpenIDClientInterface {
+    private _clients: Map<string, Client> = new Map();
+
+    private async _getClient(
+        config: OpenIDProviderConfiguration
+    ): Promise<Client> {
+        let client = this._clients.get(config.id);
+        if (!client) {
+            const issuer = await Issuer.discover(config.discoveryUri);
+            client = new issuer.Client({
+                client_id: config.clientId,
+                client_secret: config.clientSecret,
+                redirect_uris: [config.redirectUri],
+                response_types: ['code'],
+            });
+            this._clients.set(config.id, client);
+        }
+        return client;
+    }
+
+    @traced(TRACE_NAME, SPAN_OPTIONS)
+    async generateAuthorizationUrl(
+        config: OpenIDProviderConfiguration,
+        state: string
+    ): Promise<GenericOpenIDAuthorizationUrlResult> {
+        const client = await this._getClient(config);
+        const codeVerifier = generators.codeVerifier();
+        const codeChallenge = generators.codeChallenge(codeVerifier);
+        const codeMethod = 'S256';
+        const scope = config.requestScopes.join(' ');
+
+        const url = client.authorizationUrl({
+            scope,
+            code_challenge: codeChallenge,
+            code_challenge_method: codeMethod,
+            state,
+        });
+
+        return {
+            authorizationUrl: url,
+            redirectUrl: config.redirectUri,
+            codeMethod,
+            codeVerifier,
+            scope,
+        };
+    }
+
+    @traced(TRACE_NAME, SPAN_OPTIONS)
+    async processAuthorizationCallback(
+        config: OpenIDProviderConfiguration,
+        request: ProcessGenericOpenIDCallbackRequest
+    ): Promise<ProcessGenericOpenIDCallbackResponse> {
+        const client = await this._getClient(config);
+        const tokens = await client.callback(
+            request.redirectUrl,
+            {
+                code: request.code,
+                state: request.state,
+            },
+            {
+                state: request.state,
+                code_verifier: request.codeVerifier,
+            }
+        );
+
+        const data: any = await client.userinfo(tokens.access_token);
+
+        const schema = z.object({
+            sub: z.string(),
+            email: z.string().optional().nullable(),
+            name: z.string().optional().nullable(),
+        });
+
+        const validated = schema.parse(data);
+
+        return {
+            accessToken: tokens.access_token,
+            refreshToken: tokens.refresh_token,
+            idToken: tokens.id_token,
+            expiresIn: tokens.expires_in,
+            tokenType: tokens.token_type,
+            userInfo: {
+                sub: validated.sub,
+                email: validated.email,
+                name: validated.name,
+            },
+        };
+    }
+}

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -22,6 +22,7 @@ import type {
     AuthInvoice,
     AuthLoginRequest,
     AuthOpenIDLoginRequest,
+    AuthCustomOpenIDIdentity,
     AuthSession,
     AuthStore,
     AuthSubscription,
@@ -167,6 +168,7 @@ import type {
     StoredUpdates,
 } from './websockets';
 import type { PrivoConfiguration } from './PrivoConfiguration';
+import type { OpenIDConfiguration } from './OpenIDConfiguration';
 import type {
     ModerationFileScanResult,
     ModerationJob,
@@ -192,6 +194,7 @@ import type { WebManifest } from '@casual-simulation/aux-common/common/WebManife
 export interface MemoryConfiguration {
     subscriptions: SubscriptionConfiguration;
     privo?: PrivoConfiguration;
+    openid?: OpenIDConfiguration;
     moderation?: ModerationConfiguration;
     webConfig?: WebConfig;
 }
@@ -215,6 +218,7 @@ export class MemoryStore
     private _userAuthenticators: AuthUserAuthenticator[] = [];
     private _loginRequests: AuthLoginRequest[] = [];
     private _oidLoginRequests: AuthOpenIDLoginRequest[] = [];
+    private _openIdIdentities: AuthCustomOpenIDIdentity[] = [];
     private _webauthnLoginRequests: AuthWebAuthnLoginRequest[] = [];
     private _sessions: AuthSession[] = [];
     private _subscriptions: AuthSubscription[] = [];
@@ -247,6 +251,7 @@ export class MemoryStore
 
     private _subscriptionConfiguration: SubscriptionConfiguration | null;
     private _privoConfiguration: PrivoConfiguration | null = null;
+    private _openIdConfiguration: OpenIDConfiguration | null = null;
     private _moderationConfiguration: ModerationConfiguration | null = null;
     private _webConfig: WebConfig | null = null;
     private _playerWebManifest: WebManifest | null = null;
@@ -339,6 +344,10 @@ export class MemoryStore
         return this._oidLoginRequests;
     }
 
+    get openIdIdentities() {
+        return this._openIdIdentities;
+    }
+
     get webauthnLoginRequests() {
         return this._webauthnLoginRequests;
     }
@@ -385,6 +394,14 @@ export class MemoryStore
 
     set privoConfiguration(value: PrivoConfiguration | null) {
         this._privoConfiguration = value;
+    }
+
+    get openIdConfiguration() {
+        return this._openIdConfiguration;
+    }
+
+    set openIdConfiguration(value: OpenIDConfiguration | null) {
+        this._openIdConfiguration = value;
     }
 
     get moderationConfiguration() {
@@ -478,6 +495,7 @@ export class MemoryStore
     constructor(config: MemoryConfiguration) {
         this._subscriptionConfiguration = config.subscriptions;
         this._privoConfiguration = config.privo ?? null;
+        this._openIdConfiguration = config.openid ?? null;
         this._moderationConfiguration = config.moderation ?? null;
         this.policies = {};
         this.roles = {};
@@ -521,6 +539,8 @@ export class MemoryStore
                 finalValue as ModerationConfiguration;
         } else if (key === 'privo') {
             this._privoConfiguration = finalValue as PrivoConfiguration;
+        } else if (key === 'openid') {
+            this._openIdConfiguration = finalValue as OpenIDConfiguration;
         } else if (key === 'subscriptions') {
             this._subscriptionConfiguration =
                 finalValue as SubscriptionConfiguration;
@@ -548,6 +568,11 @@ export class MemoryStore
                     .parse(defaultValue ?? null)) as ConfigurationOutput<TKey>;
         } else if (key === 'privo') {
             return (this._privoConfiguration ??
+                CONFIGURATION_SCHEMAS_MAP[key]
+                    .nullable()
+                    .parse(defaultValue ?? null)) as ConfigurationOutput<TKey>;
+        } else if (key === 'openid') {
+            return (this._openIdConfiguration ??
                 CONFIGURATION_SCHEMAS_MAP[key]
                     .nullable()
                     .parse(defaultValue ?? null)) as ConfigurationOutput<TKey>;
@@ -779,6 +804,7 @@ export class MemoryStore
         const newStore = new MemoryStore({
             subscriptions: cloneDeep(this._subscriptionConfiguration),
             privo: cloneDeep(this._privoConfiguration),
+            openid: cloneDeep(this._openIdConfiguration),
             moderation: cloneDeep(this._moderationConfiguration),
             webConfig: cloneDeep(this._webConfig),
         });
@@ -786,6 +812,7 @@ export class MemoryStore
         newStore._users = cloneDeep(this._users);
         newStore._loginRequests = cloneDeep(this._loginRequests);
         newStore._oidLoginRequests = cloneDeep(this._oidLoginRequests);
+        newStore._openIdIdentities = cloneDeep(this._openIdIdentities);
         newStore._sessions = cloneDeep(this._sessions);
         newStore._subscriptions = cloneDeep(this._subscriptions);
         newStore._periods = cloneDeep(this._periods);
@@ -809,6 +836,7 @@ export class MemoryStore
             this._subscriptionConfiguration
         );
         newStore._privoConfiguration = cloneDeep(this._privoConfiguration);
+        newStore._openIdConfiguration = cloneDeep(this._openIdConfiguration);
         newStore._moderationConfiguration = cloneDeep(
             this._moderationConfiguration
         );
@@ -930,6 +958,10 @@ export class MemoryStore
 
     async getPrivoConfiguration(): Promise<PrivoConfiguration | null> {
         return this._privoConfiguration;
+    }
+
+    async getOpenIDConfiguration(): Promise<OpenIDConfiguration | null> {
+        return this._openIdConfiguration;
     }
 
     async getModerationConfig(): Promise<ModerationConfiguration | null> {
@@ -2006,6 +2038,32 @@ export class MemoryStore
             lr.authorizationTimeMs = authorizationTimeMs;
         } else {
             throw new Error('Request not found.');
+        }
+    }
+
+    async findUserIdForOpenIDIdentity(
+        provider: string,
+        subject: string
+    ): Promise<string | null> {
+        const identity = this._openIdIdentities.find(
+            (i) => i.provider === provider && i.subject === subject
+        );
+        return identity?.userId ?? null;
+    }
+
+    async saveOpenIDIdentity(
+        identity: AuthCustomOpenIDIdentity
+    ): Promise<void> {
+        const index = this._openIdIdentities.findIndex(
+            (i) =>
+                i.provider === identity.provider &&
+                i.subject === identity.subject
+        );
+
+        if (index >= 0) {
+            this._openIdIdentities[index] = identity;
+        } else {
+            this._openIdIdentities.push(identity);
         }
     }
 

--- a/src/aux-records/OpenIDConfiguration.ts
+++ b/src/aux-records/OpenIDConfiguration.ts
@@ -17,36 +17,98 @@
  */
 import z from 'zod';
 
-export const openIdProviderSchema = z.object({
-    id: z.string().nonempty().describe('The unique ID of the provider.'),
-    name: z
-        .string()
-        .nonempty()
-        .describe('The human-readable name of the provider.'),
-    discoveryUri: z
-        .string()
-        .nonempty()
-        .describe(
-            'The URI that OpenID configuration info should be discovered from.'
-        ),
-    redirectUri: z
-        .string()
-        .nonempty()
-        .describe('The URI that users should be redirected to after a login.'),
-    clientId: z
-        .string()
-        .nonempty()
-        .describe('The Client ID that should be used.'),
-    clientSecret: z
-        .string()
-        .nonempty()
-        .describe('The client secret that should be used.'),
-    requestScopes: z
-        .array(z.string().nonempty())
-        .optional()
-        .prefault(['openid', 'email', 'profile'])
-        .describe('The scopes that should be requested during login.'),
-});
+export const issuerMetadataSchema = z
+    .object({
+        issuer: z
+            .string()
+            .nonempty()
+            .describe('The identifier (URL) of the issuer.'),
+        authorization_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the authorization endpoint.'),
+        token_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the token endpoint.'),
+        jwks_uri: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the JSON Web Key Set document.'),
+        userinfo_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the userinfo endpoint.'),
+        revocation_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the token revocation endpoint.'),
+        end_session_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the end-session (logout) endpoint.'),
+        registration_endpoint: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe('The URL of the dynamic client registration endpoint.'),
+    })
+    .catchall(z.unknown())
+    .describe(
+        'Manually-specified issuer metadata. Passed directly to the openid-client Issuer constructor. Use this instead of discoveryUri when the provider does not support (or should not be trusted for) OpenID discovery.'
+    );
+
+export type IssuerMetadata = z.infer<typeof issuerMetadataSchema>;
+
+export const openIdProviderSchema = z
+    .object({
+        id: z.string().nonempty().describe('The unique ID of the provider.'),
+        name: z
+            .string()
+            .nonempty()
+            .describe('The human-readable name of the provider.'),
+        discoveryUri: z
+            .string()
+            .nonempty()
+            .optional()
+            .describe(
+                'The URI that OpenID configuration info should be discovered from. Either this or issuer must be specified.'
+            ),
+        issuer: issuerMetadataSchema
+            .optional()
+            .describe(
+                'The issuer metadata that should be used instead of discovery. Either this or discoveryUri must be specified.'
+            ),
+        redirectUri: z
+            .string()
+            .nonempty()
+            .describe(
+                'The URI that users should be redirected to after a login.'
+            ),
+        clientId: z
+            .string()
+            .nonempty()
+            .describe('The Client ID that should be used.'),
+        clientSecret: z
+            .string()
+            .nonempty()
+            .describe('The client secret that should be used.'),
+        requestScopes: z
+            .array(z.string().nonempty())
+            .optional()
+            .prefault(['openid', 'email', 'profile'])
+            .describe('The scopes that should be requested during login.'),
+    })
+    .refine((data) => !!data.discoveryUri || !!data.issuer, {
+        message: 'Either discoveryUri or issuer must be specified.',
+        path: ['discoveryUri'],
+    });
 
 export type OpenIDProviderConfiguration = z.infer<typeof openIdProviderSchema>;
 

--- a/src/aux-records/OpenIDConfiguration.ts
+++ b/src/aux-records/OpenIDConfiguration.ts
@@ -1,0 +1,79 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import z from 'zod';
+
+export const openIdProviderSchema = z.object({
+    id: z.string().nonempty().describe('The unique ID of the provider.'),
+    name: z
+        .string()
+        .nonempty()
+        .describe('The human-readable name of the provider.'),
+    discoveryUri: z
+        .string()
+        .nonempty()
+        .describe(
+            'The URI that OpenID configuration info should be discovered from.'
+        ),
+    redirectUri: z
+        .string()
+        .nonempty()
+        .describe('The URI that users should be redirected to after a login.'),
+    clientId: z
+        .string()
+        .nonempty()
+        .describe('The Client ID that should be used.'),
+    clientSecret: z
+        .string()
+        .nonempty()
+        .describe('The client secret that should be used.'),
+    requestScopes: z
+        .array(z.string().nonempty())
+        .optional()
+        .prefault(['openid', 'email', 'profile'])
+        .describe('The scopes that should be requested during login.'),
+});
+
+export type OpenIDProviderConfiguration = z.infer<typeof openIdProviderSchema>;
+
+export const openIdSchema = z.object({
+    providers: z
+        .array(openIdProviderSchema)
+        .optional()
+        .prefault([])
+        .describe('The list of custom OpenID providers that are configured.'),
+});
+
+export type OpenIDConfiguration = z.infer<typeof openIdSchema>;
+
+export function parseOpenIDConfiguration(
+    config: any,
+    defaultConfig: OpenIDConfiguration
+): OpenIDConfiguration {
+    if (config) {
+        const result = openIdSchema.safeParse(config);
+        if (result.success) {
+            return result.data as OpenIDConfiguration;
+        } else {
+            console.error(
+                '[OpenIDConfiguration] Invalid openid config',
+                result
+            );
+        }
+    }
+    return defaultConfig;
+}

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -137,6 +137,7 @@ import {
 import type { ConnectionInfo } from '@casual-simulation/aux-common/common/ConnectionInfo';
 import { constructInitializationUpdate } from '@casual-simulation/aux-common';
 import type { PrivoClientInterface } from './PrivoClient';
+import type { GenericOpenIDClientInterface } from './GenericOpenIDClient';
 import { DateTime } from 'luxon';
 import { ModerationController } from './ModerationController';
 import type {
@@ -557,6 +558,8 @@ describe('RecordsServer', () => {
     const recordName = 'testRecord';
     let privoClient: PrivoClientInterface;
     let privoClientMock: jest.MockedObject<PrivoClientInterface>;
+    let genericOpenIDClient: GenericOpenIDClientInterface;
+    let genericOpenIDClientMock: jest.MockedObject<GenericOpenIDClientInterface>;
 
     let domainNameValidator: jest.Mocked<DomainNameValidator>;
 
@@ -616,6 +619,10 @@ describe('RecordsServer', () => {
             resendConsentRequest: jest.fn(),
             lookupServiceId: jest.fn(),
         };
+        genericOpenIDClient = genericOpenIDClientMock = {
+            generateAuthorizationUrl: jest.fn(),
+            processAuthorizationCallback: jest.fn(),
+        };
         relyingParty = {
             id: 'relying_party_id',
             name: 'Relying Party',
@@ -628,7 +635,8 @@ describe('RecordsServer', () => {
             store,
             store,
             privoClient,
-            [relyingParty]
+            [relyingParty],
+            genericOpenIDClient
         );
 
         // manually disable the Privo flag for tests
@@ -4164,6 +4172,201 @@ describe('RecordsServer', () => {
             httpPost('/api/v2/login/privo', body, authenticatedHeaders)
         );
         testRateLimit('POST', `/api/v2/login/privo`, () => JSON.stringify({}));
+    });
+
+    describe('GET /api/v2/login/openid/list', () => {
+        it('should list the configured providers', async () => {
+            store.openIdConfiguration = {
+                providers: [
+                    {
+                        id: 'google',
+                        name: 'Google',
+                        discoveryUri:
+                            'https://accounts.google.com/.well-known/openid-configuration',
+                        redirectUri: 'https://example.com/redirect',
+                        clientId: 'clientId',
+                        clientSecret: 'clientSecret',
+                        requestScopes: ['openid', 'email', 'profile'],
+                    },
+                ],
+            };
+
+            const result = await server.handleHttpRequest(
+                httpGet('/api/v2/login/openid/list', {
+                    origin: 'https://account-origin.com',
+                })
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    providers: [
+                        {
+                            id: 'google',
+                            name: 'Google',
+                        },
+                    ],
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        it('should support procedures', async () => {
+            store.openIdConfiguration = {
+                providers: [
+                    {
+                        id: 'google',
+                        name: 'Google',
+                        discoveryUri:
+                            'https://accounts.google.com/.well-known/openid-configuration',
+                        redirectUri: 'https://example.com/redirect',
+                        clientId: 'clientId',
+                        clientSecret: 'clientSecret',
+                        requestScopes: ['openid', 'email', 'profile'],
+                    },
+                ],
+            };
+
+            const result = await server.handleHttpRequest(
+                procedureRequest('listOpenIDProviders', undefined, {
+                    origin: 'https://account-origin.com',
+                })
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    providers: [
+                        {
+                            id: 'google',
+                            name: 'Google',
+                        },
+                    ],
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        testOrigin('GET', '/api/v2/login/openid/list');
+    });
+
+    describe('POST /api/v2/login/openid', () => {
+        const providerConfig = {
+            id: 'google',
+            name: 'Google',
+            discoveryUri:
+                'https://accounts.google.com/.well-known/openid-configuration',
+            redirectUri: 'https://example.com/redirect',
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            requestScopes: ['openid', 'email', 'profile'],
+        };
+
+        beforeEach(() => {
+            store.openIdConfiguration = {
+                providers: [providerConfig],
+            };
+        });
+
+        it('should return a login request with the authorization URL', async () => {
+            genericOpenIDClientMock.generateAuthorizationUrl.mockResolvedValueOnce(
+                {
+                    authorizationUrl: 'https://authorization_url',
+                    codeMethod: 'method',
+                    codeVerifier: 'verifier',
+                    redirectUrl: 'https://redirect_url',
+                    scope: 'openid email profile',
+                }
+            );
+
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/login/openid`,
+                    JSON.stringify({ provider: 'google' }),
+                    {
+                        origin: 'https://account-origin.com',
+                    },
+                    '123.456.789'
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    authorizationUrl: 'https://authorization_url',
+                    requestId: expect.any(String),
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        it('should support procedures', async () => {
+            genericOpenIDClientMock.generateAuthorizationUrl.mockResolvedValueOnce(
+                {
+                    authorizationUrl: 'https://authorization_url',
+                    codeMethod: 'method',
+                    codeVerifier: 'verifier',
+                    redirectUrl: 'https://redirect_url',
+                    scope: 'openid email profile',
+                }
+            );
+
+            const result = await server.handleHttpRequest(
+                procedureRequest(
+                    `requestOpenIDLogin`,
+                    { provider: 'google' },
+                    {
+                        origin: 'https://account-origin.com',
+                    }
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    authorizationUrl: 'https://authorization_url',
+                    requestId: expect.any(String),
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        it('should return not_supported for an unconfigured provider', async () => {
+            const result = await server.handleHttpRequest(
+                httpPost(
+                    `/api/v2/login/openid`,
+                    JSON.stringify({ provider: 'not_google' }),
+                    {
+                        origin: 'https://account-origin.com',
+                    },
+                    '123.456.789'
+                )
+            );
+
+            await expectResponseBodyToEqual(result, {
+                statusCode: 501,
+                body: {
+                    success: false,
+                    errorCode: 'not_supported',
+                    errorMessage: 'The given provider is not supported.',
+                },
+                headers: accountCorsHeaders,
+            });
+        });
+
+        testOrigin('POST', '/api/v2/login/openid', () =>
+            JSON.stringify({ provider: 'google' })
+        );
+        testBodyIsJson((body) =>
+            httpPost('/api/v2/login/openid', body, authenticatedHeaders)
+        );
+        testRateLimit('POST', `/api/v2/login/openid`, () =>
+            JSON.stringify({ provider: 'google' })
+        );
     });
 
     describe('POST /api/v2/oauth/code', () => {

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -1272,6 +1272,32 @@ export class RecordsServer {
                     return result;
                 }),
 
+            listOpenIDProviders: procedure()
+                .origins('account')
+                .http('GET', '/api/v2/login/openid/list')
+                .handler(async (_, context) => {
+                    const result = await this._auth.listOpenIDProviders();
+
+                    return result;
+                }),
+
+            requestOpenIDLogin: procedure()
+                .origins('account')
+                .http('POST', '/api/v2/login/openid')
+                .inputs(
+                    z.object({
+                        provider: z.string().nonempty(),
+                    })
+                )
+                .handler(async ({ provider }, context) => {
+                    const result = await this._auth.requestOpenIDLogin({
+                        provider,
+                        ipAddress: context.ipAddress,
+                    });
+
+                    return result;
+                }),
+
             processOAuthCode: procedure()
                 .origins('account')
                 .http('POST', '/api/v2/oauth/code')
@@ -1304,6 +1330,7 @@ export class RecordsServer {
                     const result = await this._auth.completeOpenIDLogin({
                         ipAddress: context.ipAddress,
                         requestId,
+                        sessionKey: context.sessionKey ?? null,
                     });
 
                     return result;

--- a/src/aux-records/ServerConfig.ts
+++ b/src/aux-records/ServerConfig.ts
@@ -18,6 +18,7 @@
 import { moderationSchema } from './ModerationConfiguration';
 import { notificationsSchema } from './SystemNotificationMessenger';
 import { privoSchema } from './PrivoConfiguration';
+import { openIdSchema } from './OpenIDConfiguration';
 import { getSubscriptionConfigSchema } from './SubscriptionConfiguration';
 import { z } from 'zod';
 import { WEB_CONFIG_SCHEMA } from '@casual-simulation/aux-common';
@@ -1500,6 +1501,12 @@ Because repo/add_updates is a very common permission, we periodically cache perm
             .optional()
             .describe(
                 'Privo configuration options. If omitted, then Privo features will be disabled.'
+            ),
+
+        openid: openIdSchema
+            .optional()
+            .describe(
+                'Custom OpenID Connect provider configuration options. If omitted, then no custom OpenID providers will be available.'
             ),
 
         webauthn: webauthnSchema

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -1622,6 +1622,7 @@ Object {
             "values": Array [
               "subscriptions",
               "privo",
+              "openid",
               "moderation",
               "web",
               "playerWebManifest",
@@ -4055,6 +4056,14 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/login/openid/list",
+      },
+      "name": "listOpenIDProviders",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/records/package/list",
       },
       "inputs": Object {
@@ -6045,6 +6054,22 @@ Object {
         "type": "object",
       },
       "name": "requestLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login/openid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "provider": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestOpenIDLogin",
       "origins": "account",
     },
     Object {
@@ -9208,6 +9233,120 @@ Object {
                     "hasDefault": true,
                     "optional": true,
                     "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          Object {
+            "schema": Object {
+              "key": Object {
+                "type": "literal",
+                "value": "openid",
+              },
+              "value": Object {
+                "schema": Object {
+                  "providers": Object {
+                    "defaultValue": Array [],
+                    "description": "The list of custom OpenID providers that are configured.",
+                    "hasDefault": true,
+                    "optional": true,
+                    "schema": Object {
+                      "schema": Object {
+                        "clientId": Object {
+                          "description": "The Client ID that should be used.",
+                          "type": "string",
+                        },
+                        "clientSecret": Object {
+                          "description": "The client secret that should be used.",
+                          "type": "string",
+                        },
+                        "discoveryUri": Object {
+                          "description": "The URI that OpenID configuration info should be discovered from. Either this or issuer must be specified.",
+                          "optional": true,
+                          "type": "string",
+                        },
+                        "id": Object {
+                          "description": "The unique ID of the provider.",
+                          "type": "string",
+                        },
+                        "issuer": Object {
+                          "catchall": Object {
+                            "type": "any",
+                          },
+                          "description": "The issuer metadata that should be used instead of discovery. Either this or discoveryUri must be specified.",
+                          "optional": true,
+                          "schema": Object {
+                            "authorization_endpoint": Object {
+                              "description": "The URL of the authorization endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "end_session_endpoint": Object {
+                              "description": "The URL of the end-session (logout) endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "issuer": Object {
+                              "description": "The identifier (URL) of the issuer.",
+                              "type": "string",
+                            },
+                            "jwks_uri": Object {
+                              "description": "The URL of the JSON Web Key Set document.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "registration_endpoint": Object {
+                              "description": "The URL of the dynamic client registration endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "revocation_endpoint": Object {
+                              "description": "The URL of the token revocation endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "token_endpoint": Object {
+                              "description": "The URL of the token endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "userinfo_endpoint": Object {
+                              "description": "The URL of the userinfo endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "name": Object {
+                          "description": "The human-readable name of the provider.",
+                          "type": "string",
+                        },
+                        "redirectUri": Object {
+                          "description": "The URI that users should be redirected to after a login.",
+                          "type": "string",
+                        },
+                        "requestScopes": Object {
+                          "defaultValue": Array [
+                            "openid",
+                            "email",
+                            "profile",
+                          ],
+                          "description": "The scopes that should be requested during login.",
+                          "hasDefault": true,
+                          "optional": true,
+                          "schema": Object {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "array",
                   },
                 },
                 "type": "object",
@@ -12244,6 +12383,7 @@ Object {
             "values": Array [
               "subscriptions",
               "privo",
+              "openid",
               "moderation",
               "web",
               "playerWebManifest",
@@ -14677,6 +14817,14 @@ Object {
     Object {
       "http": Object {
         "method": "GET",
+        "path": "/api/v2/login/openid/list",
+      },
+      "name": "listOpenIDProviders",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "GET",
         "path": "/api/v2/records/package/list",
       },
       "inputs": Object {
@@ -16667,6 +16815,22 @@ Object {
         "type": "object",
       },
       "name": "requestLogin",
+      "origins": "account",
+    },
+    Object {
+      "http": Object {
+        "method": "POST",
+        "path": "/api/v2/login/openid",
+      },
+      "inputs": Object {
+        "schema": Object {
+          "provider": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "requestOpenIDLogin",
       "origins": "account",
     },
     Object {
@@ -19830,6 +19994,120 @@ Object {
                     "hasDefault": true,
                     "optional": true,
                     "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          Object {
+            "schema": Object {
+              "key": Object {
+                "type": "literal",
+                "value": "openid",
+              },
+              "value": Object {
+                "schema": Object {
+                  "providers": Object {
+                    "defaultValue": Array [],
+                    "description": "The list of custom OpenID providers that are configured.",
+                    "hasDefault": true,
+                    "optional": true,
+                    "schema": Object {
+                      "schema": Object {
+                        "clientId": Object {
+                          "description": "The Client ID that should be used.",
+                          "type": "string",
+                        },
+                        "clientSecret": Object {
+                          "description": "The client secret that should be used.",
+                          "type": "string",
+                        },
+                        "discoveryUri": Object {
+                          "description": "The URI that OpenID configuration info should be discovered from. Either this or issuer must be specified.",
+                          "optional": true,
+                          "type": "string",
+                        },
+                        "id": Object {
+                          "description": "The unique ID of the provider.",
+                          "type": "string",
+                        },
+                        "issuer": Object {
+                          "catchall": Object {
+                            "type": "any",
+                          },
+                          "description": "The issuer metadata that should be used instead of discovery. Either this or discoveryUri must be specified.",
+                          "optional": true,
+                          "schema": Object {
+                            "authorization_endpoint": Object {
+                              "description": "The URL of the authorization endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "end_session_endpoint": Object {
+                              "description": "The URL of the end-session (logout) endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "issuer": Object {
+                              "description": "The identifier (URL) of the issuer.",
+                              "type": "string",
+                            },
+                            "jwks_uri": Object {
+                              "description": "The URL of the JSON Web Key Set document.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "registration_endpoint": Object {
+                              "description": "The URL of the dynamic client registration endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "revocation_endpoint": Object {
+                              "description": "The URL of the token revocation endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "token_endpoint": Object {
+                              "description": "The URL of the token endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                            "userinfo_endpoint": Object {
+                              "description": "The URL of the userinfo endpoint.",
+                              "optional": true,
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "name": Object {
+                          "description": "The human-readable name of the provider.",
+                          "type": "string",
+                        },
+                        "redirectUri": Object {
+                          "description": "The URI that users should be redirected to after a login.",
+                          "type": "string",
+                        },
+                        "requestScopes": Object {
+                          "defaultValue": Array [
+                            "openid",
+                            "email",
+                            "profile",
+                          ],
+                          "description": "The scopes that should be requested during login.",
+                          "hasDefault": true,
+                          "optional": true,
+                          "schema": Object {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "array",
                   },
                 },
                 "type": "object",

--- a/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBAuthStore.ts
@@ -43,6 +43,7 @@ import type {
     AuthInvoice,
     AuthLoginRequest,
     AuthOpenIDLoginRequest,
+    AuthCustomOpenIDIdentity,
     AuthSession,
     AuthStore,
     AuthSubscription,
@@ -76,6 +77,7 @@ export const RECORD_KEYS_COLLECTION_NAME = 'recordKeys';
 export const STUDIOS_COLLECTION_NAME = 'studios';
 export const STUDIO_COM_ID_REQEUSTS_COLLECTION_NAME = 'studioComIdRequests';
 export const WEB_AUTHN_LOGIN_REQUESTS_COLLECTION_NAME = 'webAuthnLoginRequests';
+export const OPENID_IDENTITIES_COLLECTION_NAME = 'openIdIdentities';
 
 export class MongoDBAuthStore implements AuthStore, RecordsStore {
     private _users: Collection<MongoDBAuthUser>;
@@ -92,6 +94,7 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
     private _comIdRequests: Collection<MongoDBStudioComIdRequest>;
     private _userAuthenticators: Collection<MongoDBUserAuthenticator>;
     private _webauthnLoginRequests: Collection<MongoDBWebAuthnLoginRequest>;
+    private _openIdIdentities: Collection<MongoDBOpenIdIdentity>;
 
     private _db: Db;
 
@@ -137,6 +140,9 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
             db.collection<MongoDBWebAuthnLoginRequest>(
                 WEB_AUTHN_LOGIN_REQUESTS_COLLECTION_NAME
             );
+        this._openIdIdentities = db.collection<MongoDBOpenIdIdentity>(
+            OPENID_IDENTITIES_COLLECTION_NAME
+        );
     }
 
     saveCustomDomain(domain: CustomDomain): Promise<void> {
@@ -471,6 +477,36 @@ export class MongoDBAuthStore implements AuthStore, RecordsStore {
         authorizationTimeMs: number
     ): Promise<void> {
         throw new Error('Method not implemented.');
+    }
+
+    async findUserIdForOpenIDIdentity(
+        provider: string,
+        subject: string
+    ): Promise<string | null> {
+        const identity = await this._openIdIdentities.findOne({
+            provider,
+            subject,
+        });
+        return identity?.userId ?? null;
+    }
+
+    async saveOpenIDIdentity(
+        identity: AuthCustomOpenIDIdentity
+    ): Promise<void> {
+        await this._openIdIdentities.updateOne(
+            {
+                provider: identity.provider,
+                subject: identity.subject,
+            },
+            {
+                $set: {
+                    ...identity,
+                },
+            },
+            {
+                upsert: true,
+            }
+        );
     }
 
     async listEmailRules(): Promise<RegexRule[]> {
@@ -1570,6 +1606,14 @@ export interface MongoDBUserAuthenticator extends AuthUserAuthenticator {
 
 export interface MongoDBWebAuthnLoginRequest extends AuthWebAuthnLoginRequest {
     _id: string;
+}
+
+export interface MongoDBOpenIdIdentity {
+    _id?: string;
+    provider: string;
+    subject: string;
+    userId: string;
+    createdAtMs: number;
 }
 
 export interface MongoDBLoginRequest {

--- a/src/aux-server/aux-backend/mongo/MongoDBConfigurationStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBConfigurationStore.ts
@@ -24,6 +24,7 @@ import type {
 } from '@casual-simulation/aux-records';
 import {
     MODERATION_CONFIG_KEY,
+    OPENID_CONFIG_KEY,
     PLAYER_WEB_MANIFEST_KEY,
     PRIVO_CONFIG_KEY,
     SUBSCRIPTIONS_CONFIG_KEY,
@@ -33,6 +34,8 @@ import {
 import type { SubscriptionConfiguration } from '@casual-simulation/aux-records/SubscriptionConfiguration';
 import type { PrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
 import { parsePrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
+import type { OpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
+import { parseOpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
 import type { Collection } from 'mongodb';
 import type { ModerationConfiguration } from '@casual-simulation/aux-records/ModerationConfiguration';
 import { parseModerationConfiguration } from '@casual-simulation/aux-records/ModerationConfiguration';
@@ -108,6 +111,17 @@ export class MongoDBConfigurationStore implements ConfigurationStore {
         return parsePrivoConfiguration(
             item?.data,
             this._defaultConfiguration.privo
+        );
+    }
+
+    async getOpenIDConfiguration(): Promise<OpenIDConfiguration> {
+        const item = await this._collection.findOne({
+            _id: OPENID_CONFIG_KEY,
+        });
+
+        return parseOpenIDConfiguration(
+            item?.data,
+            this._defaultConfiguration.openid
         );
     }
 

--- a/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaAuthStore.ts
@@ -28,6 +28,7 @@ import type {
     AuthInvoice,
     AuthLoginRequest,
     AuthOpenIDLoginRequest,
+    AuthCustomOpenIDIdentity,
     AuthSession,
     AuthStore,
     AuthSubscription,
@@ -724,6 +725,46 @@ export class PrismaAuthStore implements AuthStore {
             data: {
                 authorizationCode: authorizationCode,
                 authorizationTime: convertToDate(authorizationTimeMs),
+            },
+        });
+    }
+
+    @traced(TRACE_NAME)
+    async findUserIdForOpenIDIdentity(
+        provider: string,
+        subject: string
+    ): Promise<string | null> {
+        const identity = await this._client.openIdIdentity.findUnique({
+            where: {
+                provider_subject: {
+                    provider,
+                    subject,
+                },
+            },
+        });
+
+        return identity?.userId ?? null;
+    }
+
+    @traced(TRACE_NAME)
+    async saveOpenIDIdentity(
+        identity: AuthCustomOpenIDIdentity
+    ): Promise<void> {
+        await this._client.openIdIdentity.upsert({
+            where: {
+                provider_subject: {
+                    provider: identity.provider,
+                    subject: identity.subject,
+                },
+            },
+            create: {
+                provider: identity.provider,
+                subject: identity.subject,
+                userId: identity.userId,
+                createdAt: convertToDate(identity.createdAtMs),
+            },
+            update: {
+                userId: identity.userId,
             },
         });
     }

--- a/src/aux-server/aux-backend/prisma/PrismaConfigurationStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaConfigurationStore.ts
@@ -27,6 +27,7 @@ import type {
 import {
     CONFIGURATION_SCHEMAS_MAP,
     MODERATION_CONFIG_KEY,
+    OPENID_CONFIG_KEY,
     PLAYER_WEB_MANIFEST_KEY,
     PRIVO_CONFIG_KEY,
     SUBSCRIPTIONS_CONFIG_KEY,
@@ -35,6 +36,8 @@ import {
 } from '@casual-simulation/aux-records';
 import type { PrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
 import { parsePrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
+import type { OpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
+import { parseOpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
 import type { PrismaClient } from './generated';
 import { parseModerationConfiguration } from '@casual-simulation/aux-records/ModerationConfiguration';
 import { traced } from '@casual-simulation/aux-records/tracing/TracingDecorators';
@@ -65,6 +68,9 @@ export class PrismaConfigurationStore implements ConfigurationStore {
         } else if (key === 'privo') {
             return this._defaultConfiguration
                 .privo as ConfigurationOutput<TKey>;
+        } else if (key === 'openid') {
+            return this._defaultConfiguration
+                .openid as ConfigurationOutput<TKey>;
         } else if (key === 'web') {
             return this._defaultConfiguration
                 .webConfig as ConfigurationOutput<TKey>;
@@ -179,6 +185,20 @@ export class PrismaConfigurationStore implements ConfigurationStore {
         return parsePrivoConfiguration(
             result?.data,
             this._defaultConfiguration.privo
+        );
+    }
+
+    @traced(TRACE_NAME)
+    async getOpenIDConfiguration(): Promise<OpenIDConfiguration> {
+        const result = await this._client.configuration.findUnique({
+            where: {
+                key: OPENID_CONFIG_KEY,
+            },
+        });
+
+        return parseOpenIDConfiguration(
+            result?.data,
+            this._defaultConfiguration.openid
         );
     }
 

--- a/src/aux-server/aux-backend/prisma/sqlite/SqliteAuthStore.ts
+++ b/src/aux-server/aux-backend/prisma/sqlite/SqliteAuthStore.ts
@@ -28,6 +28,7 @@ import type {
     AuthInvoice,
     AuthLoginRequest,
     AuthOpenIDLoginRequest,
+    AuthCustomOpenIDIdentity,
     AuthSession,
     AuthStore,
     AuthSubscription,
@@ -745,6 +746,46 @@ export class SqliteAuthStore implements AuthStore {
                 authorizationCode: authorizationCode,
                 authorizationTime: authorizationTimeMs,
                 updatedAt: Date.now(),
+            },
+        });
+    }
+
+    @traced(TRACE_NAME)
+    async findUserIdForOpenIDIdentity(
+        provider: string,
+        subject: string
+    ): Promise<string | null> {
+        const identity = await this._client.openIdIdentity.findUnique({
+            where: {
+                provider_subject: {
+                    provider,
+                    subject,
+                },
+            },
+        });
+
+        return identity?.userId ?? null;
+    }
+
+    @traced(TRACE_NAME)
+    async saveOpenIDIdentity(
+        identity: AuthCustomOpenIDIdentity
+    ): Promise<void> {
+        await this._client.openIdIdentity.upsert({
+            where: {
+                provider_subject: {
+                    provider: identity.provider,
+                    subject: identity.subject,
+                },
+            },
+            create: {
+                provider: identity.provider,
+                subject: identity.subject,
+                userId: identity.userId,
+                createdAt: identity.createdAtMs,
+            },
+            update: {
+                userId: identity.userId,
             },
         });
     }

--- a/src/aux-server/aux-backend/prisma/sqlite/SqliteConfigurationStore.ts
+++ b/src/aux-server/aux-backend/prisma/sqlite/SqliteConfigurationStore.ts
@@ -27,6 +27,7 @@ import type {
 import {
     CONFIGURATION_SCHEMAS_MAP,
     MODERATION_CONFIG_KEY,
+    OPENID_CONFIG_KEY,
     PLAYER_WEB_MANIFEST_KEY,
     PRIVO_CONFIG_KEY,
     SUBSCRIPTIONS_CONFIG_KEY,
@@ -35,6 +36,8 @@ import {
 } from '@casual-simulation/aux-records';
 import type { PrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
 import { parsePrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
+import type { OpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
+import { parseOpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
 import type { PrismaClient } from '../generated-sqlite';
 import { parseModerationConfiguration } from '@casual-simulation/aux-records/ModerationConfiguration';
 import { traced } from '@casual-simulation/aux-records/tracing/TracingDecorators';
@@ -66,6 +69,9 @@ export class SqliteConfigurationStore implements ConfigurationStore {
         } else if (key === 'privo') {
             return this._defaultConfiguration
                 .privo as ConfigurationOutput<TKey>;
+        } else if (key === 'openid') {
+            return this._defaultConfiguration
+                .openid as ConfigurationOutput<TKey>;
         } else if (key === 'web') {
             return this._defaultConfiguration
                 .webConfig as ConfigurationOutput<TKey>;
@@ -183,6 +189,20 @@ export class SqliteConfigurationStore implements ConfigurationStore {
         return parsePrivoConfiguration(
             result?.data,
             this._defaultConfiguration.privo
+        );
+    }
+
+    @traced(TRACE_NAME)
+    async getOpenIDConfiguration(): Promise<OpenIDConfiguration> {
+        const result = await this._client.configuration.findUnique({
+            where: {
+                key: OPENID_CONFIG_KEY,
+            },
+        });
+
+        return parseOpenIDConfiguration(
+            result?.data,
+            this._defaultConfiguration.openid
         );
     }
 

--- a/src/aux-server/aux-backend/schemas/auth.prisma
+++ b/src/aux-server/aux-backend/schemas/auth.prisma
@@ -64,6 +64,7 @@ model User {
 
     loginRequests LoginRequest[]
     webauthnLoginRequests WebAuthnLoginRequest[]
+    openIdIdentities OpenIdIdentity[]
     sessions AuthSession[]
     records Record[]
     recordKeys RecordKey[]
@@ -235,6 +236,19 @@ model OpenIDLoginRequest {
     updatedAt DateTime @updatedAt
 
     authSessions AuthSession[]
+}
+
+model OpenIdIdentity {
+    provider String
+    subject String
+
+    userId String
+    user User @relation(fields: [userId], references: [id], onDelete: Cascade, map: "OpenIdIdentity_userId_fkey1")
+
+    createdAt DateTime @default(now())
+
+    @@id([provider, subject])
+    @@index([userId])
 }
 
 model WebAuthnLoginRequest {

--- a/src/aux-server/aux-backend/schemas/migrations/20260708163000_add_openid_provider_config/migration.sql
+++ b/src/aux-server/aux-backend/schemas/migrations/20260708163000_add_openid_provider_config/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "OpenIdIdentity" (
+    "provider" STRING NOT NULL,
+    "subject" STRING NOT NULL,
+    "userId" STRING NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OpenIdIdentity_pkey" PRIMARY KEY ("provider","subject")
+);
+
+-- CreateIndex
+CREATE INDEX "OpenIdIdentity_userId_idx" ON "OpenIdIdentity"("userId");
+
+-- AddForeignKey
+ALTER TABLE "OpenIdIdentity" ADD CONSTRAINT "OpenIdIdentity_userId_fkey1" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
+++ b/src/aux-server/aux-backend/schemas/sqlite/auth.sqlite.prisma
@@ -62,6 +62,7 @@ model User {
 
     loginRequests LoginRequest[]
     webauthnLoginRequests WebAuthnLoginRequest[]
+    openIdIdentities OpenIdIdentity[]
     sessions AuthSession[]
     records Record[]
     recordKeys RecordKey[]
@@ -235,6 +236,19 @@ model OpenIDLoginRequest {
     updatedAt Decimal
 
     authSessions AuthSession[]
+}
+
+model OpenIdIdentity {
+    provider String
+    subject String
+
+    userId String
+    user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+    createdAt Decimal
+
+    @@id([provider, subject])
+    @@index([userId])
 }
 
 model WebAuthnLoginRequest {

--- a/src/aux-server/aux-backend/schemas/sqlite/migrations/20260708162856_add_openid_provider_config/migration.sql
+++ b/src/aux-server/aux-backend/schemas/sqlite/migrations/20260708162856_add_openid_provider_config/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "OpenIdIdentity" (
+    "provider" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" DECIMAL NOT NULL,
+
+    PRIMARY KEY ("provider", "subject"),
+    CONSTRAINT "OpenIdIdentity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "OpenIdIdentity_userId_idx" ON "OpenIdIdentity"("userId");

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -152,6 +152,8 @@ import { RedisMultiCache } from '../redis/RedisMultiCache';
 import { PrivoClient } from '@casual-simulation/aux-records/PrivoClient';
 import { PrismaPrivoStore } from '../prisma/PrismaPrivoStore';
 import type { PrivoConfiguration } from '@casual-simulation/aux-records/PrivoConfiguration';
+import type { OpenIDConfiguration } from '@casual-simulation/aux-records/OpenIDConfiguration';
+import { GenericOpenIDClient } from '@casual-simulation/aux-records/GenericOpenIDClient';
 import { SlackNotificationMessenger } from '../notifications/SlackNotificationMessenger';
 import { TelegramNotificationMessenger } from '../notifications/TelegramNotificationMessenger';
 import { PrismaModerationStore } from '../prisma/PrismaModerationStore';
@@ -325,6 +327,8 @@ export class ServerBuilder implements SubscriptionLike {
 
     private _privoClient: PrivoClient;
     private _privoStore: PrivoStore;
+    private _genericOpenIDClient: GenericOpenIDClient =
+        new GenericOpenIDClient();
 
     private _configStore: ConfigurationStore;
     private _metricsStore: MetricsStore;
@@ -643,6 +647,7 @@ export class ServerBuilder implements SubscriptionLike {
             | 'moderation'
             | 'server'
             | 'privo'
+            | 'openid'
             | 'meta'
         > = this._options
     ): this {
@@ -694,6 +699,7 @@ export class ServerBuilder implements SubscriptionLike {
                             options.moderation as ModerationConfiguration,
                         webConfig: options.server?.webConfig as WebConfig,
                         privo: options.privo as PrivoConfiguration,
+                        openid: options.openid as OpenIDConfiguration,
                         playerWebManifest: options.server?.playerWebManifest,
                         meta: options.meta,
                     },
@@ -2315,7 +2321,8 @@ export class ServerBuilder implements SubscriptionLike {
             this._configStore,
             this._recordsStore,
             this._privoClient,
-            this._relyingParties ?? []
+            this._relyingParties ?? [],
+            this._genericOpenIDClient
         );
         this._recordsController = new RecordsController({
             store: this._recordsStore,
@@ -2873,6 +2880,7 @@ export class ServerBuilder implements SubscriptionLike {
             | 'subscriptions'
             | 'moderation'
             | 'privo'
+            | 'openid'
             | 'server'
             | 'meta'
         >
@@ -2883,6 +2891,7 @@ export class ServerBuilder implements SubscriptionLike {
                 subscriptions:
                     options.subscriptions as SubscriptionConfiguration,
                 privo: options.privo as PrivoConfiguration,
+                openid: options.openid as OpenIDConfiguration,
                 moderation: options.moderation as ModerationConfiguration,
                 webConfig: options.server?.webConfig as WebConfig,
                 playerWebManifest: options.server?.playerWebManifest,
@@ -2893,6 +2902,7 @@ export class ServerBuilder implements SubscriptionLike {
                 subscriptions:
                     options.subscriptions as SubscriptionConfiguration,
                 privo: options.privo as PrivoConfiguration,
+                openid: options.openid as OpenIDConfiguration,
                 moderation: options.moderation as ModerationConfiguration,
                 webConfig: options.server?.webConfig as WebConfig,
                 playerWebManifest: options.server?.playerWebManifest,


### PR DESCRIPTION
Servers can now configure arbitrary OpenID Connect providers via
ServerConfig (openid.providers), in addition to the existing
Privo integration. Adds listOpenIDProviders and requestOpenIDLogin
procedures, generalizes AuthController's OpenID login flow to
dispatch between Privo and custom providers, and gates linking a
custom OpenID identity to an existing user behind a valid session
key (session_key_required_for_openid) to prevent account takeover
via a rogue OpenID account sharing an existing user's email.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018gnNNpkUou5rTWEZbizjPp