### PR TITLE
Add YouTube oEmbed support for link previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CasualOS Changelog
 
+## V4.2.8
+
+#### Date: TBD
+
+### :rocket: Features
+
+-   Improved link previews to suppport YouTube videos.
+-   Improved Custom OpenID Connect providers to support sending nonces.
+
 ## V4.2.7
 
 #### Date: 8/13/2026

--- a/src/aux-records/LinkPreviewController.spec.ts
+++ b/src/aux-records/LinkPreviewController.spec.ts
@@ -19,8 +19,10 @@ import { lookup as dnsLookup } from 'node:dns/promises';
 import {
     LinkPreviewController,
     extractLinkPreviewData,
+    extractYouTubeOEmbedData,
     getCacheKey,
     isPrivateOrReservedAddress,
+    isYouTubeHostname,
     normalizeUrl,
 } from './LinkPreviewController';
 import { MemoryLinkPreviewStore } from './MemoryLinkPreviewStore';
@@ -84,6 +86,17 @@ describe('LinkPreviewController', () => {
                     responseUrl: 'https://example.com/page',
                 },
             },
+        });
+    }
+
+    function mockOEmbedResponse(
+        data: object,
+        options: { status?: number; headers?: { [key: string]: string } } = {}
+    ) {
+        mockAxios.__setResponse({
+            status: options.status ?? 200,
+            data,
+            headers: options.headers ?? {},
         });
     }
 
@@ -331,6 +344,166 @@ describe('LinkPreviewController', () => {
                 }),
             ]);
         });
