### PR TITLE
fix: 501 error on records endpoint for billing

### DIFF
--- a/src/aux-records/DataRecordsController.spec.ts
+++ b/src/aux-records/DataRecordsController.spec.ts
@@ -1735,6 +1735,92 @@ describe('DataRecordsController', () => {
                 );
             });
 
+            it('should bill the record credit account for reads when record billing is enabled and a records store is provided', async () => {
+                const dataStoreWithoutRecordLookup = {
+                    setData: store.setData.bind(store),
+                    getData: store.getData.bind(store),
+                    listData: store.listData.bind(store),
+                    listDataByMarker: store.listDataByMarker.bind(store),
+                    eraseData: store.eraseData.bind(store),
+                } as any;
+
+                const localManager = new DataRecordsController({
+                    policies,
+                    store: dataStoreWithoutRecordLookup,
+                    metrics: store,
+                    config: store,
+                    financialController,
+                    recordsStore: store,
+                } as any);
+
+                const ownerAccount = unwrap(
+                    await financialController.getAccountBalance({
+                        userId: userId,
+                        ledger: LEDGERS.credits,
+                    })
+                );
+
+                const recordBudgetAccount = unwrap(
+                    await financialController.getOrCreateFinancialAccount({
+                        userId: otherUserId,
+                        ledger: LEDGERS.credits,
+                    })
+                );
+
+                unwrap(
+                    await financialController.internalTransaction({
+                        transfers: [
+                            {
+                                amount: 1000n,
+                                debitAccountId: ACCOUNT_IDS.liquidity_credits,
+                                creditAccountId: recordBudgetAccount.account.id,
+                                code: TransferCodes.admin_credit,
+                                currency: CurrencyCodes.credits,
+                            },
+                        ],
+                    })
+                );
+
+                const record = await store.getRecordByName('testRecord');
+                await store.updateRecord({
+                    ...record,
+                    creditAccountId: recordBudgetAccount.account.id,
+                    creditBillingEnabled: true,
+                } as any);
+
+                const result = (await localManager.getData(
+                    'testRecord',
+                    'address'
+                )) as GetDataSuccess;
+
+                expect(result.success).toBe(true);
+
+                await checkAccounts(financialInterface, [
+                    {
+                        id: BigInt(ownerAccount!.accountId),
+                        credits_posted: 1000n,
+                        debits_posted: 0n,
+                        credits_pending: 0n,
+                        debits_pending: 0n,
+                    },
+                    {
+                        id: recordBudgetAccount.account.id,
+                        credits_posted: 1000n,
+                        debits_posted: 25n,
+                        credits_pending: 0n,
+                        debits_pending: 0n,
+                    },
+                ]);
+
+                await checkBillingTotals(
+                    financialController,
+                    recordBudgetAccount.account.id.toString(),
+                    {
+                        [BillingCodes.data_read]: 25n,
+                    }
+                );
+            });
+
             it('should bill the record credit account for reads when record billing is enabled', async () => {
                 const ownerAccount = unwrap(
                     await financialController.getAccountBalance({

--- a/src/aux-records/DataRecordsController.ts
+++ b/src/aux-records/DataRecordsController.ts
@@ -50,6 +50,7 @@ import {
 } from '@casual-simulation/aux-common';
 import type { MetricsStore } from './MetricsStore';
 import type { ConfigurationStore } from './ConfigurationStore';
+import type { RecordsStore } from './RecordsStore';
 import { getSubscriptionFeatures } from './SubscriptionConfiguration';
 import { byteLengthOfString } from './Utils';
 import type { ZodIssue } from 'zod';
@@ -74,6 +75,7 @@ export interface DataRecordsConfiguration {
     policies: PolicyController;
     metrics: MetricsStore;
     config: ConfigurationStore;
+    recordsStore?: RecordsStore | null;
 
     searchSyncQueue?: IQueue<SearchSyncQueueEvent> | null;
 
@@ -88,6 +90,7 @@ export class DataRecordsController {
     private _policies: PolicyController;
     private _metrics: MetricsStore;
     private _config: ConfigurationStore;
+    private _recordsStore: RecordsStore | null;
     private _financialController: FinancialController | null;
 
     private _searchSyncQueue: IQueue<SearchSyncQueueEvent> | null;
@@ -101,6 +104,7 @@ export class DataRecordsController {
         this._policies = config.policies;
         this._metrics = config.metrics;
         this._config = config.config;
+        this._recordsStore = config.recordsStore || null;
         this._searchSyncQueue = config.searchSyncQueue || null;
         this._financialController = config.financialController || null;
     }
@@ -343,7 +347,7 @@ export class DataRecordsController {
                 // Determine the billing account - either the record's credit account or the owner
                 const billingAccountResult = await getBillingAccountForRecord(
                     recordName,
-                    this._store as {
+                    (this._recordsStore ?? this._store) as {
                         getRecordByName?: (name: string) => Promise<{
                             ownerId?: string;
                             studioId?: string;
@@ -509,7 +513,7 @@ export class DataRecordsController {
                 // Determine the billing account - either the record's credit account or the owner
                 const billingAccountResult = await getBillingAccountForRecord(
                     context.context.recordName,
-                    this._store as {
+                    (this._recordsStore ?? this._store) as {
                         getRecordByName?: (name: string) => Promise<{
                             ownerId?: string;
                             studioId?: string;

--- a/src/aux-records/FileRecordsController.ts
+++ b/src/aux-records/FileRecordsController.ts
@@ -47,6 +47,7 @@ import {
 import { getMarkersOrDefault, getRootMarkersOrDefault } from './Utils';
 import type { MetricsStore } from './MetricsStore';
 import type { ConfigurationStore } from './ConfigurationStore';
+import type { RecordsStore } from './RecordsStore';
 import { getSubscriptionFeatures } from './SubscriptionConfiguration';
 import { traced } from './tracing/TracingDecorators';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
@@ -66,6 +67,7 @@ export interface FileRecordsConfiguration {
     store: FileRecordsStore;
     metrics: MetricsStore;
     config: ConfigurationStore;
+    recordsStore?: RecordsStore | null;
     financialController?: FinancialController | null;
 }
 
@@ -77,6 +79,7 @@ export class FileRecordsController {
     private _store: FileRecordsStore;
     private _metrics: MetricsStore;
     private _config: ConfigurationStore;
+    private _recordsStore: RecordsStore | null;
     private _financialController: FinancialController | null;
 
     constructor(config: FileRecordsConfiguration) {
@@ -84,6 +87,7 @@ export class FileRecordsController {
         this._store = config.store;
         this._metrics = config.metrics;
         this._config = config.config;
+        this._recordsStore = config.recordsStore || null;
         this._financialController = config.financialController || null;
     }
 
@@ -307,7 +311,7 @@ export class FileRecordsController {
                 // Determine the billing account - either the record's credit account or the owner
                 const billingAccountResult = await getBillingAccountForRecord(
                     recordName,
-                    this._store as {
+                    (this._recordsStore ?? this._store) as {
                         getRecordByName?: (name: string) => Promise<{
                             ownerId?: string | null;
                             studioId?: string | null;

--- a/src/aux-server/aux-backend/shared/ServerBuilder.ts
+++ b/src/aux-server/aux-backend/shared/ServerBuilder.ts
@@ -2343,6 +2343,7 @@ export class ServerBuilder implements SubscriptionLike {
             config: this._configStore,
             policies: this._policyController,
             metrics: this._metricsStore,
+            recordsStore: this._recordsStore,
             searchSyncQueue: this._searchQueue,
             financialController: this._financialController,
         });
@@ -2351,6 +2352,7 @@ export class ServerBuilder implements SubscriptionLike {
             config: this._configStore,
             policies: this._policyController,
             metrics: this._metricsStore,
+            recordsStore: this._recordsStore,
             financialController: this._financialController,
         });
         this._filesController = new FileRecordsController({
@@ -2358,6 +2360,7 @@ export class ServerBuilder implements SubscriptionLike {
             config: this._configStore,
             policies: this._policyController,
             metrics: this._metricsStore,
+            recordsStore: this._recordsStore,
             financialController: this._financialController,
         });
         this._eventsController = new EventRecordsController({


### PR DESCRIPTION
### Fix applied for the 501 on the records endpoint
The problem was not the route itself; it was the newer record-level billing path that runs for data reads/writes. When billing was enabled, the data/file controllers tried to resolve the record through the data-store object, but that object does not provide record lookup, which caused the backend to fall through to a not_supported result and return 501.
What changed

- Wired record lookup for billing through the real records store in `DataRecordsController.ts`
- Applied the same fix to file billing in `FileRecordsController.ts`
- Passed the records store from the server builder in `ServerBuilder.ts`
- Added regression coverage in `DataRecordsController.spec.ts`