### PR TITLE
Add configurable update retention for branch permanent storage

### DIFF
--- a/src/aux-records/MemoryStore.ts
+++ b/src/aux-records/MemoryStore.ts
@@ -4049,7 +4049,8 @@ export class MemoryStore
         inst: string,
         branch: string,
         updateToAdd: string,
-        sizeInBytes: number
+        sizeInBytes: number,
+        numberOfUpdatesToKeep?: number
     ): Promise<ReplaceUpdatesResult> {
         const r = this._instRecords.get(recordName);
 
@@ -4095,13 +4096,24 @@ export class MemoryStore
         storedUpdates.updates = [];
         storedUpdates.timestamps = [];
 
-        return this.addUpdates(
+        const result = await this.addUpdates(
             recordName,
             inst,
             branch,
             [updateToAdd],
             sizeInBytes
         );
+
+        if (typeof numberOfUpdatesToKeep === 'number') {
+            const archived = b.archived;
+            const excess = archived.updates.length - numberOfUpdatesToKeep;
+            if (excess > 0) {
+                archived.updates.splice(0, excess);
+                archived.timestamps.splice(0, excess);
+            }
+        }
+
+        return result;
     }
 
     async deleteBranch(

--- a/src/aux-records/SubscriptionConfigBuilder.ts
+++ b/src/aux-records/SubscriptionConfigBuilder.ts
@@ -531,6 +531,11 @@ export class SubscriptionConfigBuilder {
         return this;
     }
 
+    withNumberOfInstUpdatesToKeep(count?: number): this {
+        this._config.defaultFeatures.numberOfInstUpdatesToKeep = count;
+        return this;
+    }
+
     withWebhookSecret(secret: string): this {
         this._config.webhookSecret = secret;
         return this;

--- a/src/aux-records/SubscriptionConfiguration.ts
+++ b/src/aux-records/SubscriptionConfiguration.ts
@@ -1119,6 +1119,13 @@ export const getSubscriptionConfigSchema = memoize(() =>
                     .describe(
                         'The feature limits for public insts (insts that do not belong to a record and will expire after a preset time). Defaults to an object that allows all features.'
                     ),
+                numberOfInstUpdatesToKeep: z
+                    .int()
+                    .positive()
+                    .optional()
+                    .describe(
+                        'The number of branch updates that should be kept in permanent storage for each branch. Older updates beyond this count are deleted whenever a branch is merged into permanent storage. If omitted, then all updates are kept.'
+                    ),
             })
             .optional(),
     })
@@ -1322,6 +1329,12 @@ export interface DefaultFeaturesConfiguration {
      * The configuration for temporary insts.
      */
     publicInsts?: PublicInstsConfiguration;
+
+    /**
+     * The number of branch updates that should be kept in permanent storage for each branch.
+     * If omitted, then all updates are kept.
+     */
+    numberOfInstUpdatesToKeep?: number;
 }
 
 export interface PublicInstsConfiguration {

--- a/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
+++ b/src/aux-records/__snapshots__/RecordsServer.spec.ts.snap
@@ -6693,6 +6693,11 @@ Object {
                         },
                         "type": "object",
                       },
+                      "numberOfInstUpdatesToKeep": Object {
+                        "description": "The number of branch updates that should be kept in permanent storage for each branch. Older updates beyond this count are deleted whenever a branch is merged into permanent storage. If omitted, then all updates are kept.",
+                        "optional": true,
+                        "type": "number",
+                      },
                       "publicInsts": Object {
                         "description": "The feature limits for public insts (insts that do not belong to a record and will expire after a preset time). Defaults to an object that allows all features.",
                         "optional": true,
@@ -17459,6 +17464,11 @@ Object {
                           },
                         },
                         "type": "object",