+
+        describe('YouTube oEmbed previews', () => {
+            it('should use the YouTube oEmbed endpoint for youtube.com URLs', async () => {
+                mockOEmbedResponse({
+                    title: 'Rick Astley - Never Gonna Give You Up',
+                    author_name: 'Rick Astley',
+                    author_url: 'https://www.youtube.com/@RickAstleyYT',
+                    provider_name: 'YouTube',
+                    provider_url: 'https://www.youtube.com/',
+                    thumbnail_url:
+                        'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+                    thumbnail_width: 480,
+                    thumbnail_height: 360,
+                    type: 'video',
+                    version: '1.0',
+                });
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                });
+
+                expect(result).toEqual({
+                    success: true,
+                    title: 'Rick Astley - Never Gonna Give You Up',
+                    description: undefined,
+                    imageUrl:
+                        'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+                    imageWidth: 480,
+                    imageHeight: 360,
+                    imageAlt: 'Rick Astley - Never Gonna Give You Up',
+                    type: 'video',
+                    canonicalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                    siteName: 'YouTube',
+                    locale: undefined,
+                    cachedUntilMs: 1800 * 1000,
+                    meta: expect.objectContaining({
+                        title: 'Rick Astley - Never Gonna Give You Up',
+                        author_name: 'Rick Astley',
+                        provider_name: 'YouTube',
+                    }),
+                });
+
+                expect(mockAxios.__getLastGet()).toEqual([
+                    'https://www.youtube.com/oembed',
+                    expect.objectContaining({
+                        params: {
+                            url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                            format: 'json',
+                        },
+                    }),
+                ]);
+            });
+
+            it('should recognize youtu.be short links', async () => {
+                mockOEmbedResponse({
+                    title: 'Short link video',
+                    provider_name: 'YouTube',
+                    thumbnail_url:
+                        'https://i.ytimg.com/vi/abc123/hqdefault.jpg',
+                });
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://youtu.be/abc123',
+                });
+
+                expect(result.success).toBe(true);
+                expect(mockAxios.__getLastGet()[0]).toBe(
+                    'https://www.youtube.com/oembed'
+                );
+                expect(mockAxios.__getLastGet()[1]).toEqual(
+                    expect.objectContaining({
+                        params: {
+                            url: 'https://youtu.be/abc123',
+                            format: 'json',
+                        },
+                    })
+                );
+            });
+
+            it('should recognize m.youtube.com links', async () => {
+                mockOEmbedResponse({
+                    title: 'Mobile video',
+                    provider_name: 'YouTube',
+                });
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://m.youtube.com/watch?v=abc123',
+                });
+
+                expect(result.success).toBe(true);
+                expect(mockAxios.__getLastGet()[0]).toBe(
+                    'https://www.youtube.com/oembed'
+                );
+            });
+
+            it('should return unacceptable_url if the oEmbed request returns a non-200 status', async () => {
+                mockOEmbedResponse({ error: 'Unauthorized' }, { status: 401 });
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://www.youtube.com/watch?v=private-video',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_url',
+                    errorMessage: 'The given URL is not able to be previewed.',
+                });
+            });
+
+            it('should return unacceptable_url if the oEmbed response fails schema validation', async () => {
+                mockOEmbedResponse({
+                    thumbnail_width: 'not-a-number',
+                });
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://www.youtube.com/watch?v=bad-shape',
+                });
+
+                expect(result).toEqual({
+                    success: false,
+                    errorCode: 'unacceptable_url',
+                    errorMessage: 'The given URL is not able to be previewed.',
+                });
+            });
+
+            it('should cache successful YouTube previews and not fetch again while the cache is valid', async () => {
+                mockOEmbedResponse({
+                    title: 'Cached video',
+                    provider_name: 'YouTube',
+                });
+
+                const first = await subject.getLinkPreview({
+                    url: 'https://www.youtube.com/watch?v=cached',
+                });
+                expect(first.success).toBe(true);
+                expect(mockAxios.__getRequests().length).toBe(1);
+
+                const second = await subject.getLinkPreview({
+                    url: 'https://www.youtube.com/watch?v=cached',
+                });
+
+                expect(second).toEqual(first);
+                expect(mockAxios.__getRequests().length).toBe(1);
+            });
+
+            it('should not use the oEmbed endpoint for non-YouTube URLs', async () => {
+                mockHtmlResponse(
+                    '<html><head><title>Not YouTube</title></head></html>'
+                );
+
+                const result = await subject.getLinkPreview({
+                    url: 'https://example.com/page',
+                });
+
+                expect(result.success).toBe(true);
+                expect(mockAxios.__getLastGet()[0]).toBe(
+                    'https://example.com/page'
+                );
+            });
+        });
     });
 
     describe('normalizeUrl()', () => {
@@ -375,6 +548,67 @@ describe('LinkPreviewController', () => {
                 'og:title': 'Title',
                 'twitter:card': 'summary',
             });
+        });
+    });
+
+    describe('isYouTubeHostname()', () => {
+        it.each([
+            ['youtube.com', true],
+            ['www.youtube.com', true],
+            ['m.youtube.com', true],
+            ['youtube-nocookie.com', true],
+            ['www.youtube-nocookie.com', true],
+            ['youtu.be', true],
+            ['www.youtu.be', true],
+            ['YOUTUBE.COM', true],
+            ['example.com', false],
+            ['notyoutube.com', false],
+            ['youtube.com.evil.com', false],
+        ])('should classify %s as YouTube=%s', (hostname, expected) => {
+            expect(isYouTubeHostname(hostname)).toBe(expected);
+        });
+    });
+
+    describe('extractYouTubeOEmbedData()', () => {
+        it('should map the oEmbed fields onto link preview data', () => {
+            const data = extractYouTubeOEmbedData(
+                {
+                    title: 'Example Video',
+                    author_name: 'Example Author',
+                    provider_name: 'YouTube',
+                    thumbnail_url: 'https://i.ytimg.com/vi/abc/hqdefault.jpg',
+                    thumbnail_width: 480,
+                    thumbnail_height: 360,
+                },
+                'https://www.youtube.com/watch?v=abc'
+            );
+
+            expect(data).toEqual({
+                title: 'Example Video',
+                description: undefined,
+                imageUrl: 'https://i.ytimg.com/vi/abc/hqdefault.jpg',
+                imageWidth: 480,
+                imageHeight: 360,
+                imageAlt: 'Example Video',
+                type: 'video',
+                canonicalUrl: 'https://www.youtube.com/watch?v=abc',
+                siteName: 'YouTube',
+                locale: undefined,
+                meta: expect.objectContaining({
+                    title: 'Example Video',
+                    author_name: 'Example Author',
+                    provider_name: 'YouTube',
+                }),
+            });
+        });
+
+        it('should default siteName to YouTube when provider_name is missing', () => {
+            const data = extractYouTubeOEmbedData(
+                { title: 'No provider' },
+                'https://www.youtube.com/watch?v=xyz'
+            );
+
+            expect(data.siteName).toBe('YouTube');
         });
     });
 

