### PR TITLE
Support filtering data records by arbitrary filters (#873)

### DIFF
--- a/src/aux-records/DataRecordsController.spec.ts
+++ b/src/aux-records/DataRecordsController.spec.ts
@@ -2635,6 +2635,50 @@ describe('DataRecordsController', () => {
                 },
             });
         });
+
+        it('should only return items that match the given filter', async () => {
+            for (let i = 0; i < 5; i++) {
+                await store.setData(
+                    'testRecord',
+                    'address/' + i,
+                    { num: i },
+                    userId,
+                    'subjectId',
+                    true,
+                    true,
+                    [PUBLIC_READ_MARKER]
+                );
+            }
+
+            const result = await manager.listDataByMarker({
+                recordKeyOrName: 'testRecord',
+                startingAddress: null,
+                userId,
+                marker: PUBLIC_READ_MARKER,
+                filter: {
+                    num: { $gt: 2 },
+                },
+            });
+
+            expect(result).toEqual({
+                success: true,
+                recordName: 'testRecord',
+                items: [
+                    {
+                        address: 'address/3',
+                        data: { num: 3 },
+                        markers: [PUBLIC_READ_MARKER],
+                    },
+                    {
+                        address: 'address/4',
+                        data: { num: 4 },
+                        markers: [PUBLIC_READ_MARKER],
+                    },
+                ],
+                totalCount: 2,
+                marker: PUBLIC_READ_MARKER,
+            });
+        });
     });
 
     describe('eraseData()', () => {

--- a/src/aux-records/DataRecordsController.ts
+++ b/src/aux-records/DataRecordsController.ts
@@ -26,6 +26,7 @@ import type {
     UserPolicy,
     ListDataStoreFailure,
 } from './DataRecordsStore';
+import type { DataFilter } from './DataRecordsFilters';
 import { doesSubjectMatchPolicy, isValidUserPolicy } from './DataRecordsStore';
 import type { ValidatePublicRecordKeyFailure } from './RecordsController';
 import type {
@@ -697,6 +698,7 @@ export class DataRecordsController {
                 marker: request.marker,
                 startingAddress: request.startingAddress,
                 sort: request.sort,
+                filter: request.filter,
             });
 
             if (result2.success === false) {
@@ -1119,6 +1121,12 @@ export interface ListDataByMarkerRequest {
      * Defaults to "ascending".
      */
     sort?: 'ascending' | 'descending';
+
+    /**
+     * The filter that should be used to narrow down the items that are returned.
+     * Only supported when listing by marker.
+     */
+    filter?: DataFilter;
 }
 
 /**

--- a/src/aux-records/DataRecordsFilters.spec.ts
+++ b/src/aux-records/DataRecordsFilters.spec.ts
@@ -1,0 +1,300 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import {
+    buildPrismaJsonWhereFilter,
+    matchesDataFilter,
+    parseDataFilter,
+} from './DataRecordsFilters';
+
+describe('parseDataFilter()', () => {
+    it('should return a failure when given null or undefined', () => {
+        expect(parseDataFilter(null).success).toBe(false);
+        expect(parseDataFilter(undefined).success).toBe(false);
+    });
+
+    it('should return a failure when given a non-object', () => {
+        expect(parseDataFilter('abc').success).toBe(false);
+        expect(parseDataFilter(123).success).toBe(false);
+        expect(parseDataFilter([1, 2, 3]).success).toBe(false);
+    });
+
+    it('should return a failure when given an empty object', () => {
+        expect(parseDataFilter({}).success).toBe(false);
+    });
+
+    const operatorCases: [string, any][] = [
+        ['$eq', { abc: { $eq: 'def' } }],
+        ['$gt', { num: { $gt: 10 } }],
+        ['$gte', { num: { $gte: 10 } }],
+        ['$lt', { num: { $lt: 10 } }],
+        ['$lte', { num: { $lte: 10 } }],
+        ['$in', { prop1: { $in: ['abc', 'def', 123, true] } }],
+        ['$startsWith', { name: { $startsWith: 'abc' } }],
+        ['$endsWith', { name: { $endsWith: 'abc' } }],
+        ['$contains', { name: { $contains: 'abc' } }],
+        ['$isNull', { name: { $isNull: true } }],
+    ];
+
+    it.each(operatorCases)('should accept a valid %s filter', (op, filter) => {
+        const result = parseDataFilter(filter);
+        expect(result.success).toBe(true);
+    });
+
+    it('should accept $and combinations', () => {
+        const result = parseDataFilter({
+            $and: [{ prop1: { $eq: true } }, { prop2: { $eq: true } }],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('should accept $or combinations', () => {
+        const result = parseDataFilter({
+            $or: [{ prop1: { $eq: true } }, { prop2: { $eq: true } }],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('should accept $not', () => {
+        const result = parseDataFilter({
+            $not: { prop1: { $eq: true } },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject an unknown operator', () => {
+        const result = parseDataFilter({ abc: { $regex: 'def' } });
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept a filter nested using the maximum of 5 combination expressions', () => {
+        // Every additional $and/$or/$not also counts against the 5-combinator
+        // limit, so the deepest reachable nesting chains exactly 5 of them.
+        let filter: any = { prop: { $eq: true } };
+        for (let i = 0; i < 5; i++) {
+            filter = { $not: filter };
+        }
+        const result = parseDataFilter(filter);
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject more than 10 conditions in an $and array', () => {
+        const conditions = [];
+        for (let i = 0; i < 11; i++) {
+            conditions.push({ [`prop${i}`]: { $eq: true } });
+        }
+        const result = parseDataFilter({ $and: conditions });
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept up to 10 conditions in an $and array', () => {
+        const conditions = [];
+        for (let i = 0; i < 10; i++) {
+            conditions.push({ [`prop${i}`]: { $eq: true } });
+        }
+        const result = parseDataFilter({ $and: conditions });
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject more than 5 total combination expressions', () => {
+        // 1 outer $and + 5 inner $or = 6 total combinators, over the limit of 5.
+        const result = parseDataFilter({
+            $and: [
+                { $or: [{ a: { $eq: 1 } }, { b: { $eq: 2 } }] },
+                { $or: [{ c: { $eq: 1 } }, { d: { $eq: 2 } }] },
+                { $or: [{ e: { $eq: 1 } }, { f: { $eq: 2 } }] },
+                { $or: [{ g: { $eq: 1 } }, { h: { $eq: 2 } }] },
+                { $or: [{ i: { $eq: 1 } }, { j: { $eq: 2 } }] },
+            ],
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept exactly 5 total combination expressions', () => {
+        // 1 outer $and + 4 inner $or = 5 total combinators, exactly at the limit.
+        const result = parseDataFilter({
+            $and: [
+                { $or: [{ a: { $eq: 1 } }, { b: { $eq: 2 } }] },
+                { $or: [{ c: { $eq: 1 } }, { d: { $eq: 2 } }] },
+                { $or: [{ e: { $eq: 1 } }, { f: { $eq: 2 } }] },
+                { $or: [{ g: { $eq: 1 } }, { h: { $eq: 2 } }] },
+            ],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject strings longer than 200 characters', () => {
+        const result = parseDataFilter({
+            prop: { $eq: 'a'.repeat(201) },
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept strings up to 200 characters', () => {
+        const result = parseDataFilter({
+            prop: { $eq: 'a'.repeat(200) },
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject objects with more than 10 properties', () => {
+        const filter: any = {};
+        for (let i = 0; i < 11; i++) {
+            filter[`prop${i}`] = { $eq: true };
+        }
+        const result = parseDataFilter(filter);
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept objects with up to 10 properties', () => {
+        const filter: any = {};
+        for (let i = 0; i < 10; i++) {
+            filter[`prop${i}`] = { $eq: true };
+        }
+        const result = parseDataFilter(filter);
+        expect(result.success).toBe(true);
+    });
+
+    it('should reject $in sets with more than 20 values', () => {
+        const values = [];
+        for (let i = 0; i < 21; i++) {
+            values.push(i);
+        }
+        const result = parseDataFilter({ prop: { $in: values } });
+        expect(result.success).toBe(false);
+    });
+
+    it('should accept $in sets with up to 20 values', () => {
+        const values = [];
+        for (let i = 0; i < 20; i++) {
+            values.push(i);
+        }
+        const result = parseDataFilter({ prop: { $in: values } });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('matchesDataFilter()', () => {
+    const cases: [boolean, any, any][] = [
+        [true, { abc: 'def' }, { abc: { $eq: 'def' } }],
+        [false, { abc: 'xyz' }, { abc: { $eq: 'def' } }],
+        [true, { num: 11 }, { num: { $gt: 10 } }],
+        [false, { num: 10 }, { num: { $gt: 10 } }],
+        [true, { num: 10 }, { num: { $gte: 10 } }],
+        [true, { num: 9 }, { num: { $lt: 10 } }],
+        [false, { num: 10 }, { num: { $lt: 10 } }],
+        [true, { num: 10 }, { num: { $lte: 10 } }],
+        [true, { prop1: 'abc' }, { prop1: { $in: ['abc', 'def'] } }],
+        [false, { prop1: 'xyz' }, { prop1: { $in: ['abc', 'def'] } }],
+        [true, { name: 'abcdef' }, { name: { $startsWith: 'abc' } }],
+        [false, { name: 'defabc' }, { name: { $startsWith: 'abc' } }],
+        [true, { name: 'defabc' }, { name: { $endsWith: 'abc' } }],
+        [false, { name: 'abcdef' }, { name: { $endsWith: 'abc' } }],
+        [true, { name: 'xyzabcdef' }, { name: { $contains: 'abc' } }],
+        [false, { name: 'xyzdef' }, { name: { $contains: 'abc' } }],
+        [true, { name: null }, { name: { $isNull: true } }],
+        [true, {}, { name: { $isNull: true } }],
+        [false, { name: 'abc' }, { name: { $isNull: true } }],
+        [true, { name: 'abc' }, { name: { $isNull: false } }],
+    ];
+
+    it.each(cases)(
+        'should return %s for %s given %s',
+        (expected, data, filter) => {
+            expect(matchesDataFilter(data, filter)).toBe(expected);
+        }
+    );
+
+    it('should support $and', () => {
+        const filter = {
+            $and: [{ prop1: { $eq: true } }, { prop2: { $eq: true } }],
+        };
+        expect(matchesDataFilter({ prop1: true, prop2: true }, filter)).toBe(
+            true
+        );
+        expect(matchesDataFilter({ prop1: true, prop2: false }, filter)).toBe(
+            false
+        );
+    });
+
+    it('should support $or', () => {
+        const filter = {
+            $or: [{ prop1: { $eq: true } }, { prop2: { $eq: true } }],
+        };
+        expect(matchesDataFilter({ prop1: true, prop2: false }, filter)).toBe(
+            true
+        );
+        expect(matchesDataFilter({ prop1: false, prop2: false }, filter)).toBe(
+            false
+        );
+    });
+
+    it('should support $not', () => {
+        const filter = {
+            $not: { prop1: { $eq: true } },
+        };
+        expect(matchesDataFilter({ prop1: false }, filter)).toBe(true);
+        expect(matchesDataFilter({ prop1: true }, filter)).toBe(false);
+    });
+
+    it('should support multiple operators on the same field as an implicit AND', () => {
+        const filter = { num: { $gt: 5, $lt: 10 } };
+        expect(matchesDataFilter({ num: 7 }, filter)).toBe(true);
+        expect(matchesDataFilter({ num: 3 }, filter)).toBe(false);
+        expect(matchesDataFilter({ num: 12 }, filter)).toBe(false);
+    });
+});
+
+describe('buildPrismaJsonWhereFilter()', () => {
+    it('should build a path/equals condition for $eq', () => {
+        const result = buildPrismaJsonWhereFilter(
+            { abc: { $eq: 'def' } },
+            'data'
+        );
+        expect(result).toEqual({
+            data: { path: ['abc'], equals: 'def' },
+        });
+    });
+
+    it('should build an OR of equals conditions for $in', () => {
+        const result = buildPrismaJsonWhereFilter(
+            { prop1: { $in: ['abc', 'def'] } },
+            'data'
+        );
+        expect(result).toEqual({
+            OR: [
+                { data: { path: ['prop1'], equals: 'abc' } },
+                { data: { path: ['prop1'], equals: 'def' } },
+            ],
+        });
+    });
+
+    it('should build nested AND/OR/NOT conditions', () => {
+        const result = buildPrismaJsonWhereFilter(
+            {
+                $and: [{ prop1: { $eq: true } }, { prop2: { $eq: true } }],
+            },
+            'data'
+        );
+        expect(result).toEqual({
+            AND: [
+                { data: { path: ['prop1'], equals: true } },
+                { data: { path: ['prop2'], equals: true } },
+            ],
+        });
+    });
+});

--- a/src/aux-records/DataRecordsFilters.ts
+++ b/src/aux-records/DataRecordsFilters.ts
@@ -1,0 +1,606 @@
+/* CasualOS is a set of web-based tools designed to facilitate the creation of real-time, multi-user, context-aware interactive experiences.
+ *
+ * Copyright (c) 2019-2025 Casual Simulation, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The maximum depth that a data filter can be nested to.
+ */
+export const MAX_FILTER_DEPTH = 25;
+
+/**
+ * The maximum number of conditions that a single $and/$or array can contain.
+ */
+export const MAX_COMBINATOR_CONDITIONS = 10;
+
+/**
+ * The maximum number of combination expressions ($and, $or, $not) that are allowed in a filter.
+ */
+export const MAX_TOTAL_COMBINATORS = 5;
+
+/**
+ * The maximum length that a string value in a filter can be.
+ */
+export const MAX_FILTER_STRING_LENGTH = 200;
+
+/**
+ * The maximum number of properties that an object in a filter can have.
+ */
+export const MAX_FILTER_OBJECT_PROPERTIES = 10;
+
+/**
+ * The maximum number of values that a $in set can contain.
+ */
+export const MAX_FILTER_SET_VALUES = 20;
+
+const FIELD_FILTER_OPERATORS = [
+    '$eq',
+    '$gt',
+    '$gte',
+    '$lt',
+    '$lte',
+    '$in',
+    '$startsWith',
+    '$endsWith',
+    '$contains',
+    '$isNull',
+] as const;
+
+const COMBINATOR_KEYS = ['$and', '$or', '$not'] as const;
+
+/**
+ * A single scalar value that can appear in a data filter.
+ */
+export type DataFilterValue = string | number | boolean | null;
+
+/**
+ * Defines the operators that can be applied to a single field of the data.
+ */
+export interface DataFieldFilter {
+    $eq?: DataFilterValue;
+    $gt?: number | string;
+    $gte?: number | string;
+    $lt?: number | string;
+    $lte?: number | string;
+    $in?: DataFilterValue[];
+    $startsWith?: string;
+    $endsWith?: string;
+    $contains?: string;
+    $isNull?: boolean;
+}
+
+/**
+ * Defines a filter that can be applied to JSON data.
+ * Each key is either a combination expression ($and, $or, $not) or the name of a
+ * property that should be tested with a DataFieldFilter.
+ */
+export interface DataFilter {
+    $and?: DataFilter[];
+    $or?: DataFilter[];
+    $not?: DataFilter;
+    [field: string]: DataFieldFilter | DataFilter[] | DataFilter | undefined;
+}
+
+/**
+ * Defines the result of attempting to parse a data filter.
+ */
+export type ParseDataFilterResult =
+    | {
+          success: true;
+          filter: DataFilter;
+      }
+    | {
+          success: false;
+          errorMessage: string;
+      };
+
+interface ParseContext {
+    /**
+     * The total number of combination expressions ($and, $or, $not) that have been
+     * encountered so far while parsing the filter.
+     */
+    totalCombinators: number;
+}
+
+/**
+ * Attempts to parse the given value as a data filter.
+ * Returns a failure result if the value is not a valid filter, or if the filter
+ * exceeds any of the size/depth limits.
+ * @param value The value that should be parsed.
+ */
+export function parseDataFilter(value: unknown): ParseDataFilterResult {
+    if (value === null || value === undefined) {
+        return {
+            success: false,
+            errorMessage: 'filter must be an object.',
+        };
+    }
+
+    const context: ParseContext = {
+        totalCombinators: 0,
+    };
+
+    const result = _parseFilterNode(value, 1, context);
+    if (result.success === false) {
+        return result;
+    }
+
+    return {
+        success: true,
+        filter: result.filter,
+    };
+}
+
+function _parseFilterNode(
+    value: unknown,
+    depth: number,
+    context: ParseContext
+): ParseDataFilterResult {
+    if (depth > MAX_FILTER_DEPTH) {
+        return {
+            success: false,
+            errorMessage: `filter must not be nested more than ${MAX_FILTER_DEPTH} levels deep.`,
+        };
+    }
+
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {
+            success: false,
+            errorMessage: 'filter must be an object.',
+        };
+    }
+
+    const keys = Object.keys(value as object);
+    if (keys.length === 0) {
+        return {
+            success: false,
+            errorMessage: 'filter must have at least one property.',
+        };
+    }
+    if (keys.length > MAX_FILTER_OBJECT_PROPERTIES) {
+        return {
+            success: false,
+            errorMessage: `filter objects must not have more than ${MAX_FILTER_OBJECT_PROPERTIES} properties.`,
+        };
+    }
+
+    const filter: DataFilter = {};
+
+    for (let key of keys) {
+        const propValue = (value as any)[key];
+
+        if (key === '$and' || key === '$or') {
+            context.totalCombinators += 1;
+            if (context.totalCombinators > MAX_TOTAL_COMBINATORS) {
+                return {
+                    success: false,
+                    errorMessage: `filters must not contain more than ${MAX_TOTAL_COMBINATORS} combination expressions ($and, $or, $not).`,
+                };
+            }
+
+            if (!Array.isArray(propValue)) {
+                return {
+                    success: false,
+                    errorMessage: `${key} must be an array of filters.`,
+                };
+            }
+            if (propValue.length === 0) {
+                return {
+                    success: false,
+                    errorMessage: `${key} must not be empty.`,
+                };
+            }
+            if (propValue.length > MAX_COMBINATOR_CONDITIONS) {
+                return {
+                    success: false,
+                    errorMessage: `${key} must not contain more than ${MAX_COMBINATOR_CONDITIONS} conditions.`,
+                };
+            }
+
+            const parsedChildren: DataFilter[] = [];
+            for (let child of propValue) {
+                const childResult = _parseFilterNode(child, depth + 1, context);
+                if (childResult.success === false) {
+                    return childResult;
+                }
+                parsedChildren.push(childResult.filter);
+            }
+
+            filter[key] = parsedChildren;
+        } else if (key === '$not') {
+            context.totalCombinators += 1;
+            if (context.totalCombinators > MAX_TOTAL_COMBINATORS) {
+                return {
+                    success: false,
+                    errorMessage: `filters must not contain more than ${MAX_TOTAL_COMBINATORS} combination expressions ($and, $or, $not).`,
+                };
+            }
+
+            const childResult = _parseFilterNode(propValue, depth + 1, context);
+            if (childResult.success === false) {
+                return childResult;
+            }
+
+            filter.$not = childResult.filter;
+        } else {
+            const fieldResult = _parseFieldFilter(key, propValue, depth);
+            if (fieldResult.success === false) {
+                return fieldResult;
+            }
+            filter[key] = fieldResult.filter;
+        }
+    }
+
+    return {
+        success: true,
+        filter,
+    };
+}
+
+function _parseFieldFilter(
+    field: string,
+    value: unknown,
+    depth: number
+): { success: true; filter: DataFieldFilter } | ParseDataFilterResult {
+    if (field.length > MAX_FILTER_STRING_LENGTH) {
+        return {
+            success: false,
+            errorMessage: `field names must not be longer than ${MAX_FILTER_STRING_LENGTH} characters.`,
+        };
+    }
+
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {
+            success: false,
+            errorMessage: `${field} must be an object that specifies a filter operator.`,
+        };
+    }
+
+    const keys = Object.keys(value as object);
+    if (keys.length === 0) {
+        return {
+            success: false,
+            errorMessage: `${field} must specify at least one filter operator.`,
+        };
+    }
+    if (keys.length > MAX_FILTER_OBJECT_PROPERTIES) {
+        return {
+            success: false,
+            errorMessage: `filter objects must not have more than ${MAX_FILTER_OBJECT_PROPERTIES} properties.`,
+        };
+    }
+
+    const result: DataFieldFilter = {};
+
+    for (let key of keys) {
+        if (!(FIELD_FILTER_OPERATORS as readonly string[]).includes(key)) {
+            return {
+                success: false,
+                errorMessage: `${field}.${key} is not a supported filter operator.`,
+            };
+        }
+
+        const opValue = (value as any)[key];
+
+        if (key === '$in') {
+            if (!Array.isArray(opValue)) {
+                return {
+                    success: false,
+                    errorMessage: `${field}.$in must be an array of values.`,
+                };
+            }
+            if (opValue.length > MAX_FILTER_SET_VALUES) {
+                return {
+                    success: false,
+                    errorMessage: `${field}.$in must not contain more than ${MAX_FILTER_SET_VALUES} values.`,
+                };
+            }
+            for (let v of opValue) {
+                const valueResult = _validateScalarValue(`${field}.$in`, v);
+                if (valueResult.success === false) {
+                    return valueResult;
+                }
+            }
+            result.$in = opValue;
+        } else if (
+            key === '$startsWith' ||
+            key === '$endsWith' ||
+            key === '$contains'
+        ) {
+            if (typeof opValue !== 'string') {
+                return {
+                    success: false,
+                    errorMessage: `${field}.${key} must be a string.`,
+                };
+            }
+            if (opValue.length > MAX_FILTER_STRING_LENGTH) {
+                return {
+                    success: false,
+                    errorMessage: `${field}.${key} must not be longer than ${MAX_FILTER_STRING_LENGTH} characters.`,
+                };
+            }
+            (result as any)[key] = opValue;
+        } else if (key === '$isNull') {
+            if (typeof opValue !== 'boolean') {
+                return {
+                    success: false,
+                    errorMessage: `${field}.$isNull must be a boolean.`,
+                };
+            }
+            result.$isNull = opValue;
+        } else if (
+            key === '$gt' ||
+            key === '$gte' ||
+            key === '$lt' ||
+            key === '$lte'
+        ) {
+            if (typeof opValue !== 'number' && typeof opValue !== 'string') {
+                return {
+                    success: false,
+                    errorMessage: `${field}.${key} must be a number or a string.`,
+                };
+            }
+            if (
+                typeof opValue === 'string' &&
+                opValue.length > MAX_FILTER_STRING_LENGTH
+            ) {
+                return {
+                    success: false,
+                    errorMessage: `${field}.${key} must not be longer than ${MAX_FILTER_STRING_LENGTH} characters.`,
+                };
+            }
+            (result as any)[key] = opValue;
+        } else if (key === '$eq') {
+            const valueResult = _validateScalarValue(`${field}.$eq`, opValue);
+            if (valueResult.success === false) {
+                return valueResult;
+            }
+            result.$eq = opValue;
+        }
+    }
+
+    return {
+        success: true,
+        filter: result,
+    };
+}
+
+function _validateScalarValue(
+    path: string,
+    value: unknown
+): { success: true } | ParseDataFilterResult {
+    if (
+        value !== null &&
+        typeof value !== 'string' &&
+        typeof value !== 'number' &&
+        typeof value !== 'boolean'
+    ) {
+        return {
+            success: false,
+            errorMessage: `${path} must be a string, number, boolean, or null.`,
+        };
+    }
+    if (typeof value === 'string' && value.length > MAX_FILTER_STRING_LENGTH) {
+        return {
+            success: false,
+            errorMessage: `${path} must not be longer than ${MAX_FILTER_STRING_LENGTH} characters.`,
+        };
+    }
+    return { success: true };
+}
+
+/**
+ * Determines if the given data matches the given filter.
+ * @param data The data that should be tested.
+ * @param filter The filter that the data should be tested against.
+ */
+export function matchesDataFilter(data: any, filter: DataFilter): boolean {
+    for (let key of Object.keys(filter)) {
+        if (key === '$and') {
+            const children = filter.$and as DataFilter[];
+            if (!children.every((child) => matchesDataFilter(data, child))) {
+                return false;
+            }
+        } else if (key === '$or') {
+            const children = filter.$or as DataFilter[];
+            if (!children.some((child) => matchesDataFilter(data, child))) {
+                return false;
+            }
+        } else if (key === '$not') {
+            const child = filter.$not as DataFilter;
+            if (matchesDataFilter(data, child)) {
+                return false;
+            }
+        } else {
+            const fieldFilter = filter[key] as DataFieldFilter;
+            const fieldValue =
+                data !== null && typeof data === 'object'
+                    ? data[key]
+                    : undefined;
+            if (!_matchesFieldFilter(fieldValue, fieldFilter)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+function _matchesFieldFilter(
+    value: any,
+    fieldFilter: DataFieldFilter
+): boolean {
+    for (let op of Object.keys(fieldFilter) as (keyof DataFieldFilter)[]) {
+        switch (op) {
+            case '$eq':
+                if (value !== fieldFilter.$eq) {
+                    return false;
+                }
+                break;
+            case '$gt':
+                if (!(value > fieldFilter.$gt!)) {
+                    return false;
+                }
+                break;
+            case '$gte':
+                if (!(value >= fieldFilter.$gte!)) {
+                    return false;
+                }
+                break;
+            case '$lt':
+                if (!(value < fieldFilter.$lt!)) {
+                    return false;
+                }
+                break;
+            case '$lte':
+                if (!(value <= fieldFilter.$lte!)) {
+                    return false;
+                }
+                break;
+            case '$in':
+                if (!fieldFilter.$in!.includes(value)) {
+                    return false;
+                }
+                break;
+            case '$startsWith':
+                if (
+                    typeof value !== 'string' ||
+                    !value.startsWith(fieldFilter.$startsWith!)
+                ) {
+                    return false;
+                }
+                break;
+            case '$endsWith':
+                if (
+                    typeof value !== 'string' ||
+                    !value.endsWith(fieldFilter.$endsWith!)
+                ) {
+                    return false;
+                }
+                break;
+            case '$contains':
+                if (
+                    typeof value !== 'string' ||
+                    !value.includes(fieldFilter.$contains!)
+                ) {
+                    return false;
+                }
+                break;
+            case '$isNull': {
+                const isNull = value === null || value === undefined;
+                if (isNull !== fieldFilter.$isNull) {
+                    return false;
+                }
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Builds a Prisma JSON where-filter fragment for the given data filter.
+ * The returned object is shaped like a Prisma `WhereInput` and can be merged
+ * into a store's existing where clause via an `AND` array.
+ * @param filter The filter that should be translated.
+ * @param fieldName The name of the JSON column that the filter should be applied to.
+ */
+export function buildPrismaJsonWhereFilter(
+    filter: DataFilter,
+    fieldName: string
+): any {
+    const conditions: any[] = [];
+
+    for (let key of Object.keys(filter)) {
+        if (key === '$and') {
+            conditions.push({
+                AND: (filter.$and as DataFilter[]).map((child) =>
+                    buildPrismaJsonWhereFilter(child, fieldName)
+                ),
+            });
+        } else if (key === '$or') {
+            conditions.push({
+                OR: (filter.$or as DataFilter[]).map((child) =>
+                    buildPrismaJsonWhereFilter(child, fieldName)
+                ),
+            });
+        } else if (key === '$not') {
+            conditions.push({
+                NOT: buildPrismaJsonWhereFilter(
+                    filter.$not as DataFilter,
+                    fieldName
+                ),
+            });
+        } else {
+            const fieldFilter = filter[key] as DataFieldFilter;
+            for (let op of Object.keys(
+                fieldFilter
+            ) as (keyof DataFieldFilter)[]) {
+                if (op === '$in') {
+                    conditions.push({
+                        OR: fieldFilter.$in!.map((v) => ({
+                            [fieldName]: { path: [key], equals: v },
+                        })),
+                    });
+                } else {
+                    conditions.push({
+                        [fieldName]: _buildPrismaFieldCondition(
+                            key,
+                            op,
+                            fieldFilter
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    if (conditions.length === 1) {
+        return conditions[0];
+    }
+
+    return { AND: conditions };
+}
+
+function _buildPrismaFieldCondition(
+    field: string,
+    op: Exclude<keyof DataFieldFilter, '$in'>,
+    fieldFilter: DataFieldFilter
+): any {
+    const path = [field];
+    switch (op) {
+        case '$eq':
+            return { path, equals: fieldFilter.$eq };
+        case '$gt':
+            return { path, gt: fieldFilter.$gt };
+        case '$gte':
+            return { path, gte: fieldFilter.$gte };
+        case '$lt':
+            return { path, lt: fieldFilter.$lt };
+        case '$lte':
+            return { path, lte: fieldFilter.$lte };
+        case '$startsWith':
+            return { path, string_starts_with: fieldFilter.$startsWith };
+        case '$endsWith':
+            return { path, string_ends_with: fieldFilter.$endsWith };
+        case '$contains':
+            return { path, string_contains: fieldFilter.$contains };
+        case '$isNull':
+            return fieldFilter.$isNull
+                ? { path, equals: null }
+                : { path, not: null };
+    }
+}

--- a/src/aux-records/DataRecordsStore.ts
+++ b/src/aux-records/DataRecordsStore.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import type { ServerError } from '@casual-simulation/aux-common/Errors';
+import type { DataFilter } from './DataRecordsFilters';
 
 /**
  * Defines an interface for objects that can store data records.
@@ -126,7 +127,7 @@ export interface ListDataStoreSuccess {
 
 export interface ListDataStoreFailure {
     success: false;
-    errorCode: ServerError;
+    errorCode: ServerError | 'not_supported';
     errorMessage: string;
 }
 
@@ -167,6 +168,12 @@ export interface ListDataStoreByMarkerRequest {
      * If not provided, a default value will be used.
      */
     count?: number;
+
+    /**
+     * The filter that should be used to narrow down the items that are returned.
+     * If not provided, then all items with the given marker will be returned.
+     */
+    filter?: DataFilter;
 }
 
 /**

--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -70,6 +70,7 @@ import type {
     SetDataResult,
     UserPolicy,
 } from './DataRecordsStore';
+import { matchesDataFilter } from './DataRecordsFilters';
 import type {
     AddFileResult,
     EraseFileStoreResult,
@@ -2603,7 +2604,11 @@ export class MemoryStore
 
         let count = 0;
         for (let [key, item] of record.entries()) {
-            if (item.markers.includes(marker)) {
+            if (
+                item.markers.includes(marker) &&
+                (!request.filter ||
+                    matchesDataFilter(item.data, request.filter))
+            ) {
                 count += 1;
                 if (
                     !address ||

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -10664,6 +10664,116 @@ describe('RecordsServer', () => {
             });
         });
 
+        describe('?filter', () => {
+            beforeEach(async () => {
+                await dataController.recordData(
+                    recordKey,
+                    'address4',
+                    { num: 5 },
+                    userId,
+                    null,
+                    null
+                );
+                await dataController.recordData(
+                    recordKey,
+                    'address5',
+                    { num: 10 },
+                    userId,
+                    null,
+                    null
+                );
+            });
+
+            it('should only return items that match the filter', async () => {
+                const filter = encodeURIComponent(
+                    JSON.stringify({ num: { $gt: 6 } })
+                );
+                const result = await server.handleHttpRequest(
+                    httpGet(
+                        `/api/v2/records/data/list?recordName=${recordName}&marker=${PUBLIC_READ_MARKER}&filter=${filter}`,
+                        defaultHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 200,
+                    body: {
+                        success: true,
+                        recordName,
+                        items: [
+                            {
+                                address: 'address5',
+                                data: { num: 10 },
+                                markers: [PUBLIC_READ_MARKER],
+                            },
+                        ],
+                        totalCount: 1,
+                        marker: PUBLIC_READ_MARKER,
+                    },
+                    headers: corsHeaders(defaultHeaders['origin']),
+                });
+            });
+
+            it('should return an unacceptable_request result when filter is given without a marker', async () => {
+                const filter = encodeURIComponent(
+                    JSON.stringify({ num: { $gt: 6 } })
+                );
+                const result = await server.handleHttpRequest(
+                    httpGet(
+                        `/api/v2/records/data/list?recordName=${recordName}&filter=${filter}`,
+                        defaultHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 400,
+                    body: {
+                        success: false,
+                        errorCode: 'unacceptable_request',
+                        errorMessage:
+                            'filter can only be used when listing data by marker.',
+                    },
+                    headers: corsHeaders(defaultHeaders['origin']),
+                });
+            });
+
+            it('should return an unacceptable_request result when the filter is malformed', async () => {
+                const filter = encodeURIComponent(
+                    JSON.stringify({ num: { $regex: 'abc' } })
+                );
+                const result = await server.handleHttpRequest(
+                    httpGet(
+                        `/api/v2/records/data/list?recordName=${recordName}&marker=${PUBLIC_READ_MARKER}&filter=${filter}`,
+                        defaultHeaders
+                    )
+                );
+
+                expect(result.statusCode).toBe(400);
+                const body = JSON.parse(result.body as string);
+                expect(body.success).toBe(false);
+                expect(body.errorCode).toBe('unacceptable_request');
+            });
+
+            it('should return an unacceptable_request result when the filter is not valid JSON', async () => {
+                const result = await server.handleHttpRequest(
+                    httpGet(
+                        `/api/v2/records/data/list?recordName=${recordName}&marker=${PUBLIC_READ_MARKER}&filter=not-json`,
+                        defaultHeaders
+                    )
+                );
+
+                await expectResponseBodyToEqual(result, {
+                    statusCode: 400,
+                    body: {
+                        success: false,
+                        errorCode: 'unacceptable_request',
+                        errorMessage: 'filter must be valid JSON.',
+                    },
+                    headers: corsHeaders(defaultHeaders['origin']),
+                });
+            });
+        });
+
         it('should be able to list all data', async () => {
             await dataController.recordData(
                 recordKey,

--- a/src/aux-records/RecordsServer.spec.ts
+++ b/src/aux-records/RecordsServer.spec.ts
@@ -399,7 +399,7 @@ describe('RecordsServer', () => {
         });
 
         savedMemoryStore = services.store;
-    });
+    }, 60000);
 
     afterAll(() => {
         if (tbClient) {

--- a/src/aux-records/RecordsServer.tsx
+++ b/src/aux-records/RecordsServer.tsx
@@ -43,6 +43,8 @@ import type { LivekitController } from './LivekitController';
 import type { RecordsController } from './RecordsController';
 import type { EventRecordsController } from './EventRecordsController';
 import type { DataRecordsController } from './DataRecordsController';
+import { parseDataFilter } from './DataRecordsFilters';
+import type { DataFilter } from './DataRecordsFilters';
 import type { FileRecordsController } from './FileRecordsController';
 import type {
     CreateManageSubscriptionRequest,
@@ -2049,11 +2051,19 @@ export class RecordsServer {
                             .nullable(),
                         instances:
                             INSTANCES_ARRAY_VALIDATION.optional().nullable(),
+                        filter: z.any().optional().nullable(),
                     })
                 )
                 .handler(
                     async (
-                        { recordName, address, instances, marker, sort },
+                        {
+                            recordName,
+                            address,
+                            instances,
+                            marker,
+                            sort,
+                            filter,
+                        },
                         context
                     ) => {
                         if (!recordName || typeof recordName !== 'string') {
@@ -2075,6 +2085,42 @@ export class RecordsServer {
                                 errorMessage:
                                     'address must be null or a string.',
                             } as const;
+                        }
+
+                        let parsedFilter: DataFilter | undefined;
+                        if (filter !== null && typeof filter !== 'undefined') {
+                            if (!marker) {
+                                return {
+                                    success: false,
+                                    errorCode: 'unacceptable_request',
+                                    errorMessage:
+                                        'filter can only be used when listing data by marker.',
+                                } as const;
+                            }
+
+                            let filterValue: unknown = filter;
+                            if (typeof filter === 'string') {
+                                const jsonResult = tryParseJson(filter);
+                                if (!jsonResult.success) {
+                                    return {
+                                        success: false,
+                                        errorCode: 'unacceptable_request',
+                                        errorMessage:
+                                            'filter must be valid JSON.',
+                                    } as const;
+                                }
+                                filterValue = jsonResult.value;
+                            }
+
+                            const filterResult = parseDataFilter(filterValue);
+                            if (filterResult.success === false) {
+                                return {
+                                    success: false,
+                                    errorCode: 'unacceptable_request',
+                                    errorMessage: filterResult.errorMessage,
+                                } as const;
+                            }
+                            parsedFilter = filterResult.filter;
                         }
 
                         const sessionKeyValidation =
@@ -2102,6 +2148,7 @@ export class RecordsServer {
                                 sort: sort,
                                 userId: sessionKeyValidation.userId,
                                 instances,
+                                filter: parsedFilter,
                             });
 
                             return result;

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -3741,6 +3741,11 @@ Object {
             "optional": true,
             "type": "string",
           },
+          "filter": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "any",
+          },
           "instances": Object {
             "maxLength": 3,
             "minLength": 1,
@@ -14507,6 +14512,11 @@ Object {
             "nullable": true,
             "optional": true,
             "type": "string",
+          },
+          "filter": Object {
+            "nullable": true,
+            "optional": true,
+            "type": "any",
           },
           "instances": Object {
             "maxLength": 3,

--- a/src/aux-records/index.ts
+++ b/src/aux-records/index.ts
@@ -23,6 +23,7 @@ export * from './RecordsStore';
 export * from './Utils';
 export * from './DataRecordsController';
 export * from './DataRecordsStore';
+export * from './DataRecordsFilters';
 
 export * from './FileRecordsController';
 export * from './FileRecordsStore';

--- a/src/aux-server/aux-backend/mongo/MongoDBDataRecordsStore.ts
+++ b/src/aux-server/aux-backend/mongo/MongoDBDataRecordsStore.ts
@@ -131,6 +131,15 @@ export class MongoDBDataRecordsStore implements DataRecordsStore {
     async listDataByMarker(
         request: ListDataStoreByMarkerRequest
     ): Promise<ListDataStoreResult> {
+        if (request.filter) {
+            return {
+                success: false,
+                errorCode: 'not_supported',
+                errorMessage:
+                    'Filtering data by a custom filter is not supported by this store.',
+            };
+        }
+
         let query = {
             recordName: { $eq: request.recordName },
             markers: request.marker,

--- a/src/aux-server/aux-backend/prisma/PrismaDataRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaDataRecordsStore.ts
@@ -24,6 +24,7 @@ import type {
     UserPolicy,
     ListDataStoreByMarkerRequest,
 } from '@casual-simulation/aux-records';
+import { buildPrismaJsonWhereFilter } from '@casual-simulation/aux-records';
 
 import type { PrismaClient } from './generated';
 import { Prisma } from './generated';
@@ -197,12 +198,23 @@ export class PrismaDataRecordsStore implements DataRecordsStore {
             }
         }
 
+        let countQuery: Prisma.DataRecordWhereInput = {
+            recordName: request.recordName,
+            markers: { has: request.marker },
+        };
+
+        if (request.filter) {
+            const filterCondition = buildPrismaJsonWhereFilter(
+                request.filter,
+                'data'
+            ) as Prisma.DataRecordWhereInput;
+            query = { AND: [query, filterCondition] };
+            countQuery = { AND: [countQuery, filterCondition] };
+        }
+
         const [count, records] = await Promise.all([
             (this._collection.count as PrismaClient['dataRecord']['count'])({
-                where: {
-                    recordName: request.recordName,
-                    markers: { has: request.marker },
-                },
+                where: countQuery,
             }),
             (
                 this._collection

--- a/src/aux-server/aux-backend/prisma/sqlite/SqliteDataRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/sqlite/SqliteDataRecordsStore.ts
@@ -24,6 +24,7 @@ import type {
     UserPolicy,
     ListDataStoreByMarkerRequest,
 } from '@casual-simulation/aux-records';
+import { matchesDataFilter } from '@casual-simulation/aux-records';
 
 import type {
     PrismaClient,
@@ -219,11 +220,42 @@ export class SqliteDataRecordsStore implements DataRecordsStore {
         //     }),
         // ]);
 
+        const limit = request.count || 10;
+
+        if (request.filter) {
+            // SQLite can't push JSON filters into SQL, so LIMIT is dropped and the filter is applied in JS before slicing the page.
+            const recordsPromise: Prisma.PrismaPromise<PrismaDataRecord[]> =
+                !!request.startingAddress
+                    ? request.sort === 'descending'
+                        ? this._client
+                              .$queryRaw`SELECT "address", "data", "markers" FROM "DataRecord" WHERE "recordName" = ${request.recordName} AND ${request.marker} IN json_each("markers") AND "address" < ${request.startingAddress} ORDER BY "address" DESC`
+                        : this._client
+                              .$queryRaw`SELECT "address", "data", "markers" FROM "DataRecord" WHERE "recordName" = ${request.recordName} AND ${request.marker} IN json_each("markers") AND "address" > ${request.startingAddress} ORDER BY "address" ASC`
+                    : this._client
+                          .$queryRaw`SELECT "address", "data", "markers" FROM "DataRecord" WHERE "recordName" = ${request.recordName} AND ${request.marker} IN json_each("markers") ORDER BY "address" ASC`;
+
+            const records = await recordsPromise;
+            const filtered = records.filter((r) =>
+                matchesDataFilter(r.data, request.filter)
+            );
+            const page = filtered.slice(0, limit);
+
+            return {
+                success: true,
+                items: page.map((r) => ({
+                    address: r.address,
+                    data: r.data,
+                    markers: convertMarkers(r.markers as string[]),
+                })),
+                totalCount: filtered.length,
+                marker: null,
+            };
+        }
+
         const countPromise = this._client.$queryRaw<
             { count: number }[]
         >`SELECT COUNT(*) as count FROM "DataRecord" WHERE "recordName" = ${request.recordName} AND ${request.marker} IN json_each("markers")`;
 
-        const limit = request.count || 10;
         const recordsPromise: Prisma.PrismaPromise<PrismaDataRecord[]> =
             !!request.startingAddress
                 ? request.sort === 'descending'


### PR DESCRIPTION
Adds a MongoDB-style `filter` option to `listData` when listing by
marker, so callers can narrow results by JSON content in addition to
marker/address pagination. Filters support $eq/$gt/$gte/$lt/$lte/$in/
$startsWith/$endsWith/$contains/$isNull with $and/$or/$not combinators,
and are bounded by depth/size limits.

Implemented via a new DataRecordsFilters module (parser + JS evaluator
+ Prisma JSON where-clause builder), wired through RecordsServer,
DataRecordsController, DataRecordsStore, and all four store
implementations (Memory, Prisma, Sqlite, Mongo). Sqlite applies the
filter in JS on top of its existing raw marker query since Prisma
can't push JSON filters into SQLite; Mongo rejects filters as
not_supported since it's out of the issue's listed scope.