+                      },
+                      "numberOfInstUpdatesToKeep": Object {
+                        "description": "The number of branch updates that should be kept in permanent storage for each branch. Older updates beyond this count are deleted whenever a branch is merged into permanent storage. If omitted, then all updates are kept.",
+                        "optional": true,
+                        "type": "number",
                       },
                       "publicInsts": Object {
                         "description": "The feature limits for public insts (insts that do not belong to a record and will expire after a preset time). Defaults to an object that allows all features.",

--- a/src/aux-records/websockets/InstRecordsStore.ts
+++ b/src/aux-records/websockets/InstRecordsStore.ts
@@ -163,13 +163,15 @@ export interface InstRecordsStore {
      * @param updatesToRemove The updates that should be moved. Only valid if the result from getUpdates() is used.
      * @param updateToAdd The update that should be added.
      * @param sizeInBytes The size of the new update in bytes.
+     * @param numberOfUpdatesToKeep If provided, then older stored updates for the branch beyond this count should be deleted, keeping only the most recent updates (including the one being added). If omitted, then all updates are kept.
      */
     replaceCurrentUpdates(
         recordName: string | null,
         inst: string,
         branch: string,
         updateToAdd: string,
-        sizeInBytes: number
+        sizeInBytes: number,
+        numberOfUpdatesToKeep?: number
     ): Promise<ReplaceUpdatesResult>;
 
     /**

--- a/src/aux-records/websockets/SplitInstRecordsStore.spec.ts
+++ b/src/aux-records/websockets/SplitInstRecordsStore.spec.ts
@@ -1412,5 +1412,37 @@ describe('SplitInstRecordsStore', () => {
                 instSizeInBytes: 10,
             });
         });
+
+        it('should trim the permanent store to the given number of updates when numberOfUpdatesToKeep is provided', async () => {
+            await temp.addUpdates(
+                recordName,
+                instName,
+                branchName,
+                ['abc', 'def'],
+                6
+            );
+            await perm.addUpdates(recordName, instName, branchName, ['abc'], 3);
+            await perm.addUpdates(recordName, instName, branchName, ['def'], 3);
+
+            await store.replaceCurrentUpdates(
+                recordName,
+                instName,
+                branchName,
+                'test',
+                4,
+                1
+            );
+
+            const allUpdates = await perm.getAllUpdates(
+                recordName,
+                instName,
+                branchName
+            );
+            expect(allUpdates).toEqual({
+                updates: ['test'],
+                timestamps: [expect.any(Number)],
+                instSizeInBytes: 10,
+            });
+        });
     });
 });

--- a/src/aux-records/websockets/SplitInstRecordsStore.ts
+++ b/src/aux-records/websockets/SplitInstRecordsStore.ts
@@ -410,7 +410,8 @@ export class SplitInstRecordsStore implements InstRecordsStore {
         inst: string,
         branch: string,
         updateToAdd: string,
-        sizeInBytes: number
+        sizeInBytes: number,
+        numberOfUpdatesToKeep?: number
     ): Promise<ReplaceUpdatesResult> {
         const updateCount = await this._temp.countBranchUpdates(
             recordName,
@@ -423,7 +424,8 @@ export class SplitInstRecordsStore implements InstRecordsStore {
                 inst,
                 branch,
                 updateToAdd,
-                sizeInBytes
+                sizeInBytes,
+                numberOfUpdatesToKeep
             );
         if (permanentReplaceResult.success === false) {
             return permanentReplaceResult;

--- a/src/aux-records/websockets/WebsocketController.spec.ts
+++ b/src/aux-records/websockets/WebsocketController.spec.ts
@@ -13507,6 +13507,54 @@ describe('WebsocketController', () => {
                 ).toEqual([]);
             });
 
+            it('should keep all permanent updates across multiple merge cycles by default', async () => {
+                await server.savePermanentBranches();
+
+                await server.addUpdates(serverConnectionId, {
+                    type: 'repo/add_updates',
+                    recordName,
+                    inst,
+                    branch: 'branch',
+                    updates: [update1Base64],
+                    updateId: 2,
+                });
+
+                await server.savePermanentBranches();
+
+                const allUpdates = await instStore.perm.getAllUpdates(
+                    recordName,
+                    inst,
+                    'branch'
+                );
+                expect(allUpdates?.updates.length).toBe(2);
+            });
+
+            it('should trim permanent updates to numberOfInstUpdatesToKeep when configured', async () => {
+                store.subscriptionConfiguration = buildSubscriptionConfig(
+                    (config) => config.withNumberOfInstUpdatesToKeep(1)
+                );
+
+                await server.savePermanentBranches();
+
+                await server.addUpdates(serverConnectionId, {
+                    type: 'repo/add_updates',
+                    recordName,
+                    inst,
+                    branch: 'branch',
+                    updates: [update1Base64],
+                    updateId: 2,
+                });
+
+                await server.savePermanentBranches();
+
+                const allUpdates = await instStore.perm.getAllUpdates(
+                    recordName,
+                    inst,
+                    'branch'
+                );
+                expect(allUpdates?.updates.length).toBe(1);
+            });
+
             it('should acquire a lock before trying to save branch data', async () => {
                 const generation =
                     await instStore.temp.getDirtyBranchGeneration();

--- a/src/aux-records/websockets/WebsocketController.ts
+++ b/src/aux-records/websockets/WebsocketController.ts
@@ -3379,6 +3379,10 @@ export class WebsocketController {
             `[WebsocketController] Saving branch updates for ${branch.recordName}/${branch.inst}/${branch.branch}`
         );
 
+        const config = await this._config.getSubscriptionConfiguration();
+        const numberOfUpdatesToKeep =
+            config?.defaultFeatures?.numberOfInstUpdatesToKeep;
+
         let [updateCount, size] = await Promise.all([
             store.temp.countBranchUpdates(
                 branch.recordName,
@@ -3437,7 +3441,8 @@ export class WebsocketController {
                     branch.inst,
                     branch.branch,
                     mergedBase64,
-                    mergedBase64.length
+                    mergedBase64.length,
+                    numberOfUpdatesToKeep
                 );
 
             if (permanentReplaceResult.success === false) {

--- a/src/aux-server/aux-backend/prisma/PrismaInstRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/PrismaInstRecordsStore.ts
@@ -565,7 +565,8 @@ export class PrismaInstRecordsStore implements InstRecordsStore {
         inst: string,
         branch: string,
         updateToAdd: string,
-        sizeInBytes: number
+        sizeInBytes: number,
+        numberOfUpdatesToKeep?: number
     ): Promise<ReplaceUpdatesResult> {
         const branchUpdateId = uuid();
         try {
@@ -601,6 +602,29 @@ export class PrismaInstRecordsStore implements InstRecordsStore {
                     };
                 }
                 throw err;
+            }
+        }
+
+        if (typeof numberOfUpdatesToKeep === 'number') {
+            const excess = await this._prisma.branchUpdate.findMany({
+                where: {
+                    recordName: recordName,
+                    instName: inst,
+                    branchName: branch,
+                },
+                orderBy: {
+                    createdAt: 'desc',
+                },
+                skip: numberOfUpdatesToKeep,
+                select: { id: true },
+            });
+
+            if (excess.length > 0) {
+                await this._prisma.branchUpdate.deleteMany({
+                    where: {
+                        id: { in: excess.map((u) => u.id) },
+                    },
+                });
             }
         }
 

--- a/src/aux-server/aux-backend/prisma/sqlite/SqliteInstRecordsStore.ts
+++ b/src/aux-server/aux-backend/prisma/sqlite/SqliteInstRecordsStore.ts
@@ -575,7 +575,8 @@ export class SqliteInstRecordsStore implements InstRecordsStore {
         inst: string,
         branch: string,
         updateToAdd: string,
-        sizeInBytes: number
+        sizeInBytes: number,
+        numberOfUpdatesToKeep?: number
     ): Promise<ReplaceUpdatesResult> {
         const branchUpdateId = uuid();
         try {
@@ -613,6 +614,29 @@ export class SqliteInstRecordsStore implements InstRecordsStore {
                     };
                 }
                 throw err;
+            }
+        }
+
+        if (typeof numberOfUpdatesToKeep === 'number') {
+            const excess = await this._prisma.branchUpdate.findMany({
+                where: {
+                    recordName: recordName,
+                    instName: inst,
+                    branchName: branch,
+                },
+                orderBy: {
+                    createdAt: 'desc',
+                },
+                skip: numberOfUpdatesToKeep,
+                select: { id: true },
+            });
+
+            if (excess.length > 0) {
+                await this._prisma.branchUpdate.deleteMany({
+                    where: {
+                        id: { in: excess.map((u) => u.id) },
+                    },
+                });
             }
         }
 


### PR DESCRIPTION
## Summary
This PR adds support for configuring the number of branch updates to retain in permanent storage. When configured, older updates beyond the specified count are automatically deleted during branch merges, allowing for storage optimization while maintaining the ability to keep all updates by default.

## Key Changes
- **Configuration**: Added `numberOfInstUpdatesToKeep` optional parameter to `DefaultFeaturesConfiguration` in subscription settings, allowing administrators to limit the number of stored updates per branch
- **Store Implementations**: Updated all `InstRecordsStore` implementations (`PrismaInstRecordsStore`, `SqliteInstRecordsStore`, `MemoryStore`, `SplitInstRecordsStore`) to accept and handle the `numberOfUpdatesToKeep` parameter in `replaceCurrentUpdates()`
- **WebsocketController**: Modified branch save logic to retrieve the configured update retention limit and pass it to the permanent store when merging branches
- **Schema & Builder**: Added schema validation for the new configuration option and a builder method `withNumberOfInstUpdatesToKeep()` for test configuration
- **Tests**: Added comprehensive test coverage for both default behavior (keeping all updates) and trimming behavior (respecting the configured limit)

## Implementation Details
- The trimming logic keeps the most recent N updates (ordered by `createdAt` descending) and deletes older ones
- The feature is optional and backward compatible—when `numberOfInstUpdatesToKeep` is not configured, all updates are retained
- Trimming occurs automatically during the `replaceCurrentUpdates()` operation when a branch is merged into permanent storage
- All store implementations follow the same pattern: query for excess updates, then delete them in a single operation

https://claude.ai/code/session_01YYbPsmMSYqtmZA1yHFfYoM