--- a/src/aux-records/LinkPreviewController.ts
+++ b/src/aux-records/LinkPreviewController.ts
@@ -24,10 +24,51 @@ import axios from 'axios';
 import * as net from 'node:net';
 import { lookup as dnsLookup } from 'node:dns/promises';
 import { parse as parseHtml } from 'node-html-parser';
+import { z } from 'zod';
 
 const TRACE_NAME = 'LinkPreviewController';
 
 const USER_AGENT = 'CasualOS-LinkPreview/1.0 (+https://casualos.com)';
+
+const YOUTUBE_OEMBED_URL = 'https://www.youtube.com/oembed';
+
+const YOUTUBE_HOSTNAMES = new Set([
+    'youtube.com',
+    'www.youtube.com',
+    'm.youtube.com',
+    'youtube-nocookie.com',
+    'www.youtube-nocookie.com',
+    'youtu.be',
+    'www.youtu.be',
+]);
+
+/**
+ * The schema for the response returned by YouTube's oEmbed endpoint.
+ * See https://oembed.com/ and https://www.youtube.com/oembed for details.
+ */
+export const YOUTUBE_OEMBED_SCHEMA = z.object({
+    title: z.string().optional(),
+    author_name: z.string().optional(),
+    author_url: z.string().optional(),
+    provider_name: z.string().optional(),
+    provider_url: z.string().optional(),
+    thumbnail_url: z.string().optional(),
+    thumbnail_width: z.number().optional(),
+    thumbnail_height: z.number().optional(),
+    html: z.string().optional(),
+    type: z.string().optional(),
+    version: z.string().optional(),
+});
+
+export type YouTubeOEmbedResponse = z.infer<typeof YOUTUBE_OEMBED_SCHEMA>;
+
+/**
+ * Determines if the given hostname belongs to YouTube.
+ * @param hostname The hostname to check.
+ */
+export function isYouTubeHostname(hostname: string): boolean {
+    return YOUTUBE_HOSTNAMES.has(hostname.toLowerCase());
+}
 
 export interface LinkPreviewControllerOptions {
     store: LinkPreviewStore;
@@ -130,58 +171,33 @@ export class LinkPreviewController {
                 };
             }
 
-            const response = await axios.get(normalizedUrl, {
-                headers: {
-                    'User-Agent': USER_AGENT,
-                    ...(request.locale
-                        ? { 'Accept-Language': request.locale }
-                        : {}),
-                },
-                responseType: 'text',
-                timeout: this._config.requestTimeoutMs,
-                maxRedirects: 5,
-                maxContentLength: this._config.maxResponseBytes,
-                maxBodyLength: this._config.maxResponseBytes,
-                validateStatus: () => true,
-            });
+            const result = isYouTubeHostname(target.hostname)
+                ? await this._getYouTubeOEmbedData(
+                      normalizedUrl,
+                      request.locale
+                  )
+                : await this._getGenericPreviewData(
+                      normalizedUrl,
+                      request.locale
+                  );
 
