### PR TITLE
Fix presence recovery after websocket reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   Fixed an issue where bots with rotation were being reset to null when dragged
 -   Improved loading performance when the database has lots of old inst updates.
+-   Fixed an issue where presence (participant/avatar list and host-left detection) would never recover after a websocket reconnect, because `InstRecordsClient` never cleared its cache of previously-connected devices when synthesizing disconnect events, causing the server's replayed connection list to be filtered out as duplicates.
 
 ### :rocket: Features
 

--- a/src/aux-common/websockets/InstRecordsClient.spec.ts
+++ b/src/aux-common/websockets/InstRecordsClient.spec.ts
@@ -46,6 +46,7 @@ import type {
 } from '../common/RemoteActions';
 import { device, remote } from '../common/RemoteActions';
 import { connectionInfo } from '../common/ConnectionInfo';
+import type { ConnectionInfo } from '../common/ConnectionInfo';
 import type { TimeSample } from '@casual-simulation/timesync';
 
 describe('InstRecordsClient', () => {
@@ -1268,6 +1269,91 @@ describe('InstRecordsClient', () => {
                     },
                     connection: device2,
                 },
+            ]);
+            expect(disconnections).toEqual([
+                {
+                    type: 'repo/disconnected_from_branch',
+                    broadcast: false,
+                    recordName: 'myRecord',
+                    inst: 'inst',
+                    branch: 'testBranch',
+                    connection: device1,
+                },
+                {
+                    type: 'repo/disconnected_from_branch',
+                    broadcast: false,
+                    recordName: 'myRecord',
+                    inst: 'inst',
+                    branch: 'testBranch',
+                    connection: device2,
+                },
+            ]);
+        });
+
+        it('should re-emit connected events for devices that were already known after a reconnect', async () => {
+            let connections: ConnectedToBranchMessage[] = [];
+            let disconnections: DisconnectedFromBranchMessage[] = [];
+            client
+                .watchBranchDevices('myRecord', 'inst', 'testBranch')
+                .subscribe((e) => {
+                    if (e.type === 'repo/connected_to_branch') {
+                        connections.push(e);
+                    } else {
+                        disconnections.push(e);
+                    }
+                });
+
+            let connect = new Subject<ConnectedToBranchMessage>();
+            let disconnect = new Subject<DisconnectedFromBranchMessage>();
+            connection.events.set('repo/connected_to_branch', connect);
+            connection.events.set('repo/disconnected_from_branch', disconnect);
+
+            const device1 = connectionInfo('device1', 'device1', 'device1');
+            const device2 = connectionInfo('device2', 'device2', 'device2');
+
+            connection.connect();
+            await waitAsync();
+
+            const connectedMessage = (
+                device: ConnectionInfo
+            ): ConnectedToBranchMessage => ({
+                type: 'repo/connected_to_branch',
+                broadcast: false,
+                branch: {
+                    type: 'repo/watch_branch',
+                    recordName: 'myRecord',
+                    inst: 'inst',
+                    branch: 'testBranch',
+                },
+                connection: device,
+            });
+
+            connect.next(connectedMessage(device1));
+            connect.next(connectedMessage(device2));
+
+            await waitAsync();
+
+            // Simulate the underlying socket dropping and coming back.
+            // The server always replays the full current device list on
+            // reconnect - even for devices that were already known before
+            // the drop - and those should be treated as new connections
+            // (not filtered out) so that presence recovers.
+            connection.disconnect();
+            await waitAsync();
+
+            connection.connect();
+            await waitAsync();
+
+            connect.next(connectedMessage(device1));
+            connect.next(connectedMessage(device2));
+
+            await waitAsync();
+
+            expect(connections).toEqual([
+                connectedMessage(device1),
+                connectedMessage(device2),
+                connectedMessage(device1),
+                connectedMessage(device2),
             ]);
             expect(disconnections).toEqual([
                 {

--- a/src/aux-common/websockets/InstRecordsClient.ts
+++ b/src/aux-common/websockets/InstRecordsClient.ts
@@ -502,10 +502,18 @@ export class InstRecordsClient {
         inst: string,
         branch: string
     ) {
+        const devices = this._getConnectedDevices(recordName, inst, branch);
+        const disconnectedDevices = [...devices.values()];
+
+        // Clear the cache so that when we reconnect, the devices that the
+        // server tells us are still connected are treated as newly connected
+        // instead of being filtered out as already-known. Otherwise, the
+        // server's replayed repo/connected_to_branch events would never be
+        // re-emitted and presence would never recover after a reconnect.
+        devices.clear();
+
         return of(
-            ...[
-                ...this._getConnectedDevices(recordName, inst, branch).values(),
-            ].map(
+            ...disconnectedDevices.map(
                 (device) =>
                     ({
                         type: 'repo/disconnected_from_branch',


### PR DESCRIPTION
## Summary
Fixed an issue where presence (participant/avatar list and host-left detection) would never recover after a websocket reconnect. The `InstRecordsClient` was caching connected devices and filtering out reconnection events from the server, preventing presence from being restored.

## Key Changes
- Modified `InstRecordsClient._onConnectionDisconnected()` to clear the device cache when the connection drops, rather than just reading from it
- This allows the server's replayed `repo/connected_to_branch` events (sent on reconnect) to be treated as new connections instead of being filtered out as already-known devices
- Added comprehensive test case to verify that connected events are re-emitted for previously-known devices after a reconnect

## Implementation Details
The fix involves clearing the `_connectedDevices` cache before synthesizing disconnect events. This ensures that when the websocket reconnects and the server replays the full list of currently-connected devices, those events are not deduplicated against stale cache entries. The disconnect events are still properly emitted using the devices that were cached before clearing, maintaining the correct disconnect notification behavior.

https://claude.ai/code/session_018Jvk8KKEPyv4b1LBKPxs4t