-            const contentType = (
-                (response.headers?.['content-type'] as string) ?? ''
-            ).toLowerCase();
-            if (
-                !contentType.includes('text/html') &&
-                !contentType.includes('application/xhtml+xml')
-            ) {
+            if (result.success === true) {
+                const expireTimeMs = Date.now() + result.expireSeconds * 1000;
+
+                await this._store.saveLinkPreview({
+                    cacheKey,
+                    data: result.data,
+                    expireTimeMs,
+                });
+
                 return {
-                    success: false,
-                    errorCode: 'url_not_html',
-                    errorMessage:
-                        'The given URL does not point to an HTML page.',
+                    success: true,
+                    ...result.data,
+                    cachedUntilMs: expireTimeMs,
                 };
             }
 
-            const finalUrl: string =
-                response.request?.res?.responseUrl ?? normalizedUrl;
-            const data = extractLinkPreviewData(response.data, finalUrl);
-            const expireSeconds = Math.max(
-                this._config.minCacheSeconds,
-                getCacheControlMaxAgeSeconds(
-                    response.headers?.['cache-control'] as string
-                ) ?? 0
-            );
-            const expireTimeMs = Date.now() + expireSeconds * 1000;
-
-            await this._store.saveLinkPreview({
-                cacheKey,
-                data,
-                expireTimeMs,
-            });
-
-            return {
-                success: true,
-                ...data,
-                cachedUntilMs: expireTimeMs,
-            };
+            return result;
         } catch (err) {
             const span = trace.getActiveSpan();
             span?.recordException(err);
@@ -197,6 +213,104 @@ export class LinkPreviewController {
                 errorMessage: 'A server error occurred.',
             };
         }
+    }
+
+    /**
+     * Fetches the page's HTML and scrapes OpenGraph/meta tags out of it.
+     */
+    private async _getGenericPreviewData(
+        normalizedUrl: string,
+        locale: string | undefined
+    ): Promise<PreviewDataResult> {
+        const response = await axios.get(normalizedUrl, {
+            headers: {
+                'User-Agent': USER_AGENT,
+                ...(locale ? { 'Accept-Language': locale } : {}),
+            },
+            responseType: 'text',
+            timeout: this._config.requestTimeoutMs,
+            maxRedirects: 5,
+            maxContentLength: this._config.maxResponseBytes,
+            maxBodyLength: this._config.maxResponseBytes,
+            validateStatus: () => true,
+        });
+
+        const contentType = (
+            (response.headers?.['content-type'] as string) ?? ''
+        ).toLowerCase();
+        if (
+            !contentType.includes('text/html') &&
+            !contentType.includes('application/xhtml+xml')
+        ) {
+            return {
+                success: false,
+                errorCode: 'url_not_html',
+                errorMessage: 'The given URL does not point to an HTML page.',
+            };
+        }
+
+        const finalUrl: string =
+            response.request?.res?.responseUrl ?? normalizedUrl;
+        const data = extractLinkPreviewData(response.data, finalUrl);
+        const expireSeconds = Math.max(
+            this._config.minCacheSeconds,
+            getCacheControlMaxAgeSeconds(
+                response.headers?.['cache-control'] as string
+            ) ?? 0
+        );
+
+        return {
+            success: true,
+            data,
+            expireSeconds,
+        };
+    }
+
+    /**
+     * Fetches preview data for a YouTube URL using YouTube's oEmbed endpoint.
+     */
+    private async _getYouTubeOEmbedData(
+        normalizedUrl: string,
+        locale: string | undefined
+    ): Promise<PreviewDataResult> {
+        const response = await axios.get(YOUTUBE_OEMBED_URL, {
+            params: {
+                url: normalizedUrl,
+                format: 'json',
+            },
+            headers: {
+                'User-Agent': USER_AGENT,
+                ...(locale ? { 'Accept-Language': locale } : {}),
+            },
+            timeout: this._config.requestTimeoutMs,
+            validateStatus: () => true,
+        });
+
+        const parsed =
+            response.status === 200
+                ? YOUTUBE_OEMBED_SCHEMA.safeParse(response.data)
+                : null;
+
+        if (!parsed || !parsed.success) {
+            return {
+                success: false,
+                errorCode: 'unacceptable_url',
+                errorMessage: 'The given URL is not able to be previewed.',
+            };
+        }
+
+        const expireSeconds = Math.max(
+            this._config.minCacheSeconds,
+            getCacheControlMaxAgeSeconds(
+                response.headers?.['cache-control'] as string
+            ) ?? 0
+        );
+
+        return {
+            success: true,
+            data: extractYouTubeOEmbedData(parsed.data, normalizedUrl),
+            expireSeconds,
+        };
     }
 
     private async _isBlockedHost(hostname: string): Promise<boolean> {
@@ -343,6 +457,37 @@ export function extractLinkPreviewData(
 }
 
 /**
+ * Maps a validated YouTube oEmbed response onto link preview data.
+ * @param oembed The validated oEmbed response.
+ * @param canonicalUrl The normalized URL that the oEmbed data was retrieved for.
+ */
+export function extractYouTubeOEmbedData(
+    oembed: YouTubeOEmbedResponse,
+    canonicalUrl: string
+): LinkPreviewData {
+    const meta: { [key: string]: string } = {};
+    for (const [key, value] of Object.entries(oembed)) {
+        if (value !== undefined && value !== null) {
+            meta[key] = String(value);
+        }
+    }
+
+    return {
+        title: oembed.title,
+        description: undefined,
+        imageUrl: oembed.thumbnail_url,
+        imageHeight: oembed.thumbnail_height,
+        imageWidth: oembed.thumbnail_width,
+        imageAlt: oembed.title,
+        type: 'video',
+        canonicalUrl,
+        siteName: oembed.provider_name ?? 'YouTube',
+        locale: undefined,
+        meta,
+    };
+}
+
+/**
  * Determines if the given IP address is a private, loopback, link-local, or otherwise
  * reserved address that should not be reachable from a public link preview request.
  * @param ip The IP address to check.
@@ -420,3 +565,15 @@ export interface GetLinkPreviewFailure {
         | 'site_rate_limited';
     errorMessage: string;
 }
+
+/**
+ * The result of fetching link preview data from a source (either the generic
+ * HTML scraper or a site-specific integration like YouTube's oEmbed endpoint).
+ */
+type PreviewDataResult =
+    | {
+          success: true;
+          data: LinkPreviewData;
+          expireSeconds: number;
+      }
+    | GetLinkPreviewFailure;


### PR DESCRIPTION
## Summary
This PR adds specialized support for YouTube URLs in the link preview system by integrating YouTube's oEmbed endpoint, providing better metadata extraction for video content.

## Key Changes
- **YouTube URL Detection**: Added `isYouTubeHostname()` function and `YOUTUBE_HOSTNAMES` set to identify YouTube URLs across multiple domains (youtube.com, youtu.be, m.youtube.com, youtube-nocookie.com, etc.)
- **oEmbed Integration**: Implemented `_getYouTubeOEmbedData()` method to fetch preview data from YouTube's oEmbed endpoint with proper schema validation using Zod
- **Schema Validation**: Created `YOUTUBE_OEMBED_SCHEMA` using Zod to validate and type YouTube's oEmbed responses
- **Data Extraction**: Added `extractYouTubeOEmbedData()` function to map oEmbed fields onto the standard `LinkPreviewData` format
- **Refactored Preview Logic**: Extracted generic HTML scraping into `_getGenericPreviewData()` method and introduced `PreviewDataResult` type to handle both success and failure cases uniformly
- **Comprehensive Tests**: Added extensive test coverage for YouTube URL detection, oEmbed endpoint integration, error handling, and caching behavior

## Implementation Details
- YouTube URLs are detected by hostname and routed to the oEmbed endpoint instead of generic HTML scraping
- The oEmbed response is validated against a schema before use, returning `unacceptable_url` errors for invalid responses
- Preview data is cached with the same TTL logic as generic previews, respecting cache-control headers
- The implementation maintains backward compatibility with existing generic link preview functionality
- All YouTube-specific code is properly exported for testing and reusability

https://claude.ai/code/session_01PCVUPdxNMWehtCNeGCmLXL